### PR TITLE
Feature-gate http versions in aws-smithy-runtime-api

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -116,3 +116,9 @@ message = "Types/functions that were previously `#[doc(hidden)]` in `aws-config`
 references = ["smithy-rs#3226"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ysaito1001"
+
+[[smithy-rs]]
+message = "Conversions for HTTP request in aws-smithy-runtime-api are now feature gated behind the `http-02x` feature"
+references = ["smithy-rs#3236"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/aws/sdk/integration-tests/ec2/Cargo.toml
+++ b/aws/sdk/integration-tests/ec2/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async" }
 aws-smithy-runtime = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime", features = ["client", "test-util"] }
-aws-smithy-runtime-api = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime-api", features = ["client"] }
+aws-smithy-runtime-api = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime-api", features = ["client", "http-02x"] }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 aws-sdk-ec2 = { path = "../../build/aws-sdk/sdk/ec2", features = ["behavior-version-latest"] }
 tokio = { version = "1.23.1", features = ["full"]}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -305,7 +305,7 @@ data class CargoDependency(
             .withFeature("client")
         fun smithyRuntimeTestUtil(runtimeConfig: RuntimeConfig) = smithyRuntime(runtimeConfig).toDevDependency().withFeature("test-util")
         fun smithyRuntimeApi(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-runtime-api")
-        fun smithyRuntimeApiClient(runtimeConfig: RuntimeConfig) = smithyRuntimeApi(runtimeConfig).withFeature("client")
+        fun smithyRuntimeApiClient(runtimeConfig: RuntimeConfig) = smithyRuntimeApi(runtimeConfig).withFeature("client").withFeature("http-02x")
         fun smithyRuntimeApiTestUtil(runtimeConfig: RuntimeConfig) =
             smithyRuntimeApi(runtimeConfig).toDevDependency().withFeature("test-util")
         fun smithyTypes(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-types")

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -21,7 +21,7 @@ request-id = ["dep:uuid"]
 async-trait = "0.1"
 aws-smithy-http = { path = "../aws-smithy-http", features = ["rt-tokio"] }
 aws-smithy-json = { path = "../aws-smithy-json" }
-aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api" }
+aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["http-02x"] }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-0-4-x", "hyper-0-14-x"] }
 aws-smithy-xml = { path = "../aws-smithy-xml" }
 bytes = "1.1"

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -16,7 +16,7 @@ rt-tokio = ["aws-smithy-types/rt-tokio"]
 
 [dependencies]
 aws-smithy-eventstream = { path = "../aws-smithy-eventstream", optional = true }
-aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client"] }
+aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client", "http-02x"] }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["byte-stream-poll-next", "http-body-0-4-x"] }
 bytes = "1"
 bytes-utils = "0.1"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -14,12 +14,15 @@ default = []
 client = []
 http-auth = ["dep:zeroize"]
 test-util = ["aws-smithy-types/test-util"]
+http-02x = []
+http-1x = []
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 http = "0.2.9"
+http1 = { package = "http", version = "1" }
 pin-project-lite = "0.2"
 tokio = { version = "1.25", features = ["sync"] }
 tracing = "0.1"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -15,14 +15,12 @@ client = []
 http-auth = ["dep:zeroize"]
 test-util = ["aws-smithy-types/test-util"]
 http-02x = []
-http-1x = []
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 http = "0.2.9"
-http1 = { package = "http", version = "1" }
 pin-project-lite = "0.2"
 tokio = { version = "1.25", features = ["sync"] }
 tracing = "0.1"

--- a/rust-runtime/aws-smithy-runtime-api/additional-ci
+++ b/rust-runtime/aws-smithy-runtime-api/additional-ci
@@ -8,5 +8,10 @@
 
 set -e
 
+# NOTE: (rcoh) This seems to be pulling in workspace settings that pull in this dependency, but it passes if
+# no other crates enable this dependency
+# echo "### Checking external types w/ HTTP feature disabled"
+# RUSTDOCFLAGS="" cargo +"${RUST_NIGHTLY_VERSION}" check-external-types --config external-types-no-http.toml --no-default-features
+
 echo "### Testing every combination of features (excluding --all-features)"
 cargo hack test --feature-powerset --exclude-all-features

--- a/rust-runtime/aws-smithy-runtime-api/external-types-no-http.toml
+++ b/rust-runtime/aws-smithy-runtime-api/external-types-no-http.toml
@@ -1,0 +1,6 @@
+allowed_external_types = [
+    "aws_smithy_async::*",
+    "aws_smithy_types::*",
+
+    "bytes::bytes::Bytes",
+]

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -467,7 +467,7 @@ impl fmt::Display for RewindResult {
     }
 }
 
-#[cfg(all(test, feature = "test-util"))]
+#[cfg(all(test, feature = "test-util", feature = "http-02x"))]
 mod tests {
     use super::*;
     use aws_smithy_types::body::SdkBody;

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
@@ -297,7 +297,7 @@ impl RuntimePlugins {
     }
 }
 
-#[cfg(all(test, feature = "test-util"))]
+#[cfg(all(test, feature = "test-util", feature = "http-02x"))]
 mod tests {
     use super::{RuntimePlugin, RuntimePlugins};
     use crate::client::http::{

--- a/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
@@ -282,6 +282,7 @@ mod header_value {
             Ok(Self { _private: value })
         }
 
+        #[allow(dead_code)]
         pub(crate) fn into_http02x(self) -> http0::HeaderValue {
             self._private
         }

--- a/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
@@ -156,6 +156,7 @@ impl Headers {
     }
 }
 
+#[cfg(feature = "http-02x")]
 impl TryFrom<HeaderMap> for Headers {
     type Error = HttpError;
 
@@ -283,6 +284,11 @@ mod header_value {
 
         pub(crate) fn into_http02x(self) -> http0::HeaderValue {
             self._private
+        }
+
+        #[allow(dead_code)]
+        pub(crate) fn into_http1x(self) -> http1::HeaderValue {
+            http1::HeaderValue::from_bytes(self._private.as_bytes()).expect("proven valid")
         }
     }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
@@ -286,11 +286,6 @@ mod header_value {
         pub(crate) fn into_http02x(self) -> http0::HeaderValue {
             self._private
         }
-
-        #[allow(dead_code)]
-        pub(crate) fn into_http1x(self) -> http1::HeaderValue {
-            http1::HeaderValue::from_bytes(self._private.as_bytes()).expect("proven valid")
-        }
     }
 
     impl AsRef<str> for HeaderValue {

--- a/rust-runtime/aws-smithy-runtime-api/src/http/request.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/request.rs
@@ -10,7 +10,7 @@ use crate::http::HttpError;
 use aws_smithy_types::body::SdkBody;
 use http as http0;
 use http0::uri::PathAndQuery;
-use http0::{Extensions, HeaderMap, Method};
+use http0::{Extensions, Method};
 use std::borrow::Cow;
 
 /// Parts struct useful for structural decomposition that the [`Request`] type can be converted into.
@@ -164,7 +164,7 @@ impl<B> Request<B> {
             .method(self.method)
             .body(self.body)
             .expect("known valid");
-        let mut headers = HeaderMap::new();
+        let mut headers = http0::HeaderMap::new();
         headers.reserve(self.headers.headers.len());
         headers.extend(
             self.headers
@@ -289,7 +289,7 @@ impl<B> Request<B> {
     /// Adds an extension to the request extensions
     pub fn add_extension<T: Send + Sync + Clone + 'static>(&mut self, extension: T) {
         self.extensions_02x.insert(extension.clone());
-        self.extensions_1x.insert(extension.clone());
+        self.extensions_1x.insert(extension);
     }
 }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/http/request.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/request.rs
@@ -250,7 +250,7 @@ impl<B> Request<B> {
 
     /// Adds an extension to the request extensions
     pub fn add_extension<T: Send + Sync + Clone + 'static>(&mut self, extension: T) {
-        self.extensions_02x.insert(extension.clone());
+        self.extensions_02x.insert(extension);
     }
 }
 
@@ -305,7 +305,7 @@ impl<B> TryFrom<http0::Request<B>> for Request<B> {
         Ok(Self {
             body,
             uri: parts.uri.into(),
-            method: parts.method.clone(),
+            method: parts.method,
             extensions_02x: http::Extensions::new(),
             headers,
         })

--- a/rust-runtime/aws-smithy-runtime-api/src/http/response.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/response.rs
@@ -49,6 +49,7 @@ impl TryFrom<u16> for StatusCode {
     }
 }
 
+#[cfg(feature = "http-02x")]
 impl From<http0::StatusCode> for StatusCode {
     fn from(value: http0::StatusCode) -> Self {
         Self(value.as_u16())
@@ -81,6 +82,7 @@ impl<B> Response<B> {
     ///
     /// Depending on the internal storage type, this operation may be free or it may have an internal
     /// cost.
+    #[cfg(feature = "http-02x")]
     pub fn try_into_http02x(self) -> Result<http0::Response<B>, HttpError> {
         let mut res = http::Response::builder()
             .status(
@@ -169,6 +171,7 @@ impl Response<SdkBody> {
     }
 }
 
+#[cfg(feature = "http-02x")]
 impl<B> TryFrom<http0::Response<B>> for Response<B> {
     type Error = HttpError;
 
@@ -201,7 +204,7 @@ impl<B> TryFrom<http0::Response<B>> for Response<B> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "http-02x"))]
 mod test {
     use super::*;
     use aws_smithy_types::body::SdkBody;

--- a/rust-runtime/aws-smithy-runtime-api/src/http/response.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/response.rs
@@ -5,10 +5,9 @@
 
 //! Http Response Types
 
-use crate::http::{HeaderValue, Headers, HttpError};
+use crate::http::{Headers, HttpError};
 use aws_smithy_types::body::SdkBody;
 use http as http0;
-use http0::{Extensions, HeaderMap};
 use std::fmt;
 
 /// HTTP response status code
@@ -74,7 +73,7 @@ pub struct Response<B = SdkBody> {
     status: StatusCode,
     headers: Headers,
     body: B,
-    extensions: Extensions,
+    extensions: http0::Extensions,
 }
 
 impl<B> Response<B> {
@@ -91,7 +90,7 @@ impl<B> Response<B> {
             )
             .body(self.body)
             .expect("known valid");
-        let mut headers = HeaderMap::new();
+        let mut headers = http0::HeaderMap::new();
         headers.extend(
             self.headers
                 .headers
@@ -176,6 +175,8 @@ impl<B> TryFrom<http0::Response<B>> for Response<B> {
     type Error = HttpError;
 
     fn try_from(value: http0::Response<B>) -> Result<Self, Self::Error> {
+        use crate::http::headers::HeaderValue;
+        use http0::HeaderMap;
         if let Some(e) = value
             .headers()
             .values()


### PR DESCRIPTION
## Motivation and Context
Without this, we will have http = 0.2 permanently in-tree.

## Description
- Add feature gate for http 02x. 
- ~Add http 1x as an experiment.~

## Testing
CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
