### PR TITLE
Return impl AsyncBufRead from into_async_read

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -17,6 +17,12 @@ references = ["smithy-rs#3126", "aws-sdk-rust#930"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "rcoh"
 
+[[aws-sdk-rust]]
+message = "Change `ByteStream::into_async_read` to return `AsyncBufRead`"
+references = ["smithy-rs#3164"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "utkarshgupta137"
+
 [[smithy-rs]]
 message = "The HTTP `Request`, `Response`, `Headers`, and `HeaderValue` types have been moved from `aws_smithy_runtime_api::client::http::*` into `aws_smithy_runtime_api::http`"
 references = ["smithy-rs#3138"]

--- a/rust-runtime/aws-smithy-types/external-types.toml
+++ b/rust-runtime/aws-smithy-types/external-types.toml
@@ -7,7 +7,7 @@ allowed_external_types = [
     "hyper::body::body::Body",
 
     # TODO(https://github.com/awslabs/smithy-rs/issues/2412): Support cargo-features for cargo-check-external-types
-    "tokio::io::async_read::AsyncBufRead",
+    "tokio::io::async_buf_read::AsyncBufRead",
 
     # TODO(https://github.com/awslabs/smithy-rs/issues/2412): Support cargo-features for cargo-check-external-types
     "tokio::fs::file::File",

--- a/rust-runtime/aws-smithy-types/external-types.toml
+++ b/rust-runtime/aws-smithy-types/external-types.toml
@@ -7,7 +7,7 @@ allowed_external_types = [
     "hyper::body::body::Body",
 
     # TODO(https://github.com/awslabs/smithy-rs/issues/2412): Support cargo-features for cargo-check-external-types
-    "tokio::io::async_read::AsyncRead",
+    "tokio::io::async_read::AsyncBufRead",
 
     # TODO(https://github.com/awslabs/smithy-rs/issues/2412): Support cargo-features for cargo-check-external-types
     "tokio::fs::file::File",

--- a/rust-runtime/aws-smithy-types/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream.rs
@@ -204,17 +204,16 @@ pin_project! {
     ///
     ///     _Note: The `rt-tokio` feature must be active to use `.into_async_read()`._
     ///
-    ///     It's possible to convert a `ByteStream` into a struct that implements [`tokio::io::AsyncRead`](tokio::io::AsyncRead).
-    ///     Then, you can use pre-existing tools like [`tokio::io::BufReader`](tokio::io::BufReader):
+    ///     It's possible to convert a `ByteStream` into a struct that implements [`tokio::io::AsyncBufRead`](tokio::io::AsyncBufRead).
     ///     ```no_run
     ///     use aws_smithy_types::byte_stream::ByteStream;
     ///     use aws_smithy_types::body::SdkBody;
-    ///     use tokio::io::{AsyncBufReadExt, BufReader};
+    ///     use tokio::io::AsyncBufReadExt;
     ///     #[cfg(feature = "rt-tokio")]
     ///     async fn example() -> std::io::Result<()> {
     ///        let stream = ByteStream::new(SdkBody::from("hello!\nThis is some data"));
-    ///        // Wrap the stream in a BufReader
-    ///        let buf_reader = BufReader::new(stream.into_async_read());
+    ///        // Convert the stream to a BufReader
+    ///        let buf_reader = stream.into_async_read();
     ///        let mut lines = buf_reader.lines();
     ///        assert_eq!(lines.next_line().await?, Some("hello!".to_owned()));
     ///        assert_eq!(lines.next_line().await?, Some("This is some data".to_owned()));
@@ -423,23 +422,23 @@ impl ByteStream {
     }
 
     #[cfg(feature = "rt-tokio")]
-    /// Convert this `ByteStream` into a struct that implements [`AsyncRead`](tokio::io::AsyncRead).
+    /// Convert this `ByteStream` into a struct that implements [`AsyncBufRead`](tokio::io::AsyncBufRead).
     ///
     /// # Example
     ///
     /// ```rust
-    /// use tokio::io::{BufReader, AsyncBufReadExt};
+    /// use tokio::io::AsyncBufReadExt;
     /// use aws_smithy_types::byte_stream::ByteStream;
     ///
     /// # async fn dox(my_bytestream: ByteStream) -> std::io::Result<()> {
-    /// let mut lines =  BufReader::new(my_bytestream.into_async_read()).lines();
+    /// let mut lines =  my_bytestream.into_async_read().lines();
     /// while let Some(line) = lines.next_line().await? {
     ///   // Do something line by line
     /// }
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_async_read(self) -> impl tokio::io::AsyncRead {
+    pub fn into_async_read(self) -> impl tokio::io::AsyncBufRead {
         // The `Stream` trait is currently unstable so we can only use it in private.
         // Here, we create a local struct just to enable the trait for `ByteStream` and pass it
         // to `StreamReader`.


### PR DESCRIPTION
## Motivation and Context
The tokio `StreamReader` implements `AsyncBufRead`, but we're returning `AsyncRead` currently. If a user needs an `AsyncBufRead`, then they've to wrap the returned value in tokio `BufReader` for no reason. Since `ByteStream` doesn't implement `Stream` anymore, one has to either wrap the returned value unnecessarily or write a wrapper similar to this function.
See https://github.com/smithy-lang/smithy-rs/pull/2983#discussion_r1380822997.

## Description
Simply changed the return type to say `impl AsyncBufRead`. Since `AsyncBufRead` is a super-set of `AsyncRead`, this is not a breaking change.

## Testing
The code example tests it.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
