### PR TITLE
Fix aws-config CI time regression

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -12,12 +12,14 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 behavior-version-latest = []
 client-hyper = ["aws-smithy-runtime/connector-hyper-0-14-x"]
 rustls = ["aws-smithy-runtime/tls-rustls", "client-hyper"]
-allow-compilation = [] # our tests use `cargo test --all-features` and native-tls breaks CI
 rt-tokio = ["aws-smithy-async/rt-tokio", "aws-smithy-runtime/rt-tokio", "tokio/rt"]
 sso = ["dep:aws-sdk-sso", "dep:aws-sdk-ssooidc", "dep:ring", "dep:hex", "dep:zeroize", "aws-smithy-runtime-api/http-auth"]
 credentials-process = ["tokio/process"]
 
 default = ["client-hyper", "rustls", "rt-tokio", "credentials-process", "sso"]
+
+# deprecated: this feature does nothing
+allow-compilation = []
 
 [dependencies]
 aws-credential-types = { path = "../../sdk/build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -36,7 +36,7 @@ echo "${C_YELLOW}## Checking for duplicate dependency versions in the normal dep
 cargo tree -d --edges normal --all-features
 
 echo "${C_YELLOW}## Testing every combination of features${C_RESET}"
-cargo hack test --feature-powerset --exclude-all-features --exclude-features native-tls
+cargo hack check --feature-powerset --exclude-all-features --exclude-features native-tls
 
 echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasi targets${C_RESET}"
 cargo check --target wasm32-unknown-unknown --no-default-features

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -35,8 +35,18 @@ cargo "+${RUST_NIGHTLY_VERSION:-nightly}" check-external-types --all-features --
 echo "${C_YELLOW}## Checking for duplicate dependency versions in the normal dependency graph with all features enabled${C_RESET}"
 cargo tree -d --edges normal --all-features
 
-echo "${C_YELLOW}## Testing every combination of features${C_RESET}"
-cargo hack check --feature-powerset --exclude-all-features --exclude-features native-tls
+# the crate has `allow-compilation` which needs to be deprecated
+
+echo "${C_YELLOW}## Checking every combination of features${C_RESET}"
+cargo hack check --feature-powerset --exclude-all-features --exclude-features allow-compilation
+
+echo "${C_YELLOW}## Testing each feature in isolation${C_RESET}"
+# these features are missed by the following check because they are grouped
+cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls --exclude-no-default-features
+
+# This check will check other individual features and no-default-features
+# grouping these features because they don't interact
+cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls
 
 echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasi targets${C_RESET}"
 cargo check --target wasm32-unknown-unknown --no-default-features


### PR DESCRIPTION
## Motivation and Context
This reduces checking aws-config to 6 minutes, down from 28


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
