### PR TITLE
Add daily credentials verification workflow

### DIFF
--- a/.github/workflows/credentials-verification.yml
+++ b/.github/workflows/credentials-verification.yml
@@ -1,0 +1,51 @@
+name: Daily credentials verification
+on:
+  schedule:
+    # Runs 00:00 UTC every day
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  # Verifies the token used by the bot to publish crates to crates.io
+  verify-crates-io-token:
+    name: Verify Crates.io Token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout smithy-rs
+        uses: actions/checkout@v3
+      - name: Verify Crates.io Token
+        shell: bash
+        env:
+          RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+        run: |
+          cargo login -- "${RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN}"
+          echo "Checking cargo auth token..."
+          # "cargo login" only saves a token and does not actually use it, so we use "cargo yank" to verify the token.
+          # This version has already been yanked, so it is safe to execute the command below repeatedly.
+          # This command succeeds if we have a token with permission to yank the crate.
+          cargo yank aws-sigv4 --version 0.55.0
+      - name: Notify Slack on Failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST "${SLACK_WEBHOOK_URL}" -H 'Content-type: application/json' \
+          --data '{"workflow_msg":"⚠️ Invalid crates.io token. Create a new token as soon as possible!"}'
+
+  # Verifies the token used to perform actions on the repository on behalf of the bot user
+  verify-personal-access-token:
+    name: Verify Personal Access Token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout smithy-rs
+        # To test the validity of the personal access token, we only need to perform checkout with the specified token.
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
+      - name: Notify Slack on Failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST "${SLACK_WEBHOOK_URL}" -H 'Content-type: application/json' \
+          --data '{"workflow_msg":"⚠️ Invalid GitHub personal access token. Create a new token as soon as possible!"}'


### PR DESCRIPTION
## Motivation and Context
Adds a daily credentials verification workflow

## Description
We rotate credentials manually. Those credentials are `RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN` and `RELEASE_AUTOMATION_BOT_PAT`. While the validity of those credentials are checked during dry-runs of [the release workflow](https://github.com/smithy-lang/smithy-rs/blob/main/.github/workflows/release.yml) we've had instances where a dry-run failed because it was not idempotent and we nevertheless kicked off a production run, only to find out the token was invalid. This raises the need for daily credentials verification, and the PR adds one.

The workflow will check the validly of two credentials `RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN` and `RELEASE_AUTOMATION_BOT_PAT`, each checked by a separate job. Upon failure, a job will notify us as follows:

<img width="1056" alt="Screenshot 2023-12-12 at 6 26 40 PM" src="https://github.com/smithy-lang/smithy-rs/assets/15333866/1105b26b-7064-4ba2-849a-5969d59f1dd4">

## Testing
Manually triggered failures and got the messages in the above screenshot. Also verified a successful run with valid credentials.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
