### PR TITLE
Make delay between crate publishes configurable and reduce default

### DIFF
--- a/tools/ci-build/publisher/src/subcommand/publish.rs
+++ b/tools/ci-build/publisher/src/subcommand/publish.rs
@@ -23,6 +23,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::info;
 
+const DEFAULT_DELAY_MILLIS: usize = 1000;
+
 #[derive(Parser, Debug)]
 pub struct PublishArgs {
     /// Path containing the crates to publish. Crates will be discovered recursively
@@ -32,18 +34,24 @@ pub struct PublishArgs {
     /// Don't prompt for confirmation before publishing
     #[clap(short('y'))]
     skip_confirmation: bool,
+
+    /// Time delay between crate publishes to avoid crates.io throttling errors.
+    #[clap(long)]
+    delay_millis: Option<usize>,
 }
 
 pub async fn subcommand_publish(
     PublishArgs {
         location,
         skip_confirmation,
+        delay_millis,
     }: &PublishArgs,
 ) -> Result<()> {
     // Make sure cargo exists
     cargo::confirm_installed_on_path()?;
 
     let location = resolve_publish_location(location);
+    let delay_millis = Duration::from_millis(delay_millis.unwrap_or(DEFAULT_DELAY_MILLIS) as _);
 
     info!("Discovering crates to publish...");
     let (batches, stats) = discover_and_validate_package_batches(Fs::Real, &location).await?;
@@ -60,7 +68,7 @@ pub async fn subcommand_publish(
                 publish(&package.handle, &package.crate_path).await?;
 
                 // Keep things slow to avoid getting throttled by crates.io
-                tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(delay_millis).await;
 
                 // Sometimes it takes a little bit of time for the new package version
                 // to become available after publish. If we proceed too quickly, then


### PR DESCRIPTION
This change reduces the time delay between crate publishes from 5 seconds down to 1, and makes it configurable in case this leads to release issues.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
