### PR TITLE
Remove defaults for more services

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -66,3 +66,9 @@ message = "Prevent multiplication overflow in backoff computation"
 references = ["smithy-rs#3229", "aws-sdk-rust#960"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Make some types for various services optional. Previously, they defaulted to 0, but this created invalid requests."
+references = ["smithy-rs#3228"]
+meta = { "breaking" = true, "tada" = false, "bug" = true }
+author = "milesziemer"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaults.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaults.kt
@@ -35,7 +35,7 @@ object RemoveDefaults {
         }
 
         return ModelTransformer.create().mapShapes(removedRootDefaultsModel) { shape ->
-            shape.letIf(shouldRemoveMemberDefault(shape, removedRootDefaults)) {
+            shape.letIf(shouldRemoveMemberDefault(shape, removedRootDefaults, removeDefaultsFrom)) {
                 logger.info("Removing default trait from member $shape")
                 removeDefault(shape)
             }
@@ -46,8 +46,15 @@ object RemoveDefaults {
         return shape !is MemberShape && removeDefaultsFrom.contains(shape.id) && shape.hasTrait<DefaultTrait>()
     }
 
-    private fun shouldRemoveMemberDefault(shape: Shape, removeDefaultsFrom: Set<ShapeId>): Boolean {
-        return shape is MemberShape && removeDefaultsFrom.contains(shape.target) && shape.hasTrait<DefaultTrait>()
+    private fun shouldRemoveMemberDefault(
+        shape: Shape,
+        removedRootDefaults: Set<ShapeId>,
+        removeDefaultsFrom: Set<ShapeId>,
+    ): Boolean {
+        return shape is MemberShape &&
+            // Check the original set of shapes to remove for this shape id, to remove members that were in that set.
+            (removedRootDefaults.contains(shape.target) || removeDefaultsFrom.contains(shape.id)) &&
+            shape.hasTrait<DefaultTrait>()
     }
 
     private fun removeDefault(shape: Shape): Shape {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsDecorator.kt
@@ -25,6 +25,32 @@ class RemoveDefaultsDecorator : ClientCodegenDecorator {
     // Service shape id -> Shape id of each root shape to remove the default from.
     // TODO(https://github.com/smithy-lang/smithy-rs/issues/3220): Remove this customization after model updates.
     private val removeDefaults = mapOf(
+        "com.amazonaws.amplifyuibuilder#AmplifyUIBuilder".shapeId() to setOf(
+            "com.amazonaws.amplifyuibuilder#ListComponentsLimit".shapeId(),
+            "com.amazonaws.amplifyuibuilder#ListFormsLimit".shapeId(),
+            "com.amazonaws.amplifyuibuilder#ListThemesLimit".shapeId(),
+        ),
+        "com.amazonaws.drs#ElasticDisasterRecoveryService".shapeId() to setOf(
+            "com.amazonaws.drs#Validity".shapeId(),
+            "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceThreshold".shapeId(),
+            "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceDeltaThreshold".shapeId(),
+            "com.amazonaws.drs#ListStagingAccountsRequest\$maxResults".shapeId(),
+            "com.amazonaws.drs#StrictlyPositiveInteger".shapeId(),
+            "com.amazonaws.drs#MaxResultsType".shapeId(),
+            "com.amazonaws.drs#MaxResultsReplicatingSourceServers".shapeId(),
+            "com.amazonaws.drs#LaunchActionOrder".shapeId(),
+        ),
+        "com.amazonaws.evidently#Evidently".shapeId() to setOf(
+            "com.amazonaws.evidently#ResultsPeriod".shapeId(),
+        ),
+        "com.amazonaws.location#LocationService".shapeId() to setOf(
+            "com.amazonaws.location#ListPlaceIndexesRequest\$MaxResults".shapeId(),
+            "com.amazonaws.location#SearchPlaceIndexForSuggestionsRequest\$MaxResults".shapeId(),
+            "com.amazonaws.location#PlaceIndexSearchResultLimit".shapeId(),
+        ),
+        "com.amazonaws.paymentcryptographydata#PaymentCryptographyDataPlane".shapeId() to setOf(
+            "com.amazonaws.paymentcryptographydata#IntegerRangeBetween4And12".shapeId(),
+        ),
         "com.amazonaws.emrserverless#AwsToledoWebService".shapeId() to setOf(
             // Service expects this to have a min value > 0
             "com.amazonaws.emrserverless#WorkerCounts".shapeId(),

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsTest.kt
@@ -20,12 +20,14 @@ internal class RemoveDefaultsTest {
     fun `defaults should be removed`() {
         val removeDefaults = setOf(
             "test#Bar".shapeId(),
+            "test#Foo\$baz".shapeId(),
         )
         val baseModel = """
             namespace test
 
             structure Foo {
                 bar: Bar = 0
+                baz: Integer = 0
             }
 
             @default(0)
@@ -33,8 +35,10 @@ internal class RemoveDefaultsTest {
 
         """.asSmithyModel(smithyVersion = "2.0")
         val model = RemoveDefaults.processModel(baseModel, removeDefaults)
-        val member = model.lookup<MemberShape>("test#Foo\$bar")
-        member.hasTrait<DefaultTrait>() shouldBe false
+        val barMember = model.lookup<MemberShape>("test#Foo\$bar")
+        barMember.hasTrait<DefaultTrait>() shouldBe false
+        val bazMember = model.lookup<MemberShape>("test#Foo\$baz")
+        bazMember.hasTrait<DefaultTrait>() shouldBe false
         val root = model.lookup<IntegerShape>("test#Bar")
         root.hasTrait<DefaultTrait>() shouldBe false
     }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Removing defaults from these shapes may not have a codegen impact since these are in top level input, but doing this just to be safe from future changes.

## Description
<!--- Describe your changes in detail -->
Adds more services/shapes to RemoveDefaultsDecorator, which will have their models changed in the future.  Also updates RemoveDefaults to allow for members to be present in the list.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Updated unit test for RemoveDefaults
- Generated clients and looked at the output code

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
