### PR TITLE
Avoid overflow in exponential backoff computation

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -54,3 +54,15 @@ message = "Make certain types for EMR Serverless optional. Previously, they defa
 references = ["smithy-rs#3217"]
 meta = { "breaking" = true, "tada" = false, "bug" = true }
 author = "milesziemer"
+
+[[smithy-rs]]
+message = "Prevent multiplication overflow in backoff computation"
+references = ["smithy-rs#3229", "aws-sdk-rust#960"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, target = "client" }
+author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Prevent multiplication overflow in backoff computation"
+references = ["smithy-rs#3229", "aws-sdk-rust#960"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"


### PR DESCRIPTION
## Motivation and Context
aws-sdk-rust#960

## Description
Use checked_pow to avoid overflow in backoff computation

## Testing
- unit test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
