### PR TITLE
Clean up remaining `TODO(GA)` from PR#3082

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,9 +12,6 @@ rust.msrv=1.70.0
 org.gradle.jvmargs=-Xmx1024M
 
 # Version number to use for the generated stable runtime crates
-#
-# TODO(GA): This is currently a placeholder for crates we are going to stabilize at the time of GA.
-# Until then, a value of this key can contain 0 for the major version.
 smithy.rs.runtime.crate.stable.version=1.0.0
 
 # Version number to use for the generated unstable runtime crates


### PR DESCRIPTION
## Motivation and Context
This small PR cleans up remaining two `TODO(GA)` in #3082.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
