### PR TITLE
Fix generated query param serializers to omit 0-values

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ErrorGenerator.kt
@@ -55,7 +55,7 @@ class ErrorGenerator(
             rustBlock("fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result") {
                 write("write!(f, ${symbol.name.dq()})?;")
                 messageShape.map {
-                    OptionForEach(symbolProvider.toSymbol(it), "&self.message") { field ->
+                    ifSet(it, symbolProvider.toSymbol(it), "&self.message") { field ->
                         write("""write!(f, ": {}", $field)?;""")
                     }
                 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpTraitBindingGenerator.kt
@@ -105,7 +105,7 @@ class HttpTraitBindingGenerator(
                 val memberType = model.expectShape(memberShape.target)
                 val memberSymbol = symbolProvider.toSymbol(memberShape)
                 val memberName = symbolProvider.toMemberName(memberShape)
-                OptionForEach(memberSymbol, "&self.$memberName") { field ->
+                ifSet(memberType, memberSymbol, "&self.$memberName") { field ->
                     ListForEach(memberType, field) { innerField, targetId ->
                         val innerMemberType = model.expectShape(targetId)
                         val formatted = headerFmtFun(innerMemberType, memberShape, innerField)
@@ -186,7 +186,7 @@ class HttpTraitBindingGenerator(
                 val memberSymbol = symbolProvider.toSymbol(memberShape)
                 val memberName = symbolProvider.toMemberName(memberShape)
                 val outerTarget = model.expectShape(memberShape.target)
-                OptionForEach(memberSymbol, "&self.$memberName") { field ->
+                ifSet(outerTarget, memberSymbol, "&self.$memberName") { field ->
                     ListForEach(outerTarget, field) { innerField, targetId ->
                         val target = model.expectShape(targetId)
                         write(

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/HttpTraitBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/HttpTraitBindingGeneratorTest.kt
@@ -70,6 +70,12 @@ class HttpTraitBindingGeneratorTest {
                 @httpQuery("paramName")
                 someValue: String,
 
+                @httpQuery("primitive")
+                primitive: PrimitiveInteger,
+
+                @httpQuery("enabled")
+                enabled: PrimitiveBoolean,
+
                 @httpQuery("hello")
                 extras: Extras,
 
@@ -132,6 +138,28 @@ class HttpTraitBindingGeneratorTest {
             inp.uri_query(&mut o);
             assert_eq!(o.as_str(), "?paramName=svq!!%25%26&hello=0&hello=1&hello=2&hello=44")
             """
+        )
+    }
+
+    @Test
+    fun `generate serialize non-zero values`() {
+        val writer = RustWriter.forModule("input")
+        // currently rendering the operation renders the protocols—I want to separate that at some point.
+        renderOperation(writer)
+        writer.compileAndTest(
+            """
+            let ts = Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                .bucket_name("somebucket/ok")
+                .key(ts.clone())
+                .primitive(1)
+                .enabled(true)
+                .build().expect("build should succeed");
+            let mut o = String::new();
+            inp.uri_query(&mut o);
+            assert_eq!(o.as_str(), "?primitive=1&enabled=true")
+            """,
+            clippy = true
         )
     }
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #108 

*Description of changes:* Don't write 0-valued primitives into the query string. The generated code will be roughly:

```
if v != 0 {
  query_params.append(v);
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
