### PR TITLE
Use `.of()` to construct Knowledge Indices

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -110,7 +110,7 @@ class SymbolVisitor(
     private val config: SymbolVisitorConfig = DefaultConfig
 ) : SymbolProvider,
     ShapeVisitor<Symbol> {
-    private val nullableIndex = NullableIndex(model)
+    private val nullableIndex = NullableIndex.of(model)
     override fun toSymbol(shape: Shape): Symbol {
         return shape.accept(this)
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
@@ -66,7 +66,7 @@ class HttpTraitBindingGenerator(
 ) {
     // TODO: make defaultTimestampFormat configurable
     private val defaultTimestampFormat = TimestampFormatTrait.Format.EPOCH_SECONDS
-    private val index = HttpBindingIndex(model)
+    private val index = HttpBindingIndex.of(model)
 
     /**
      * Generates `update_http_builder` and all necessary dependency functions into the impl block provided by

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ServiceGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ServiceGenerator.kt
@@ -16,7 +16,7 @@ class ServiceGenerator(
     private val protocolGenerator: HttpProtocolGenerator,
     private val config: ProtocolConfig
 ) {
-    private val index = TopDownIndex(config.model)
+    private val index = TopDownIndex.of(config.model)
 
     fun render() {
         val operations = index.getContainedOperations(config.serviceShape)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -38,7 +38,7 @@ class AwsRestJsonGenerator(
     private val model = protocolConfig.model
     private val symbolProvider = protocolConfig.symbolProvider
     private val runtimeConfig = protocolConfig.runtimeConfig
-    private val httpIndex = HttpBindingIndex(model)
+    private val httpIndex = HttpBindingIndex.of(model)
     private val requestBuilder = RuntimeType.Http("request::Builder")
 
     override fun toHttpRequestImpl(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
@@ -18,7 +18,7 @@ class ProtocolLoader(private val supportedProtocols: Map<ShapeId, ProtocolGenera
         model: Model,
         serviceShape: ServiceShape
     ): Pair<ShapeId, ProtocolGeneratorFactory<HttpProtocolGenerator>> {
-        val protocols: MutableMap<ShapeId, Trait> = ServiceIndex(model).getProtocols(serviceShape)
+        val protocols: MutableMap<ShapeId, Trait> = ServiceIndex.of(model).getProtocols(serviceShape)
         val matchingProtocols =
             protocols.keys.mapNotNull { protocolId -> supportedProtocols[protocolId]?.let { protocolId to it } }
         if (matchingProtocols.isEmpty()) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxer.kt
@@ -43,7 +43,7 @@ object RecursiveShapeBoxer {
         // 4. Select the member shape in that loop with the earliest shape id
         // 5. Box it.
         // (External to this function) Go back to 1.
-        val index = TopologicalIndex(model)
+        val index = TopologicalIndex.of(model)
         val recursiveShapes = index.recursiveShapes
         val loops = recursiveShapes.map {
             // Get all the shapes in the closure (represented as Paths


### PR DESCRIPTION
*Description of changes:* 
Use `.of()` to construct Knowledge Indices
`.of()` will use a cached index on the model when it exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
