### PR TITLE
Pin Rust version & fix lint error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ on: [push]
 
 name: CI
 
+env:
+  rust_version: 1.47.0
+
 jobs:
   style:
     name: Kotlin style checks
@@ -44,7 +47,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ env.rust_version }}
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -75,7 +78,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ env.rust_version }}
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -106,6 +109,6 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ env.rust_version }}
     - name: execute runtime tests
       run: ./rust-runtime/test.sh

--- a/rust-runtime/smithy-http/src/query.rs
+++ b/rust-runtime/smithy-http/src/query.rs
@@ -82,7 +82,7 @@ pub fn write(inp: Vec<(&str, String)>, out: &mut String) {
     for (k, v) in inp {
         out.push(prefix);
         out.push_str(k);
-        out.push_str("=");
+        out.push('=');
         out.push_str(&v);
         prefix = '&';
     }


### PR DESCRIPTION
*Description of changes:*

Every 6 weeks, a new version of Rust and Clippy come out—we were upgrading implicitly which meant that our clippy (lint) checks started failing if they added new lints. This makes the Rust version explicit so we can upgrade and fix lints on our schedule.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
