### PR TITLE
Reexport `EventReceiver` in a generated client crate

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.eventReceiver
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.util.hasEventStreamMember
 import software.amazon.smithy.rust.codegen.core.util.hasEventStreamOperations
@@ -88,11 +89,13 @@ fun pubUseSmithyPrimitivesEventStream(codegenContext: CodegenContext, model: Mod
     if (codegenContext.serviceShape.hasEventStreamOperations(model)) {
         rustTemplate(
             """
+            pub use #{EventReceiver};
             pub use #{Header};
             pub use #{HeaderValue};
             pub use #{Message};
             pub use #{StrBytes};
             """,
+            "EventReceiver" to eventReceiver(rc),
             "Header" to RuntimeType.smithyTypes(rc).resolve("event_stream::Header"),
             "HeaderValue" to RuntimeType.smithyTypes(rc).resolve("event_stream::HeaderValue"),
             "Message" to RuntimeType.smithyTypes(rc).resolve("event_stream::Message"),


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
