### PR TITLE
Change default Smithy expression start character to #

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/CargoDependency.kt
@@ -61,7 +61,7 @@ class InlineDependency(name: String, val module: String, val renderer: (RustWrit
             val rustFile = this::class.java.getResource("/inlineable/src/$filename")
             check(rustFile != null)
             return InlineDependency(name, module) { writer ->
-                writer.write(rustFile.readText())
+                writer.raw(rustFile.readText())
             }
         }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustTypes.kt
@@ -179,9 +179,9 @@ data class Derives(val derives: Set<RuntimeType>) : Attribute() {
         if (derives.isEmpty()) {
             return
         }
-        writer.writeInline("#[derive(")
+        writer.raw("#[derive(")
         derives.sortedBy { it.name }.forEach { derive ->
-            writer.writeInline("\$T, ", derive)
+            writer.writeInline("#T, ", derive)
         }
         writer.write(")]")
     }
@@ -193,7 +193,7 @@ data class Derives(val derives: Set<RuntimeType>) : Attribute() {
 
 data class Custom(val annot: String, val symbols: List<RuntimeType> = listOf()) : Attribute() {
     override fun render(writer: RustWriter) {
-        writer.writeInline("#[")
+        writer.raw("#[")
         writer.writeInline(annot)
         writer.write("]")
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -62,7 +62,7 @@ class EnumGenerator(
             }
         }
 
-        writer.rustBlock("impl <T> \$T<T> for $enumName where T: \$T<str>", RuntimeType.From, RuntimeType.AsRef) {
+        writer.rustBlock("impl <T> #T<T> for $enumName where T: #T<str>", RuntimeType.From, RuntimeType.AsRef) {
             writer.rustBlock("fn from(s: T) -> Self") {
                 write("$enumName(s.as_ref().to_owned())")
             }
@@ -103,7 +103,7 @@ class EnumGenerator(
     }
 
     private fun renderFromStr() {
-        writer.rustBlock("impl <T> \$T<T> for $enumName where T: \$T<str>", RuntimeType.From, RuntimeType.AsRef) {
+        writer.rustBlock("impl <T> #T<T> for $enumName where T: #T<str>", RuntimeType.From, RuntimeType.AsRef) {
             writer.rustBlock("fn from(s: T) -> Self") {
                 writer.rustBlock("match s.as_ref()") {
                     sortedMembers.forEach { member ->

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ErrorGenerator.kt
@@ -44,7 +44,7 @@ class ErrorGenerator(
             write("pub fn throttling(&self) -> bool { $throttling }")
         }
 
-        writer.rustBlock("impl \$T for ${symbol.name}", StdFmt("Display")) {
+        writer.rustBlock("impl #T for ${symbol.name}", StdFmt("Display")) {
             rustBlock("fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result") {
                 val message = shape.getMember("message")
                 write("write!(f, ${symbol.name.dq()})?;")
@@ -57,6 +57,6 @@ class ErrorGenerator(
             }
         }
 
-        writer.write("impl \$T for ${symbol.name} {}", StdError)
+        writer.write("impl #T for ${symbol.name} {}", StdError)
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
@@ -53,8 +53,8 @@ abstract class HttpProtocolGenerator(
             val body = shapeId?.let { model.expectShape(it, StructureShape::class.java) }
             toBodyImpl(this, inputShape, body)
             // TODO: streaming shapes need special support
-            rustBlock("pub fn assemble(builder: \$T, body: Vec<u8>) -> \$T<Vec<u8>>", RuntimeType.HttpRequestBuilder, RuntimeType.Http("request::Request")) {
-                write("builder.header(\$T, body.len()).body(body)", RuntimeType.Http("header::CONTENT_LENGTH"))
+            rustBlock("pub fn assemble(builder: #T, body: Vec<u8>) -> #T<Vec<u8>>", RuntimeType.HttpRequestBuilder, RuntimeType.Http("request::Request")) {
+                write("builder.header(#T, body.len()).body(body)", RuntimeType.Http("header::CONTENT_LENGTH"))
                 write(""".expect("http request should be valid")""")
             }
         }
@@ -62,7 +62,7 @@ abstract class HttpProtocolGenerator(
 
     protected fun httpBuilderFun(implBlockWriter: RustWriter, f: RustWriter.() -> Unit) {
         implBlockWriter.rustBlock(
-            "pub fn request_builder_base(&self) -> \$T",
+            "pub fn request_builder_base(&self) -> #T",
             RuntimeType.HttpRequestBuilder
         ) {
             f(this)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
@@ -80,7 +80,7 @@ class HttpTraitBindingGenerator(
         val hasHeaders = addHeaders(implBlockWriter)
         val hasQuery = uriQuery(implBlockWriter)
         implBlockWriter.rustBlock(
-            "fn update_http_builder(&self, builder: \$1T) -> \$1T",
+            "fn update_http_builder(&self, builder: #1T) -> #1T",
             RuntimeType.HttpRequestBuilder
         ) {
             write("let mut uri = String::new();")
@@ -107,7 +107,7 @@ class HttpTraitBindingGenerator(
             return false
         }
         writer.rustBlock(
-            "fn add_headers(&self, mut builder: \$1T) -> \$1T",
+            "fn add_headers(&self, mut builder: #1T) -> #1T",
             RuntimeType.HttpRequestBuilder
         ) {
             headers.forEach { httpBinding ->
@@ -211,7 +211,7 @@ class HttpTraitBindingGenerator(
                     }
                 }
             }
-            write("\$T(params, output)", RuntimeType.QueryFormat(runtimeConfig, "write"))
+            write("#T(params, output)", RuntimeType.QueryFormat(runtimeConfig, "write"))
         }
         return true
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -49,7 +49,7 @@ class StructureGenerator(
         if (renderBuilder) {
             val symbol = symbolProvider.toSymbol(shape)
             // TODO: figure out exactly what docs we want on a the builder module
-            writer.docs("See \$D", symbol)
+            writer.docs("See #D", symbol)
             writer.withModule(symbol.name.toSnakeCase()) {
                 renderBuilder(this)
             }
@@ -95,14 +95,14 @@ class StructureGenerator(
                 val memberName = symbolProvider.toMemberName(member)
                 writer.documentShape(member, model)
                 symbolProvider.toSymbol(member).expectRustMetadata().render(this)
-                write("$memberName: \$T,", symbolProvider.toSymbol(member))
+                write("$memberName: #T,", symbolProvider.toSymbol(member))
             }
         }
         if (renderBuilder) {
             writer.rustBlock("impl ${symbol.name}") {
-                docs("Creates a new builder-style object to manufacture \$D", symbol)
-                rustBlock("pub fn builder() -> \$T", builderSymbol) {
-                    write("\$T::default()", builderSymbol)
+                docs("Creates a new builder-style object to manufacture #D", symbol)
+                rustBlock("pub fn builder() -> #T", builderSymbol) {
+                    write("#T::default()", builderSymbol)
                 }
             }
         }
@@ -112,16 +112,16 @@ class StructureGenerator(
         val builderName = "Builder"
 
         val symbol = symbolProvider.toSymbol(shape)
-        writer.docs("A builder for \$D", symbol)
-        writer.write("#[non_exhaustive]")
-        writer.write("#[derive(Debug, Clone, Default)]")
+        writer.docs("A builder for #D", symbol)
+        writer.writeWithNoFormatting("#[non_exhaustive]")
+        writer.writeWithNoFormatting("#[derive(Debug, Clone, Default)]")
         writer.rustBlock("pub struct $builderName") {
             members.forEach { member ->
                 val memberName = symbolProvider.toMemberName(member)
                 // All fields in the builder are optional
                 val memberSymbol = symbolProvider.toSymbol(member).makeOptional()
                 // TODO: should the builder members be public?
-                write("$memberName: \$T,", memberSymbol)
+                write("$memberName: #T,", memberSymbol)
             }
         }
 
@@ -152,14 +152,14 @@ class StructureGenerator(
 
             val fallibleBuilder = fallibleBuilder(shape, symbolProvider)
             val returnType = when (fallibleBuilder) {
-                true -> "Result<\$T, String>"
-                false -> "\$T"
+                true -> "Result<#T, String>"
+                false -> "#T"
             }
 
-            writer.docs("Consumes the builder and constructs a \$D", symbol)
+            writer.docs("Consumes the builder and constructs a #D", symbol)
             rustBlock("pub fn build(self) -> $returnType", structureSymbol) {
                 conditionalBlock("Ok(", ")", conditional = fallibleBuilder) {
-                    rustBlock("\$T", structureSymbol) {
+                    rustBlock("#T", structureSymbol) {
                         members.forEach { member ->
                             val memberName = symbolProvider.toMemberName(member)
                             val memberSymbol = symbolProvider.toSymbol(member)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -33,7 +33,7 @@ class UnionGenerator(
             sortedMembers.forEach { member ->
                 val memberSymbol = symbolProvider.toSymbol(member)
                 memberSymbol.expectRustMetadata().renderAttributes(this)
-                write("${member.memberName.toPascalCase()}(\$T),", symbolProvider.toSymbol(member))
+                write("${member.memberName.toPascalCase()}(#T),", symbolProvider.toSymbol(member))
             }
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
@@ -131,7 +131,7 @@ class BasicAwsJsonGenerator(
         inputShape: StructureShape
     ) {
         httpBuilderFun(implBlockWriter) {
-            write("let builder = \$T::new();", RuntimeType.HttpRequestBuilder)
+            write("let builder = #T::new();", RuntimeType.HttpRequestBuilder)
             write(
                 """
                 builder
@@ -151,8 +151,8 @@ class BasicAwsJsonGenerator(
             return
         }
         val bodySymbol = protocolConfig.symbolProvider.toSymbol(inputBody)
-        implBlockWriter.rustBlock("fn body(&self) -> \$T", bodySymbol) {
-            rustBlock("\$T", bodySymbol) {
+        implBlockWriter.rustBlock("fn body(&self) -> #T", bodySymbol) {
+            rustBlock("#T", bodySymbol) {
                 for (member in inputBody.members()) {
                     val name = protocolConfig.symbolProvider.toMemberName(member)
                     write("$name: &self.$name,")
@@ -160,7 +160,7 @@ class BasicAwsJsonGenerator(
             }
         }
         bodyBuilderFun(implBlockWriter) {
-            write("\$T(&self.body()).expect(\"serialization should succeed\")", RuntimeType.SerdeJson("to_vec"))
+            write("""#T(&self.body()).expect("serialization should succeed")""", RuntimeType.SerdeJson("to_vec"))
         }
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.rust.codegen.lang.RustWriter
+import software.amazon.smithy.rust.codegen.lang.rust
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.generators.HttpProtocolGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.HttpTraitBindingGenerator
@@ -76,9 +77,14 @@ class AwsRestJsonGenerator(
             httpIndex.determineRequestContentType(operationShape, "application/json").orElse("application/json")
         httpBindingGenerator.renderUpdateHttpBuilder(implBlockWriter)
         httpBuilderFun(implBlockWriter) {
-            write("let builder = \$T::new();", requestBuilder)
-            write("let builder = builder.header(\"Content-Type\", ${contentType.dq()});")
-            write("self.update_http_builder(builder)")
+            rust(
+                """
+            let builder = #T::new();
+            let builder = builder.header("Content-Type", ${contentType.dq()});
+            self.update_http_builder(builder)
+            """,
+                requestBuilder
+            )
         }
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/JsonSerializerSymbolProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/JsonSerializerSymbolProvider.kt
@@ -119,7 +119,7 @@ class SerializerBuilder(
         "optionblob_ser" to { writer ->
             writer.rustBlock("match $inp") {
                 write(
-                    "Some(blob) => $ser.serialize_str(&\$T(blob.as_ref())),",
+                    "Some(blob) => $ser.serialize_str(&#T(blob.as_ref())),",
                     RuntimeType.Base64Encode(runtimeConfig)
                 )
                 write("None => $ser.serialize_none()")
@@ -127,7 +127,7 @@ class SerializerBuilder(
         },
         "blob_ser" to { writer ->
             writer.write(
-                "$ser.serialize_str(&\$T($inp.as_ref()))",
+                "$ser.serialize_str(&#T($inp.as_ref()))",
                 RuntimeType.Base64Encode(runtimeConfig)
             )
         },
@@ -136,7 +136,7 @@ class SerializerBuilder(
             val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, TimestampFormatTrait.Format.HTTP_DATE)
             writer.rustBlock("match $inp") {
                 write(
-                    "Some(ts) => $ser.serialize_some(&ts.fmt(\$T)),", timestampFormatType
+                    "Some(ts) => $ser.serialize_some(&ts.fmt(#T)),", timestampFormatType
                 )
                 write("None => _serializer.serialize_none()")
             }
@@ -145,7 +145,7 @@ class SerializerBuilder(
             val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, TimestampFormatTrait.Format.DATE_TIME)
             writer.rustBlock("match $inp") {
                 write(
-                    "Some(ts) => $ser.serialize_some(&ts.fmt(\$T)),", timestampFormatType
+                    "Some(ts) => $ser.serialize_some(&ts.fmt(#T)),", timestampFormatType
                 )
                 write("None => _serializer.serialize_none()")
             }
@@ -195,8 +195,8 @@ class SerializerBuilder(
         body: RustWriter.() -> Unit
     ) {
         rustWriter.rustBlock(
-            "pub fn $functionName<S>(_inp: \$1T, _serializer: S) -> " +
-                "Result<<S as \$2T>::Ok, <S as \$2T>::Error> where S: \$2T",
+            "pub fn $functionName<S>(_inp: #1T, _serializer: S) -> " +
+                "Result<<S as #2T>::Ok, <S as #2T>::Error> where S: #2T",
             serializerType(symbol),
             RuntimeType.Serializer
         ) {
@@ -211,7 +211,7 @@ class SerializerBuilder(
         body: RustWriter.() -> Unit
     ) {
         rustWriter.rustBlock(
-            "pub fn $functionName<'de, D>(_deser: D) -> Result<\$T, D::Error> where D: \$T<'de>",
+            "pub fn $functionName<'de, D>(_deser: D) -> Result<#T, D::Error> where D: #T<'de>",
             symbol,
             RuntimeType.Deserializer
         ) {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/HttpTraitBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/HttpTraitBindingGeneratorTest.kt
@@ -109,8 +109,8 @@ class HttpTraitBindingGeneratorTest {
                 symbolProvider,
                 TestRuntimeConfig, writer, operationShape, inputShape, httpTrait
             ).renderUpdateHttpBuilder(this)
-            rustBlock("pub fn request_builder_base(&self) -> \$T", RuntimeType.HttpRequestBuilder) {
-                write("let builder = \$T::new();", RuntimeType.HttpRequestBuilder)
+            rustBlock("pub fn request_builder_base(&self) -> #T", RuntimeType.HttpRequestBuilder) {
+                write("let builder = #T::new();", RuntimeType.HttpRequestBuilder)
                 write("self.update_http_builder(builder)")
             }
         }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.lang.Custom
 import software.amazon.smithy.rust.codegen.lang.RustMetadata
 import software.amazon.smithy.rust.codegen.lang.RustWriter
 import software.amazon.smithy.rust.codegen.lang.docs
+import software.amazon.smithy.rust.codegen.lang.raw
 import software.amazon.smithy.rust.codegen.lang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.canUseDefault
 import software.amazon.smithy.rust.codegen.smithy.generators.StructureGenerator
@@ -82,7 +83,7 @@ class StructureGeneratorTest {
         // By putting the test in another module, it can't access the struct
         // fields if they are private
         writer.withModule("inline") {
-            write("#[test]")
+            raw("#[test]")
             rustBlock("fn test_public_fields()") {
                 write(
                     """

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGeneratorTest.kt
@@ -93,16 +93,16 @@ class HttpProtocolTestGeneratorTest {
         writer.withModule("operation") {
             StructureGenerator(model, symbolProvider, this, model.lookup("com.example#SayHelloInput")).render()
             rustBlock("impl SayHelloInput") {
-                rustBlock("pub fn request_builder_base(&self) -> \$T", RuntimeType.HttpRequestBuilder) {
-                    write("\$T::new()", RuntimeType.HttpRequestBuilder)
+                rustBlock("pub fn request_builder_base(&self) -> #T", RuntimeType.HttpRequestBuilder) {
+                    write("#T::new()", RuntimeType.HttpRequestBuilder)
                     write(httpRequestBuilder)
                 }
                 rustBlock("pub fn build_body(&self) -> String") {
                     write(body)
                 }
-                rustBlock("pub fn assemble<T: Into<Vec<u8>>>(builder: \$T, body: T) -> \$T<Vec<u8>>", RuntimeType.HttpRequestBuilder, RuntimeType.Http("request::Request")) {
+                rustBlock("pub fn assemble<T: Into<Vec<u8>>>(builder: #T, body: T) -> #T<Vec<u8>>", RuntimeType.HttpRequestBuilder, RuntimeType.Http("request::Request")) {
                     write("let body = body.into();")
-                    write("builder.header(\$T, body.len()).body(body)", RuntimeType.Http("header::CONTENT_LENGTH"))
+                    write("builder.header(#T, body.len()).body(body)", RuntimeType.Http("header::CONTENT_LENGTH"))
                     write(""".expect("http request should be valid")""")
                 }
             }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/InstantiatorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/InstantiatorTest.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.lang.RustWriter
+import software.amazon.smithy.rust.codegen.lang.raw
 import software.amazon.smithy.rust.codegen.lang.rust
 import software.amazon.smithy.rust.codegen.lang.rustBlock
 import software.amazon.smithy.rust.codegen.lang.withBlock
@@ -66,6 +67,13 @@ class InstantiatorTest {
 
     // TODO: test of recursive structures when supported
 
+    fun RustWriter.test(block: RustWriter.() -> Unit) {
+        raw("#[test]")
+        rustBlock("fn inst()") {
+            block(this)
+        }
+    }
+
     @Test
     fun `generate unions`() {
         val union = model.lookup<UnionShape>("com.test#MyUnion")
@@ -77,8 +85,7 @@ class InstantiatorTest {
         )
         val writer = RustWriter.forModule("model")
         UnionGenerator(model, symbolProvider, writer, union).render()
-        writer.write("#[test]")
-        writer.rustBlock("fn inst()") {
+        writer.test {
             writer.withBlock("let result = ", ";") {
                 sut.render(this, union, data)
             }
@@ -100,8 +107,7 @@ class InstantiatorTest {
         val writer = RustWriter.forModule("model")
         val structureGenerator = StructureGenerator(model, symbolProvider, writer, structure)
         structureGenerator.render()
-        writer.write("#[test]")
-        writer.rustBlock("fn inst()") {
+        writer.test {
             writer.withBlock("let result = ", ";") {
                 sut.render(this, structure, data)
             }
@@ -126,8 +132,7 @@ class InstantiatorTest {
         val writer = RustWriter.forModule("model")
         val structureGenerator = StructureGenerator(model, symbolProvider, writer, structure)
         structureGenerator.render()
-        writer.write("#[test]")
-        writer.rustBlock("fn inst()") {
+        writer.test {
             withBlock("let result = ", ";") {
                 sut.render(this, structure, data)
             }
@@ -157,8 +162,7 @@ class InstantiatorTest {
         )
         val writer = RustWriter.forModule("lib")
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
-        writer.write("#[test]")
-        writer.rustBlock("fn inst()") {
+        writer.test {
             writer.withBlock("let result = ", ";") {
                 sut.render(writer, model.lookup("com.test#MyList"), data)
             }
@@ -179,8 +183,7 @@ class InstantiatorTest {
         )
         val writer = RustWriter.forModule("lib")
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
-        writer.write("#[test]")
-        writer.rustBlock("fn inst()") {
+        writer.test {
             writer.withBlock("let result = ", ";") {
                 sut.render(writer, model.lookup("com.test#MySparseList"), data)
             }
@@ -203,8 +206,7 @@ class InstantiatorTest {
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
         val structureGenerator = StructureGenerator(model, symbolProvider, writer, model.lookup("com.test#Inner"))
         structureGenerator.render()
-        writer.write("#[test]")
-        writer.rustBlock("fn inst()") {
+        writer.test {
             writer.withBlock("let result = ", ";") {
                 sut.render(writer, model.lookup("com.test#NestedMap"), data)
             }
@@ -226,8 +228,7 @@ class InstantiatorTest {
         // that can be represented in plain text (for example, use "foo" and not "Zm9vCg==")."
         val writer = RustWriter.forModule("lib")
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
-        writer.write("#[test]")
-        writer.rustBlock("fn test_blob()") {
+        writer.test {
             withBlock("let blob = ", ";") {
                 sut.render(
                     this,

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
@@ -43,7 +43,7 @@ class RustWriterTest {
         val sut = RustWriter.forModule("parent")
         val requestBuilder = RuntimeType.HttpRequestBuilder
         sut.withModule("inner") {
-            rustBlock("fn build(builer: \$T)", requestBuilder) {
+            rustBlock("fn build(builer: #T)", requestBuilder) {
             }
         }
         val httpDep = CargoDependency.Http.dependencies[0]
@@ -68,8 +68,8 @@ class RustWriterTest {
         val setSymbol = provider.toSymbol(set)
         val stringSymbol = provider.toSymbol(stringShape)
         sut.rustBlock("struct Test") {
-            write("member: \$T,", setSymbol)
-            write("otherMember: \$T,", stringSymbol)
+            write("member: #T,", setSymbol)
+            write("otherMember: #T,", stringSymbol)
         }
         val output = sut.toString()
         output.shouldCompile()
@@ -109,7 +109,7 @@ class RustWriterTest {
         val shape = model.lookup<StructureShape>("test#Foo")
         val symbol = testSymbolProvider(model).toSymbol(shape)
         val sut = RustWriter.forModule("lib")
-        sut.docs("A link! \$D", symbol)
+        sut.docs("A link! #D", symbol)
         sut.toString() shouldContain "/// A link! [`Foo`](crate::model::Foo)"
     }
 }


### PR DESCRIPTION
*Description of changes:*
To enable more readable code generation, this diff changes the expression start character from `$` to `#`. This enables formatting code using multiline strings & avoids the need to constantly escape the `$` sign.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
