### PR TITLE
Fix BadSSL by building everything from source

### DIFF
--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -27,9 +27,9 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
 sudo make certs-test
 sudo make docker-build
-screen -dmS badssl sudo make serve
-sleep 5
-screen -ls s | grep "badssl"
+sudo make serve
+# sleep 5
+# screen -ls s | grep "badssl"
 
 # Check if the process is still running
 # if ps -p $bg_pid > /dev/null; thenqigq

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -27,7 +27,7 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
 sudo make certs-test
 sudo make docker-build
-sudo make serve
+screen -mS sudo make serve
 # sleep 5
 # screen -ls s | grep "badssl"
 

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -27,7 +27,7 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
 sudo make certs-test
 sudo make docker-build
-screen -mS sudo make serve
+sudo docker run -t -p 80:80 -p 443:443 -p 1000-1024:1000-1024 badssl
 # sleep 5
 # screen -ls s | grep "badssl"
 

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -22,4 +22,15 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 # This command patches this behavior to run the test immediately.
 # See: https://github.com/chromium/badssl.com/blob/df8d5a9d062f4b99fc19d8aacdea5333b399d624/certs/Makefile#L177
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
-screen -dmS badssl sudo make serve
+sudo make docker-build
+sudo make serve &
+sleep 10
+bg_pid=$!
+
+# Check if the process is still running
+if ps -p $bg_pid > /dev/null; then
+  echo "badssl is running with PID $bg_pid."
+else
+  echo "badssl is not running!"
+  exit 1
+fi

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -27,14 +27,12 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
 sudo make certs-test
 sudo make docker-build
-sudo make serve &
-sleep 10
-bg_pid=$!
+screen -dmS badssl sudo make serve
 
 # Check if the process is still running
-if ps -p $bg_pid > /dev/null; then
-  echo "badssl is running with PID $bg_pid."
-else
-  echo "badssl is not running!"
-  exit 1
-fi
+# if ps -p $bg_pid > /dev/null; thenqigq
+#   echo "badssl is running with PID $bg_pid."
+# else
+#   echo "badssl is not running!"
+#   exit 1
+# fi

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -25,6 +25,7 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 # This command patches this behavior to run the test immediately.
 # See: https://github.com/chromium/badssl.com/blob/df8d5a9d062f4b99fc19d8aacdea5333b399d624/certs/Makefile#L177
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
+sudo make certs-test
 sudo make docker-build
 sudo make serve &
 sleep 10

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -8,33 +8,18 @@ set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-
+# replace the broken dockerfile with our own (upstream?)
 cp "$DIR/new-badssl-dockerfile" Dockerfile
 grep -q 'start of badssl\.test hosts' /etc/hosts || make list-hosts | sudo tee -a /etc/hosts
-# badssl fails to create dh480.pem on our Ubuntu host.
-# Create it manually inside the docker container.
-sed -i '/CMD /i \
-RUN echo "-----BEGIN DH PARAMETERS-----" >/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-RUN echo "-----END DH PARAMETERS-----" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-' Dockerfile
 sed -i '/ 480/c \\ttrue' certs/Makefile
 # badssl does not create an expired certificate;
 # it creates a certificate that expires after 1 day and waits for 1 day to run the "expired certificate" test.
 # This command patches this behavior to run the test immediately.
 # See: https://github.com/chromium/badssl.com/blob/df8d5a9d062f4b99fc19d8aacdea5333b399d624/certs/Makefile#L177
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
+# there is a command "make serve" We don't want to actually run that because we want to error out early on `docker build`
 sudo make certs-test
 sudo make docker-build
-screen -dmS badssl sudo docker run -t -p 80:80 -p 443:443 -p 1000-1024:1000-1024 badssl
-# sleep 5
-# screen -ls s | grep "badssl"
 
-# Check if the process is still running
-# if ps -p $bg_pid > /dev/null; thenqigq
-#   echo "badssl is running with PID $bg_pid."
-# else
-#   echo "badssl is not running!"
-#   exit 1
-# fi
+# manually invoke the "serve" part of things
+screen -dmS badssl sudo docker run -t -p 80:80 -p 443:443 -p 1000-1024:1000-1024 badssl

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -6,7 +6,10 @@
 
 set -euxo pipefail
 
-perl -p -i -e 's/ruby2\.4/ruby2.6/' Dockerfile
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+
+cp "$DIR/new-badssl-dockerfile" Dockerfile
 grep -q 'start of badssl\.test hosts' /etc/hosts || make list-hosts | sudo tee -a /etc/hosts
 # badssl fails to create dh480.pem on our Ubuntu host.
 # Create it manually inside the docker container.

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -11,14 +11,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cp "$DIR/new-badssl-dockerfile" Dockerfile
 grep -q 'start of badssl\.test hosts' /etc/hosts || make list-hosts | sudo tee -a /etc/hosts
-# badssl fails to create dh480.pem on our Ubuntu host.
-# Create it manually inside the docker container.
-# sed -i '/CMD /i \
-# RUN echo "-----BEGIN DH PARAMETERS-----" >/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-# RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-# RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-# RUN echo "-----END DH PARAMETERS-----" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-# ' Dockerfile
+
+# we manually create this in the dockerfile. Tell the makefile not to bother to generate it.
 sed -i '/ 480/c \\ttrue' certs/Makefile
 # badssl does not create an expired certificate;
 # it creates a certificate that expires after 1 day and waits for 1 day to run the "expired certificate" test.
@@ -30,4 +24,5 @@ sudo make certs-test
 sudo make docker-build
 
 # manually invoke the "serve" part of things
+# if things are broken, try removing the screen session to see any failure logs.
 screen -dmS badssl sudo docker run -t -p 80:80 -p 443:443 -p 1000-1024:1000-1024 badssl

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -28,6 +28,8 @@ sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool si
 sudo make certs-test
 sudo make docker-build
 screen -dmS badssl sudo make serve
+sleep 5
+screen -ls s | grep "badssl"
 
 # Check if the process is still running
 # if ps -p $bg_pid > /dev/null; thenqigq

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -27,7 +27,7 @@ sed -i '/ 480/c \\ttrue' certs/Makefile
 sed -i 's%./tool sign $@ $(D) 1 sha256 req_v3_usr $^%faketime -f "-2d" ./tool sign $@ $(D) 1 sha256 req_v3_usr $^%' certs/Makefile
 sudo make certs-test
 sudo make docker-build
-sudo docker run -t -p 80:80 -p 443:443 -p 1000-1024:1000-1024 badssl
+screen -dmS badssl sudo docker run -t -p 80:80 -p 443:443 -p 1000-1024:1000-1024 badssl
 # sleep 5
 # screen -ls s | grep "badssl"
 

--- a/tools/ci-scripts/configure-tls/configure-badssl
+++ b/tools/ci-scripts/configure-tls/configure-badssl
@@ -8,9 +8,17 @@ set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# replace the broken dockerfile with our own (upstream?)
+
 cp "$DIR/new-badssl-dockerfile" Dockerfile
 grep -q 'start of badssl\.test hosts' /etc/hosts || make list-hosts | sudo tee -a /etc/hosts
+# badssl fails to create dh480.pem on our Ubuntu host.
+# Create it manually inside the docker container.
+# sed -i '/CMD /i \
+# RUN echo "-----BEGIN DH PARAMETERS-----" >/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+# RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+# RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+# RUN echo "-----END DH PARAMETERS-----" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+# ' Dockerfile
 sed -i '/ 480/c \\ttrue' certs/Makefile
 # badssl does not create an expired certificate;
 # it creates a certificate that expires after 1 day and waits for 1 day to run the "expired certificate" test.

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -1,0 +1,24 @@
+# Start with Ubuntu 16.04 (LTS), and build badssl.com up from there
+FROM ubuntu:22.04
+MAINTAINER April King <april@pokeinthe.io>
+EXPOSE 80 443
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    libffi-dev \
+    make \
+    nginx \
+    ruby3.0 \
+    ruby3.0-dev
+#RUN gem update --system
+RUN gem install jekyll
+
+# Install badssl.com
+ADD . badssl.com
+WORKDIR badssl.com
+RUN make inside-docker
+
+# Start things up!
+CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -1,8 +1,6 @@
-# What is this??
-# badssl seems to be abandoned. The orginal dockerfile was based on ubuntu 16.04 and all the bits were rotting.
-# I've updated the dockerfiel to ubuntu 22.04 which will hopefully let everything limp along a little longer.
-# Stage 2: Build Nginx using the OpenSSL built in Stage 1
-# Stage 2: Build Nginx using the OpenSSL built in Stage 1
+# Why does this file exist?
+# badssl seems to be abandoned. The orginal Dockerfile was based on ubuntu 16.04 and all the bits were rotting.
+# I've updated the Dockerfile to ubuntu 22.04 which will hopefully let everything limp along a little longer.
 FROM ubuntu:22.04 as nginx
 # Install necessary packages for building NGINX
 RUN apt-get update && apt-get install -y \
@@ -68,17 +66,19 @@ RUN tail -n10 /etc/ssl/openssl.cnf
 
 RUN nginx -V
 RUN mkdir /etc/nginx
+# `make-in-docker` requires this file to exist.
 RUN ln -s /usr/local/nginx/conf/nginx.conf /etc/nginx/nginx.conf
 
+# Update the nginx config to include the badssl configs.
 RUN head -n-1 /etc/nginx/nginx.conf > wip.conf
 RUN echo "# Virtual Host Configs\ninclude /var/www/badssl/_site/nginx.conf;\n}" >> wip.conf
 RUN mv wip.conf /usr/local/nginx/conf/nginx.conf
 RUN make inside-docker
 
+# Allow unsecure certs
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
-RUN tail -n10 /etc/ssl/openssl.cnf
-RUN cat /usr/local/nginx/conf/nginx.conf
 
+# Fix DH key that can't be generated...works in docker bug not on github. Who knows.
 RUN echo "-----BEGIN DH PARAMETERS-----" >/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
 RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
 RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -1,6 +1,6 @@
 # Why does this file exist?
 # badssl seems to be abandoned. The orginal Dockerfile was based on ubuntu 16.04 and all the bits were rotting.
-# I've updated the Dockerfile to ubuntu 22.04 which will hopefully let everything limp along a little longer.
+# I've updated the Dockerfilet l to ubuntu 22.04 which will hopefully let everything limp along a little longer.
 FROM ubuntu:22.04 as nginx
 # Install necessary packages for building NGINX
 RUN apt-get update && apt-get install -y \
@@ -79,10 +79,10 @@ RUN make inside-docker
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
 
 # Fix DH key that can't be generated...works in docker bug not on github. Who knows.
-RUN echo "-----BEGIN DH PARAMETERS-----" >/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
-RUN echo "-----END DH PARAMETERS-----" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+RUN echo "-----BEGIN DH PARAMETERS-----" > /var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem
+RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >> /var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem
+RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >> /var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem
+RUN echo "-----END DH PARAMETERS-----" >> /var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem
 
 RUN nginx -t
 # Start things up!

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -40,7 +40,6 @@ RUN /usr/local/nginx/sbin/nginx -V
 
 FROM ubuntu:22.04
 
-MAINTAINER April King <april@pokeinthe.io>
 EXPOSE 80 443
 RUN apt-get update && apt-get install -y apt-transport-https
 RUN apt-get install -y software-properties-common

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -1,7 +1,46 @@
 # What is this??
 # badssl seems to be abandoned. The orginal dockerfile was based on ubuntu 16.04 and all the bits were rotting.
 # I've updated the dockerfiel to ubuntu 22.04 which will hopefully let everything limp along a little longer.
+# Stage 2: Build Nginx using the OpenSSL built in Stage 1
+FROM ubuntu:22.04 as nginx
+# Install necessary packages for building NGINX
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpcre3 \
+    libpcre3-dev \
+    zlib1g \
+    zlib1g-dev \
+    wget
+
+# Define NGINX version
+ARG NGINX_VERSION=1.25.3
+ARG OPEN_SSL_VERSION=3.2.0
+
+RUN wget https://github.com/openssl/openssl/releases/download/openssl-${OPEN_SSL_VERSION}/openssl-${OPEN_SSL_VERSION}.tar.gz \
+    && tar -xzvf openssl-${OPEN_SSL_VERSION}.tar.gz
+
+# Download NGINX source code
+RUN wget http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz \
+    && tar -xzvf nginx-$NGINX_VERSION.tar.gz \
+    && cd nginx-$NGINX_VERSION
+
+
+# Configure NGINX before building it
+RUN cd nginx-$NGINX_VERSION \
+    && ./configure \
+        --prefix=/usr/local/nginx \
+        --with-http_ssl_module \
+        --with-openssl=../openssl-${OPEN_SSL_VERSION} \
+        --with-openssl-opt=enable-weak-ssl-ciphers \
+        --with-stream \
+        --with-threads \
+    && make \
+    && make install
+
+RUN /usr/local/nginx/sbin/nginx -V
+
 FROM ubuntu:22.04
+
 MAINTAINER April King <april@pokeinthe.io>
 EXPOSE 80 443
 RUN apt-get update && apt-get install -y apt-transport-https
@@ -11,19 +50,26 @@ RUN apt-get update && apt-get install -y \
     git \
     libffi-dev \
     make \
-    nginx \
     ruby3.0 \
     ruby3.0-dev
 #RUN gem update --system
 RUN gem install jekyll
 
+COPY --from=nginx /usr/local/nginx /usr/local/nginx
+ENV PATH="/usr/local/nginx/sbin:${PATH}"
+
 # Install badssl.com
 ADD . badssl.com
 WORKDIR badssl.com
+
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
+RUN tail -n10 /etc/ssl/openssl.cnf
+
+RUN nginx -V
 RUN make inside-docker
 
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
 RUN tail -n10 /etc/ssl/openssl.cnf
 
 # Start things up!
-CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log
+# CMD nginx && tail -f /usr/local/nginx/logs/access.log /usr/local/nginx/logs/error.log

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -2,6 +2,7 @@
 # badssl seems to be abandoned. The orginal dockerfile was based on ubuntu 16.04 and all the bits were rotting.
 # I've updated the dockerfiel to ubuntu 22.04 which will hopefully let everything limp along a little longer.
 # Stage 2: Build Nginx using the OpenSSL built in Stage 1
+# Stage 2: Build Nginx using the OpenSSL built in Stage 1
 FROM ubuntu:22.04 as nginx
 # Install necessary packages for building NGINX
 RUN apt-get update && apt-get install -y \
@@ -12,11 +13,11 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     wget
 
-# Define NGINX version
-ARG NGINX_VERSION=1.25.3
-ARG OPEN_SSL_VERSION=3.2.0
+# Define NGINX version (this is the old version from ubuntu 16.04 to match)
+ARG NGINX_VERSION=1.14.2
+ARG OPEN_SSL_VERSION=1.0.2g
 
-RUN wget https://github.com/openssl/openssl/releases/download/openssl-${OPEN_SSL_VERSION}/openssl-${OPEN_SSL_VERSION}.tar.gz \
+RUN wget https://www.openssl.org/source/openssl-${OPEN_SSL_VERSION}.tar.gz \
     && tar -xzvf openssl-${OPEN_SSL_VERSION}.tar.gz
 
 # Download NGINX source code
@@ -34,8 +35,8 @@ RUN cd nginx-$NGINX_VERSION \
         --with-openssl-opt=enable-weak-ssl-ciphers \
         --with-stream \
         --with-threads \
-    && make \
-    && make install
+    && make -j 6 \
+    && make install -j 6
 
 RUN /usr/local/nginx/sbin/nginx -V
 
@@ -66,10 +67,15 @@ RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
 RUN tail -n10 /etc/ssl/openssl.cnf
 
 RUN nginx -V
+RUN mkdir /etc/nginx
+RUN ln -s /usr/local/nginx/conf/nginx.conf /etc/nginx/nginx.conf
+
+RUN head -n-1 /etc/nginx/nginx.conf > wip.conf
+RUN echo "# Virtual Host Configs\ninclude /var/www/badssl/_site/nginx.conf;\n}" >> wip.conf
+RUN mv wip.conf /usr/local/nginx/conf/nginx.conf
 RUN make inside-docker
 
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
 RUN tail -n10 /etc/ssl/openssl.cnf
-
-# Start things up!
-# CMD nginx && tail -f /usr/local/nginx/logs/access.log /usr/local/nginx/logs/error.log
+RUN cat /usr/local/nginx/conf/nginx.conf
+RUN nginx -t

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -78,4 +78,10 @@ RUN make inside-docker
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
 RUN tail -n10 /etc/ssl/openssl.cnf
 RUN cat /usr/local/nginx/conf/nginx.conf
+
+RUN echo "-----BEGIN DH PARAMETERS-----" >/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+RUN echo "MEICPQDZ/YFp3iEs3/k9iRGoC/5/To2+5pUF/C6GkO6VjXHHyRVy68I0rI0q7IAq" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+RUN echo "-----END DH PARAMETERS-----" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
+
 RUN nginx -t

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -1,4 +1,6 @@
-# Start with Ubuntu 16.04 (LTS), and build badssl.com up from there
+# What is this??
+# badssl seems to be abandoned. The orginal dockerfile was based on ubuntu 16.04 and all the bits were rotting.
+# I've updated the dockerfiel to ubuntu 22.04 which will hopefully let everything limp along a little longer.
 FROM ubuntu:22.04
 MAINTAINER April King <april@pokeinthe.io>
 EXPOSE 80 443

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -22,7 +22,8 @@ ADD . badssl.com
 WORKDIR badssl.com
 RUN make inside-docker
 
-RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf
+RUN tail -n10 /etc/ssl/openssl.cnf
 
 # Start things up!
 CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -22,5 +22,7 @@ ADD . badssl.com
 WORKDIR badssl.com
 RUN make inside-docker
 
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf
+
 # Start things up!
 CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/tools/ci-scripts/configure-tls/new-badssl-dockerfile
+++ b/tools/ci-scripts/configure-tls/new-badssl-dockerfile
@@ -85,3 +85,5 @@ RUN echo "VyyGQ7/5Q/Iu0QQnHT4X9uMCAQI=" >>/var/www/badssl/_site/certs/sets/curre
 RUN echo "-----END DH PARAMETERS-----" >>/var/www/badssl/_site/certs/sets/current/gen/dhparam/dh480.pem \
 
 RUN nginx -t
+# Start things up!
+CMD nginx && tail -f /usr/local/nginx/logs/access.log /usr/local/nginx/logs/error.log


### PR DESCRIPTION
## Motivation and Context
The TLS test broke. Why? Because Bad SSL stopped working.

Why did BadSSL stop working? Because it used an ancient version of ruby and it couldn't install packages anymore.

So I:
- Got it working on a newer version of ruby
- But that only work on Ubuntu 22.04.
- The version of nginx/openssl that you can install on 22.04 version actually serve these terrible certificates.

So instead, we compile nginx and openssl from source.

I also fixed things up so they won't fail silently in the future.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
Mostly just sadness.

## Testing
The check passes again.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
