### PR TITLE
Remove some defaults for s3 control

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Make properties of S3Control PublicAccessBlockConfiguration optional. Previously, they defaulted to false, but this created invalid requests."
+references = ["smithy-rs#3246"]
+meta = { "breaking" = true, "tada" = false, "bug" = true }
+author = "milesziemer"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsDecorator.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rustsdk.customize
 
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.util.shapeId
@@ -24,38 +25,43 @@ class RemoveDefaultsDecorator : ClientCodegenDecorator {
 
     // Service shape id -> Shape id of each root shape to remove the default from.
     // TODO(https://github.com/smithy-lang/smithy-rs/issues/3220): Remove this customization after model updates.
-    private val removeDefaults = mapOf(
-        "com.amazonaws.amplifyuibuilder#AmplifyUIBuilder".shapeId() to setOf(
-            "com.amazonaws.amplifyuibuilder#ListComponentsLimit".shapeId(),
-            "com.amazonaws.amplifyuibuilder#ListFormsLimit".shapeId(),
-            "com.amazonaws.amplifyuibuilder#ListThemesLimit".shapeId(),
+    private val removeDefaults: Map<ShapeId, Set<ShapeId>> = mapOf(
+        "com.amazonaws.amplifyuibuilder#AmplifyUIBuilder" to setOf(
+            "com.amazonaws.amplifyuibuilder#ListComponentsLimit",
+            "com.amazonaws.amplifyuibuilder#ListFormsLimit",
+            "com.amazonaws.amplifyuibuilder#ListThemesLimit",
         ),
-        "com.amazonaws.drs#ElasticDisasterRecoveryService".shapeId() to setOf(
-            "com.amazonaws.drs#Validity".shapeId(),
-            "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceThreshold".shapeId(),
-            "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceDeltaThreshold".shapeId(),
-            "com.amazonaws.drs#ListStagingAccountsRequest\$maxResults".shapeId(),
-            "com.amazonaws.drs#StrictlyPositiveInteger".shapeId(),
-            "com.amazonaws.drs#MaxResultsType".shapeId(),
-            "com.amazonaws.drs#MaxResultsReplicatingSourceServers".shapeId(),
-            "com.amazonaws.drs#LaunchActionOrder".shapeId(),
+        "com.amazonaws.drs#ElasticDisasterRecoveryService" to setOf(
+            "com.amazonaws.drs#Validity",
+            "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceThreshold",
+            "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceDeltaThreshold",
+            "com.amazonaws.drs#ListStagingAccountsRequest\$maxResults",
+            "com.amazonaws.drs#StrictlyPositiveInteger",
+            "com.amazonaws.drs#MaxResultsType",
+            "com.amazonaws.drs#MaxResultsReplicatingSourceServers",
+            "com.amazonaws.drs#LaunchActionOrder",
         ),
-        "com.amazonaws.evidently#Evidently".shapeId() to setOf(
-            "com.amazonaws.evidently#ResultsPeriod".shapeId(),
+        "com.amazonaws.evidently#Evidently" to setOf(
+            "com.amazonaws.evidently#ResultsPeriod",
         ),
-        "com.amazonaws.location#LocationService".shapeId() to setOf(
-            "com.amazonaws.location#ListPlaceIndexesRequest\$MaxResults".shapeId(),
-            "com.amazonaws.location#SearchPlaceIndexForSuggestionsRequest\$MaxResults".shapeId(),
-            "com.amazonaws.location#PlaceIndexSearchResultLimit".shapeId(),
+        "com.amazonaws.location#LocationService" to setOf(
+            "com.amazonaws.location#ListPlaceIndexesRequest\$MaxResults",
+            "com.amazonaws.location#SearchPlaceIndexForSuggestionsRequest\$MaxResults",
+            "com.amazonaws.location#PlaceIndexSearchResultLimit",
         ),
-        "com.amazonaws.paymentcryptographydata#PaymentCryptographyDataPlane".shapeId() to setOf(
-            "com.amazonaws.paymentcryptographydata#IntegerRangeBetween4And12".shapeId(),
+        "com.amazonaws.paymentcryptographydata#PaymentCryptographyDataPlane" to setOf(
+            "com.amazonaws.paymentcryptographydata#IntegerRangeBetween4And12",
         ),
-        "com.amazonaws.emrserverless#AwsToledoWebService".shapeId() to setOf(
-            // Service expects this to have a min value > 0
-            "com.amazonaws.emrserverless#WorkerCounts".shapeId(),
+        "com.amazonaws.emrserverless#AwsToledoWebService" to setOf(
+            "com.amazonaws.emrserverless#WorkerCounts",
         ),
-    )
+        "com.amazonaws.s3control#AWSS3ControlServiceV20180820" to setOf(
+            "com.amazonaws.s3control#PublicAccessBlockConfiguration\$BlockPublicAcls",
+            "com.amazonaws.s3control#PublicAccessBlockConfiguration\$IgnorePublicAcls",
+            "com.amazonaws.s3control#PublicAccessBlockConfiguration\$BlockPublicPolicy",
+            "com.amazonaws.s3control#PublicAccessBlockConfiguration\$RestrictPublicBuckets",
+        ),
+    ).map { (k, v) -> k.shapeId() to v.map { it.shapeId() }.toSet() }.toMap()
 
     private fun applies(service: ServiceShape) =
         removeDefaults.containsKey(service.id)


### PR DESCRIPTION


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

S3 Control's PublicAccessBlockConfiguration is incorrectly modeled, and all the members should be nullable. These members are not meant to have a default, as you are meant to be able to configure one member at a time - if you're just trying to turn BlockPublicAcls on, you don't want to accidentally turn off IgnorePublicAcls. This change makes these members nullable and is a break-fix.

## Description
<!--- Describe your changes in detail -->

Adds the members of PublicAccessBlockConfiguration to the RemoveDefaults customization. 
Also refactors the map of shapes to remove defaults from to avoid having to call .shapeId everywhere.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Generated the client and looked at it

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
