### PR TITLE
Disable dev preview for `CrateVersioner`

### DIFF
--- a/buildSrc/src/main/kotlin/aws/sdk/CrateVersioner.kt
+++ b/buildSrc/src/main/kotlin/aws/sdk/CrateVersioner.kt
@@ -24,7 +24,7 @@ object CrateVersioner {
                 IndependentCrateVersioner(
                     VersionsManifest.fromFile(versionsManifestPath),
                     ModelMetadata.fromFile(modelMetadataPath),
-                    devPreview = true,
+                    devPreview = false,
                     smithyRsVersion = getSmithyRsVersion(rootProject),
                 )
             }


### PR DESCRIPTION
## Motivation and Context
In this stable release branch, `CrateVersioner` needs to start versioning SDK crates in a way they are stable.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
