### PR TITLE
Update CredentialsProcess to support no-expiry credentials

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,9 @@ message = "Serialize 0/false in query parameters, and ignore actual default valu
 references = ["smithy-rs#3252", "smithy-rs#3312"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "milesziemer"
+
+[[aws-sdk-rust]]
+message = "Fix bug in `CredentialsProcess` provider where `expiry` was incorrectly treated as a required field."
+references = ["smithy-rs#3335", "aws-sdk-rust#1021"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"


### PR DESCRIPTION
## Motivation and Context
- aws-sdk-rust#1021

## Description
Fix bug in CredentialsProcess provider where expiry was erroneously required

## Testing
- unit test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
