### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Smithy Rust [![CI on Branch `main`](https://github.com/smithy-lang/smithy-rs/act
 Smithy code generators for Rust that generate clients, servers, and the entire AWS SDK.
 The latest unreleased SDK build can be found in [aws-sdk-rust/next](https://github.com/awslabs/aws-sdk-rust/tree/next).
 
-[Design documentation](https://awslabs.github.io/smithy-rs/design)
+[Design documentation](https://smithy-lang.github.io/smithy-rs/design/)
 
 **All internal and external interfaces are considered unstable and subject to change without notice.**
 


### PR DESCRIPTION
## Motivation and Context
The link to the design documentation in the root-level README is broken. It produces a 404 error.

## Description
I changed the link in the README from `https://awslabs.github.io/smithy-rs/design` to `https://smithy-lang.github.io/smithy-rs/design/`

## Testing
I clicked the new link and it worked :)

## Checklist
N/A

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
