### PR TITLE
Allow `publisher` to put downgraded crates into `gradle.properties`

### DIFF
--- a/tools/ci-scripts/upgrade-gradle-properties
+++ b/tools/ci-scripts/upgrade-gradle-properties
@@ -15,7 +15,7 @@ mkdir -p "${ARTIFACTS_DIR}"
 pushd "${SMITHY_RS_DIR}"
 echo "gradle.properties BEFORE the upgrade"
 cat gradle.properties
-publisher upgrade-runtime-crates-version --stable-version "${STABLE_SEMANTIC_VERSION}" --version "${UNSTABLE_SEMANTIC_VERSION}"
+publisher upgrade-runtime-crates-version --stable-version "${STABLE_SEMANTIC_VERSION}" --version "${UNSTABLE_SEMANTIC_VERSION}" --allow-downgrade
 echo "gradle.properties AFTER the upgrade"
 cat gradle.properties
 git status


### PR DESCRIPTION
## Motivation and Context
We are currently in a circumstance where we need to publish `0.60.1` unstable runtime crates even though `0.61.0` were published to `crates.io` in the previous release.

## Description
This PR allows `publisher` to specify downgraded runtime crate versions in `gradle.properties` via the `--allow-downgrade` flag and updates a script `upgrade-gradle-properties` to use that flag. This is a bare minimum change in that we could update a release workflow to have a new checkbox whether we allow downgrade or not and thread through that value to the `upgrade-gradle-properties` script, instead of directly specifying like so.

## Testing
Added unit tests for `publisher` and manually ran `publisher upgrade-runtime-crates-version` with `--allow-downgrade` to check the functionality.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
