### PR TITLE
Pre-emptively update the S3 model with transform

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,9 @@ message = "The `AssumeRoleBuilder::policy_arns` now accepts strings instead of a
 references = ["smithy-rs#3205"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Fix optional types in S3. Many types in S3 were modeled as non-optional but this causes serialization issues."
+references = ["smithy-rs#3213"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/MakeS3BoolsAndNumbersOptional.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/MakeS3BoolsAndNumbersOptional.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk.customize.s3
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.AbstractShapeBuilder
+import software.amazon.smithy.model.shapes.BooleanShape
+import software.amazon.smithy.model.shapes.NumberShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.traits.DefaultTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+
+/**
+ * The s3 model is being updated but if we consume that model update, then we'll run into an issue with examples compilation
+ *
+ * This "pre-updates" the model so we can fix examples without requiring complex coordination
+ */
+class MakeS3BoolsAndNumbersOptional {
+    fun processModel(model: Model): Model {
+        val updates = arrayListOf<Shape>()
+        for (struct in model.structureShapes) {
+            for (member in struct.allMembers.values) {
+                val target = model.expectShape(member.target)
+                val boolTarget = target as? BooleanShape
+                val numberTarget = target as? NumberShape
+                if (boolTarget != null || numberTarget != null) {
+                    updates.add(member.toBuilder().removeTrait(DefaultTrait.ID).build())
+                    val builder: AbstractShapeBuilder<*, *> = Shape.shapeToBuilder(target)
+                    updates.add(builder.removeTrait(DefaultTrait.ID).build())
+                }
+            }
+        }
+        return ModelTransformer.create().replaceShapes(model, updates)
+    }
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
@@ -88,6 +88,7 @@ class S3Decorator : ClientCodegenDecorator {
             )
             // enable optional auth for operations commonly used with public buckets
             .let(AddOptionalAuth()::transform)
+            .let(MakeS3BoolsAndNumbersOptional()::processModel)
 
     override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> {
         return listOf(

--- a/aws/sdk/integration-tests/s3/tests/select-object-content.rs
+++ b/aws/sdk/integration-tests/s3/tests/select-object-content.rs
@@ -67,7 +67,9 @@ async fn test_success() {
                 let stats = stats.details.unwrap();
                 received.push(format!(
                     "scanned:{},processed:{},returned:{}",
-                    stats.bytes_scanned, stats.bytes_processed, stats.bytes_returned
+                    stats.bytes_scanned.unwrap(),
+                    stats.bytes_processed.unwrap(),
+                    stats.bytes_returned.unwrap()
                 ))
             }
             SelectObjectContentEventStream::End(_) => {}

--- a/aws/sdk/integration-tests/s3/tests/size-type.rs
+++ b/aws/sdk/integration-tests/s3/tests/size-type.rs
@@ -12,5 +12,5 @@ fn size_type() {
 
     // Should only compile if the type is correctly customized
     let object = Object::builder().size(size).build();
-    assert_eq!(size, object.size);
+    assert_eq!(Some(size), object.size);
 }


### PR DESCRIPTION
## Motivation and Context
S3 models is being updated but this creates issues with examples-compilation. This fixes that issue by pre-emptively updating the model so we can synchronize codegen and examples updates

## Testing
- [x] generated S3, verified the same compilation errors

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
