### PR TITLE
Fix escaping bug

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Strings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Strings.kt
@@ -15,8 +15,8 @@
 
 package software.amazon.smithy.rust.codegen.util
 
-fun String.doubleQuote(): String = "\"$this\""
-fun String.singleQuote(): String = "\'$this\'"
+fun String.doubleQuote(): String = "\"${this.slashEscape('"')}\""
+fun String.slashEscape(char: Char) = this.replace(char.toString(), """\$char""")
 
 /**
  * Double quote a string, eg. "abc" -> "\"abc\""

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/util/StringsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/util/StringsTest.kt
@@ -1,0 +1,13 @@
+package software.amazon.smithy.rust.codegen.util
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class StringsTest {
+
+    @Test
+    fun doubleQuote() {
+        "abc".doubleQuote() shouldBe "\"abc\""
+        """{"some": "json"}""".doubleQuote() shouldBe """"{\"some\": \"json\"}""""
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #8 

*Description of changes:* As exposed by generating protocol tests for Aws JSON 1.1, double quote needs to escape double quotes within the string.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
