### PR TITLE
Fix StackOverflow in SdkBody Debug

### DIFF
--- a/rust-runtime/smithy-http/src/body.rs
+++ b/rust-runtime/smithy-http/src/body.rs
@@ -44,16 +44,8 @@ enum Inner {
 impl Debug for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self {
-            Inner::Once(once) => {
-                let mut dbg = f.debug_tuple("Once");
-                dbg.field(once);
-                dbg.finish()
-            }
-            Inner::Streaming(streaming) => {
-                let mut dbg = f.debug_tuple("Streaming");
-                dbg.field(streaming);
-                dbg.finish()
-            }
+            Inner::Once(once) => f.debug_tuple("Once").field(once).finish(),
+            Inner::Streaming(streaming) => f.debug_tuple("Streaming").field(streaming).finish(),
             Inner::Taken => f.debug_tuple("Taken").finish(),
             Inner::Dyn(_) => write!(f, "BoxBody"),
         }


### PR DESCRIPTION
*Description of changes:*

An incorrect debug implementation lead to infinite recursion when printing `SdkBody` with the debug formatter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
