### PR TITLE
Correcting wording for S3 client docs.

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
@@ -67,7 +67,7 @@ object AwsDocs {
                 ## }
                 ```
 
-                Occasionally, SDKs may have additional service-specific that can be set on the [`Config`] that
+                Occasionally, SDKs may have additional service-specific values that can be set on the [`Config`] that
                 is absent from [`SdkConfig`], or slightly different settings for a specific client may be desired.
                 The [`Config`] struct implements `From<&SdkConfig>`, so setting these specific settings can be
                 done as follows:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Correcting wording in S3 client documentation.

## Description
<!--- Describe your changes in detail -->
The S3 client documentation seems to omit the word "values".

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
