### PR TITLE
Remove `supports_v2023_11_09` from behavior versions

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
@@ -34,9 +34,4 @@ impl BehaviorVersion {
     pub fn v2023_11_09() -> Self {
         Self {}
     }
-
-    /// Returns whether the current version is `v2023_11_09`
-    pub fn supports_v2023_11_09(&self) -> bool {
-        true
-    }
 }


### PR DESCRIPTION
This function isn't useful.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
