### PR TITLE
Remove cargo doc from all-services check to speed up CI

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-smoketest-docs-clippy-udeps
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-docs-clippy-udeps
@@ -10,7 +10,7 @@ set -eux
 pushd aws-sdk-smoketest &>/dev/null
 
 # Override "fail on warning" for smoke test docs since DynamoDB's modeled docs cause rustdoc warnings
-RUSTDOCFLAGS="" cargo doc --no-deps --document-private-items --all-features
+RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
 cargo clippy --all-features
 cargo +"${RUST_NIGHTLY_VERSION}" udeps

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -13,7 +13,6 @@ cd aws-sdk
 sed -i '/"examples\//d' Cargo.toml
 
 cargo check --all-targets --all-features
-RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then


### PR DESCRIPTION
## Motivation and Context
Running this check on all services significantly slows down CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
