### PR TITLE
Re-introduce default generic for server service struct

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -488,7 +488,16 @@ class ServerServiceGenerator(
             ///
             /// See the [root](crate) documentation for more information.
             ##[derive(Clone)]
-            pub struct $serviceName<S> {
+            pub struct $serviceName<
+                S = #{SmithyHttpServer}::routing::RoutingService<
+                    #{Router}<
+                        #{SmithyHttpServer}::routing::Route<
+                            #{SmithyHttpServer}::body::BoxBody
+                        >,
+                    >,
+                    #{Protocol},
+                >
+            > {
                 // This is the router wrapped by layers.
                 svc: S,
             }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorTest.kt
@@ -31,7 +31,7 @@ internal class ServerServiceGeneratorTest {
 
                         service.boxed()
                     }
-                    """
+                    """,
                 )
             }
         }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.testModule
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
+import java.io.File
+
+internal class ServerServiceGeneratorTest {
+    /**
+     * See <https://github.com/smithy-lang/smithy-rs/issues/3177>.
+     */
+    @Test
+    fun `one should be able to return a built service from a function`() {
+        val model = File("../codegen-core/common-test-models/simple.smithy").readText().asSmithyModel()
+
+        serverIntegrationTest(model) { _, rustCrate ->
+            rustCrate.testModule {
+                // No actual tests: we just want to check that this compiles.
+                rust(
+                    """
+                    fn _build_service() -> crate::SimpleService {
+                        let config = crate::SimpleServiceConfig::builder().build();
+                        let service = crate::SimpleService::builder(config).build_unchecked();
+
+                        service.boxed()
+                    }
+                    """
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This was accidentally removed in #3095.

Fixes #3177.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
