### PR TITLE
feat(aws-smithy-runtime): introduce `tls-rustls-webpki` feature

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -97,3 +97,15 @@ message = "[`Number`](https://docs.rs/aws-smithy-types/latest/aws_smithy_types/e
 references = ["smithy-rs#3294"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
 author = "rcoh"
+
+[[aws-smithy-runtime]]
+message = "`rustls-webpki` feature is now available to use [`webpki-roots`](https://docs.rs/webpki-roots/latest/webpki_roots/) CA bundle rather than native one"
+references = ["smithy-rs#3309"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
+author = "rvolosatovs"
+
+[[aws-config]]
+message = "`tls-rustls-webpki` feature is now available to use [`webpki-roots`](https://docs.rs/webpki-roots/latest/webpki_roots/) CA bundle rather than native one"
+references = ["smithy-rs#3309"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
+author = "rvolosatovs"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 behavior-version-latest = []
 client-hyper = ["aws-smithy-runtime/connector-hyper-0-14-x"]
 rustls = ["aws-smithy-runtime/tls-rustls", "client-hyper"]
+rustls-webpki = ["aws-smithy-runtime/tls-rustls-webpki", "client-hyper"]
 rt-tokio = ["aws-smithy-async/rt-tokio", "aws-smithy-runtime/rt-tokio", "tokio/rt"]
 sso = ["dep:aws-sdk-sso", "dep:aws-sdk-ssooidc", "dep:ring", "dep:hex", "dep:zeroize", "aws-smithy-runtime-api/http-auth"]
 credentials-process = ["tokio/process"]

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 client = ["aws-smithy-runtime-api/client"]
 http-auth = ["aws-smithy-runtime-api/http-auth"]
 connector-hyper-0-14-x = ["dep:hyper-0-14", "hyper-0-14?/client", "hyper-0-14?/http2", "hyper-0-14?/http1", "hyper-0-14?/tcp", "hyper-0-14?/stream", "dep:h2"]
-tls-rustls = ["dep:hyper-rustls", "dep:rustls", "connector-hyper-0-14-x"]
+tls-rustls = ["dep:hyper-rustls", "hyper-rustls/rustls-native-certs", "dep:rustls", "connector-hyper-0-14-x"]
+tls-rustls-webpki = ["dep:hyper-rustls", "hyper-rustls/webpki-roots", "dep:rustls", "connector-hyper-0-14-x"]
 rt-tokio = ["tokio/rt"]
 
 # Features for testing
@@ -32,7 +33,7 @@ h2 = { version = "0.3", default-features = false, optional = true }
 http = { version = "0.2.8" }
 http-body-0-4 = { package = "http-body", version = "0.4.4" }
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, optional = true }
-hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
+hyper-rustls = { version = "0.24", features = ["http2"], optional = true }
 once_cell = "1.18.0"
 pin-project-lite = "0.2.7"
 pin-utils = "0.1.0"


### PR DESCRIPTION
## Motivation and Context
This allows (eventually) for downstream crates to not depend on native CA bundle, but rather use https://docs.rs/webpki-roots/latest/webpki_roots/

This is especially important, because on platforms where native CA bundle is missing, currently-used `hyper-rustls` panics at runtime (latest release uses version prior to https://github.com/rustls/hyper-rustls/commit/77154daea8663b9fd5263e70119ad145a050895e)

## Description
<!--- Describe your changes in detail -->

Provide a feature flag, which gives downstream developers a choice of the PKI bundle

## Testing
`cargo test` in respective crates with the new features (and old)

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
