### PR TITLE
Add a job to release workflow that checks the current actor for prod run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,37 @@ on:
         default: true
 
 jobs:
+  check-actor-for-prod-run:
+    name: Check actor for prod run
+    if: inputs.dry_run == false
+    runs-on: ubuntu-latest
+    env:
+      ACTOR: ${{ github.actor }}
+    steps:
+    - name: Check actor for prod run
+      run: |
+        set -e
+
+        if [ "${ACTOR}" != "aws-sdk-rust-ci" ]; then
+          echo "Error: The current actor is '${ACTOR}' but only 'aws-sdk-rust-ci' is allowed to run a prod release workflow."
+          exit 1
+        fi
+
+        echo "The current actor is 'aws-sdk-rust-ci', continuing with the workflow."
+
   # We'll need to build a base image to work against if:
   # - a release was kicked off before the image build step triggered by a push to the release branch/main completed
   # - a dry-run release was kicked off against a feature branch to test automation changes
   # This job will be a no-op if an image had already been built.
   acquire-base-image:
     name: Acquire Base Image
+    needs:
+    - check-actor-for-prod-run
+    # We need `always` here otherwise this job won't run if the previous job has been skipped
+    # See https://samanpavel.medium.com/github-actions-conditional-job-execution-e6aa363d2867
+    if: |
+      always() &&
+      (needs.check-actor-for-prod-run.result == 'success' || needs.check-actor-for-prod-run.result == 'skipped')
     runs-on: smithy_ubuntu-latest_16-core
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation and Context
In our GitHub [release workflow](https://github.com/smithy-lang/smithy-rs/actions/workflows/release.yml), we require production runs to be triggered by the bot user `aws-sdk-rust-ci`, which has special permissions. There are times we have triggered a production run by our own actors and later realized it wasn't the bot user.

Although there is a way to recover from that (logging in as the bot user and rerunning the failed step), it's so much easier to add the initial check to the workflow, especially when that's cheap to add. This PR, therefore, adds a job `check-actor-for-prod-run` to the workflow.

Note that if it's a dry-run, `check-actor-for-prod-run` will be skipped and the rest of the jobs in the workflow will be executed normally. 

## Testing
Tested the following scenarios using the release workflow:
- making sure that `check-actor-for-prod-run` will be skipped in a dry-run and the dry-run should succeed ([link](https://github.com/smithy-lang/smithy-rs/actions/runs/6886643811))
- making sure that `check-actor-for-prod-run` will kick in for a prod run and let the prod run fail if run by me ([link](https://github.com/smithy-lang/smithy-rs/actions/runs/6886709963/job/18732793128))
- making sure that `check-actor-for-prod-run` will kick in for a prod run and let the prod run proceed if run by the bot user ([link](https://github.com/smithy-lang/smithy-rs/actions/runs/6886738756/job/18732857316) - I canceled the run as soon as I conformed the check worked)
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
