### PR TITLE
Fix the build against JDK 20

### DIFF
--- a/aws/rust-runtime/build.gradle.kts
+++ b/aws/rust-runtime/build.gradle.kts
@@ -12,6 +12,11 @@ group = "software.amazon.aws.rustruntime"
 
 version = "0.0.3"
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.jar {
     from("./") {
         include("aws-inlineable/src/*.rs")

--- a/aws/sdk-adhoc-test/build.gradle.kts
+++ b/aws/sdk-adhoc-test/build.gradle.kts
@@ -12,6 +12,11 @@ plugins {
     id("software.amazon.smithy")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 val smithyVersion: String by project
 val defaultRustDocFlags: String by project
 val properties = PropertyRetriever(rootProject, project)

--- a/aws/sdk-codegen/build.gradle.kts
+++ b/aws/sdk-codegen/build.gradle.kts
@@ -30,6 +30,11 @@ dependencies {
     implementation("software.amazon.smithy:smithy-aws-endpoints:$smithyVersion")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.compileKotlin {
     kotlinOptions.jvmTarget = "11"
 }

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -18,6 +18,11 @@ plugins {
     id("software.amazon.smithy")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 configure<software.amazon.smithy.gradle.SmithyExtension> {
     smithyBuildConfigs = files(layout.buildDirectory.file("smithy-build.json"))
     allowUnknownTraits = true

--- a/codegen-client/build.gradle.kts
+++ b/codegen-client/build.gradle.kts
@@ -34,6 +34,11 @@ dependencies {
     testImplementation("software.amazon.smithy:smithy-validation-model:$smithyVersion")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.compileKotlin {
     kotlinOptions.jvmTarget = "11"
 }

--- a/codegen-core/build.gradle.kts
+++ b/codegen-core/build.gradle.kts
@@ -97,6 +97,11 @@ val generateSmithyRuntimeCrateVersion by tasks.registering {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.compileKotlin {
     kotlinOptions.jvmTarget = "11"
     dependsOn(generateSmithyRuntimeCrateVersion)

--- a/codegen-server/build.gradle.kts
+++ b/codegen-server/build.gradle.kts
@@ -32,6 +32,11 @@ dependencies {
     testImplementation("software.amazon.smithy:smithy-validation-model:$smithyVersion")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.compileKotlin { kotlinOptions.jvmTarget = "11" }
 
 // Reusable license copySpec

--- a/codegen-server/python/build.gradle.kts
+++ b/codegen-server/python/build.gradle.kts
@@ -32,6 +32,11 @@ dependencies {
     testImplementation("software.amazon.smithy:smithy-validation-model:$smithyVersion")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.compileKotlin { kotlinOptions.jvmTarget = "11" }
 
 // Reusable license copySpec

--- a/codegen-server/typescript/build.gradle.kts
+++ b/codegen-server/typescript/build.gradle.kts
@@ -29,6 +29,11 @@ dependencies {
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.compileKotlin { kotlinOptions.jvmTarget = "11" }
 
 // Reusable license copySpec

--- a/rust-runtime/build.gradle.kts
+++ b/rust-runtime/build.gradle.kts
@@ -13,6 +13,11 @@ group = "software.amazon.rustruntime"
 
 version = "0.0.3"
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.jar {
     from("./") {
         include("inlineable/src/")


### PR DESCRIPTION
When using JDK 20, the following error would occur when attempting to build or run tests:

```
Execution failed for task ':codegen-client:compileKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileJava' (20) and 'compileKotlin' (11).
```

This PR explicitly sets the Java source and target versions to fix this error.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
