### PR TITLE
Refactor HttpProtocolTestGeneratorTest

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
@@ -27,13 +27,14 @@ import software.amazon.smithy.rust.codegen.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.implBlock
 import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolLoader
+import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolMap
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.util.CommandFailed
 import software.amazon.smithy.rust.codegen.util.runCommand
 import java.util.logging.Logger
 
-class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
+class CodegenVisitor(context: PluginContext, extraProtocols: ProtocolMap = mapOf()) : ShapeVisitor.Default<Unit>() {
 
     private val logger = Logger.getLogger(javaClass.name)
     private val settings = RustSettings.from(context.model, context.settings)
@@ -51,7 +52,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
             SymbolVisitorConfig(runtimeConfig = settings.runtimeConfig, codegenConfig = settings.codegenConfig)
         val baseModel = baselineTransform(context.model)
         val service = settings.getService(baseModel)
-        val (protocol, generator) = ProtocolLoader.Default.protocolFor(context.model, service)
+        val (protocol, generator) = ProtocolLoader.withAdditional(extraProtocols).protocolFor(context.model, service)
         protocolGenerator = generator
         model = generator.transformModel(baseModel)
         val baseProvider = RustCodegenPlugin.BaseSymbolProvider(model, symbolVisitorConfig)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
@@ -17,8 +17,11 @@ import software.amazon.smithy.model.traits.Trait
 import software.amazon.smithy.rust.codegen.smithy.generators.HttpProtocolGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolGeneratorFactory
 
+typealias ProtocolMap = Map<ShapeId, ProtocolGeneratorFactory<HttpProtocolGenerator>>
+
+// typealias ProtocolMap =
 // TODO: supportedProtocols must be runtime loadable via SPI; 2d
-class ProtocolLoader(private val supportedProtocols: Map<ShapeId, ProtocolGeneratorFactory<HttpProtocolGenerator>>) {
+class ProtocolLoader(private val supportedProtocols: ProtocolMap) {
     fun protocolFor(
         model: Model,
         serviceShape: ServiceShape
@@ -39,5 +42,6 @@ class ProtocolLoader(private val supportedProtocols: Map<ShapeId, ProtocolGenera
             RestJson1Trait.ID to AwsRestJsonFactory()
         )
         val Default = ProtocolLoader(Protocols)
+        fun withAdditional(protocols: ProtocolMap) = ProtocolLoader(Protocols + protocols)
     }
 }


### PR DESCRIPTION
*Description of changes:*
As the ServiceGenerator grew more complex, it was becoming tedious to keep the hand-written operation in the HttpProtocolTestGenerator updated.

This diff replaces the hand-written operation with a custom protocol. To support this, rudimentary support for pluggable protocols was added to CodegenVisitor—eventually this will be driven by SPI.

Verified this has no impact on generated code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
