### PR TITLE
Generate Builders for Structures

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
@@ -65,7 +65,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
             )
             cargoToml.render()
         }
-        writers.useFileWriter("src/lib.rs") {
+        writers.useFileWriter("src/lib.rs", "crate::lib") {
             // TODO: a more structured method of signaling what modules should get loaded.
             val modules = PublicModules.filter { writers.writers.containsKey("src/$it.rs") }
             LibRsGenerator(modules, it).render()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -10,24 +10,43 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.ErrorTrait
+import software.amazon.smithy.rust.codegen.lang.RustType
 import software.amazon.smithy.rust.codegen.lang.RustWriter
+import software.amazon.smithy.rust.codegen.lang.render
+import software.amazon.smithy.rust.codegen.lang.rustBlock
+import software.amazon.smithy.rust.codegen.lang.withBlock
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.canUseDefault
+import software.amazon.smithy.rust.codegen.smithy.isOptional
+import software.amazon.smithy.rust.codegen.smithy.makeOptional
+import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.utils.CaseUtils
 
 // TODO(maybe): extract struct generation from Smithy shapes to support generating body objects
-// TODO: generate builders; 1d
+// TODO: generate documentation
 class StructureGenerator(
     val model: Model,
     private val symbolProvider: SymbolProvider,
     private val writer: RustWriter,
-    private val shape: StructureShape
+    private val shape: StructureShape,
+    private val renderBuilder: Boolean = true
 ) {
-    private val sortedMembers: List<MemberShape> = shape.allMembers.values.sortedBy { symbolProvider.toMemberName(it) }
+    private val members: List<MemberShape> = shape.allMembers.values.toList()
+    private val structureSymbol = symbolProvider.toSymbol(shape)
+    private val builderSymbol = RuntimeType("Builder", null, "${structureSymbol.namespace}::${structureSymbol.name.toSnakeCase()}")
     fun render() {
         renderStructure()
         val errorTrait = shape.getTrait(ErrorTrait::class.java)
         errorTrait.map {
             val errorGenerator = ErrorGenerator(model, symbolProvider, writer, shape, it)
             errorGenerator.render()
+        }
+        if (renderBuilder) {
+            val symbol = symbolProvider.toSymbol(shape)
+            writer.withModule(symbol.name.toSnakeCase()) {
+                renderBuilder(this)
+            }
         }
     }
 
@@ -36,11 +55,95 @@ class StructureGenerator(
         // TODO(maybe): Pull derive info from the symbol so that the symbol provider can alter things as necessary; 4h
         writer.write("#[non_exhaustive]")
         writer.write("#[derive(Debug, PartialEq, Clone)]")
-        val blockWriter = writer.openBlock("pub struct ${symbol.name} {")
-        sortedMembers.forEach { member ->
-            val memberName = symbolProvider.toMemberName(member)
-            blockWriter.write("pub $memberName: \$T,", symbolProvider.toSymbol(member)) }
-        blockWriter.closeBlock("}")
+        writer.rustBlock("pub struct ${symbol.name}") {
+            members.forEach { member ->
+                val memberName = symbolProvider.toMemberName(member)
+                write("pub $memberName: \$T,", symbolProvider.toSymbol(member))
+            }
+        }
+
+        if (renderBuilder) {
+            writer.rustBlock("impl ${symbol.name}") {
+                rustBlock("pub fn builder() -> \$T", builderSymbol) {
+                    write("\$T::default()", builderSymbol)
+                }
+            }
+        }
+    }
+
+    private fun renderBuilder(writer: RustWriter) {
+        // Eventually, I want to do a fancier module layout:
+        // model/some_model.rs [contains builder and impl for a single model] struct SomeModel, struct Builder
+        // model/mod.rs [contains pub use for each model to bring it into top level scope]
+        // users will do models::SomeModel, models::SomeModel::builder()
+        val builderName = "Builder"
+        writer.write("#[non_exhaustive]")
+        writer.write("#[derive(Debug, Clone, Default)]")
+        writer.rustBlock("pub struct $builderName") {
+            members.forEach { member ->
+                val memberName = symbolProvider.toMemberName(member)
+                // All fields in the builder are optional
+                val memberSymbol = symbolProvider.toSymbol(member).makeOptional()
+                // TODO: should the builder members be public?
+                write("$memberName: \$T,", memberSymbol)
+            }
+        }
+
+        fun builderConverter(rustType: RustType) = when (rustType) {
+            is RustType.String -> "inp.into()"
+            else -> "inp"
+        }
+
+        writer.rustBlock("impl $builderName") {
+            members.forEach { member ->
+                val memberName = symbolProvider.toMemberName(member)
+                // All fields in the builder are optional
+                val memberSymbol = symbolProvider.toSymbol(member)
+                val coreType = memberSymbol.rustType().let {
+                    when (it) {
+                        is RustType.Option -> it.value
+                        else -> it
+                    }
+                }
+                val signature = when (coreType) {
+                    is RustType.String -> "<T: Into<String>>(mut self, inp: T) -> Self"
+                    else -> "(mut self, inp: ${coreType.render()}) -> Self"
+                }
+                writer.rustBlock("pub fn $memberName$signature") {
+                    write("self.$memberName = Some(${builderConverter(coreType)});")
+                    write("self")
+                }
+            }
+
+            val fallible = members.map { symbolProvider.toSymbol(it) }.any {
+                // If any members are not optional && we can't use a default, we need to
+                // generate a fallible builder
+                !it.isOptional() && !it.canUseDefault()
+            }
+
+            val returnType = when (fallible) {
+                true -> "Result<\$T, String>"
+                false -> "\$T"
+            }
+
+            writer.rustBlock("pub fn build(self) -> $returnType", structureSymbol) {
+                withBlock("Ok(", ")", conditional = fallible) {
+                    rustBlock("\$T", structureSymbol) {
+                        members.forEach { member ->
+                            val memberName = symbolProvider.toMemberName(member)
+                            val memberSymbol = symbolProvider.toSymbol(member)
+                            val errorWhenMissing = "$memberName is required when building ${structureSymbol.name}"
+                            val modifier = when {
+                                !memberSymbol.isOptional() && memberSymbol.canUseDefault() -> ".unwrap_or_default()"
+                                !memberSymbol.isOptional() -> ".ok_or(${errorWhenMissing.dq()})?"
+                                else -> ""
+                            }
+                            write("$memberName: self.$memberName$modifier,")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Exec.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Exec.kt
@@ -23,8 +23,9 @@ fun String.runCommand(workdir: Path? = null): String? {
 
     proc.waitFor(60, TimeUnit.MINUTES)
     if (proc.exitValue() != 0) {
-        val output = proc.errorStream.bufferedReader().readText()
-        throw CommandFailed("Command Failed\n$output")
+        val stdErr = proc.errorStream.bufferedReader().readText()
+        val stdOut = proc.inputStream.bufferedReader().readText()
+        throw CommandFailed("Command Failed\n$stdErr\n$stdOut")
     }
     return proc.inputStream.bufferedReader().readText()
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
@@ -46,7 +46,7 @@ class EnumGeneratorTest {
             .assemble()
             .unwrap()
         val provider: SymbolProvider = SymbolVisitor(model, "test")
-        val writer = RustWriter("model.rs", "model")
+        val writer = RustWriter.forModule("model")
         val generator = EnumGenerator(provider, writer, shape, trait)
         generator.render()
         val result = writer.toString()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -6,76 +6,111 @@
 package software.amazon.smithy.rust.codegen.generators
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
-import software.amazon.smithy.model.traits.DocumentationTrait
-import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.rust.codegen.lang.RustWriter
 import software.amazon.smithy.rust.codegen.smithy.SymbolVisitor
+import software.amazon.smithy.rust.codegen.smithy.canUseDefault
 import software.amazon.smithy.rust.codegen.smithy.generators.StructureGenerator
+import software.amazon.smithy.rust.testutil.asSmithy
 import software.amazon.smithy.rust.testutil.shouldCompile
 import software.amazon.smithy.rust.testutil.testSymbolProvider
 
 class StructureGeneratorTest {
-    private val model: Model
-    private val struct: StructureShape
-    private val error: StructureShape
-    init {
-        val member1 = MemberShape.builder().id("com.test#MyStruct\$foo").target("smithy.api#String").build()
-        val member2 = MemberShape.builder().id("com.test#MyStruct\$bar").target("smithy.api#PrimitiveInteger").addTrait(
-            DocumentationTrait("This *is* documentation about the member.")
-        ).build()
-        val member3 = MemberShape.builder().id("com.test#MyStruct\$baz").target("smithy.api#Integer").build()
-        val member4 = MemberShape.builder().id("com.test#MyStruct\$ts").target("smithy.api#Timestamp").build()
-
-        // struct 2 will be of type `Qux` under `MyStruct::quux` member
-        val struct2 = StructureShape.builder()
-            .id("com.test#Qux")
-            .build()
-        // structure member shape - note the capitalization of the member name (generated code should use the Kotlin class member name)
-        // val member4 = MemberShape.builder().id("com.test#MyStruct\$Quux").target(struct2).build()
-        val member5 = MemberShape.builder().id("com.test#MyStruct\$byteValue").target("smithy.api#Byte").build()
-
-        struct = StructureShape.builder()
-            .id("com.test#MyStruct")
-            .addMember(member1)
-            .addMember(member2)
-            .addMember(member3)
-            .addMember(member4)
-            .addMember(member5)
-            .addTrait(DocumentationTrait("This *is* documentation about the shape."))
-            .build()
-
-        val messageMember = MemberShape.builder().id("com.test#MyError\$message").target("smithy.api#String").build()
-
-        error = StructureShape.builder()
-            .id("com.test#MyError")
-            .addTrait(ErrorTrait("server"))
-            .addMember(messageMember).build()
-        model = Model.assembler()
-            .addShapes(struct, error, struct2, member1, member2, member3, messageMember)
-            .assemble()
-            .unwrap()
-    }
+    private val model = """
+        namespace com.test
+        @documentation("this documents the shape")
+        structure MyStruct {
+           foo: String,
+           @documentation("This *is* documentation about the member.")
+           bar: PrimitiveInteger,
+           baz: Integer,
+           ts: Timestamp,
+           inner: Inner,
+           byteValue: Byte
+        }
+        
+        // Intentionally empty
+        structure Inner {
+        }
+        
+        @error("server")
+        structure MyError {
+            message: String
+        }
+        """.asSmithy()
+    private val struct = model.expectShape(ShapeId.from("com.test#MyStruct"), StructureShape::class.java)
+    private val inner = model.expectShape(ShapeId.from("com.test#Inner"), StructureShape::class.java)
+    private val error = model.expectShape(ShapeId.from("com.test#MyError"), StructureShape::class.java)
 
     @Test
     fun `generate basic structures`() {
         val provider: SymbolProvider = testSymbolProvider(model)
-        val writer = RustWriter("model.rs", "model")
+        val writer = RustWriter.forModule("model")
+        val innerGenerator = StructureGenerator(model, provider, writer, inner)
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()
+        innerGenerator.render()
         writer.shouldCompile("""
             let s: Option<MyStruct> = None;
             s.map(|i|println!("{:?}, {:?}", i.ts, i.byte_value));
-        """.trimIndent())
+        """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `generate builders`() {
+        val provider: SymbolProvider = testSymbolProvider(model)
+        val writer = RustWriter.forModule("model")
+        val innerGenerator = StructureGenerator(model, provider, writer, inner)
+        val generator = StructureGenerator(model, provider, writer, struct)
+        generator.render()
+        innerGenerator.render()
+        writer.shouldCompile(
+            """
+            let my_struct = MyStruct::builder().byte_value(4).foo("hello!").build();
+            assert_eq!(my_struct.foo.unwrap(), "hello!");
+            assert_eq!(my_struct.bar, 0);
+        """
+        )
+    }
+
+    @Test
+    fun `generate fallible builders`() {
+        val baseProvider: SymbolProvider = testSymbolProvider(model)
+        val provider =
+            object : SymbolProvider {
+                override fun toSymbol(shape: Shape?): Symbol {
+                    return baseProvider.toSymbol(shape).toBuilder().canUseDefault(false).build()
+                }
+
+                override fun toMemberName(shape: MemberShape?): String {
+                    return baseProvider.toMemberName(shape)
+                }
+            }
+        val writer = RustWriter.forModule("model")
+        val innerGenerator = StructureGenerator(model, provider, writer, inner)
+        val generator = StructureGenerator(model, provider, writer, struct)
+        generator.render()
+        innerGenerator.render()
+        writer.shouldCompile(
+            """
+            let my_struct = MyStruct::builder().byte_value(4).foo("hello!").bar(0).build().expect("required field was not provided");
+            assert_eq!(my_struct.foo.unwrap(), "hello!");
+            assert_eq!(my_struct.bar, 0);
+        """
+        )
+
     }
 
     @Test
     fun `generate error structures`() {
         val provider: SymbolProvider = SymbolVisitor(model, "test")
-        val writer = RustWriter("errors.rs", "errors")
+        val writer = RustWriter.forModule("error")
         val generator = StructureGenerator(model, provider, writer, error)
         generator.render()
         writer.shouldCompile()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/UnionGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/UnionGeneratorTest.kt
@@ -39,7 +39,7 @@ class UnionGeneratorTest {
             .assemble()
             .unwrap()
         val provider: SymbolProvider = SymbolVisitor(model, "test")
-        val writer = RustWriter("model.rs", "model")
+        val writer = RustWriter.forModule("model")
         val generator = UnionGenerator(model, provider, writer, union)
         generator.render()
         val result = writer.toString()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
@@ -22,7 +22,7 @@ import software.amazon.smithy.rust.testutil.shouldParseAsRust
 class RustWriterTest {
     @Test
     fun `empty file`() {
-        val sut = RustWriter("empty.rs", "")
+        val sut = RustWriter.forModule("empty")
         sut.toString().shouldParseAsRust()
         sut.toString().shouldCompile()
         sut.toString().shouldMatchResource(javaClass, "empty.rs")
@@ -30,7 +30,7 @@ class RustWriterTest {
 
     @Test
     fun `manually created struct`() {
-        val sut = RustWriter("lib.rs", "")
+        val sut = RustWriter.forModule("lib")
         val stringShape = StringShape.builder().id("test#Hello").build()
         val set = SetShape.builder()
             .id("foo.bar#Records")


### PR DESCRIPTION
*Description of changes:*
A builder object is generated for Structure shapes. The builder will be fallible (return `Result<T, String>`) if the structure has required members without defaults.

If the structure has no required members, the `build()` method directly returns the constructed object. This required a number of refinements to our module handling as the builders are namespaced to 1-module-per-shape.

Generate builders for structures. These are accessible via
```
MyStructure::builder().field1(123).field2("hello there!").build()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
