### PR TITLE
Add missing semicolon to generated URI label bindings

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
@@ -196,7 +196,7 @@ class HttpTraitBindingGenerator(
                                 memberShape,
                                 innerField
                             )
-                            }))"
+                            }));"
                         )
                     }
                 }


### PR DESCRIPTION
*Description of changes:*
This used to generate uncompilable expressions for required URI label bindings, e.g.

```
﻿    fn uri_query(&self, output: &mut String) {
        let mut params = Vec::new();
        if let Some(inner_313) = &self.version_id {
            params.push(("versionId", ::smithy_http::query::fmt_string(&inner_313)))
        }
        params.push((
            "partNumber",
            ::smithy_http::query::fmt_default(&&self.part_number),
        )) // note this is not a statement
        ::smithy_http::query::write(params, output)
    }

```

Compilation fails with this error:

```
error: expected one of `.`, `;`, `?`, `}`, or an operator, found `::`
    --> input.rs:5053:9
     |
5052 |         ))
     |           - expected one of `.`, `;`, `?`, `}`, or an operator
5053 |         ::smithy_http::query::write(params, output)
     |         ^^ unexpected token

```

This change just adds the suggested semicolon:

```
    fn uri_query(&self, output: &mut String) {
        let mut params = Vec::new();
        if let Some(inner_313) = &self.version_id {
            params.push(("versionId", ::smithy_http::query::fmt_string(&inner_313))); // semicolon added
        }
        params.push((
            "partNumber",
            ::smithy_http::query::fmt_default(&&self.part_number),
        )); // semicolon added
        ::smithy_http::query::write(params, output)
    }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
