### PR TITLE
Send Poll::Ready(None) on empty body

### DIFF
--- a/rust-runtime/smithy-http/src/body.rs
+++ b/rust-runtime/smithy-http/src/body.rs
@@ -32,6 +32,7 @@ impl SdkBody {
             SdkBody::Once(ref mut opt) => {
                 let data = opt.take();
                 match data {
+                    Some(bytes) if bytes.is_empty() => Poll::Ready(None),
                     Some(bytes) => Poll::Ready(Some(Ok(bytes))),
                     None => Poll::Ready(None),
                 }


### PR DESCRIPTION
*Description of changes:*

When used over H/2, sending an empty data frame for a GET can trigger some problematic behavior in Hyper. Hyper should probably handle this, but this ensures that we will
not hit this behavior.

When sending data to API Gateway services, we are getting GOAWAY because this causes to send duplicate empty data frames.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
