### PR TITLE
Upgrade jsoup to 1.16.2

### DIFF
--- a/aws/sdk-codegen/build.gradle.kts
+++ b/aws/sdk-codegen/build.gradle.kts
@@ -23,7 +23,7 @@ val smithyVersion: String by project
 dependencies {
     implementation(project(":codegen-core"))
     implementation(project(":codegen-client"))
-    implementation("org.jsoup:jsoup:1.15.3")
+    implementation("org.jsoup:jsoup:1.16.2")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")

--- a/codegen-core/build.gradle.kts
+++ b/codegen-core/build.gradle.kts
@@ -23,7 +23,7 @@ val smithyVersion: String by project
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jsoup:jsoup:1.15.3")
+    implementation("org.jsoup:jsoup:1.16.2")
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     api("com.moandjiezana.toml:toml4j:0.7.2")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")


### PR DESCRIPTION
## Motivation and Context
Upgrades `jsoup` to 1.16.2, a version that we know is supported internally.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
