### PR TITLE
restJson1 Header Deserialization Support

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.rust.codegen.rustlang.InlineDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asType
 import java.util.Optional
 
 data class RuntimeConfig(val cratePrefix: String = "smithy", val relativePath: String = "../") {
@@ -125,6 +126,7 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
                 func, CargoDependency.ProtocolTestHelpers(runtimeConfig), "protocol_test_helpers"
             )
 
+        val http = CargoDependency.Http.asType()
         fun Http(path: String): RuntimeType =
             RuntimeType(name = path, dependency = CargoDependency.Http, namespace = "http")
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.rustlang.withBlock
@@ -141,5 +142,18 @@ class EnumGenerator(
                 }
             }
         }
+
+        writer.rust(
+            """
+            impl std::str::FromStr for $enumName {
+                type Err = std::convert::Infallible;
+
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    Ok($enumName::from(s))
+                }
+            }
+
+        """
+        )
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-package software.amazon.smithy.rust.codegen.smithy.generators
+package software.amazon.smithy.rust.codegen.smithy.generators.http
 
-import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.knowledge.HttpBindingIndex
@@ -22,6 +21,8 @@ import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
 
@@ -50,9 +51,9 @@ fun HttpTrait.uriFormatString(): String {
  * TODO: httpPrefixHeaders; 4h
  * TODO: Deserialization of all fields; 1w
  */
-class HttpTraitBindingGenerator(
+class RequestBindingGenerator(
     val model: Model,
-    private val symbolProvider: SymbolProvider,
+    private val symbolProvider: RustSymbolProvider,
     private val runtimeConfig: RuntimeConfig,
     private val writer: RustWriter,
     private val shape: OperationShape,
@@ -62,6 +63,7 @@ class HttpTraitBindingGenerator(
     // TODO: make defaultTimestampFormat configurable
     private val defaultTimestampFormat = TimestampFormatTrait.Format.EPOCH_SECONDS
     private val index = HttpBindingIndex.of(model)
+    private val instant = RuntimeType.Instant(runtimeConfig).toSymbol().rustType()
 
     /**
      * Generates `update_http_builder` and all necessary dependency functions into the impl block provided by

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.generators.http
+
+import software.amazon.smithy.model.knowledge.HttpBinding
+import software.amazon.smithy.model.knowledge.HttpBindingIndex
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.ListShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.SetShape
+import software.amazon.smithy.model.traits.MediaTypeTrait
+import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.render
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.stripOuter
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.generators.builderSymbol
+import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.outputShape
+
+class ResponseBindingGenerator(protocolConfig: ProtocolConfig, private val operationShape: OperationShape) {
+    private val runtimeConfig = protocolConfig.runtimeConfig
+    private val symbolProvider = protocolConfig.symbolProvider
+    private val model = protocolConfig.model
+    private val index = HttpBindingIndex.of(model)
+    fun renderUpdateOutputBuilder(implBlockWriter: RustWriter) {
+        implBlockWriter.renderDeserializer()
+    }
+
+    fun RustWriter.renderDeserializer(): Boolean {
+        val headerUtil = CargoDependency.SmithyHttp(runtimeConfig).asType().member("header")
+        val outputShape = operationShape.outputShape(model).builderSymbol(symbolProvider)
+        val headerBindings = index.getResponseBindings(operationShape, HttpBinding.Location.HEADER)
+        val instant = RuntimeType.Instant(runtimeConfig).toSymbol().rustType()
+        // TODO: I think we need to load this from the service shape or configure it via the protocol
+        val defaultTimestampFormat = TimestampFormatTrait.Format.EPOCH_SECONDS
+
+        if (headerBindings.isEmpty()) {
+            return false
+        }
+        rustBlock(
+            "pub fn update_output(output: #1T, _headers: &#2T::HeaderMap) -> Result<#1T, #3T::ParseError>",
+            outputShape,
+            RuntimeType.http,
+            headerUtil
+        ) {
+            rust("let mut output = output;")
+
+            headerBindings.forEach { binding ->
+                val rustMemberName = symbolProvider.toMemberName(binding.member)
+                val targetType = model.expectShape(binding.member.target)
+                val rustType = symbolProvider.toSymbol(targetType).rustType().stripOuter<RustType.Option>()
+                val (coreType, coreShape) = if (targetType is CollectionShape) {
+                    rustType.stripOuter<RustType.Container>() to model.expectShape(targetType.member.target)
+                } else {
+                    rustType to targetType
+                }
+                val name = safeName()
+                if (coreType == instant) {
+                    val timestampFormat =
+                        index.determineTimestampFormat(
+                            binding.member,
+                            HttpBinding.Location.HEADER,
+                            defaultTimestampFormat
+                        )
+                    val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, timestampFormat)
+                    rust(
+                        "let $name: Vec<${coreType.render(true)}> = #T::many_dates(&_headers, ${binding.locationName.dq()}, #T)?;",
+                        headerUtil,
+                        timestampFormatType
+                    )
+                } else {
+                    rust(
+                        "let $name: Vec<${coreType.render(true)}> = #T::read_many(&_headers, ${binding.locationName.dq()})?;",
+                        headerUtil
+                    )
+                    if (coreShape.hasTrait(MediaTypeTrait::class.java)) {
+                        rustTemplate(
+                            """let $name: Result<Vec<_>, _> = $name
+                            .iter().map(|s|
+                                #{base_64_decode}(s).map_err(|_|#{header}::ParseError)
+                                .and_then(|bytes|String::from_utf8(bytes).map_err(|_|#{header}::ParseError))
+                            ).collect();""",
+                            "base_64_decode" to RuntimeType.Base64Decode(runtimeConfig),
+                            "header" to headerUtil
+                        )
+                        rust("let $name = $name?;")
+                    }
+                }
+                if (targetType is ListShape) {
+                    rust("output = output.$rustMemberName($name);")
+                } else if (targetType is SetShape) {
+                    rust("let _ = $name;")
+                } else {
+                    rustTemplate(
+                        """
+                        if $name.len() > 1 {
+                            return Err(#{header_util}::ParseError)
+                        }
+                        let mut $name = $name;
+                        if let Some(el) = $name.pop() {
+                            output = output.$rustMemberName(el);
+                        }
+                    """,
+                        "header_util" to headerUtil
+                    )
+                }
+            }
+            rust("Ok(output)")
+        }
+        return true
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -26,10 +26,11 @@ import software.amazon.smithy.rust.codegen.rustlang.writable
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.generators.HttpProtocolGenerator
-import software.amazon.smithy.rust.codegen.smithy.generators.HttpTraitBindingGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolGeneratorFactory
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolSupport
+import software.amazon.smithy.rust.codegen.smithy.generators.http.RequestBindingGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.http.ResponseBindingGenerator
 import software.amazon.smithy.rust.codegen.smithy.isOptional
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.util.dq
@@ -97,6 +98,10 @@ class AwsRestJsonGenerator(
     }
 
     override fun fromResponseImpl(implBlockWriter: RustWriter, operationShape: OperationShape) {
+        val httpBindingGenerator = ResponseBindingGenerator(protocolConfig, operationShape)
+
+        httpBindingGenerator.renderUpdateOutputBuilder(implBlockWriter)
+
         fromResponseFun(implBlockWriter, operationShape) {
             // avoid non-usage warnings
             rust(
@@ -211,7 +216,7 @@ class AwsRestJsonGenerator(
     ) {
         val httpTrait = operationShape.expectTrait(HttpTrait::class.java)
 
-        val httpBindingGenerator = HttpTraitBindingGenerator(
+        val httpBindingGenerator = RequestBindingGenerator(
             model,
             symbolProvider,
             runtimeConfig,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/TestHelpers.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/TestHelpers.kt
@@ -6,6 +6,8 @@
 package software.amazon.smithy.rust.codegen.testutil
 
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.smithy.CodegenConfig
@@ -14,6 +16,7 @@ import software.amazon.smithy.rust.codegen.smithy.RustCodegenPlugin
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.smithy.generators.ModelBuilderGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
 import software.amazon.smithy.rust.codegen.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.implBlock
 import software.amazon.smithy.rust.codegen.smithy.letIf
@@ -21,13 +24,30 @@ import software.amazon.smithy.rust.codegen.util.dq
 import java.io.File
 
 val TestRuntimeConfig = RuntimeConfig(relativePath = File("../rust-runtime/").absolutePath)
-val TestSymbolVisitorConfig = SymbolVisitorConfig(runtimeConfig = TestRuntimeConfig, codegenConfig = CodegenConfig(), handleOptionality = true, handleRustBoxing = true)
-fun testSymbolProvider(model: Model): RustSymbolProvider = RustCodegenPlugin.BaseSymbolProvider(model, TestSymbolVisitorConfig)
+val TestSymbolVisitorConfig = SymbolVisitorConfig(
+    runtimeConfig = TestRuntimeConfig,
+    codegenConfig = CodegenConfig(),
+    handleOptionality = true,
+    handleRustBoxing = true
+)
+
+fun testSymbolProvider(model: Model): RustSymbolProvider =
+    RustCodegenPlugin.BaseSymbolProvider(model, TestSymbolVisitorConfig)
+
+fun testProtocolConfig(model: Model): ProtocolConfig = ProtocolConfig(
+    model,
+    testSymbolProvider(model),
+    TestRuntimeConfig,
+    ServiceShape.builder().version("test").id("test#Service").build(),
+    ShapeId.from("test#Protocol"),
+    "test"
+)
 
 private const val SmithyVersion = "1.0"
 fun String.asSmithyModel(sourceLocation: String? = null): Model {
     val processed = letIf(!this.startsWith("\$version")) { "\$version: ${SmithyVersion.dq()}\n$it" }
-    return Model.assembler().discoverModels().addUnparsedModel(sourceLocation ?: "test.smithy", processed).assemble().unwrap()
+    return Model.assembler().discoverModels().addUnparsedModel(sourceLocation ?: "test.smithy", processed).assemble()
+        .unwrap()
 }
 
 /**

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/RequestBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/RequestBindingGeneratorTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-package software.amazon.smithy.rust.codegen.generators
+package software.amazon.smithy.rust.codegen.generators.http
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
@@ -14,8 +14,8 @@ import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.smithy.generators.HttpTraitBindingGenerator
-import software.amazon.smithy.rust.codegen.smithy.generators.uriFormatString
+import software.amazon.smithy.rust.codegen.smithy.generators.http.RequestBindingGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.http.uriFormatString
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.testutil.TestRuntimeConfig
 import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
@@ -24,7 +24,7 @@ import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.util.dq
 
-class HttpTraitBindingGeneratorTest {
+class RequestBindingGeneratorTest {
     private val baseModel = """
             namespace smithy.example
 
@@ -100,7 +100,7 @@ class HttpTraitBindingGeneratorTest {
         inputShape.renderWithModelBuilder(model, symbolProvider, writer)
         val inputShape = model.expectShape(operationShape.input.get(), StructureShape::class.java)
         writer.rustBlock("impl PutObjectInput") {
-            HttpTraitBindingGenerator(
+            RequestBindingGenerator(
                 model,
                 symbolProvider,
                 TestRuntimeConfig, writer, operationShape, inputShape, httpTrait

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/ResponseBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/ResponseBindingGeneratorTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.generators.http
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.generators.builderSymbol
+import software.amazon.smithy.rust.codegen.smithy.generators.http.ResponseBindingGenerator
+import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
+import software.amazon.smithy.rust.codegen.testutil.testProtocolConfig
+import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+import software.amazon.smithy.rust.codegen.util.outputShape
+
+class ResponseBindingGeneratorTest {
+    private val baseModel = """
+            namespace smithy.example
+
+            @idempotent
+            @http(method: "PUT", uri: "/", code: 200)
+            operation PutObject {
+                output: PutObjectResponse
+            }
+
+            list Extras {
+                member: Integer
+            }
+
+            list Dates {
+                member: Timestamp
+            }
+
+            @mediaType("video/quicktime")
+            string Video
+
+            structure PutObjectResponse {
+                // Sent in the X-Dates header
+                @httpHeader("X-Dates")
+                dateHeaderList: Dates,
+
+                @httpHeader("X-Ints")
+                intList: Extras,
+
+                @httpHeader("X-MediaType")
+                mediaType: Video,
+
+                // Sent in the body
+                data: Blob,
+
+                // Sent in the body
+                additional: String,
+            }
+        """.asSmithyModel()
+    private val model = OperationNormalizer(baseModel).transformModel(
+        inputBodyFactory = OperationNormalizer.NoBody,
+        outputBodyFactory = OperationNormalizer.NoBody
+    )
+    private val operationShape = model.expectShape(ShapeId.from("smithy.example#PutObject"), OperationShape::class.java)
+    private val symbolProvider = testSymbolProvider(model)
+    private val testProtocolConfig: ProtocolConfig = testProtocolConfig(model)
+
+    private fun RustWriter.renderOperation() {
+        operationShape.outputShape(model).renderWithModelBuilder(model, symbolProvider, this)
+        rustBlock("impl PutObjectOutput") {
+            ResponseBindingGenerator(
+                testProtocolConfig, operationShape
+            ).renderUpdateOutputBuilder(this)
+            val builderSymbol = operationShape.outputShape(model).builderSymbol(symbolProvider)
+            rustBlock("pub fn parse_http_response<B>(resp: &#T<B>) -> #T", RuntimeType.http.member("Response"), builderSymbol) {
+                write("let builder = #T::default();", builderSymbol)
+                write("Self::update_output(builder, resp.headers()).unwrap()")
+            }
+        }
+    }
+
+    @Test
+    fun deserializeHeadersIntoOutputShape() {
+        val testProject = TestWorkspace.testProject(symbolProvider)
+        testProject.withModule(RustModule.default("output", public = true)) {
+            it.renderOperation()
+            it.unitTest(
+                """
+                let resp = http::Response::builder()
+                    .header("X-Ints", "1,2,3")
+                    .header("X-Ints", "4,5,6")
+                    .header("X-MediaType", "c21pdGh5LXJz")
+                    .header("X-Dates", "Mon, 16 Dec 2019 23:48:18 GMT")
+                    .header("X-Dates", "Mon, 16 Dec 2019 23:48:18 GMT,Tue, 17 Dec 2019 23:48:18 GMT")
+                    .body(()).expect("valid request");
+                let output = PutObjectOutput::parse_http_response(&resp).build();
+                assert_eq!(output.int_list.unwrap(), vec![1,2,3,4,5,6]);
+                assert_eq!(output.media_type.unwrap(), "smithy-rs");
+                assert_eq!(output.date_header_list.unwrap().len(), 3);
+            """
+            )
+        }
+        testProject.compileAndTest()
+    }
+}

--- a/rust-runtime/smithy-http/src/header.rs
+++ b/rust-runtime/smithy-http/src/header.rs
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! Utilities for parsing information from headers
+
+use smithy_types::instant::Format;
+use smithy_types::Instant;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct ParseError;
+
+/// Read all the dates from the header map at `key` according the `format`
+///
+/// This is separate from `read_many` below because we need to invoke `Instant::read` to take advantage
+/// of comma-aware parsing
+pub fn many_dates(
+    headers: &http::HeaderMap,
+    key: &str,
+    format: Format,
+) -> Result<Vec<Instant>, ParseError> {
+    let mut out = vec![];
+    for header in headers.get_all(key).iter() {
+        let mut header = header.to_str().map_err(|_| ParseError)?;
+        while !header.is_empty() {
+            let (v, next) = Instant::read(header, format, ',').map_err(|_| ParseError)?;
+            out.push(v);
+            header = next;
+        }
+    }
+    Ok(out)
+}
+
+/// Read many comma / header delimited values from HTTP headers for `FromStr` types
+pub fn read_many<T>(headers: &http::HeaderMap, key: &str) -> Result<Vec<T>, ParseError>
+where
+    T: FromStr,
+{
+    let mut out = vec![];
+    for header in headers.get_all(key).iter() {
+        let mut header = header.as_bytes();
+        while !header.is_empty() {
+            let (v, next) = read_one::<T>(&header)?;
+            out.push(v);
+            header = next;
+        }
+    }
+    Ok(out)
+}
+
+/// Read one comma delimited value for `FromStr` types
+pub fn read_one<T>(s: &[u8]) -> Result<(T, &[u8]), ParseError>
+where
+    T: FromStr,
+{
+    let (head, rest) = split_at_delim(s);
+    let head = std::str::from_utf8(head).map_err(|_| ParseError)?;
+    Ok((T::from_str(head).map_err(|_| ParseError)?, rest))
+}
+
+fn split_at_delim(s: &[u8]) -> (&[u8], &[u8]) {
+    let next_delim = s.iter().position(|b| b == &b',').unwrap_or(s.len());
+    let (first, next) = s.split_at(next_delim);
+    (first, then_delim(next).unwrap())
+}
+
+fn then_delim(s: &[u8]) -> Result<&[u8], ParseError> {
+    if s.is_empty() {
+        Ok(&s)
+    } else if s.starts_with(b",") {
+        Ok(&s[1..])
+    } else {
+        Err(ParseError)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::header::read_many;
+
+    #[test]
+    fn read_many_bools() {
+        let test_request = http::Request::builder()
+            .header("X-Bool-Multi", "true,false")
+            .header("X-Bool-Multi", "true")
+            .header("X-Bool", "true")
+            .header("X-Bool-Invalid", "truth,falsy")
+            .header("X-Bool-Single", "true,false,true,true")
+            .body(())
+            .unwrap();
+        assert_eq!(
+            read_many::<bool>(test_request.headers(), "X-Bool-Multi").expect("valid"),
+            vec![true, false, true]
+        );
+
+        assert_eq!(
+            read_many::<bool>(test_request.headers(), "X-Bool").unwrap(),
+            vec![true]
+        );
+        assert_eq!(
+            read_many::<bool>(test_request.headers(), "X-Bool-Single").unwrap(),
+            vec![true, false, true, true]
+        );
+        read_many::<bool>(test_request.headers(), "X-Bool-Invalid").expect_err("invalid");
+    }
+
+    #[test]
+    fn read_many_u16() {
+        let test_request = http::Request::builder()
+            .header("X-Multi", "123,456")
+            .header("X-Multi", "789")
+            .header("X-Num", "777")
+            .header("X-Num-Invalid", "12ef3")
+            .header("X-Num-Single", "1,2,3,4,5")
+            .body(())
+            .unwrap();
+        assert_eq!(
+            read_many::<u16>(test_request.headers(), "X-Multi").expect("valid"),
+            vec![123, 456, 789]
+        );
+
+        assert_eq!(
+            read_many::<u16>(test_request.headers(), "X-Num").unwrap(),
+            vec![777]
+        );
+        assert_eq!(
+            read_many::<u16>(test_request.headers(), "X-Num-Single").unwrap(),
+            vec![1, 2, 3, 4, 5]
+        );
+        read_many::<u16>(test_request.headers(), "X-Num-Invalid").expect_err("invalid");
+    }
+}

--- a/rust-runtime/smithy-http/src/lib.rs
+++ b/rust-runtime/smithy-http/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod base64;
 pub mod body;
 pub mod endpoint;
+pub mod header;
 pub mod label;
 pub mod middleware;
 pub mod operation;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds support for the `@httpHeader` trait during request deserialization. This is facilitated via a `Read` abstraction which allows parsers to consume part of an input and return the remaining input. We use this to enable things like `HttpDates` which actually include commas to be parsed in a comma delimited fashion.

The internal libraries may eventually be refactored to reduce the amount of generics if it proves to be a compiler bottleneck.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
