### PR TITLE
Pascal case operation names

### DIFF
--- a/codegen-core/common-test-models/naming-obstacle-course-ops.smithy
+++ b/codegen-core/common-test-models/naming-obstacle-course-ops.smithy
@@ -5,6 +5,7 @@ use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 use aws.protocols#awsJson1_1
 use aws.api#service
+use smithy.framework#ValidationException
 
 /// Confounds model generation machinery with lots of problematic names
 @awsJson1_1
@@ -41,17 +42,20 @@ service Config {
     }
 ])
 operation ReservedWordsAsMembers {
-    input: ReservedWords
+    input: ReservedWords,
+    errors: [ValidationException],
 }
 
 // tests that module names are properly escaped
 operation Match {
     input: ReservedWords
+    errors: [ValidationException],
 }
 
 // Should generate a PascalCased `RpcEchoInput` struct.
 operation RPCEcho {
     input: ReservedWords
+    errors: [ValidationException],
 }
 
 structure ReservedWords {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
@@ -284,16 +284,10 @@ open class SymbolVisitor(
         TODO("Not yet implemented: https://github.com/awslabs/smithy-rs/issues/312")
     }
 
-    override fun operationShape(shape: OperationShape): Symbol {
-        return symbolBuilder(
-            RustType.Opaque(
-                shape.contextName(serviceShape)
-                    .replaceFirstChar { it.uppercase() },
-            ),
-        )
+    override fun operationShape(shape: OperationShape) =
+        symbolBuilder(RustType.Opaque(shape.contextName(serviceShape).toPascalCase()))
             .locatedIn(Operations)
             .build()
-    }
 
     override fun resourceShape(shape: ResourceShape?): Symbol {
         TODO("Not yet implemented: resources are not supported")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
@@ -404,7 +404,6 @@ class HttpBindingGenerator(
     /**
      * Generate a unique name for the deserializer function for a given [operationShape] and HTTP binding.
      */
-    // Rename here technically not required, operations and members cannot be renamed.
     private fun fnName(operationShape: OperationShape, binding: HttpBindingDescriptor) =
         "${operationShape.id.getName(service).toSnakeCase()}_${binding.member.container.name.toSnakeCase()}_${binding.memberName.toSnakeCase()}"
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/OperationNormalizer.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/OperationNormalizer.kt
@@ -32,7 +32,6 @@ import kotlin.streams.toList
  */
 object OperationNormalizer {
     // Functions to construct synthetic shape IDs—Don't rely on these in external code.
-    // Rename safety: Operations cannot be renamed
     // In order to ensure that the fully qualified smithy id of a synthetic shape can never conflict with an existing shape,
     // the `synthetic` namespace is appended.
     private fun OperationShape.syntheticInputId() =

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationGenerator.kt
@@ -30,7 +30,7 @@ class ServerOperationGenerator(
     private val symbolProvider = codegenContext.symbolProvider
     private val model = codegenContext.model
 
-    private val operationName = symbolProvider.toSymbol(operation).name.toPascalCase()
+    private val operationName = symbolProvider.toSymbol(operation).name
     private val operationId = operation.id
 
     /** Returns `std::convert::Infallible` if the model provides no errors. */


### PR DESCRIPTION
And hence pascal case operation error struct names too, like we're
currently doing with operation input and output struct names.

Fixes #1826.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
