### PR TITLE
Skip `aws-config` from running `semver-checks`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     exclude: ^aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/
   - id: trailing-whitespace
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.10.0
+  rev: v2.11.0
   hooks:
   - id: pretty-format-kotlin
     args: [--autofix, --ktlint-version, 0.48.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ November 25th, 2023
 
 November 21st, 2023
 ===================
+**Internal changes only with this release**
+
 
 November 17th, 2023
 ===================

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWords.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWords.kt
@@ -69,7 +69,7 @@ class RustReservedWordSymbolProvider(
             "RustReservedWordSymbolProvider should only run once"
         }
 
-        var renamedSymbol = internal.toSymbol(shape)
+        val renamedSymbol = internal.toSymbol(shape)
         return when (shape) {
             is MemberShape -> {
                 val container = model.expectShape(shape.container)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/OperationNormalizer.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/OperationNormalizer.kt
@@ -62,7 +62,7 @@ object OperationNormalizer {
         check(
             shapeConflict == null,
         ) {
-            "shape $shapeConflict conflicted with an existing shape in the model (${model.getShape(shapeConflict!!.id)}. This is a bug."
+            "shape $shapeConflict conflicted with an existing shape in the model (${model.expectShape(shapeConflict!!.id)}). This is a bug."
         }
         val modelWithOperationInputs = model.toBuilder().addShapes(newShapes).build()
         return transformer.mapShapes(modelWithOperationInputs) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/CustomShapeSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/CustomShapeSymbolProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.AnnotationTrait
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.WrappingSymbolProvider
+import software.amazon.smithy.rust.codegen.core.util.getTrait
+
+class SyntheticCustomShapeTrait(val ID: ShapeId, val symbol: Symbol) : AnnotationTrait(ID, Node.objectNode())
+
+/**
+ * This SymbolProvider honors [`SyntheticCustomShapeTrait`] and returns this trait's symbol when available.
+ */
+class CustomShapeSymbolProvider(private val base: RustSymbolProvider) : WrappingSymbolProvider(base) {
+    override fun toSymbol(shape: Shape): Symbol {
+        return shape.getTrait<SyntheticCustomShapeTrait>()?.symbol ?: base.toSymbol(shape)
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
@@ -93,5 +93,7 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
                 .let { RustReservedWordSymbolProvider(it, ServerReservedWords) }
                 // Allows decorators to inject a custom symbol provider
                 .let { codegenDecorator.symbolProvider(it) }
+                // Inject custom symbols.
+                .let { CustomShapeSymbolProvider(it) }
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
@@ -31,6 +31,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
+import software.amazon.smithy.rust.codegen.core.smithy.generators.lifetimeDeclaration
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.isRustBoxed
 import software.amazon.smithy.rust.codegen.core.smithy.makeMaybeConstrained
@@ -147,6 +148,7 @@ class ServerBuilderGenerator(
     private val isBuilderFallible = hasFallibleBuilder(shape, model, symbolProvider, takeInUnconstrainedTypes)
     private val serverBuilderConstraintViolations =
         ServerBuilderConstraintViolations(codegenContext, shape, takeInUnconstrainedTypes, customValidationExceptionWithReasonConversionGenerator)
+    private val lifetime = shape.lifetimeDeclaration(symbolProvider)
 
     private val codegenScope = arrayOf(
         "RequestRejection" to protocol.requestRejection(codegenContext.runtimeConfig),
@@ -196,11 +198,11 @@ class ServerBuilderGenerator(
             it == RuntimeType.Debug || it == RuntimeType.Clone
         } + RuntimeType.Default
         Attribute(derive(builderDerives)).render(writer)
-        writer.rustBlock("${visibility.toRustQualifier()} struct Builder") {
+        writer.rustBlock("${visibility.toRustQualifier()} struct Builder$lifetime") {
             members.forEach { renderBuilderMember(this, it) }
         }
 
-        writer.rustBlock("impl Builder") {
+        writer.rustBlock("impl $lifetime Builder $lifetime") {
             for (member in members) {
                 if (publicConstrainedTypes) {
                     renderBuilderMemberFn(this, member)
@@ -262,7 +264,7 @@ class ServerBuilderGenerator(
                 self.build_enforcing_all_constraints()
             }
             """,
-            "ReturnType" to buildFnReturnType(isBuilderFallible, structureSymbol),
+            "ReturnType" to buildFnReturnType(isBuilderFallible, structureSymbol, lifetime),
         )
         renderBuildEnforcingAllConstraintsFn(implBlockWriter)
     }
@@ -270,7 +272,7 @@ class ServerBuilderGenerator(
     private fun renderBuildEnforcingAllConstraintsFn(implBlockWriter: RustWriter) {
         implBlockWriter.rustBlockTemplate(
             "fn build_enforcing_all_constraints(self) -> #{ReturnType:W}",
-            "ReturnType" to buildFnReturnType(isBuilderFallible, structureSymbol),
+            "ReturnType" to buildFnReturnType(isBuilderFallible, structureSymbol, lifetime),
         ) {
             conditionalBlock("Ok(", ")", conditional = isBuilderFallible) {
                 coreBuilder(this)
@@ -280,7 +282,7 @@ class ServerBuilderGenerator(
 
     fun renderConvenienceMethod(implBlock: RustWriter) {
         implBlock.docs("Creates a new builder-style object to manufacture #D.", structureSymbol)
-        implBlock.rustBlock("pub fn builder() -> #T", builderSymbol) {
+        implBlock.rustBlock("pub fn builder() -> #T $lifetime", builderSymbol) {
             write("#T::default()", builderSymbol)
         }
     }
@@ -413,10 +415,10 @@ class ServerBuilderGenerator(
     private fun renderTryFromBuilderImpl(writer: RustWriter) {
         writer.rustTemplate(
             """
-            impl #{TryFrom}<Builder> for #{Structure} {
+            impl #{TryFrom}<Builder $lifetime> for #{Structure}$lifetime {
                 type Error = ConstraintViolation;
 
-                fn try_from(builder: Builder) -> Result<Self, Self::Error> {
+                fn try_from(builder: Builder $lifetime) -> Result<Self, Self::Error> {
                     builder.build()
                 }
             }
@@ -428,7 +430,7 @@ class ServerBuilderGenerator(
     private fun renderFromBuilderImpl(writer: RustWriter) {
         writer.rustTemplate(
             """
-            impl #{From}<Builder> for #{Structure} {
+            impl #{From}<Builder $lifetime> for #{Structure} $lifetime {
                 fn from(builder: Builder) -> Self {
                     builder.build()
                 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorCommon.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorCommon.kt
@@ -57,11 +57,11 @@ import software.amazon.smithy.rust.codegen.server.smithy.hasPublicConstrainedWra
 /**
  * Returns a writable to render the return type of the server builders' `build()` method.
  */
-fun buildFnReturnType(isBuilderFallible: Boolean, structureSymbol: Symbol) = writable {
+fun buildFnReturnType(isBuilderFallible: Boolean, structureSymbol: Symbol, lifetime: String) = writable {
     if (isBuilderFallible) {
-        rust("Result<#T, ConstraintViolation>", structureSymbol)
+        rust("Result<#T $lifetime, ConstraintViolation>", structureSymbol)
     } else {
-        rust("#T", structureSymbol)
+        rust("#T $lifetime", structureSymbol)
     }
 }
 

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/CustomShapeSymbolProviderTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/CustomShapeSymbolProviderTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.smithy.rustType
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.util.lookup
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverTestSymbolProvider
+
+class CustomShapeSymbolProviderTest {
+    private val baseModel =
+        """
+        namespace test
+
+        service TestService {
+            version: "1"
+            operations: [TestOperation]
+        }
+
+        operation TestOperation {
+            input: TestInputOutput
+            output: TestInputOutput
+        }
+
+        structure TestInputOutput {
+            myString: String,
+        }
+        """.asSmithyModel(smithyVersion = "2.0")
+    private val serviceShape = baseModel.lookup<ServiceShape>("test#TestService")
+    private val rustType = RustType.Opaque("fake-type")
+    private val symbol = Symbol.builder()
+        .name("fake-symbol")
+        .rustType(rustType)
+        .build()
+    private val model = ModelTransformer.create()
+        .mapShapes(baseModel) {
+            if (it is MemberShape) {
+                it.toBuilder().addTrait(SyntheticCustomShapeTrait(ShapeId.from("some#id"), symbol)).build()
+            } else {
+                it
+            }
+        }
+    private val symbolProvider = serverTestSymbolProvider(baseModel, serviceShape)
+        .let { CustomShapeSymbolProvider(it) }
+
+    @Test
+    fun `override with custom symbol`() {
+        val shape = model.lookup<Shape>("test#TestInputOutput\$myString")
+        symbolProvider.toSymbol(shape) shouldBe symbol
+    }
+}

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -41,7 +41,11 @@ def main(skip_generation=False):
     ]
     for path in list(os.listdir())[:10]:
         eprint(f'checking {path}...', end='')
-        if path not in deny_list and get_cmd_status(f'git cat-file -e base:{sdk_directory}/{path}/Cargo.toml') == 0:
+        if path in deny_list:
+            eprint(f"skipping {path} because it is in 'deny_list'")
+        elif get_cmd_status(f'git cat-file -e base:{sdk_directory}/{path}/Cargo.toml') != 0:
+            eprint(f'skipping {path} because it does not exist in base')
+        else:
             get_cmd_output('cargo generate-lockfile', quiet=True)
             (_, out, _) = get_cmd_output('cargo pkgid', cwd=path, quiet=True)
             pkgid = parse_package_id(out)
@@ -61,8 +65,6 @@ def main(skip_generation=False):
                 if out:
                     eprint(out)
                 eprint(err)
-        else:
-            eprint(f'skipping {path} because it does not exist in base')
     if failures:
         eprint('One or more crates failed semver checks!')
         eprint("\n".join(failures))

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -36,6 +36,8 @@ def main(skip_generation=False):
     failures = []
     deny_list = [
         # add crate names here to exclude them from the semver checks
+        # TODO(https://github.com/smithy-lang/smithy-rs/issues/3265)
+        'aws-config'
     ]
     for path in list(os.listdir())[:10]:
         eprint(f'checking {path}...', end='')


### PR DESCRIPTION
## Motivation and Context
Skip running `semver-checks` on `aws-config` to enable clean runs for CI while #3265 is investigated.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
