### PR TITLE
Remove wildcard dependencies

### DIFF
--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1"
 [dev-dependencies]
 async-trait = "0.1.50"
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["rt-tokio"] }
-env_logger = "*"
+env_logger = "0.9"
 http = "0.2.3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/ec2/Cargo.toml
+++ b/aws/sdk/examples/ec2/Cargo.toml
@@ -10,6 +10,5 @@ edition = "2018"
 aws-config = { path = "../../build/aws-sdk/aws-config" }
 aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
 tokio = { version = "1", features = ["full"]}
-actix-rt = "*"
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"


### PR DESCRIPTION
## Motivation and Context
Crates with wildcard dependencies can't be published to crates.io.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
