### PR TITLE
Remove `#[doc(hidden)]` from stable crates

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,15 @@ message = "The `AssumeRoleBuilder::policy_arns` now accepts strings instead of a
 references = ["smithy-rs#3205"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Types/functions that were previously `#[doc(hidden)]` in `aws-config`, `aws-inlineable`, `aws-types`, and the SDK crates are now visible. For those that are not intended to be used directly, they are called out in their docs as such."
+references = ["smithy-rs#3225"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "ysaito1001"
+
+[[smithy-rs]]
+message = "Types/functions that were previously `#[doc(hidden)]` in `aws-smithy-async`, `aws-smithy-runtime-api`, `aws-smithy-runtime`, `aws-smithy-types`, and the SDK crates are now visible. For those that are not intended to be used directly, they are called out in their docs as such."
+references = ["smithy-rs#3225"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+author = "ysaito1001"

--- a/aws/rust-runtime/aws-config/src/default_provider/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/app_name.rs
@@ -41,11 +41,10 @@ pub struct Builder {
 }
 
 impl Builder {
-    #[doc(hidden)]
     /// Configure the default chain
     ///
     /// Exposed for overriding the environment when unit-testing providers
-    pub fn configure(self, configuration: &ProviderConfig) -> Self {
+    pub(crate) fn configure(self, configuration: &ProviderConfig) -> Self {
         Self {
             provider_config: configuration.clone(),
         }

--- a/aws/rust-runtime/aws-config/src/default_provider/region.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/region.rs
@@ -45,11 +45,10 @@ pub struct Builder {
 }
 
 impl Builder {
-    #[doc(hidden)]
     /// Configure the default chain
     ///
     /// Exposed for overriding the environment when unit-testing providers
-    pub fn configure(mut self, configuration: &ProviderConfig) -> Self {
+    pub(crate) fn configure(mut self, configuration: &ProviderConfig) -> Self {
         self.env_provider = EnvironmentVariableRegionProvider::new_with_env(configuration.env());
         self.profile_file = self.profile_file.configure(configuration);
         self.imds = self.imds.configure(configuration);

--- a/aws/rust-runtime/aws-config/src/environment/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/environment/app_name.rs
@@ -21,14 +21,6 @@ impl EnvironmentVariableAppNameProvider {
         Self { env: Env::real() }
     }
 
-    #[doc(hidden)]
-    /// Create an region provider from a given `Env`
-    ///
-    /// This method is used for tests that need to override environment variables.
-    pub fn new_with_env(env: Env) -> Self {
-        Self { env }
-    }
-
     /// Attempts to create an `AppName` from the `AWS_SDK_UA_APP_ID` environment variable.
     pub fn app_name(&self) -> Option<AppName> {
         if let Ok(name) = self.env.get("AWS_SDK_UA_APP_ID") {

--- a/aws/rust-runtime/aws-config/src/environment/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/environment/credentials.rs
@@ -58,11 +58,10 @@ impl EnvironmentVariableCredentialsProvider {
         Self::new_with_env(Env::real())
     }
 
-    #[doc(hidden)]
     /// Create a new `EnvironmentVariableCredentialsProvider` with `Env` overridden
     ///
     /// This function is intended for tests that mock out the process environment.
-    pub fn new_with_env(env: Env) -> Self {
+    pub(crate) fn new_with_env(env: Env) -> Self {
         Self { env }
     }
 }

--- a/aws/rust-runtime/aws-config/src/environment/region.rs
+++ b/aws/rust-runtime/aws-config/src/environment/region.rs
@@ -22,11 +22,10 @@ impl EnvironmentVariableRegionProvider {
         EnvironmentVariableRegionProvider { env: Env::real() }
     }
 
-    #[doc(hidden)]
     /// Create an region provider from a given `Env`
     ///
     /// This method is used for tests that need to override environment variables.
-    pub fn new_with_env(env: Env) -> Self {
+    pub(crate) fn new_with_env(env: Env) -> Self {
         EnvironmentVariableRegionProvider { env }
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -237,7 +237,6 @@ impl From<ProfileParseError> for ProfileFileLoadError {
     }
 }
 
-#[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct CouldNotReadProfileFile {
     pub(crate) path: PathBuf,

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -237,6 +237,7 @@ impl From<ProfileParseError> for ProfileFileLoadError {
     }
 }
 
+/// An error encountered while reading the AWS config file
 #[derive(Debug, Clone)]
 pub struct CouldNotReadProfileFile {
     pub(crate) path: PathBuf,

--- a/aws/rust-runtime/aws-inlineable/external-types.toml
+++ b/aws/rust-runtime/aws-inlineable/external-types.toml
@@ -2,6 +2,7 @@ allowed_external_types = [
     "aws_credential_types::provider::ProvideCredentials",
     "aws_smithy_http::*",
     "aws_smithy_runtime_api::*",
+    "aws_smithy_types::error::metadata::Builder",
 
     "http::error::Error",
     "http::header::map::HeaderMap",

--- a/aws/rust-runtime/aws-inlineable/src/s3_request_id.rs
+++ b/aws/rust-runtime/aws-inlineable/src/s3_request_id.rs
@@ -70,7 +70,6 @@ where
 }
 
 /// Applies the extended request ID to a generic error builder
-#[doc(hidden)]
 pub fn apply_extended_request_id(
     builder: ErrorMetadataBuilder,
     headers: &Headers,

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -17,7 +17,6 @@
 pub mod app_name;
 pub mod build_metadata;
 pub mod endpoint_config;
-#[doc(hidden)]
 pub mod os_shim_internal;
 pub mod region;
 pub mod request_id;

--- a/aws/rust-runtime/aws-types/src/os_shim_internal.rs
+++ b/aws/rust-runtime/aws-types/src/os_shim_internal.rs
@@ -45,14 +45,17 @@ impl Default for Fs {
 }
 
 impl Fs {
+    /// Create `Fs` representing a real file system.
     pub fn real() -> Self {
         Fs(fs::Inner::Real)
     }
 
+    /// Create `Fs` from a map of `OsString` to `Vec<u8>`.
     pub fn from_raw_map(fs: HashMap<OsString, Vec<u8>>) -> Self {
         Fs(fs::Inner::Fake(Arc::new(Fake::MapFs(Mutex::new(fs)))))
     }
 
+    /// Create `Fs` from a map of `String` to `Vec<u8>`.
     pub fn from_map(data: HashMap<String, impl Into<Vec<u8>>>) -> Self {
         let fs = data
             .into_iter()
@@ -224,6 +227,7 @@ impl Default for Env {
 }
 
 impl Env {
+    /// Retrieve a value for the given `k` and return `VarError` is that key is not present.
     pub fn get(&self, k: &str) -> Result<String, VarError> {
         use env::Inner;
         match &self.0 {

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -25,9 +25,9 @@ use aws_smithy_runtime_api::shared::IntoShared;
 pub use aws_smithy_types::retry::RetryConfig;
 pub use aws_smithy_types::timeout::TimeoutConfig;
 
-#[doc(hidden)]
 /// Unified docstrings to keep crates in sync. Not intended for public use
 pub mod unified_docs {
+    /// A macro that generates docs for selected fields of `SdkConfig`.
     #[macro_export]
     macro_rules! docs_for {
         (use_fips) => {
@@ -592,7 +592,6 @@ impl SdkConfig {
         self.timeout_config.as_ref()
     }
 
-    #[doc(hidden)]
     /// Configured sleep implementation
     pub fn sleep_impl(&self) -> Option<SharedAsyncSleep> {
         self.sleep_impl.clone()

--- a/aws/sdk/sdk-external-types.toml
+++ b/aws/sdk/sdk-external-types.toml
@@ -14,6 +14,7 @@ allowed_external_types = [
     "aws_smithy_eventstream::*",
 
     "aws_smithy_runtime::client::identity::cache::IdentityCache",
+    "aws_smithy_runtime::client::retries::RetryPartition",
 
     "aws_runtime::invocation_id::SharedInvocationIdGenerator",
     "aws_runtime::invocation_id::InvocationIdGenerator",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -65,7 +65,6 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                             self.config.load::<#{TimeoutConfig}>()
                         }
 
-                        ##[doc(hidden)]
                         /// Returns a reference to the retry partition contained in this config, if any.
                         ///
                         /// WARNING: This method is unstable and may be removed at any time. Do not rely on this
@@ -248,7 +247,6 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                         *codegenScope,
                     )
 
-                    Attribute.DocHidden.render(this)
                     rustTemplate(
                         """
                         /// Set the partition for retry-related state. When clients share a retry partition, they will
@@ -262,7 +260,6 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                         *codegenScope,
                     )
 
-                    Attribute.DocHidden.render(this)
                     rustTemplate(
                         """
                         /// Set the partition for retry-related state. When clients share a retry partition, they will

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -10,7 +10,6 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.configReexport
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
-import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.protocols.ClientHttpBou
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute.Companion.derive
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.implBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.isNotEmpty
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
@@ -77,10 +78,9 @@ open class OperationGenerator(
         )
         Attribute(derive(RuntimeType.Clone, RuntimeType.Default, RuntimeType.Debug)).render(operationWriter)
         Attribute.NonExhaustive.render(operationWriter)
-        Attribute.DocHidden.render(operationWriter)
         operationWriter.rust("pub struct $operationName;")
         operationWriter.implBlock(symbolProvider.toSymbol(operationShape)) {
-            Attribute.DocHidden.render(operationWriter)
+            docs("Creates a new `$operationName`")
             rustBlock("pub fn new() -> Self") {
                 rust("Self")
             }

--- a/rust-runtime/aws-smithy-async/src/future/pagination_stream/collect.rs
+++ b/rust-runtime/aws-smithy-async/src/future/pagination_stream/collect.rs
@@ -14,7 +14,6 @@ pub(crate) mod sealed {
     ///
     /// Currently the trait may not be implemented by clients so we can make changes in the future
     /// without breaking code depending on it.
-    #[doc(hidden)]
     pub trait Collectable<T> {
         type Collection;
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -222,7 +222,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Advance to the Serialization phase.
-    #[doc(hidden)]
     pub fn enter_serialization_phase(&mut self) {
         debug!("entering \'serialization\' phase");
         debug_assert!(
@@ -233,7 +232,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Advance to the BeforeTransmit phase.
-    #[doc(hidden)]
     pub fn enter_before_transmit_phase(&mut self) {
         debug!("entering \'before transmit\' phase");
         debug_assert!(
@@ -253,7 +251,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Advance to the Transmit phase.
-    #[doc(hidden)]
     pub fn enter_transmit_phase(&mut self) {
         debug!("entering \'transmit\' phase");
         debug_assert!(
@@ -264,7 +261,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Advance to the BeforeDeserialization phase.
-    #[doc(hidden)]
     pub fn enter_before_deserialization_phase(&mut self) {
         debug!("entering \'before deserialization\' phase");
         debug_assert!(
@@ -283,7 +279,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Advance to the Deserialization phase.
-    #[doc(hidden)]
     pub fn enter_deserialization_phase(&mut self) {
         debug!("entering \'deserialization\' phase");
         debug_assert!(
@@ -294,7 +289,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Advance to the AfterDeserialization phase.
-    #[doc(hidden)]
     pub fn enter_after_deserialization_phase(&mut self) {
         debug!("entering \'after deserialization\' phase");
         debug_assert!(
@@ -309,7 +303,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Set the request checkpoint. This should only be called once, right before entering the retry loop.
-    #[doc(hidden)]
     pub fn save_checkpoint(&mut self) {
         trace!("saving request checkpoint...");
         self.request_checkpoint = self.request().and_then(|r| r.try_clone());
@@ -320,7 +313,6 @@ impl<I, O, E> InterceptorContext<I, O, E> {
     }
 
     /// Returns false if rewinding isn't possible
-    #[doc(hidden)]
     pub fn rewind(&mut self, _cfg: &mut ConfigBag) -> RewindResult {
         // If request_checkpoint was never set, but we've already made one attempt,
         // then this is not a retryable request
@@ -351,7 +343,6 @@ where
     E: Debug,
 {
     /// Decomposes the context into its constituent parts.
-    #[doc(hidden)]
     #[allow(clippy::type_complexity)]
     pub fn into_parts(
         self,
@@ -370,7 +361,6 @@ where
     }
 
     /// Convert this context into the final operation result that is returned in client's the public API.
-    #[doc(hidden)]
     pub fn finalize(self) -> Result<O, SdkError<E, HttpResponse>> {
         let Self {
             output_or_error,
@@ -399,8 +389,8 @@ where
 }
 
 /// The result of attempting to rewind a request.
+#[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[doc(hidden)]
 pub enum RewindResult {
     /// The request couldn't be rewound because it wasn't cloneable.
     Impossible,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -215,7 +215,6 @@ impl<E> OrchestratorError<E> {
     }
 
     /// Maps the error type in `ErrorKind::Operation`
-    #[doc(hidden)]
     pub fn map_operation_error<E2>(self, map: impl FnOnce(E) -> E2) -> OrchestratorError<E2> {
         let kind = match self.kind {
             ErrorKind::Connector { source } => ErrorKind::Connector { source },

--- a/rust-runtime/aws-smithy-runtime-api/src/client/result.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/result.rs
@@ -438,7 +438,6 @@ impl<E, R> SdkError<E, R> {
     }
 
     /// Maps the service error type in `SdkError::ServiceError`
-    #[doc(hidden)]
     pub fn map_service_error<E2>(self, map: impl FnOnce(E) -> E2) -> SdkError<E2, R> {
         match self {
             SdkError::ServiceError(context) => SdkError::<E2, R>::ServiceError(ServiceError {

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
@@ -228,7 +228,6 @@ macro_rules! apply_plugins {
 }
 
 /// Used internally in the orchestrator implementation and in the generated code. Not intended to be used elsewhere.
-#[doc(hidden)]
 #[derive(Default, Clone, Debug)]
 pub struct RuntimePlugins {
     client_plugins: Vec<SharedRuntimePlugin>,

--- a/rust-runtime/aws-smithy-runtime-api/src/lib.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/lib.rs
@@ -33,8 +33,7 @@ pub mod client;
 
 pub mod http;
 
-/// Internal builder macros. Not intended to be used outside of the aws-smithy-runtime crates.
-#[doc(hidden)]
+/// Builder macros. Not intended to be used outside of the aws-smithy-runtime crates.
 pub mod macros;
 
 pub mod shared;

--- a/rust-runtime/aws-smithy-runtime-api/src/macros.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/macros.rs
@@ -111,7 +111,6 @@
 ///     }
 /// }
 /// ```
-#[doc(hidden)]
 #[macro_export]
 macro_rules! builder {
     ($($tt:tt)+) => {
@@ -129,7 +128,6 @@ macro_rules! builder {
 
 /// Define a new builder struct, its fields, and their docs. This macro is intended to be called
 /// by the `builder!` macro and should not be called directly.
-#[doc(hidden)]
 #[macro_export]
 macro_rules! builder_struct {
     ($($_setter_name:ident, $field_name:ident, $ty:ty, $doc:literal $(,)?)+) => {
@@ -145,7 +143,6 @@ macro_rules! builder_struct {
 
 /// Define setter methods for a builder struct. Must be called from within an `impl` block. This
 /// macro is intended to be called by the `builder!` macro and should not be called directly.
-#[doc(hidden)]
 #[macro_export]
 macro_rules! builder_methods {
     ($fn_name:ident, $arg_name:ident, $ty:ty, $doc:literal, $($tail:tt)+) => {

--- a/rust-runtime/aws-smithy-runtime/src/client/http/test_util/wire.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/test_util/wire.rs
@@ -75,7 +75,6 @@ type Matcher = (
 );
 
 /// This method should only be used by the macro
-#[doc(hidden)]
 pub fn check_matches(events: &[RecordedEvent], matchers: &[Matcher]) {
     let mut events_iter = events.iter();
     let mut matcher_iter = matchers.iter();

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -43,7 +43,6 @@ pub mod endpoints;
 mod http;
 
 /// Utility for making one-off unmodeled requests with the orchestrator.
-#[doc(hidden)]
 pub mod operation;
 
 macro_rules! halt {

--- a/rust-runtime/aws-smithy-runtime/src/client/retries.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries.rs
@@ -18,11 +18,10 @@ use std::fmt;
 pub use client_rate_limiter::ClientRateLimiter;
 pub use token_bucket::TokenBucket;
 
-#[doc(hidden)]
 pub use client_rate_limiter::ClientRateLimiterPartition;
 use std::borrow::Cow;
 
-#[doc(hidden)]
+/// Represents the retry partition, e.g. an endpoint, a region
 #[non_exhaustive]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct RetryPartition {
@@ -30,6 +29,7 @@ pub struct RetryPartition {
 }
 
 impl RetryPartition {
+    /// Creates a new `RetryPartition` from the given `name`.
     pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
         Self { name: name.into() }
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/client_rate_limiter.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/client_rate_limiter.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::debug;
 
-#[doc(hidden)]
+/// Represents a partition for the rate limiter, e.g. an endpoint, a region
 #[non_exhaustive]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ClientRateLimiterPartition {
@@ -22,6 +22,7 @@ pub struct ClientRateLimiterPartition {
 }
 
 impl ClientRateLimiterPartition {
+    /// Creates a `ClientRateLimiterPartition` from the given [`RetryPartition`]
     pub fn new(retry_partition: RetryPartition) -> Self {
         Self { retry_partition }
     }

--- a/rust-runtime/aws-smithy-types/src/error/metadata.rs
+++ b/rust-runtime/aws-smithy-types/src/error/metadata.rs
@@ -27,7 +27,6 @@ pub trait ProvideErrorMetadata {
 }
 
 /// Empty error metadata
-#[doc(hidden)]
 pub const EMPTY_ERROR_METADATA: ErrorMetadata = ErrorMetadata {
     code: None,
     message: None,


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
