### PR TITLE
Update copyrights on every file

### DIFF
--- a/codegen-test/dynamo-it/src/main.rs
+++ b/codegen-test/dynamo-it/src/main.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use dynamo::model::{AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType, ProvisionedThroughput};
 use dynamo::operation::CreateTable;
 use dynamo::output::{ListTablesOutput };

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustModule.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustModule.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.lang
 
 data class RustModule(val name: String, val rustMetadata: RustMetadata) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustReservedWords.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/lang/RustReservedWords.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.lang
 
 import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy
 
 import software.amazon.smithy.codegen.core.writer.CodegenWriterDelegator

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolMetadataProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolMetadataProvider.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy
 
 import software.amazon.smithy.codegen.core.CodegenException

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import software.amazon.smithy.model.Model

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGenerator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import software.amazon.smithy.codegen.core.SymbolProvider

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGenerator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import software.amazon.smithy.codegen.core.CodegenException

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
@@ -1,16 +1,6 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 package software.amazon.smithy.rust.codegen.smithy.generators

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import software.amazon.smithy.codegen.core.SymbolProvider

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/JsonSerializerSymbolProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/JsonSerializerSymbolProvider.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.protocols
 
 import software.amazon.smithy.codegen.core.Symbol

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.protocols
 
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticOutputTrait.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticOutputTrait.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.traits
 
 import software.amazon.smithy.model.node.ObjectNode

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxer.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.transformers
 
 import software.amazon.smithy.codegen.core.TopologicalIndex

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Option.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Option.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.util
 
 import java.util.Optional

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Smithy.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Smithy.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.util
 
 import software.amazon.smithy.model.Model

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Strings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Strings.kt
@@ -1,16 +1,6 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 package software.amazon.smithy.rust.codegen.util

--- a/codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -3,4 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0.
 #
 
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+#
+
 software.amazon.smithy.rust.codegen.smithy.RustCodegenPlugin

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/HttpTraitBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/HttpTraitBindingGeneratorTest.kt
@@ -1,16 +1,6 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 package software.amazon.smithy.rust.codegen.generators

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/lang/InlineDependencyTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/lang/InlineDependencyTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.lang
 
 import io.kotest.matchers.shouldBe

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGeneratorTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import org.junit.jupiter.api.Test

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGeneratorTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import io.kotest.matchers.string.shouldContain

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/InstantiatorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/InstantiatorTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import org.junit.jupiter.api.Test

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ModelBuilderGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ModelBuilderGeneratorTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import org.junit.jupiter.api.Test

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/SerializerBuilderTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/SerializerBuilderTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.protocols
 
 import io.kotest.matchers.shouldBe

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxerTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxerTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.transformers
 
 import io.kotest.matchers.shouldBe

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapesIntegrationTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapesIntegrationTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.transformers
 
 import io.kotest.matchers.string.shouldContain

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/util/StringsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/util/StringsTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.smithy.rust.codegen.util
 
 import io.kotest.matchers.shouldBe

--- a/rust-runtime/build.gradle.kts
+++ b/rust-runtime/build.gradle.kts
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 description = "Rust Runtime"
 plugins {
     kotlin("jvm")

--- a/rust-runtime/inlineable/src/doc_json.rs
+++ b/rust-runtime/inlineable/src/doc_json.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use serde::{Serialize, Serializer};
 use serde_json::Value;
 use smithy_types::{Document, Number};

--- a/rust-runtime/inlineable/src/error_code.rs
+++ b/rust-runtime/inlineable/src/error_code.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use http::header::ToStrError;
 
 pub fn is_error<B>(response: &http::Response<B>) -> bool {

--- a/rust-runtime/inlineable/src/generic_error.rs
+++ b/rust-runtime/inlineable/src/generic_error.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 /// GenericError represents an error from a service that is not modeled
 #[derive(Debug, PartialEq, Eq)]
 pub struct GenericError {

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 mod doc_json;
 #[allow(dead_code)]
 mod error_code;

--- a/rust-runtime/inlineable/src/uuid.rs
+++ b/rust-runtime/inlineable/src/uuid.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 pub fn v4(input: u128) -> String {
     let mut out = String::with_capacity(36);
     // u4-aligned index into [input]

--- a/rust-runtime/io-v0/src/lib.rs
+++ b/rust-runtime/io-v0/src/lib.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use aws_sigv4::{sign, Credentials, Region, RequestExt, SignedService};
 pub use http;
 use http_body::Body;

--- a/rust-runtime/protocol-test-helpers/src/lib.rs
+++ b/rust-runtime/protocol-test-helpers/src/lib.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use assert_json_diff::assert_json_eq_no_panic;
 use http::{Request, Uri};
 use std::collections::HashSet;

--- a/rust-runtime/test.sh
+++ b/rust-runtime/test.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+#
+
 set -e
 for crate in "$(dirname "$0")"/*/
 do


### PR DESCRIPTION
*Description of changes:* An editor upgrade removed the copyright configuration so a few files were missing copyright headers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
