### PR TITLE
Operations on scopes

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![feature(generic_const_exprs)]
 
 //! HTTP server runtime and utilities, loosely based on [axum].
 //!

--- a/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
@@ -7,41 +7,71 @@ use std::marker::PhantomData;
 
 use super::Plugin;
 
-/// Marker struct for `true`.
-///
-/// Implements [`ConditionalApply`] which applies the [`Plugin`].
-pub struct True;
-
-/// Marker struct for `false`.
-///
-/// Implements [`ConditionalApply`] which does nothing.
-pub struct False;
+pub struct Boolean<const VALUE: bool>;
 
 /// Conditionally applies a [`Plugin`] `Pl` to some service `S`.
 ///
-/// See [`True`] and [`False`].
+/// See [`Boolean<true>`] and [`Boolean<false>`].
 pub trait ConditionalApply<Ser, Op, Pl, T> {
-    type Service;
+    type Output;
 
-    fn apply(plugin: &Pl, svc: T) -> Self::Service;
+    fn apply(plugin: &Pl, input: T) -> Self::Output;
 }
 
-impl<Ser, Op, Pl, T> ConditionalApply<Ser, Op, Pl, T> for True
+impl<Ser, Op, Pl, T> ConditionalApply<Ser, Op, Pl, T> for Boolean<true>
 where
     Pl: Plugin<Ser, Op, T>,
 {
-    type Service = Pl::Output;
+    type Output = Pl::Output;
 
-    fn apply(plugin: &Pl, input: T) -> Self::Service {
+    fn apply(plugin: &Pl, input: T) -> Self::Output {
         plugin.apply(input)
     }
 }
 
-impl<P, Op, Pl, T> ConditionalApply<P, Op, Pl, T> for False {
-    type Service = T;
+impl<P, Op, Pl, T> ConditionalApply<P, Op, Pl, T> for Boolean<false> {
+    type Output = T;
 
-    fn apply(_plugin: &Pl, input: T) -> Self::Service {
+    fn apply(_plugin: &Pl, input: T) -> Self::Output {
         input
+    }
+}
+
+/// Implements a NAND gate.
+const fn nand(a: bool, b: bool) -> bool {
+    !(a && b)
+}
+
+/// Holds a constant boolean value.
+/// It is used to resolve an expression after applying [`nand`].
+trait BooleanExpr {
+    const RESOLVED: bool;
+}
+
+impl<const VALUE: bool> BooleanExpr for Boolean<VALUE> {
+    const RESOLVED: bool = VALUE;
+}
+
+impl<B1, B2> BooleanExpr for NAnd<B1, B2>
+where
+    B1: BooleanExpr,
+    B2: BooleanExpr,
+{
+    const RESOLVED: bool = nand(B1::RESOLVED, B2::RESOLVED);
+}
+
+pub struct NAnd<Boolean1, Boolean2>(pub Boolean1, pub Boolean2);
+
+impl<Ser, Op, Pl, T, B1, B2> ConditionalApply<Ser, Op, Pl, T> for NAnd<B1, B2>
+where
+    B1: BooleanExpr,
+    B2: BooleanExpr,
+    Boolean<{ NAnd::<B1, B2>::RESOLVED }>: ConditionalApply<Ser, Op, Pl, T>,
+{
+    type Output = <Boolean<{ NAnd::<B1, B2>::RESOLVED }> as ConditionalApply<Ser, Op, Pl, T>>::Output;
+
+    fn apply(plugin: &Pl, input: T) -> Self::Output {
+        <Boolean<{ NAnd::<B1, B2>::RESOLVED }> as ConditionalApply<Ser, Op, Pl, T>>::apply(plugin, input)
     }
 }
 
@@ -95,7 +125,7 @@ where
     Scope: Membership<Op>,
     Scope::Contains: ConditionalApply<Ser, Op, Pl, T>,
 {
-    type Output = <Scope::Contains as ConditionalApply<Ser, Op, Pl, T>>::Service;
+    type Output = <Scope::Contains as ConditionalApply<Ser, Op, Pl, T>>::Output;
 
     fn apply(&self, input: T) -> Self::Output {
         <Scope::Contains as ConditionalApply<Ser, Op, Pl, T>>::apply(&self.plugin, input)
@@ -138,12 +168,12 @@ macro_rules! scope {
 
         $(
             impl $crate::plugin::scoped::Membership<$include> for $name {
-                type Contains = $crate::plugin::scoped::True;
+                type Contains = $crate::plugin::scoped::Boolean<true>;
             }
         )*
         $(
             impl $crate::plugin::scoped::Membership<$exclude> for $name {
-                type Contains = $crate::plugin::scoped::False;
+                type Contains = $crate::plugin::scoped::Boolean<false>;
             }
         )*
     };
@@ -153,16 +183,33 @@ macro_rules! scope {
 mod tests {
     use crate::plugin::Plugin;
 
-    use super::Scoped;
+    use super::*;
 
     struct OperationA;
     struct OperationB;
+    struct OperationC;
 
     scope! {
-        /// Includes A, not B.
-        pub struct AuthScope {
+        /// Includes A and B, not C.
+        pub struct OnlyAB {
+            includes: [OperationA, OperationB],
+            excludes: [OperationC]
+        }
+    }
+
+    scope! {
+        // Includes only A.
+        pub struct OnlyA {
             includes: [OperationA],
-            excludes: [OperationB]
+            excludes: [OperationB, OperationC]
+        }
+    }
+
+    scope! {
+        // Includes only A.
+        pub struct OnlyC {
+            includes: [OperationC],
+            excludes: [OperationA, OperationB]
         }
     }
 
@@ -171,19 +218,112 @@ mod tests {
     impl<P, Op> Plugin<P, Op, u32> for MockPlugin {
         type Output = String;
 
-        fn apply(&self, svc: u32) -> Self::Output {
-            svc.to_string()
+        fn apply(&self, input: u32) -> Self::Output {
+            input.to_string()
         }
     }
 
     #[test]
     fn scope() {
         let plugin = MockPlugin;
-        let scoped_plugin = Scoped::new::<AuthScope>(plugin);
+        let scoped_plugin = Scoped::new::<OnlyAB>(plugin);
+
+        let out: String = Plugin::<(), OperationA, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+        let out: String = Plugin::<(), OperationB, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+        let out: u32 = Plugin::<(), OperationC, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, 3);
+    }
+
+    #[test]
+    fn combinator() {
+        let plugin = MockPlugin;
+
+        type NewScope = Intersection<OnlyAB, OnlyA>;
+        type NewScope2 = Union<NewScope, OnlyC>;
+        type NewScope3 = Complement<NewScope2>;
+        type NewScope4 = Complement<NewScope3>;
+        let scoped_plugin = Scoped::new::<NewScope4>(plugin);
 
         let out: String = Plugin::<(), OperationA, _>::apply(&scoped_plugin, 3_u32);
         assert_eq!(out, "3".to_string());
         let out: u32 = Plugin::<(), OperationB, _>::apply(&scoped_plugin, 3_u32);
         assert_eq!(out, 3);
+        let out: String = Plugin::<(), OperationC, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
     }
+
+    #[test]
+    fn intersection() {
+        let plugin = MockPlugin;
+
+        let scoped_plugin = Scoped::new::<Intersection<OnlyAB, OnlyA>>(plugin);
+
+        let out: String = Plugin::<(), OperationA, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+        let out: u32 = Plugin::<(), OperationB, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, 3);
+        let out: u32 = Plugin::<(), OperationC, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, 3);
+    }
+
+    #[test]
+    fn union() {
+        let plugin = MockPlugin;
+
+        let scoped_plugin = Scoped::new::<Union<OnlyAB, OnlyC>>(plugin);
+
+        let out: String = Plugin::<(), OperationA, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+        let out: String = Plugin::<(), OperationB, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+        let out: String = Plugin::<(), OperationC, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+    }
+
+    #[test]
+    fn complement() {
+        let plugin = MockPlugin;
+
+        let scoped_plugin = Scoped::new::<Complement<OnlyAB>>(plugin);
+
+        let out: u32 = Plugin::<(), OperationA, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, 3);
+        let out: u32 = Plugin::<(), OperationB, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, 3);
+        let out: String = Plugin::<(), OperationC, _>::apply(&scoped_plugin, 3_u32);
+        assert_eq!(out, "3".to_string());
+    }
+}
+
+struct Complement<Scope>(Scope);
+
+impl<Op, Scope> Membership<Op> for Complement<Scope>
+where
+    Scope: Membership<Op>,
+{
+    type Contains = NAnd<Scope::Contains, Scope::Contains>;
+}
+
+pub struct Intersection<ScopeA, ScopeB>(ScopeA, ScopeB);
+
+impl<Op, ScopeA, ScopeB> Membership<Op> for Intersection<ScopeA, ScopeB>
+where
+    ScopeA: Membership<Op>,
+    ScopeB: Membership<Op>,
+{
+    // ScopeA & ScopeB
+    type Contains = NAnd<NAnd<ScopeA::Contains, ScopeB::Contains>, NAnd<ScopeA::Contains, ScopeB::Contains>>;
+}
+
+pub struct Union<ScopeA, ScopeB>(ScopeA, ScopeB);
+
+impl<Op, ScopeA, ScopeB> Membership<Op> for Union<ScopeA, ScopeB>
+where
+    ScopeA: Membership<Op>,
+    ScopeB: Membership<Op>,
+{
+    // ScopeA | ScopeB
+    type Contains = NAnd<NAnd<ScopeA::Contains, ScopeA::Contains>, NAnd<ScopeB::Contains, ScopeB::Contains>>;
 }


### PR DESCRIPTION

## Description
Customers can create unions, complements and intersections of scopes at compile time.

This change requires a nightly feature. Because of this, the PR is marked as a draft. Is there a way to implement this without [`generic_const_exprs`](https://github.com/rust-lang/rust/issues/76560)?

## Testing
Unit tests.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
