### PR TITLE
Update Pokémon Service to use Smithy IDL v2 (#2523)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@
 # BlueJ files
 *.ctxt
 
-# IntelliJ module file
-*.iml
-
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # BlueJ files
 *.ctxt
 
+# IntelliJ module file
+*.iml
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2"
 
 namespace com.aws.example
 
@@ -158,7 +158,7 @@ operation StreamPokemonRadio {
 @output
 structure StreamPokemonRadioOutput {
     @httpPayload
-    data: StreamingBlob
+    data: StreamingBlob = ""
 }
 
 @streaming

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,11 +26,10 @@ installation of Rust, including `cargo`, to compile the generated code.
 (Optional) The [Cargo Lambda](https://cargo-lambda.info/) sub-command for
 `cargo` is required to support the AWS Lambda integration.
 
-
 ## Building
 
 Since these examples require both the server and client SDK to be code-generated
-from their [model](/codegen-server-test/model/pokemon.smithy), a Makefile is
+from their [model](/codegen-core/common-test-models/pokemon.smithy), a Makefile is
 provided to build and run the service. Just run `make` to prepare the first
 build.
 


### PR DESCRIPTION
## Motivation and Context
Smithy IDL v2 has been released. The example Pokemon Service model should be updated to use v2.

[Open issue 2523](https://github.com/awslabs/smithy-rs/issues/2523).

## Description
Made appropriate changes to pokemon.smithy following the [Smithy IDL v1 -> v2 migration guide](https://smithy.io/2.0/guides/migrating-idl-1-to-2.html).

The `StreamingBlob` was not marked as `@required` so I made it optional in the `StreamPokemonRadioOutput`.

**Additional Changes:**
* Fix model link in Pokemon example make file.
* Add `*.iml` files to `.gitignore`.

## Testing
Manual test by running the example Pokemon Service

## Checklist
N/A

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
