### PR TITLE
Migrate to EnumShape

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitor.kt
@@ -106,6 +106,8 @@ class CodegenVisitor(
      */
     internal fun baselineTransform(model: Model) =
         model
+            // Convert string shapes with an @enum trait to an enum shape
+            .let { ModelTransformer.create().changeStringEnumsToEnumShapes(model, true) }
             // Flattens mixins out of the model and removes them from the model
             .let { ModelTransformer.create().flattenAndRemoveMixins(it) }
             // Add errors attached at the service level to the models

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitor.kt
@@ -213,7 +213,10 @@ class CodegenVisitor(
      */
     override fun stringShape(shape: StringShape) {
         if (shape.hasTrait<EnumTrait>()) {
-            throw CodegenException("Unnamed @enum shapes are unsupported: $shape")
+            throw CodegenException(
+                "Code generation has failed because this unnamed @enum could not be converted to an enum shape: $shape." +
+                    "For more info, look above at the logs from awslabs/smithy.",
+            )
         }
         super.stringShape(shape)
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitor.kt
@@ -209,7 +209,7 @@ class CodegenVisitor(
     /**
      * String Shape Visitor
      *
-     * Although raw strings require no code generation, enums are actually `EnumTrait` applied to string shapes.
+     * Unnamed @enum shapes are not supported. If they could not be converted to EnumShape, this will fail.
      */
     override fun stringShape(shape: StringShape) {
         if (shape.hasTrait<EnumTrait>()) {
@@ -218,6 +218,9 @@ class CodegenVisitor(
         super.stringShape(shape)
     }
 
+    /**
+     * Enum Shape Visitor
+     */
     override fun enumShape(shape: EnumShape) {
         rustCrate.useShapeWriter(shape) {
             EnumGenerator(model, symbolProvider, this, shape).render()

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CodegenVisitorTest.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ClientCustomizations
 import software.amazon.smithy.rust.codegen.client.smithy.customize.CombinedCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customize.NoOpEventStreamSigningDecorator
@@ -61,5 +62,43 @@ class CodegenVisitorTest {
         val visitor = CodegenVisitor(ctx, codegenDecorator)
         val baselineModel = visitor.baselineTransform(model)
         baselineModel.getShapesWithTrait(ShapeId.from("smithy.api#mixin")).isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `baseline transform verify string enum converted to EnumShape`() {
+        val model = """
+            namespace com.example
+            use aws.protocols#restJson1
+            @restJson1
+            service Example {
+                operations: [ BasicOperation ]
+            }
+            operation BasicOperation {
+                input: Shape
+            }
+            structure Shape {
+                enum: BasicEnum
+            }
+            @enum([
+                {
+                    value: "a0",
+                },
+                {
+                    value: "a1",
+                }
+            ])
+            string BasicEnum
+        """.asSmithyModel(smithyVersion = "2.0")
+        val (ctx, testDir) = generatePluginContext(model)
+        testDir.resolve("src").createDirectory()
+        testDir.resolve("src/main.rs").writeText("fn main() {}")
+        val codegenDecorator =
+            CombinedCodegenDecorator.fromClasspath(
+                ctx,
+                ClientCustomizations(),
+            )
+        val visitor = CodegenVisitor(ctx, codegenDecorator)
+        val baselineModel = visitor.baselineTransform(model)
+        baselineModel.getShapesWithTrait(EnumTrait.ID).isEmpty() shouldBe true
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolMetadataProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolMetadataProvider.kt
@@ -8,18 +8,17 @@ package software.amazon.smithy.rust.codegen.core.smithy
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumDefinition
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
-import software.amazon.smithy.rust.codegen.core.util.hasTrait
 
 /**
  * Default delegator to enable easily decorating another symbol provider.
@@ -54,9 +53,8 @@ abstract class SymbolMetadataProvider(private val base: RustSymbolProvider) : Wr
             is MemberShape -> memberMeta(shape)
             is StructureShape -> structureMeta(shape)
             is UnionShape -> unionMeta(shape)
-            is StringShape -> if (shape.hasTrait<EnumTrait>()) {
-                enumMeta(shape)
-            } else null
+            is EnumShape -> enumMeta(shape)
+            is StringShape -> null
 
             else -> null
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.model.shapes.BooleanShape
 import software.amazon.smithy.model.shapes.ByteShape
 import software.amazon.smithy.model.shapes.DocumentShape
 import software.amazon.smithy.model.shapes.DoubleShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.FloatShape
 import software.amazon.smithy.model.shapes.IntegerShape
 import software.amazon.smithy.model.shapes.ListShape
@@ -36,7 +37,6 @@ import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumDefinition
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
@@ -271,14 +271,11 @@ open class SymbolVisitor(
     override fun longShape(shape: LongShape): Symbol = simpleShape(shape)
     override fun floatShape(shape: FloatShape): Symbol = simpleShape(shape)
     override fun doubleShape(shape: DoubleShape): Symbol = simpleShape(shape)
-    override fun stringShape(shape: StringShape): Symbol {
-        return if (shape.hasTrait<EnumTrait>()) {
-            val rustType = RustType.Opaque(shape.contextName(serviceShape).toPascalCase())
-            symbolBuilder(shape, rustType).locatedIn(Models).build()
-        } else {
-            simpleShape(shape)
-        }
+    override fun enumShape(shape: EnumShape): Symbol {
+        val rustType = RustType.Opaque(shape.contextName(serviceShape).toPascalCase())
+        return symbolBuilder(shape, rustType).locatedIn(Models).build()
     }
+    override fun stringShape(shape: StringShape): Symbol = simpleShape(shape)
 
     override fun listShape(shape: ListShape): Symbol {
         val inner = this.toSymbol(shape.member)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.BooleanShape
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.DocumentShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
@@ -28,7 +29,6 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.HttpPrefixHeadersTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
@@ -279,7 +279,7 @@ open class Instantiator(
 
     private fun renderString(writer: RustWriter, shape: StringShape, arg: StringNode) {
         val data = writer.escape(arg.value).dq()
-        if (!shape.hasTrait<EnumTrait>()) {
+        if (shape !is EnumShape) {
             writer.rust("$data.to_owned()")
         } else {
             val enumSymbol = symbolProvider.toSymbol(shape)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
@@ -129,6 +129,7 @@ open class Instantiator(
             }
 
             // Simple Shapes
+            is EnumShape -> renderEnum(writer, shape, data as StringNode)
             is StringShape -> renderString(writer, shape, data as StringNode)
             is NumberShape -> when (data) {
                 is StringNode -> {
@@ -279,12 +280,13 @@ open class Instantiator(
 
     private fun renderString(writer: RustWriter, shape: StringShape, arg: StringNode) {
         val data = writer.escape(arg.value).dq()
-        if (shape !is EnumShape) {
-            writer.rust("$data.to_owned()")
-        } else {
-            val enumSymbol = symbolProvider.toSymbol(shape)
-            writer.rustTemplate("#{EnumFromStringFn:W}", "EnumFromStringFn" to enumFromStringFn(enumSymbol, data))
-        }
+        writer.rust("$data.to_owned()")
+    }
+
+    private fun renderEnum(writer: RustWriter, shape: EnumShape, arg: StringNode) {
+        val enumSymbol = symbolProvider.toSymbol(shape)
+        val data = writer.escape(arg.value).dq()
+        writer.rustTemplate("#{EnumFromStringFn:W}", "EnumFromStringFn" to enumFromStringFn(enumSymbol, data))
     }
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.knowledge.HttpBindingIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.DocumentShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
@@ -22,7 +23,6 @@ import software.amazon.smithy.model.shapes.SimpleShape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.MediaTypeTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
@@ -303,7 +303,7 @@ class HttpBindingGenerator(
                             rust("let body_str = std::str::from_utf8(body)?;")
                         }
                     }
-                    if (targetShape.hasTrait<EnumTrait>()) {
+                    if (targetShape is EnumShape) {
                         if (codegenTarget == CodegenTarget.SERVER) {
                             rust(
                                 "Ok(#T::try_from(body_str)?)",

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.BooleanShape
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.DocumentShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.NumberShape
@@ -19,7 +20,6 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
@@ -303,7 +303,7 @@ class JsonParserGenerator(
 
     private fun RustWriter.deserializeStringInner(target: StringShape, escapedStrName: String) {
         withBlock("$escapedStrName.to_unescaped().map(|u|", ")") {
-            when (target.hasTrait<EnumTrait>()) {
+            when (target is EnumShape) {
                 true -> {
                     if (returnSymbolToParse(target).isUnconstrained) {
                         rust("u.into_owned()")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.knowledge.HttpBindingIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.BooleanShape
 import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.NumberShape
@@ -22,7 +23,6 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.XmlFlattenedTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
@@ -658,7 +658,7 @@ class XmlBindingTraitParserGenerator(
 
     private fun RustWriter.parseStringInner(shape: StringShape, provider: Writable) {
         withBlock("Result::<#T, #T>::Ok(", ")", symbolProvider.toSymbol(shape), xmlDecodeError) {
-            if (shape.hasTrait<EnumTrait>()) {
+            if (shape is EnumShape) {
                 val enumSymbol = symbolProvider.toSymbol(shape)
                 if (convertsToEnumInServer(shape)) {
                     withBlock("#T::try_from(", ")", enumSymbol) {
@@ -678,7 +678,7 @@ class XmlBindingTraitParserGenerator(
         }
     }
 
-    private fun convertsToEnumInServer(shape: StringShape) = target == CodegenTarget.SERVER && shape.hasTrait<EnumTrait>()
+    private fun convertsToEnumInServer(shape: StringShape) = target == CodegenTarget.SERVER && shape is EnumShape
 
     private fun MemberShape.xmlName(): XmlName {
         return XmlName(xmlIndex.memberName(this))

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
@@ -10,7 +10,6 @@ import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
-import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.CratesIo
@@ -71,7 +70,6 @@ fun String.asSmithyModel(sourceLocation: String? = null, smithyVersion: String =
     val processed = letIf(!this.startsWith("\$version")) { "\$version: ${smithyVersion.dq()}\n$it" }
     return Model.assembler().discoverModels().addUnparsedModel(sourceLocation ?: "test.smithy", processed).assemble()
         .unwrap()
-        .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 }
 
 // Intentionally only visible to codegen-core since the other modules have their own symbol providers

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.CratesIo
@@ -70,6 +71,7 @@ fun String.asSmithyModel(sourceLocation: String? = null, smithyVersion: String =
     val processed = letIf(!this.startsWith("\$version")) { "\$version: ${smithyVersion.dq()}\n$it" }
     return Model.assembler().discoverModels().addUnparsedModel(sourceLocation ?: "test.smithy", processed).assemble()
         .unwrap()
+        .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 }
 
 // Intentionally only visible to codegen-core since the other modules have their own symbol providers

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Smithy.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Smithy.kt
@@ -116,13 +116,13 @@ inline fun <reified T : Trait> UnionShape.findMemberWithTrait(model: Model): Mem
     return this.members().find { it.getMemberTrait(model, T::class.java).isPresent }
 }
 
-/** Kotlin sugar for hasTrait() check. e.g. shape.hasTrait<EnumTrait>() instead of shape.hasTrait(EnumTrait::class.java) */
+/** Kotlin sugar for hasTrait() check. e.g. shape.hasTrait<HttpTrait>() instead of shape.hasTrait(HttpTrait::class.java) */
 inline fun <reified T : Trait> Shape.hasTrait(): Boolean = hasTrait(T::class.java)
 
-/** Kotlin sugar for expectTrait() check. e.g. shape.expectTrait<EnumTrait>() instead of shape.expectTrait(EnumTrait::class.java) */
+/** Kotlin sugar for expectTrait() check. e.g. shape.expectTrait<HttpTrait>() instead of shape.expectTrait(HttpTrait::class.java) */
 inline fun <reified T : Trait> Shape.expectTrait(): T = expectTrait(T::class.java)
 
-/** Kotlin sugar for getTrait() check. e.g. shape.getTrait<EnumTrait>() instead of shape.getTrait(EnumTrait::class.java) */
+/** Kotlin sugar for getTrait() check. e.g. shape.getTrait<HttpTrait>() instead of shape.getTrait(HttpTrait::class.java) */
 inline fun <reified T : Trait> Shape.getTrait(): T? = getTrait(T::class.java).orNull()
 
 fun Shape.isPrimitive(): Boolean {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGeneratorTest.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.traits.DeprecatedTrait
 import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.traits.EnumDefinition
+import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
@@ -44,6 +45,7 @@ class EnumGeneratorTest {
             ])
             string EnumWithUnknown
         """.asSmithyModel()
+            .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
         private val symbolProvider = testSymbolProvider(testModel)
 
         private val enum = testModel.lookup<EnumShape>("test#EnumWithUnknown")
@@ -83,7 +85,7 @@ class EnumGeneratorTest {
             rendered shouldContain
                 """
                 /// Some documentation.
-                SomeName1,
+                #[deprecated]SomeName1,
                 """.trimIndent()
         }
 
@@ -96,7 +98,7 @@ class EnumGeneratorTest {
                 /// It has some docs that #need to be escaped
                 ///
                 /// _Note: `::Unknown` has been renamed to `::UnknownValue`._
-                UnknownValue,
+                #[deprecated]UnknownValue,
                 """.trimIndent()
         }
     }
@@ -125,6 +127,7 @@ class EnumGeneratorTest {
                 @deprecated(since: "1.2.3")
                 string InstanceType
             """.asSmithyModel()
+                .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
             val provider = testSymbolProvider(model)
             val project = TestWorkspace.testProject(provider)
@@ -169,6 +172,7 @@ class EnumGeneratorTest {
                 }])
                 string FooEnum
             """.asSmithyModel()
+                .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
             val provider = testSymbolProvider(model)
             val project = TestWorkspace.testProject(provider)
@@ -203,6 +207,7 @@ class EnumGeneratorTest {
                 @deprecated
                 string FooEnum
             """.asSmithyModel()
+                .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
             val provider = testSymbolProvider(model)
             val project = TestWorkspace.testProject(provider)
@@ -235,6 +240,7 @@ class EnumGeneratorTest {
                 ])
                 string SomeEnum
             """.asSmithyModel()
+                .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
             val provider = testSymbolProvider(model)
             val project = TestWorkspace.testProject(provider)
@@ -266,6 +272,7 @@ class EnumGeneratorTest {
                 ])
                 string SomeEnum
             """.asSmithyModel()
+                .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
             val provider = testSymbolProvider(model)
             val project = TestWorkspace.testProject(provider)
@@ -296,6 +303,7 @@ class EnumGeneratorTest {
                 ])
                 string SomeEnum
             """.asSmithyModel()
+                .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
             val provider = testSymbolProvider(model)
             val project = TestWorkspace.testProject(provider)
@@ -323,6 +331,7 @@ class EnumGeneratorTest {
             ])
             string SomeEnum
         """.asSmithyModel()
+            .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
 
         val provider = testSymbolProvider(model)
         val project = TestWorkspace.testProject(provider)
@@ -374,6 +383,7 @@ class EnumGeneratorTest {
             ])
             string SomeEnum
         """.asSmithyModel()
+            .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
         val variant3AsUnknown = """SomeEnum::from("Variant3")"""
         expectMatchExpressionCompiles(modelV1, "test#SomeEnum", variant3AsUnknown)
 
@@ -387,6 +397,7 @@ class EnumGeneratorTest {
             ])
             string SomeEnum
         """.asSmithyModel()
+            .let { ModelTransformer.create().changeStringEnumsToEnumShapes(it, true) }
         val variant3AsVariant3 = "SomeEnum::Variant3"
         expectMatchExpressionCompiles(modelV2, "test#SomeEnum", variant3AsVariant3)
     }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -7,8 +7,8 @@ package software.amazon.smithy.rust.codegen.core.smithy.protocols.parse
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
@@ -26,7 +26,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.lookup
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 
@@ -197,8 +196,8 @@ class JsonParserGeneratorTest {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, this)
             model.lookup<StructureShape>("test#EmptyStruct").renderWithModelBuilder(model, symbolProvider, this)
             UnionGenerator(model, symbolProvider, this, model.lookup("test#Choice")).render()
-            val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(model, symbolProvider, this, enum, enum.expectTrait()).render()
+            val enum = model.lookup<EnumShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, this, enum).render()
         }
 
         project.withModule(RustModule.public("output")) {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGeneratorTest.kt
@@ -6,8 +6,8 @@
 package software.amazon.smithy.rust.codegen.core.smithy.protocols.parse
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
@@ -24,7 +24,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.lookup
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 
@@ -197,8 +196,8 @@ internal class XmlBindingTraitParserGeneratorTest {
         project.withModule(RustModule.public("model")) {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, this)
             UnionGenerator(model, symbolProvider, this, model.lookup("test#Choice")).render()
-            val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(model, symbolProvider, this, enum, enum.expectTrait()).render()
+            val enum = model.lookup<EnumShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, this, enum).render()
         }
 
         project.withModule(RustModule.public("output")) {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/AwsQuerySerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/AwsQuerySerializerGeneratorTest.kt
@@ -7,8 +7,8 @@ package software.amazon.smithy.rust.codegen.core.smithy.protocols.serialize
 
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
@@ -22,7 +22,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.lookup
 
@@ -135,8 +134,8 @@ class AwsQuerySerializerGeneratorTest {
         project.withModule(RustModule.public("model")) {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, this)
             UnionGenerator(model, symbolProvider, this, model.lookup("test#Choice"), renderUnknownVariant = generateUnknownVariant).render()
-            val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(model, symbolProvider, this, enum, enum.expectTrait()).render()
+            val enum = model.lookup<EnumShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, this, enum).render()
         }
 
         project.withModule(RustModule.public("input")) {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/Ec2QuerySerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/Ec2QuerySerializerGeneratorTest.kt
@@ -6,8 +6,8 @@
 package software.amazon.smithy.rust.codegen.core.smithy.protocols.serialize
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
@@ -21,7 +21,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.lookup
 
@@ -128,8 +127,8 @@ class Ec2QuerySerializerGeneratorTest {
         project.withModule(RustModule.public("model")) {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, this)
             UnionGenerator(model, symbolProvider, this, model.lookup("test#Choice")).render()
-            val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(model, symbolProvider, this, enum, enum.expectTrait()).render()
+            val enum = model.lookup<EnumShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, this, enum).render()
         }
 
         project.withModule(RustModule.public("input")) {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGeneratorTest.kt
@@ -6,8 +6,8 @@
 package software.amazon.smithy.rust.codegen.core.smithy.protocols.serialize
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
@@ -24,7 +24,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.lookup
 
@@ -144,8 +143,8 @@ class JsonSerializerGeneratorTest {
         project.withModule(RustModule.public("model")) {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, this)
             UnionGenerator(model, symbolProvider, this, model.lookup("test#Choice")).render()
-            val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(model, symbolProvider, this, enum, enum.expectTrait()).render()
+            val enum = model.lookup<EnumShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, this, enum).render()
         }
 
         project.withModule(RustModule.public("input")) {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
@@ -6,8 +6,8 @@
 package software.amazon.smithy.rust.codegen.core.smithy.protocols.serialize
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
@@ -23,7 +23,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.lookup
 
@@ -147,8 +146,8 @@ internal class XmlBindingTraitSerializerGeneratorTest {
         project.withModule(RustModule.public("model")) {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, this)
             UnionGenerator(model, symbolProvider, this, model.lookup("test#Choice")).render()
-            val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(model, symbolProvider, this, enum, enum.expectTrait()).render()
+            val enum = model.lookup<EnumShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, this, enum).render()
         }
 
         project.withModule(RustModule.public("input")) {

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -12,10 +12,8 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.ServiceShape
-import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
@@ -126,14 +124,8 @@ class PythonServerCodegenVisitor(
     }
 
     /**
-     * String Shape Visitor
-     *
-     * Although raw strings require no code generation, enums are actually [EnumTrait] applied to string shapes.
+     * Enum Shape Visitor
      */
-    override fun stringShape(shape: StringShape) {
-        super.stringShape(shape)
-    }
-
     override fun enumShape(shape: EnumShape) {
         logger.info("[rust-server-codegen] Generating an enum $shape")
         rustCrate.useShapeWriter(shape) {

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.server.python.smithy.generators
 
-import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -26,7 +26,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerEnumGe
 class PythonServerEnumGenerator(
     codegenContext: ServerCodegenContext,
     private val writer: RustWriter,
-    shape: StringShape,
+    shape: EnumShape,
 ) : ServerEnumGenerator(codegenContext, writer, shape) {
 
     private val pyo3Symbols = listOf(PythonServerCargoDependency.PyO3.toType())

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/Constraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/Constraints.kt
@@ -66,7 +66,8 @@ fun Shape.isDirectlyConstrained(symbolProvider: SymbolProvider): Boolean = when 
         this.members().map { symbolProvider.toSymbol(it) }.any { !it.isOptional() }
     }
     is MapShape -> this.hasTrait<LengthTrait>()
-    is StringShape -> this is EnumShape || this.hasTrait<LengthTrait>()
+    is EnumShape -> true
+    is StringShape -> this.hasTrait<LengthTrait>()
     else -> false
 }
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -148,6 +148,8 @@ open class ServerCodegenVisitor(
      */
     protected fun baselineTransform(model: Model) =
         model
+            // Convert string shapes with an @enum trait to an enum shape
+            .let { ModelTransformer.create().changeStringEnumsToEnumShapes(model, true) }
             // Flattens mixins out of the model and removes them from the model
             .let { ModelTransformer.create().flattenAndRemoveMixins(it) }
             // Add errors attached at the service level to the models

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -354,9 +354,9 @@ open class ServerCodegenVisitor(
     }
 
     /**
-     * Enum Shape Visitor
+     * String Shape Visitor
      *
-     * Although raw strings require no code generation, enums are actually [EnumTrait] applied to string shapes.
+     * Unnamed @enum shapes are not supported. If they could not be converted to EnumShape, this will fail.
      */
     override fun stringShape(shape: StringShape) {
         if (shape.hasTrait<EnumTrait>()) {
@@ -370,6 +370,9 @@ open class ServerCodegenVisitor(
         }
     }
 
+    /**
+     * Enum Shape Visitor
+     */
     override fun enumShape(shape: EnumShape) {
         logger.info("[rust-server-codegen] Generating an enum $shape")
         rustCrate.useShapeWriter(shape) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -360,7 +360,10 @@ open class ServerCodegenVisitor(
      */
     override fun stringShape(shape: StringShape) {
         if (shape.hasTrait<EnumTrait>()) {
-            throw CodegenException("Unnamed @enum shapes are unsupported: $shape")
+            throw CodegenException(
+                "Code generation has failed because this unnamed @enum could not be converted to an enum shape: $shape." +
+                    "For more info, look above at the logs from awslabs/smithy.",
+            )
         }
         if (shape.isDirectlyConstrained(codegenContext.symbolProvider)) {
             logger.info("[rust-server-codegen] Generating a constrained string $shape")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
@@ -18,7 +18,6 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.LengthTrait
 import software.amazon.smithy.model.traits.PatternTrait
 import software.amazon.smithy.model.traits.RangeTrait
@@ -113,7 +112,6 @@ private val allConstraintTraits = setOf(
     PatternTrait::class.java,
     RangeTrait::class.java,
     UniqueItemsTrait::class.java,
-    EnumTrait::class.java,
     RequiredTrait::class.java,
 )
 private val unsupportedConstraintsOnMemberShapes = allConstraintTraits - RequiredTrait::class.java
@@ -141,20 +139,20 @@ fun validateOperationsWithConstrainedInputHaveValidationExceptionAttached(model:
             LogMessage(
                 Level.SEVERE,
                 """
-                Operation ${it.shape.id} takes in input that is constrained 
-                (https://awslabs.github.io/smithy/2.0/spec/constraint-traits.html), and as such can fail with a validation 
+                Operation ${it.shape.id} takes in input that is constrained
+                (https://awslabs.github.io/smithy/2.0/spec/constraint-traits.html), and as such can fail with a validation
                 exception. You must model this behavior in the operation shape in your model file.
                 """.trimIndent().replace("\n", "") +
                     """
-                        
-                ```smithy
-                use smithy.framework#ValidationException
-                
-                operation ${it.shape.id.name} {
-                    ...
-                    errors: [..., ValidationException] // <-- Add this.
-                }
-                ```
+
+                    ```smithy
+                    use smithy.framework#ValidationException
+
+                    operation ${it.shape.id.name} {
+                        ...
+                        errors: [..., ValidationException] // <-- Add this.
+                    }
+                    ```
                     """.trimIndent(),
             )
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedTraitForEnumGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedTraitForEnumGenerator.kt
@@ -6,14 +6,13 @@
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.StringShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.makeMaybeConstrained
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 
 /**
  * [ConstrainedTraitForEnumGenerator] generates code that implements the [RuntimeType.ConstrainedTrait] trait on an
@@ -26,7 +25,7 @@ class ConstrainedTraitForEnumGenerator(
     val shape: StringShape,
 ) {
     fun render() {
-        shape.expectTrait<EnumTrait>()
+        check(shape is EnumShape)
 
         val symbol = symbolProvider.toSymbol(shape)
         val name = symbol.name
@@ -37,7 +36,7 @@ class ConstrainedTraitForEnumGenerator(
             impl #{ConstrainedTrait} for $name  {
                 type Unconstrained = $unconstrainedType;
             }
-            
+
             impl From<$unconstrainedType> for #{MaybeConstrained} {
                 fn from(value: $unconstrainedType) -> Self {
                     Self::Unconstrained(value)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorWithoutPublicConstrainedTypes.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorWithoutPublicConstrainedTypes.kt
@@ -138,10 +138,10 @@ class ServerBuilderGeneratorWithoutPublicConstrainedTypes(
             """,
             "ReturnType" to buildFnReturnType(isBuilderFallible, structureSymbol),
         )
-        renderBuildEnforcingRequiredAndEnumTraitsFn(implBlockWriter)
+        renderBuildEnforcingRequiredTraitAndEnumValuesFn(implBlockWriter)
     }
 
-    private fun renderBuildEnforcingRequiredAndEnumTraitsFn(implBlockWriter: RustWriter) {
+    private fun renderBuildEnforcingRequiredTraitAndEnumValuesFn(implBlockWriter: RustWriter) {
         implBlockWriter.rustBlockTemplate(
             "fn build_enforcing_required_and_enum_traits(self) -> #{ReturnType:W}",
             "ReturnType" to buildFnReturnType(isBuilderFallible, structureSymbol),
@@ -208,7 +208,7 @@ class ServerBuilderGeneratorWithoutPublicConstrainedTypes(
             """
             impl #{TryFrom}<Builder> for #{Structure} {
                 type Error = ConstraintViolation;
-                
+
                 fn try_from(builder: Builder) -> Result<Self, Self::Error> {
                     builder.build()
                 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerEnumGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerEnumGenerator.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
-import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
@@ -14,7 +14,6 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
 import software.amazon.smithy.rust.codegen.core.util.dq
-import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.server.smithy.PubCrateConstraintViolationSymbolProvider
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.traits.isReachableFromOperationInput
@@ -22,8 +21,8 @@ import software.amazon.smithy.rust.codegen.server.smithy.traits.isReachableFromO
 open class ServerEnumGenerator(
     val codegenContext: ServerCodegenContext,
     private val writer: RustWriter,
-    shape: StringShape,
-) : EnumGenerator(codegenContext.model, codegenContext.symbolProvider, writer, shape, shape.expectTrait()) {
+    shape: EnumShape,
+) : EnumGenerator(codegenContext.model, codegenContext.symbolProvider, writer, shape) {
     override var target: CodegenTarget = CodegenTarget.SERVER
 
     private val publicConstrainedTypes = codegenContext.settings.codegenConfig.publicConstrainedTypes
@@ -54,7 +53,7 @@ open class ServerEnumGenerator(
             )
 
             if (shape.isReachableFromOperationInput()) {
-                val enumValueSet = enumTrait.enumDefinitionValues.joinToString(", ")
+                val enumValueSet = sortedMembers.joinToString(", ") { it.value }
                 val message = "Value {} at '{}' failed to satisfy constraint: Member must satisfy enum value set: [$enumValueSet]"
 
                 rustTemplate(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedUnionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedUnionGenerator.kt
@@ -5,10 +5,10 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
@@ -97,7 +97,7 @@ class UnconstrainedUnionGenerator(
                 """
                 impl #{TryFrom}<$name> for #{ConstrainedSymbol} {
                     type Error = #{ConstraintViolationSymbol};
-                
+
                     fn try_from(value: $name) -> Result<Self, Self::Error> {
                         #{body:W}
                     }
@@ -115,7 +115,7 @@ class UnconstrainedUnionGenerator(
             impl #{ConstrainedTrait} for #{ConstrainedSymbol}  {
                 type Unconstrained = #{UnconstrainedSymbol};
             }
-            
+
             impl From<#{UnconstrainedSymbol}> for #{MaybeConstrained} {
                 fn from(value: #{UnconstrainedSymbol}) -> Self {
                     Self::Unconstrained(value)
@@ -201,7 +201,7 @@ class UnconstrainedUnionGenerator(
                         } else {
                             val targetShape = model.expectShape(member.target)
                             val resolveToNonPublicConstrainedType =
-                                targetShape !is StructureShape && targetShape !is UnionShape && !targetShape.hasTrait<EnumTrait>() &&
+                                targetShape !is StructureShape && targetShape !is UnionShape && targetShape !is EnumShape &&
                                     (!publicConstrainedTypes || !targetShape.isDirectlyConstrained(symbolProvider))
 
                             val (unconstrainedVar, boxIt) = if (member.hasTrait<RustBoxTrait>()) {

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerEnumGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerEnumGeneratorTest.kt
@@ -7,7 +7,7 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.Test
-import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
@@ -36,7 +36,7 @@ class ServerEnumGeneratorTest {
 
     private val codegenContext = serverTestCodegenContext(model)
     private val writer = RustWriter.forModule("model")
-    private val shape = model.lookup<StringShape>("test#InstanceType")
+    private val shape = model.lookup<EnumShape>("test#InstanceType")
 
     @Test
     fun `it generates TryFrom, FromStr and errors for enums`() {


### PR DESCRIPTION
Deprecate EnumTrait and migrate to EnumShape.

Closes #1671



## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
