### PR TITLE
Handle `Box<T>` when generating builders

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustWriter.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.lang
 
+import org.intellij.lang.annotations.Language
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.writer.CodegenWriter
@@ -33,6 +34,13 @@ fun <T : CodeWriter> T.withBlock(
         closeBlock(textAfterNewLine)
     }
     return this
+}
+
+/**
+ * Convenience wrapper that tells Intellij that the contents of this block are Rust
+ */
+fun <T : CodeWriter> T.rust(@Language("Rust", prefix = "fn foo() {", suffix = "}") contents: String, vararg args: Any) {
+    this.write(contents, *args)
 }
 
 /*

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -240,10 +240,11 @@ class SymbolVisitor(
     override fun memberShape(shape: MemberShape): Symbol {
         val target = model.expectShape(shape.target)
         val targetSymbol = this.toSymbol(target)
-        return targetSymbol.letIf(config.handleOptionality) {
-            handleOptionality(it, shape, model.expectShape(shape.container))
-        }.letIf(config.handleRustBoxing) {
+        // Handle boxing first so we end up with Option<Box<_>>, not Box<Option<_>>
+        return targetSymbol.letIf(config.handleRustBoxing) {
             handleRustBoxing(it, shape)
+        }.letIf(config.handleOptionality) {
+            handleOptionality(it, shape, model.expectShape(shape.container))
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* #32 

*Description of changes:* Generate builders that automatically `Box` inputs when required, eg.:

```rust
        pub fn member<T>(mut self, inp: T) -> Self where T: Into<Box<WithBox>> {
            self.member = Some(inp.into());
            self
        }
```

This also highlighted that we should be generating `Option<Box>` and not `Box<Option>`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
