### PR TITLE
Fix compilation error in generate code caused by name collision

### DIFF
--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/NamingObstacleCourseTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/NamingObstacleCourseTest.kt
@@ -6,7 +6,10 @@
 package software.amazon.smithy.rust.codegen.client.smithy
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
+import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.testutil.NamingObstacleCourseTestModels.reusedInputOutputShapesModel
 import software.amazon.smithy.rust.codegen.core.testutil.NamingObstacleCourseTestModels.rustPreludeEnumVariantsModel
 import software.amazon.smithy.rust.codegen.core.testutil.NamingObstacleCourseTestModels.rustPreludeEnumsModel
 import software.amazon.smithy.rust.codegen.core.testutil.NamingObstacleCourseTestModels.rustPreludeOperationsModel
@@ -31,5 +34,15 @@ class NamingObstacleCourseTest {
     @Test
     fun `test Rust prelude enum variant names compile`() {
         clientIntegrationTest(rustPreludeEnumVariantsModel()) { _, _ -> }
+    }
+
+    @Test
+    fun `test reuse of input and output shapes json`() {
+        clientIntegrationTest(reusedInputOutputShapesModel(RestJson1Trait.builder().build()))
+    }
+
+    @Test
+    fun `test reuse of input and output shapes xml`() {
+        clientIntegrationTest(reusedInputOutputShapesModel(RestXmlTrait.builder().build()))
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/ProtocolFunctions.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/ProtocolFunctions.kt
@@ -18,6 +18,10 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.contextName
+import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticInputTrait
+import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticOutputTrait
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 
 /**
@@ -139,10 +143,13 @@ internal fun RustSymbolProvider.shapeModuleName(serviceShape: ServiceShape?, sha
 
 /** Creates a unique name for a ser/de function. */
 fun RustSymbolProvider.shapeFunctionName(serviceShape: ServiceShape?, shape: Shape): String {
+    val extras = "".letIf(shape.hasTrait<SyntheticOutputTrait>()) {
+        it + "_output"
+    }.letIf(shape.hasTrait<SyntheticInputTrait>()) { it + "_input" }
     val containerName = when (shape) {
         is MemberShape -> model.expectShape(shape.container).contextName(serviceShape).toSnakeCase()
         else -> shape.contextName(serviceShape).toSnakeCase()
-    }
+    } + extras
     return when (shape) {
         is MemberShape -> shape.memberName.toSnakeCase()
         is DocumentShape -> "document"


### PR DESCRIPTION
## Motivation and Context
If you had a model like this:
```smithy
   @http(uri: "/SomeOperation2", method: "GET")
            operation GetThing {
                // input: GetThingInput,
                output: GetThingOutput
            }
```

But then nested in some other API you did something like this:
```smithy
            list GetThings {
                member: GetThingOutput
            }
```

Code would fail to compile because we generated the same method signature for two different types.

## Description
<!--- Describe your changes in detail -->

## Testing
- [x] fixes minimal reproducer

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
