### PR TITLE
Fix bug in is_virtual_hostable_s3_bucket

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Allow `--` to be used in bucket names for S3"
+references = ["smithy-rs#3253"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"

--- a/rust-runtime/inlineable/src/endpoint_lib/s3.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/s3.rs
@@ -13,7 +13,7 @@ static VIRTUAL_HOSTABLE_SEGMENT: Lazy<Regex> =
 
 static IPV4: Lazy<Regex> = Lazy::new(|| Regex::new("^(\\d+\\.){3}\\d+$").unwrap());
 
-static DOTS_AND_DASHES: Lazy<Regex> = Lazy::new(|| Regex::new("^.*[.-]{2}.*$").unwrap());
+static DOTS_AND_DASHES: Lazy<Regex> = Lazy::new(|| Regex::new(r#"^.*((\.-)|(-\.)).*$"#).unwrap());
 
 /// Evaluates whether a string is a DNS-compatible bucket name that can be used with virtual hosted-style addressing.
 pub(crate) fn is_virtual_hostable_s3_bucket(
@@ -34,4 +34,21 @@ fn is_virtual_hostable_segment(host_label: &str) -> bool {
     VIRTUAL_HOSTABLE_SEGMENT.is_match(host_label)
         && !IPV4.is_match(host_label) // don't allow ip address
         && !DOTS_AND_DASHES.is_match(host_label) // don't allow names like bucket-.name or bucket.-name
+}
+
+#[test]
+fn check_s3_bucket() {
+    // check that double dashses are valid
+    let bucket = "a--b--x-s3";
+    assert!(is_virtual_hostable_s3_bucket(
+        bucket,
+        false,
+        &mut DiagnosticCollector::new()
+    ));
+
+    assert!(!is_virtual_hostable_s3_bucket(
+        "a-.b-.c",
+        true,
+        &mut DiagnosticCollector::new()
+    ))
 }


### PR DESCRIPTION
An incorrect regex prevented `--` from being used in a bucket name

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
