### PR TITLE
Enable stable & unstable versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,7 @@ jobs:
       id: branch-push
       shell: bash
       env:
-        # TODO(GA): specify ${{ inputs.stable_semantic_version }}
-        SEMANTIC_VERSION: ${{ inputs.unstable_semantic_version }}
+        SEMANTIC_VERSION: ${{ inputs.stable_semantic_version }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -e
@@ -141,8 +140,7 @@ jobs:
       working-directory: upgrade-gradle-properties/smithy-rs
       shell: bash
       env:
-        # TODO(GA): specify ${{ inputs.stable_semantic_version }}
-        SEMANTIC_VERSION: ${{ inputs.unstable_semantic_version }}
+        SEMANTIC_VERSION: ${{ inputs.stable_semantic_version }}
         RELEASE_COMMIT_SHA: ${{ inputs.commit_sha }}
         RELEASE_BRANCH_NAME: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
         DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,13 @@ jobs:
           # to retry a release action execution that failed due to a transient issue.
           # In that case, we expect the commit to be releasable as-is, i.e. the runtime crate version in gradle.properties
           # should already be the expected one.
-          git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            # During dry-runs, "git push" without "--force" can fail if smithy-rs-release-x.y.z-preview is behind
+            # smithy-rs-release-x.y.z, but that does not matter much during dry-runs.
+            git push --force origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+          else
+            git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+          fi
 
           echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
         else

--- a/tools/ci-scripts/upgrade-gradle-properties
+++ b/tools/ci-scripts/upgrade-gradle-properties
@@ -15,8 +15,7 @@ mkdir -p "${ARTIFACTS_DIR}"
 pushd "${SMITHY_RS_DIR}"
 echo "gradle.properties BEFORE the upgrade"
 cat gradle.properties
-# TODO(GA): pass ${STABLE_SEMANTIC_VERSION} to --stable-version
-publisher upgrade-runtime-crates-version --stable-version "${UNSTABLE_SEMANTIC_VERSION}" --version "${UNSTABLE_SEMANTIC_VERSION}"
+publisher upgrade-runtime-crates-version --stable-version "${STABLE_SEMANTIC_VERSION}" --version "${UNSTABLE_SEMANTIC_VERSION}"
 echo "gradle.properties AFTER the upgrade"
 cat gradle.properties
 git status


### PR DESCRIPTION
## Motivation and Context
Addresses `TODO(GA)` from https://github.com/smithy-lang/smithy-rs/pull/3082

## Description
This small PR will remove a guard so we can truly specify different versions for stable crates and unstable crates. Previously, whatever that's entered in `Stable semantic version` in the release workflow textbox (see a screenshot in the above PR) is overwritten by what's entered in `Unstable semantic version`. With this PR, whatever that's entered in `Stable semantic version` will make its way to `smithy.rs.runtime.crate.stable.version` in `gradle.properties`.

In addition, with this PR, the name of a release branch is derived from what we enter in `Stable semantic version` in the release workflow textbox.

## Testing
~~It has been tested in the above PR.~~

EDIT:
Found a bug I introduced in the above PR where `publisher` was not reading a metadata `package.metadata.smithy-rs-release-tooling` correctly in a manifest file. Fixed it in c477d2f, confirmed that a [dry-run](https://github.com/smithy-lang/smithy-rs/actions/runs/6872502257) passed, and verified the release artifact contained both stable crate versions & unstable versions as expected.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
