### PR TITLE
Fix a bug where we aren't checking the URL

### DIFF
--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -328,6 +328,23 @@ class ProtocolTestGeneratorTest {
     }
 
     @Test
+    fun `test invalid path`() {
+        val err = assertThrows<CommandError> {
+            testService(
+                """
+                .uri("/incorrect-path?required&Hi=Hello%20there")
+                .header("X-Greeting", "Hi")
+                .method("POST")
+                """,
+            )
+        }
+
+        // Verify the test actually ran
+        err.message shouldContain "say_hello_request ... FAILED"
+        err.message shouldContain "path was incorrect"
+    }
+
+    @Test
     fun `invalid header`() {
         val err = assertThrows<CommandError> {
             testService(


### PR DESCRIPTION
## Motivation and Context
In #3059 there was an accidental deletion of a test
## Description
Re-introduce checking the URL in protocol tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
