### PR TITLE
ban mio dependency so we don't accidentally break WASM users

### DIFF
--- a/.cargo-deny-config.toml
+++ b/.cargo-deny-config.toml
@@ -59,8 +59,13 @@ highlight = "all"
 deny = [
     # We don't have any reason to bring mio in right now, and it isn't compatible with WASM.
     # We should avoid unintentionally bringing it in through tokio.
-    { name = "mio" }
+    { name = "mio" },
 ]
+
+[[bans.features]]
+name = "tokio"
+# These features aren't WASM-compatible so we should avoid bringing them in without a clear need.
+deny = ["process", "net", "full", "signal"]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/.cargo-deny-config.toml
+++ b/.cargo-deny-config.toml
@@ -56,7 +56,11 @@ license-files = [
 multiple-versions = "allow"
 wildcards = "deny" # Don't allow wildcard dependencies
 highlight = "all"
-deny = []
+deny = [
+    # We don't have any reason to bring mio in right now, and it isn't compatible with WASM.
+    # We should avoid unintentionally bringing it in through tokio.
+    { name = "mio" }
+]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -52,7 +52,7 @@ futures-util = { version = "0.3.16", default-features = false }
 tracing-test = "0.2.1"
 tracing-subscriber = { version = "0.3.16", features = ["fmt", "json"] }
 
-tokio = { version = "1.23.1", features = ["test-util", "macros"] }
+tokio = { version = "1.23.1", features = ["test-util", "macros", "rt-multi-thread"] }
 
 # used for fuzzing profile parsing
 arbitrary = "1.3"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -52,7 +52,7 @@ futures-util = { version = "0.3.16", default-features = false }
 tracing-test = "0.2.1"
 tracing-subscriber = { version = "0.3.16", features = ["fmt", "json"] }
 
-tokio = { version = "1.23.1", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["test-util", "macros"] }
 
 # used for fuzzing profile parsing
 arbitrary = "1.3"

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -20,17 +20,11 @@ tracing = "0.1"
 zeroize = "1"
 
 [dev-dependencies]
+async-trait = "0.1.68"
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["rt-tokio", "test-util"] }
-
-# used to test compatibility
-async-trait = "0.1.51"
 env_logger = "0.9.0"
-
-tokio = { version = "1.23.1", features = ["full", "test-util", "rt"] }
+tokio = { version = "1.23.1", features = ["test-util", "rt", "rt-multi-thread", "macros"] }
 tracing-test = "0.2.4"
-# TODO(https://github.com/awslabs/smithy-rs/issues/2619): Remove this
-# workaround once the fixed is upstreamed.
-regex = { version = "1.0", features = ["unicode-case", "unicode-perl"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -21,7 +21,7 @@ percent-encoding = "2.1.0"
 pin-project-lite = "0.2.9"
 
 [dev-dependencies]
-async-trait = "0.1.50"
+async-trait = "0.1.68"
 aws-credential-types = { path = "../aws-credential-types", features = ["test-util"] }
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["rt-tokio"] }
 aws-smithy-checksums = { path = "../../../rust-runtime/aws-smithy-checksums" }

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -11,6 +11,9 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/awslabs/smithy-rs"
 
+[features]
+rt-tokio = ["aws-smithy-async/rt-tokio", "tokio/rt"]
+
 [dependencies]
 aws-credential-types = { path = "../aws-credential-types" }
 aws-endpoint = { path = "../aws-endpoint" }
@@ -34,7 +37,7 @@ http = "0.2.9"
 http-body = "0.4.5"
 md-5 = "0.10.1"
 ring = "0.16"
-tokio = { version = "1.23.1", features = ["full"] }
+tokio = { version = "1.23.1" }
 tokio-stream = "0.1.5"
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"
@@ -47,6 +50,7 @@ aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api"
 tempfile = "3.6.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["test-util"] }
+tokio = { version = "1.23.1", features = ["rt", "macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aws/sdk/integration-tests/no-default-features/Cargo.toml
+++ b/aws/sdk/integration-tests/no-default-features/Cargo.toml
@@ -19,5 +19,5 @@ aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", default-features = false }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async" }
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 futures = "0.3.25"
-tokio = { version = "1.23.1", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -47,7 +47,7 @@ aws-smithy-async = { path = "../aws-smithy-async", features = ["rt-tokio"] }
 hyper-tls = { version = "0.5.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1.23.1", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["macros", "test-util"] }
 tower-test = "0.4.0"
 tracing-subscriber = "0.3.16"
 tracing-test = "0.2.4"

--- a/tools/ci-build/publisher/Cargo.toml
+++ b/tools/ci-build/publisher/Cargo.toml
@@ -15,27 +15,27 @@ opt-level = 0
 
 [dependencies]
 anyhow = "1.0"
-async-recursion = "0.3.2"
-async-trait = "0.1.51"
-cargo_toml = "0.10.1"
-clap = { version = "~3.1.18", features = ["derive"] }
-crates_io_api = "0.7.3"
+async-recursion = "0.3"
+async-trait = "0.1"
+cargo_toml = "0.10"
+clap = { version = "~3.1", features = ["derive"] }
+crates_io_api = "0.7"
 dialoguer = "0.8"
 fs-err = "2"
 handlebars = "4.2"
 lazy_static = "1"
-regex = "1.5.4"
+regex = "1.5"
 semver = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha256 = "1"
 smithy-rs-tool-common = { version = "0.1", path = "../smithy-rs-tool-common", features = ["async-shell"] }
-tempfile = "3.3.0"
-thiserror = "1.0"
-tokio = { version = "1.20.1", features = ["full"] }
-toml = { version = "0.5.8", features = ["preserve_order"] }
-tracing = "0.1.29"
-tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
+tempfile = "3.3"
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+toml = { version = "0.5", features = ["preserve_order"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3"

--- a/tools/ci-cdk/canary-runner/Cargo.toml
+++ b/tools/ci-cdk/canary-runner/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-async-trait = "0.1.56"
+async-trait = "0.1.68"
 aws-config = "0.55.3"
 aws-sdk-cloudwatch = "0.28.0"
 aws-sdk-lambda = "0.28.0"


### PR DESCRIPTION
When we bring in `mio`, it breaks WASM users. We don't currently have a need for `mio` so I've added a ban so that we don't accidentally bring it in.

This change also
- synchronizes the versions of `async-trait` we're using so that we don't bring in two versions of `syn`.
- fixes up the dep versions for the publisher so they can be less outdated.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
