### PR TITLE
Use a `&'static str` instead of `String` in `AwsJsonRouter`

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/proto/aws_json/router.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/aws_json/router.rs
@@ -47,7 +47,7 @@ const ROUTE_CUTOFF: usize = 15;
 /// [AWS JSON 1.1]: https://awslabs.github.io/smithy/2.0/aws/protocols/aws-json-1_1-protocol.html
 #[derive(Debug, Clone)]
 pub struct AwsJsonRouter<S> {
-    routes: TinyMap<String, S, ROUTE_CUTOFF>,
+    routes: TinyMap<&'static str, S, ROUTE_CUTOFF>,
 }
 
 impl<S> AwsJsonRouter<S> {
@@ -106,9 +106,9 @@ where
     }
 }
 
-impl<S> FromIterator<(String, S)> for AwsJsonRouter<S> {
+impl<S> FromIterator<(&'static str, S)> for AwsJsonRouter<S> {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = (String, S)>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = (&'static str, S)>>(iter: T) -> Self {
         Self {
             routes: iter
                 .into_iter()
@@ -128,11 +128,9 @@ mod tests {
 
     #[tokio::test]
     async fn simple_routing() {
-        let routes = vec![("Service.Operation")];
-        let router: AwsJsonRouter<_> = routes
-            .clone()
+        let router: AwsJsonRouter<_> = vec![("Service.Operation")]
             .into_iter()
-            .map(|operation| (operation.to_string(), ()))
+            .map(|operation| (operation, ()))
             .collect();
 
         let mut headers = HeaderMap::new();


### PR DESCRIPTION
## Description
I noticed they key for the routes map could be a `&'static str` so I made this change to save some allocations.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
