### PR TITLE
Remove incorrect defaults for iot

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Make some properties for IoT types optional. Previously, they defaulted to false, but that isn't how the service actual works."
+references = ["smithy-rs#3256"]
+meta = { "breaking" = true, "tada" = false, "bug" = true }
+author = "milesziemer"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/RemoveDefaultsDecorator.kt
@@ -35,7 +35,7 @@ class RemoveDefaultsDecorator : ClientCodegenDecorator {
             "com.amazonaws.drs#Validity",
             "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceThreshold",
             "com.amazonaws.drs#CostOptimizationConfiguration\$burstBalanceDeltaThreshold",
-            "com.amazonaws.drs#ListStagingAccountsRequest\$maxResults",
+            "com.amazonaws.drs.synthetic#ListStagingAccountsInput\$maxResults",
             "com.amazonaws.drs#StrictlyPositiveInteger",
             "com.amazonaws.drs#MaxResultsType",
             "com.amazonaws.drs#MaxResultsReplicatingSourceServers",
@@ -45,8 +45,8 @@ class RemoveDefaultsDecorator : ClientCodegenDecorator {
             "com.amazonaws.evidently#ResultsPeriod",
         ),
         "com.amazonaws.location#LocationService" to setOf(
-            "com.amazonaws.location#ListPlaceIndexesRequest\$MaxResults",
-            "com.amazonaws.location#SearchPlaceIndexForSuggestionsRequest\$MaxResults",
+            "com.amazonaws.location.synthetic#ListPlaceIndexesInput\$MaxResults",
+            "com.amazonaws.location.synthetic#SearchPlaceIndexForSuggestionsInput\$MaxResults",
             "com.amazonaws.location#PlaceIndexSearchResultLimit",
         ),
         "com.amazonaws.paymentcryptographydata#PaymentCryptographyDataPlane" to setOf(
@@ -60,6 +60,14 @@ class RemoveDefaultsDecorator : ClientCodegenDecorator {
             "com.amazonaws.s3control#PublicAccessBlockConfiguration\$IgnorePublicAcls",
             "com.amazonaws.s3control#PublicAccessBlockConfiguration\$BlockPublicPolicy",
             "com.amazonaws.s3control#PublicAccessBlockConfiguration\$RestrictPublicBuckets",
+        ),
+        "com.amazonaws.iot#AWSIotService" to setOf(
+            "com.amazonaws.iot#ThingConnectivity\$connected",
+            "com.amazonaws.iot.synthetic#UpdateProvisioningTemplateInput\$enabled",
+            "com.amazonaws.iot.synthetic#CreateProvisioningTemplateInput\$enabled",
+            "com.amazonaws.iot.synthetic#DescribeProvisioningTemplateOutput\$enabled",
+            "com.amazonaws.iot.synthetic#DescribeProvisioningTemplateOutput\$enabled",
+            "com.amazonaws.iot#ProvisioningTemplateSummary\$enabled",
         ),
     ).map { (k, v) -> k.shapeId() to v.map { it.shapeId() }.toSet() }.toMap()
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The IoT Smithy model we have is incorrect, resulting in some types being generated as non-optional when they should be optional.

## Description
<!--- Describe your changes in detail -->
Removes the defaults of a few shapes for iot, which are meant to be nullable. Can remove this when the model is fixed upstream.

Also changed some of the other shapes in RemoveDefaultsDecorator to use the synthetic shape id, but this didn't impact generated code - just for consistency.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Generated IoT SDK and verified diff is expected

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
