### PR TITLE
Add `aws-config` to semver-checks deny list

### DIFF
--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -36,10 +36,16 @@ def main(skip_generation=False):
     failures = []
     deny_list = [
         # add crate names here to exclude them from the semver checks
+        # TODO(https://github.com/smithy-lang/smithy-rs/issues/3265)
+        'aws-config'
     ]
     for path in list(os.listdir())[:10]:
         eprint(f'checking {path}...', end='')
-        if path not in deny_list and get_cmd_status(f'git cat-file -e base:{sdk_directory}/{path}/Cargo.toml') == 0:
+        if path in deny_list:
+            eprint(f"skipping {path} because it is in 'deny_list'")
+        elif get_cmd_status(f'git cat-file -e base:{sdk_directory}/{path}/Cargo.toml') != 0:
+            eprint(f'skipping {path} because it does not exist in base')
+        else:
             get_cmd_output('cargo generate-lockfile', quiet=True)
             (_, out, _) = get_cmd_output('cargo pkgid', cwd=path, quiet=True)
             pkgid = parse_package_id(out)
@@ -59,8 +65,6 @@ def main(skip_generation=False):
                 if out:
                     eprint(out)
                 eprint(err)
-        else:
-            eprint(f'skipping {path} because it does not exist in base')
     if failures:
         eprint('One or more crates failed semver checks!')
         eprint("\n".join(failures))


### PR DESCRIPTION
## Motivation and Context
Skip running `semver-checks` on `aws-config` to enable clean runs for CI while #3265 is investigated.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
