### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       with:
         repository: awsdocs/aws-doc-sdk-examples
         path: aws-doc-sdk-examples
+        ref: rust-launch
     - name: Run ${{ matrix.actions.action }}
       uses: ./smithy-rs/.github/actions/docker-build
       with:


### PR DESCRIPTION
updates main to use rust-launch (needed to unbreak CI) until we change to use rustv1 in the examples folder

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
