### PR TITLE
Stop tagging releases as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
       id: push-changelog
       env:
         RELEASE_BRANCH_NAME: ${{ needs.upgrade-gradle-properties.outputs.release_branch }}
+        DRY_RUN: ${{ inputs.dry_run }}
       run: |
         if ! git diff-index --quiet HEAD; then
           echo "Pushing release commits..."
@@ -239,7 +240,13 @@ jobs:
           # to retry a release action execution that failed due to a transient issue.
           # In that case, we expect the commit to be releasable as-is, i.e. the changelog should have already
           # been processed.
-          git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            # During dry-runs, "git push" without "--force" can fail if smithy-rs-release-x.y.z-preview is behind
+            # smithy-rs-release-x.y.z, but that does not matter much during dry-runs.
+            git push --force origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+          else
+            git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+          fi
         fi
         echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
     - name: Tag release

--- a/tools/ci-build/changelogger/src/render.rs
+++ b/tools/ci-build/changelogger/src/render.rs
@@ -295,7 +295,7 @@ fn update_changelogs(
             tag_name: release_metadata.tag.clone(),
             name: release_metadata.title.clone(),
             body: release_notes.clone(),
-            // GA as of release-2023-11-21
+            // stable as of release-2023-11-21
             prerelease: false,
         };
         std::fs::write(

--- a/tools/ci-build/changelogger/src/render.rs
+++ b/tools/ci-build/changelogger/src/render.rs
@@ -295,8 +295,8 @@ fn update_changelogs(
             tag_name: release_metadata.tag.clone(),
             name: release_metadata.title.clone(),
             body: release_notes.clone(),
-            // All releases are pre-releases for now
-            prerelease: true,
+            // GA as of release-2023-11-21
+            prerelease: false,
         };
         std::fs::write(
             output_path.join(&release_metadata.manifest_name),

--- a/tools/ci-build/changelogger/tests/e2e_test.rs
+++ b/tools/ci-build/changelogger/tests/e2e_test.rs
@@ -319,7 +319,7 @@ Old entry contents
   "tagName": "release-1970-01-01",
   "name": "January 1st, 1970",
   "body": "**New this release:**\n- (all, [smithy-rs#1234](https://github.com/smithy-lang/smithy-rs/issues/1234), @another-dev) Another change\n\n**Contributors**\nThank you for your contributions! ❤\n- @another-dev ([smithy-rs#1234](https://github.com/smithy-lang/smithy-rs/issues/1234))\n\n",
-  "prerelease": true
+  "prerelease": false
 }"#,
         release_manifest
     );
@@ -415,7 +415,7 @@ Old entry contents
   "tagName": "release-1970-01-01",
   "name": "January 1st, 1970",
   "body": "**New this release:**\n- :bug: ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/smithy-lang/smithy-rs/issues/567), @test-dev) Some other change\n\n**Service Features:**\n- `aws-sdk-ec2` (0.12.0): Some API change\n\n**Contributors**\nThank you for your contributions! ❤\n- @test-dev ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/smithy-lang/smithy-rs/issues/567))\n\n",
-  "prerelease": true
+  "prerelease": false
 }"#,
         release_manifest
     );
@@ -698,7 +698,7 @@ Old entry contents
   "tagName": "release-1970-01-01",
   "name": "January 1st, 1970",
   "body": "**New this release:**\n- (all, [smithy-rs#1234](https://github.com/smithy-lang/smithy-rs/issues/1234), @another-dev) Another change\n\n**Contributors**\nThank you for your contributions! ❤\n- @another-dev ([smithy-rs#1234](https://github.com/smithy-lang/smithy-rs/issues/1234))\n\n**Crate Versions**\n<details>\n<summary>Click to expand to view crate versions...</summary>\n\n|Crate|Version|\n|-|-|\n|aws-config|0.54.1|\n|aws-sdk-accessanalyzer|0.24.0|\n|aws-smithy-async|0.54.1|\n</details>\n\n",
-  "prerelease": true
+  "prerelease": false
 }"#,
         release_manifest
     );


### PR DESCRIPTION
## Motivation and Context
Now that we have started [stable releases](https://github.com/smithy-lang/smithy-rs/releases) since `release-2023-11-21`, we shouldn't set those as pre-releases.

(this PR also includes a small fix to the `Release` job in our release workflow to avoid `git push` failing during dry-runs, which [a previous dry-run](https://github.com/smithy-lang/smithy-rs/actions/runs/6989359794) ran into)

## Description
The fix is in `changelogger`, and this should remove pre-releases from releases in `smithy-rs` as well as those in `aws-sdk-rust`.

## Testing
Ran a [dry-run](https://github.com/smithy-lang/smithy-rs/actions/runs/7007835035) and checked the release artifacts as follows:
```
{
  "tagName": "release-2023-11-27",
  "name": "November 27th, 2023",
  "body": "",
  "prerelease": false
}
```

Have not verified what a release manifest looks like in `aws-sdk-rust`, but I suspect `prerelease: false` should be applied there as well given the same `changelogger` is used.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
