### PR TITLE
Fix Retryability of Unmodeled Errors

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
@@ -303,6 +303,6 @@ class BasicAwsJsonGenerator(
                 write("Err(e) => #T::unhandled(e)", errorSymbol)
             }
         }
-        write("_ => #T::unhandled(generic)", errorSymbol)
+        write("_ => #T::generic(generic)", errorSymbol)
     }
 }


### PR DESCRIPTION
*Description of changes:*

A bug was introduced in #249  which caused unmodeled response codes to be lost during error handling. This caused the unmodeled errors to always be marked as "unretryable" because their code wasn't exposed to the retry policy. This diff adds a fix and integration test for this behavior.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
