### PR TITLE
Add support for unnamed enumerations

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -22,6 +22,9 @@ class EnumGenerator(
     shape: StringShape,
     private val enumTrait: EnumTrait
 ) {
+    companion object {
+        const val Values = "values"
+    }
 
     fun render() {
         if (enumTrait.hasNames()) {
@@ -46,7 +49,7 @@ class EnumGenerator(
                 write("&self.0")
             }
 
-            writer.rustBlock("pub fn valid_values() -> &'static [&'static str]") {
+            writer.rustBlock("pub fn ${Values}() -> &'static [&'static str]") {
                 withBlock("&[", "]") {
                     val memberList = sortedMembers.joinToString(", ") { it.value.doubleQuote() }
                     write(memberList)

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
@@ -95,7 +95,7 @@ class EnumGeneratorTest {
         generator.render()
         writer.shouldCompile("""
             // Values should be sorted
-            assert_eq!(FooEnum::valid_values(), ["0", "1", "Bar", "Baz", "Foo"]);
+            assert_eq!(FooEnum::${EnumGenerator.Values}(), ["0", "1", "Bar", "Baz", "Foo"]);
         """)
     }
 }


### PR DESCRIPTION
*Description of changes:*
Unnamed enumerations are supported by creating a "newtype" that wraps the string. The newtype provides the valid values as a list for convenience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
