### PR TITLE
Fix indentation in generated code

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -81,18 +81,18 @@ class OperationInputBuilderGenerator(
                 }
                 rust(
                     """
-                    ##[allow(unused_mut)]
-                    let mut request = #T::Request::new(op.build_http_request().map(#T::from));
-                """,
+                    |##[allow(unused_mut)]
+                    |let mut request = #T::Request::new(op.build_http_request().map(#T::from));
+                """.trimMargin(),
                     operationModule, sdkBody
                 )
                 rust(
                     """
-                    #T::new(
-                        request,
-                        op
-                    )
-                """,
+                    |#T::new(
+                    |    request,
+                    |    op
+                    |)
+                """.trimMargin(),
                     operationT
                 )
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGenerator.kt
@@ -64,9 +64,9 @@ class CombinedErrorGenerator(
             }
             rust(
                 """
-                /// An unexpected error, eg. invalid JSON returned by the service
-                Unhandled(Box<dyn #T>),
-            """,
+                |/// An unexpected error, eg. invalid JSON returned by the service
+                |Unhandled(Box<dyn #T>),
+            """.trimMargin(),
                 RuntimeType.StdError
             )
         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -110,19 +110,19 @@ class EnumGenerator(
     private fun renderSerde() {
         writer.rustTemplate(
             """
-                impl #{serialize} for $enumName {
-                    fn serialize<S>(&self, serializer: S) -> Result<<S as #{serializer}>::Ok, <S as #{serializer}>::Error> where S: #{serializer}{
-                        serializer.serialize_str(self.as_str())
-                    }
-                }
+                |impl #{serialize} for $enumName {
+                |    fn serialize<S>(&self, serializer: S) -> Result<<S as #{serializer}>::Ok, <S as #{serializer}>::Error> where S: #{serializer}{
+                |        serializer.serialize_str(self.as_str())
+                |    }
+                |}
 
-                impl<'de> #{deserialize}<'de> for $enumName {
-                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: #{deserializer}<'de> {
-                        let data = <&str>::deserialize(deserializer)?;
-                        Ok(Self::from(data))
-                    }
-                }
-            """,
+                |impl<'de> #{deserialize}<'de> for $enumName {
+                |    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: #{deserializer}<'de> {
+                |        let data = <&str>::deserialize(deserializer)?;
+                |        Ok(Self::from(data))
+                |    }
+                |}
+            """.trimMargin(),
             "serializer" to RuntimeType.Serializer,
             "serialize" to RuntimeType.Serialize,
             "deserializer" to RuntimeType.Deserializer,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ErrorGenerator.kt
@@ -43,11 +43,11 @@ class ErrorGenerator(
         writer.rustBlock("impl ${symbol.name}") {
             rust(
                 """
-            pub fn retryable(&self) -> bool { $retryable }
-            pub fn throttling(&self) -> bool { $throttling }
-            pub fn code(&self) -> &str { ${shape.id.name.dq()} }
-            pub fn message(&self) -> Option<&str> { $message }
-                """
+            |pub fn retryable(&self) -> bool { $retryable }
+            |pub fn throttling(&self) -> bool { $throttling }
+            |pub fn code(&self) -> &str { ${shape.id.name.dq()} }
+            |pub fn message(&self) -> Option<&str> { $message }
+                """.trimMargin()
             )
         }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGenerator.kt
@@ -155,9 +155,9 @@ class HttpProtocolTestGenerator(
         with(httpRequestTestCase) {
             write(
                 """
-                    assert_eq!(http_request.method(), ${method.dq()});
-                    assert_eq!(http_request.uri().path(), ${uri.dq()});
-                """
+                    |assert_eq!(http_request.method(), ${method.dq()});
+                    |assert_eq!(http_request.uri().path(), ${uri.dq()});
+                """.trimMargin()
             )
         }
         checkQueryParams(this, httpRequestTestCase.queryParams)
@@ -213,10 +213,10 @@ class HttpProtocolTestGenerator(
         }
         rust(
             """
-                .status(${testCase.code})
-                .body(${testCase.body.orNull()?.dq()?.replace("#", "##") ?: "vec![]"})
-                .unwrap();
-            """
+            |   .status(${testCase.code})
+            |   .body(${testCase.body.orNull()?.dq()?.replace("#", "##") ?: "vec![]"})
+            |   .unwrap();
+            """.trimMargin()
         )
         write("let parsed = #T::from_response(&http_response);", operationSymbol)
         if (expectedShape.hasTrait(ErrorTrait::class.java)) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
@@ -91,9 +91,9 @@ class Instantiator(
             is DocumentShape -> {
                 writer.rust(
                     """{
-                    let as_json = #T! { ${Node.prettyPrintJson(arg)} };
-                    #T::json_to_doc(as_json)
-                }""",
+                    |let as_json = #T! { ${Node.prettyPrintJson(arg)} };
+                    |#T::json_to_doc(as_json)
+                }""".trimMargin(),
                     RuntimeType.SerdeJson("json"), RuntimeType.DocJson
                 )
             }
@@ -244,9 +244,7 @@ class Instantiator(
             val isSyntheticInput = shape.hasTrait(SyntheticInputTrait::class.java)
             if (isSyntheticInput) {
                 rust(
-                    """
-                let config = #T::Config::builder()
-            """,
+                    """let config = #T::Config::builder()""",
                     RuntimeType.Config
                 )
                 if (shape.allMembers.values.any { it.hasTrait(IdempotencyTokenTrait::class.java) }) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/IdempotencyProviderConfig.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/IdempotencyProviderConfig.kt
@@ -26,11 +26,11 @@ class IdempotencyProviderConfig : NamedSectionGenerator<ServiceConfig>() {
             ServiceConfig.BuilderImpl -> writable {
                 rust(
                     """
-            pub fn token_provider(mut self, token_provider: impl #T::ProvideIdempotencyToken + 'static) -> Self {
-                self.token_provider = Some(Box::new(token_provider));
-                self
-            }
-            """,
+            |pub fn token_provider(mut self, token_provider: impl #T::ProvideIdempotencyToken + 'static) -> Self {
+            |    self.token_provider = Some(Box::new(token_provider));
+            |    self
+            |}
+            """.trimMargin(),
                     RuntimeType.IdempotencyToken
                 )
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
@@ -109,9 +109,7 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
 
         writer.rustBlock("impl Config") {
             rustTemplate(
-                """
-                pub fn builder() -> ConfigBuilder { ConfigBuilder::default() }
-            """
+                """pub fn builder() -> ConfigBuilder { ConfigBuilder::default() }"""
             )
             customizations.forEach {
                 it.section(ServiceConfig.ConfigImpl)(this)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
@@ -143,13 +143,13 @@ class BasicAwsJsonGenerator(
         val operationName = symbolProvider.toSymbol(operationShape).name
         operationWriter.rustTemplate(
             """
-            impl #{parse_strict} for $operationName {
-                type Output = Result<#{output}, #{error}>;
-                fn parse(&self, response: &#{response}<#{bytes}>) -> Self::Output {
-                    self.parse_response(response)
-                }
-            }
-        """,
+            |impl #{parse_strict} for $operationName {
+            |    type Output = Result<#{output}, #{error}>;
+            |    fn parse(&self, response: &#{response}<#{bytes}>) -> Self::Output {
+            |        self.parse_response(response)
+            |    }
+            |}
+        """.trimMargin(),
             "parse_strict" to RuntimeType.parseStrict(symbolProvider.config().runtimeConfig),
             "output" to outputSymbol,
             "error" to operationShape.errorSymbol(symbolProvider),
@@ -169,11 +169,11 @@ class BasicAwsJsonGenerator(
             write("let builder = #T::new();", RuntimeType.HttpRequestBuilder)
             rust(
                 """
-                builder
-                   .method("POST")
-                   .header("Content-Type", "application/x-amz-json-${awsJsonVersion.value}")
-                   .header("X-Amz-Target", "${protocolConfig.serviceShape.id.name}.${operationShape.id.name}")
-               """
+                |builder
+                |   .method("POST")
+                |   .header("Content-Type", "application/x-amz-json-${awsJsonVersion.value}")
+                |   .header("X-Amz-Target", "${protocolConfig.serviceShape.id.name}.${operationShape.id.name}")
+               """.trimMargin()
             )
         }
     }
@@ -212,20 +212,20 @@ class BasicAwsJsonGenerator(
                 // to avoid the need to double deserialize the body.
                 rustTemplate(
                     """
-                    let body = #{sj}::from_slice(response.body().as_ref())
-                        .unwrap_or_else(|_|#{sj}::json!({}));
-                    let generic = #{aws_json_errors}::parse_generic_error(&response, &body);
-                    """,
+                    |let body = #{sj}::from_slice(response.body().as_ref())
+                    |    .unwrap_or_else(|_|#{sj}::json!({}));
+                    |let generic = #{aws_json_errors}::parse_generic_error(&response, &body);
+                    """.trimMargin(),
                     "aws_json_errors" to jsonErrors, "sj" to RuntimeType.SJ
                 )
                 if (operationShape.errors.isNotEmpty()) {
                     rustTemplate(
                         """
-
-                    let error_code = match generic.code() {
-                        Some(code) => code,
-                        None => return Err(#{error_symbol}::unhandled(generic))
-                    };""",
+                    |
+                    |let error_code = match generic.code() {
+                    |    Some(code) => code,
+                    |    None => return Err(#{error_symbol}::unhandled(generic))
+                    };""".trimMargin(),
                         "error_symbol" to errorSymbol
                     )
                     withBlock("return Err(match error_code {", "})") {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -59,9 +59,9 @@ class AwsRestJsonGenerator(
             // avoid non-usage warnings
             rust(
                 """
-                let _ = response;
-                todo!()
-            """
+                |let _ = response;
+                |todo!()
+            """.trimMargin()
             )
         }
     }
@@ -99,10 +99,10 @@ class AwsRestJsonGenerator(
         httpBuilderFun(implBlockWriter) {
             rust(
                 """
-            let builder = #T::new();
-            let builder = builder.header("Content-Type", ${contentType.dq()});
-            self.update_http_builder(builder)
-            """,
+            |let builder = #T::new();
+            |let builder = builder.header("Content-Type", ${contentType.dq()});
+            |self.update_http_builder(builder)
+            """.trimMargin(),
                 requestBuilder
             )
         }


### PR DESCRIPTION
*Description of changes:*

CodeWriter handles properly indenting lines for you, so using string literals with `trimMargin` means we only need to consider indentation from the margin we define instead of from the 0th column.

Code goes from this:

```
pub fn build(self, _config: &crate::config::Config) -> ::smithy_http::operation::Operation<GetObject, ()> {
    let op = GetObject::new(
        GetObjectInput {
            key: self.key
                .unwrap_or_default()
            ,
            bucket_name: self.bucket_name
                .unwrap_or_default()
            ,
        }
    );
    
                        #[allow(unused_mut)]
                        let mut request = ::smithy_http::operation::Request::new(op.build_http_request().map(::smithy_http::body::SdkBody::from));
                    
    
                        ::smithy_http::operation::Operation::new(
                            request,
                            op
                        )
                    
}

```

to this:

```
pub fn build(
    self,
    _config: &crate::config::Config,
) -> ::smithy_http::operation::Operation<GetObject, ()> {
    let op = GetObject::new(GetObjectInput {
        key: self.key.unwrap_or_default(),
        bucket_name: self.bucket_name.unwrap_or_default(),
    });
    #[allow(unused_mut)]
    let mut request = ::smithy_http::operation::Request::new(
        op.build_http_request()
            .map(::smithy_http::body::SdkBody::from),
    );
    ::smithy_http::operation::Operation::new(request, op)
}

```