### PR TITLE
Provide a reason for not acceptable server request rejections

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -182,9 +182,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
             httpBindingResolver.responseContentType(operationShape)?.also { contentType ->
                 rustTemplate(
                     """
-                    if !#{SmithyHttpServer}::protocols::accept_header_classifier(request.headers(), ${contentType.dq()}) {
-                        return Err(#{RequestRejection}::NotAcceptable);
-                    }
+                    #{SmithyHttpServer}::protocols::accept_header_classifier(request.headers(), ${contentType.dq()})?;
                     """,
                     *codegenScope,
                 )

--- a/rust-runtime/aws-smithy-http-server/src/proto/aws_json/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/aws_json/rejection.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::rejection::MissingContentTypeReason;
+use crate::rejection::{MissingContentTypeReason, NotAcceptableReason};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,8 +18,8 @@ pub enum ResponseRejection {
 pub enum RequestRejection {
     #[error("error converting non-streaming body to bytes: {0}")]
     BufferHttpBodyBytes(crate::Error),
-    #[error("request contains invalid value for `Accept` header")]
-    NotAcceptable,
+    #[error("request is not acceptable: {0}")]
+    NotAcceptable(#[from] NotAcceptableReason),
     #[error("expected `Content-Type` header not found: {0}")]
     MissingContentType(#[from] MissingContentTypeReason),
     #[error("error deserializing request HTTP body as JSON: {0}")]

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/rejection.rs
@@ -47,7 +47,7 @@
 //!
 //! Consult `crate::proto::$protocolName::rejection` for rejection types for other protocols.
 
-use crate::rejection::MissingContentTypeReason;
+use crate::rejection::{MissingContentTypeReason, NotAcceptableReason};
 use std::num::TryFromIntError;
 use thiserror::Error;
 
@@ -109,10 +109,10 @@ pub enum RequestRejection {
     #[error("error converting non-streaming body to bytes: {0}")]
     BufferHttpBodyBytes(crate::Error),
 
-    /// Used when the request contained an `Accept` header with a MIME type, and the server cannot
-    /// return a response body adhering to that MIME type.
-    #[error("request contains invalid value for `Accept` header")]
-    NotAcceptable,
+    /// Used when the request contained `Accept` headers with certain MIME types, and the server cannot
+    /// return a response body adhering to _any_ of those MIME types.
+    #[error("request is not acceptable: {0}")]
+    NotAcceptable(#[from] NotAcceptableReason),
 
     /// Used when checking the `Content-Type` header.
     #[error("expected `Content-Type` header not found: {0}")]

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/runtime_error.rs
@@ -115,7 +115,7 @@ impl From<RequestRejection> for RuntimeError {
         match err {
             RequestRejection::MissingContentType(_reason) => Self::UnsupportedMediaType,
             RequestRejection::ConstraintViolation(reason) => Self::Validation(reason),
-            RequestRejection::NotAcceptable => Self::NotAcceptable,
+            RequestRejection::NotAcceptable(_reason) => Self::NotAcceptable,
             _ => Self::Serialization(crate::Error::new(err)),
         }
     }

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/rejection.rs
@@ -7,7 +7,7 @@
 //! [`crate::proto::rest_json_1::rejection::RequestRejection::JsonDeserialize`] is swapped for
 //! [`RequestRejection::XmlDeserialize`].
 
-use crate::rejection::MissingContentTypeReason;
+use crate::rejection::{MissingContentTypeReason, NotAcceptableReason};
 use std::num::TryFromIntError;
 use thiserror::Error;
 
@@ -28,8 +28,8 @@ pub enum RequestRejection {
     #[error("error converting non-streaming body to bytes: {0}")]
     BufferHttpBodyBytes(crate::Error),
 
-    #[error("request contains invalid value for `Accept` header")]
-    NotAcceptable,
+    #[error("request is not acceptable: {0}")]
+    NotAcceptable(#[from] NotAcceptableReason),
 
     #[error("expected `Content-Type` header not found: {0}")]
     MissingContentType(#[from] MissingContentTypeReason),

--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::response::IntoResponse;
+use http::HeaderValue;
 use thiserror::Error;
 
 // This is used across different protocol-specific `rejection` modules.
@@ -22,6 +23,13 @@ pub enum MissingContentTypeReason {
         expected_mime: Option<mime::Mime>,
         found_mime: Option<mime::Mime>,
     },
+}
+
+// This is used across different protocol-specific `rejection` modules.
+#[derive(Debug, Error)]
+pub enum NotAcceptableReason {
+    #[error("cannot satisfy any of `Accept` header values: {0:?}")]
+    CannotSatisfyAcceptHeaders(Vec<HeaderValue>),
 }
 
 pub mod any_rejections {


### PR DESCRIPTION
This commit makes it so that when an incoming request's `Accept` header
value set cannot be satisfied by the server, the unsatisfiable value set
is stored in the `RequestRejection`. The rejection reason will thus be
`DEBUG`-logged.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
