### PR TITLE
Update formatter pre-commit hooks to 2.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     exclude: ^aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/
   - id: trailing-whitespace
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.10.0
+  rev: v2.11.0
   hooks:
   - id: pretty-format-kotlin
     args: [--autofix, --ktlint-version, 0.48.2]


### PR DESCRIPTION
Was running into
https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/181 trying to run pre-commit. It was fixed in 2.11.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
