### PR TITLE
aws-smithy-client: Support using rustls with either native roots or webpki roots

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -25,3 +25,13 @@ message = "Re-export aws_types::SdkConfig in aws_config"
 references = ["smithy-rs#1457"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "calavera"
+
+[[aws-sdk-rust]]
+message = "aws-smithy-client: Support using rustls with either native roots or webpki-roots"
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "joshtriplett"
+
+[[aws-sdk-rust]]
+message = "aws-smithy-client: Upgrade hyper-rustls to 0.23.0"
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "joshtriplett"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -9,11 +9,13 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
-rustls = ["aws-smithy-client/rustls"]
+rustls = ["rustls-native-roots"]
+rustls-native-roots = ["aws-smithy-client/rustls-native-roots"]
+rustls-webpki-roots = ["aws-smithy-client/rustls-webpki-roots"]
 native-tls = ["aws-smithy-client/native-tls"]
 rt-tokio = ["aws-smithy-async/rt-tokio"]
 
-default = ["rustls", "rt-tokio"]
+default = ["rustls-native-roots", "rt-tokio"]
 
 [dependencies]
 aws-sdk-sts = { path = "../../sdk/build/aws-sdk/sdk/sts", default-features = false }

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -11,7 +11,9 @@ repository = "https://github.com/awslabs/smithy-rs"
 rt-tokio = ["aws-smithy-async/rt-tokio"]
 test-util = ["aws-smithy-protocol-test", "serde/derive", "rustls"]
 native-tls = ["client-hyper", "hyper-tls", "rt-tokio"]
-rustls = ["client-hyper", "hyper-rustls", "rt-tokio", "lazy_static"]
+rustls = ["rustls-native-roots"]
+rustls-native-roots = ["client-hyper", "rt-tokio", "lazy_static", "hyper-rustls/native-tokio"]
+rustls-webpki-roots = ["client-hyper", "rt-tokio", "lazy_static", "hyper-rustls/webpki-tokio"]
 client-hyper = ["hyper"]
 
 [dependencies]
@@ -25,7 +27,7 @@ fastrand = "1.4.0"
 http = "0.2.3"
 http-body = "0.4.4"
 hyper = { version = "0.14", features = ["client", "http2", "http1"], optional = true }
-hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
+hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = ["http1", "http2", "tls12"] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project-lite = "0.2.7"

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -257,7 +257,7 @@ impl Builder {
     }
 }
 
-#[cfg(any(feature = "rustls", feature = "native-tls"))]
+#[cfg(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots", feature = "native-tls"))]
 impl<M> crate::Builder<crate::erase::DynConnector, M>
 where
     M: Default,
@@ -273,10 +273,9 @@ where
     /// [`DynConnector`](crate::erase::DynConnector) for details. To avoid that overhead, use
     /// [`Builder::rustls`](ClientBuilder::rustls) or `Builder::native_tls` instead.
     pub fn dyn_https() -> Self {
-        #[cfg(feature = "rustls")]
+        #[cfg(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots"))]
         let with_https = |b: ClientBuilder<_>| b.rustls();
-        // If we are compiling this function & rustls is not enabled, then native-tls MUST be enabled
-        #[cfg(not(feature = "rustls"))]
+        #[cfg(feature = "native-tls")]
         let with_https = |b: ClientBuilder<_>| b.native_tls();
 
         with_https(ClientBuilder::new())
@@ -285,7 +284,7 @@ where
     }
 }
 
-#[cfg(any(feature = "rustls", feature = "native_tls"))]
+#[cfg(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots", feature = "native-tls"))]
 impl<M> crate::Client<crate::erase::DynConnector, M>
 where
     M: Default,
@@ -305,7 +304,7 @@ where
     }
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots"))]
 impl<M, R> ClientBuilder<(), M, R> {
     /// Connect to the service over HTTPS using Rustls using dynamic dispatch.
     pub fn rustls(self) -> ClientBuilder<DynConnector, M, R> {
@@ -646,7 +645,7 @@ mod test {
 
     #[test]
     fn builder_connection_helpers_are_dyn() {
-        #[cfg(feature = "rustls")]
+        #[cfg(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots"))]
         let _builder: ClientBuilder<DynConnector, (), _> = ClientBuilder::new().rustls();
         #[cfg(feature = "native-tls")]
         let _builder: ClientBuilder<DynConnector, (), _> = ClientBuilder::new().native_tls();


### PR DESCRIPTION
Add separate cargo features for rustls-native-roots and
rustls-webpki-roots. Make the existing `rustls` feature a compatibility
alias for `rustls-native-roots`, to make this a non-breaking change.

Upgrade hyper-rustls to 0.23.0 to improve support for this. (This also
avoids having two versions of hyper-rustls (and its dependencies) in
code that uses a custom hyper-rustls connector.)

This change makes it much easier to work with webpki-roots, without having to
fight the SDK or override connectors in multiple different places to avoid
depending on native roots.

## Testing

Confirmed that every combination of features builds and passes tests.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
