### PR TITLE
Fix floating-point number default value instantiation

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/DefaultValueGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/DefaultValueGenerator.kt
@@ -6,6 +6,8 @@
 package software.amazon.smithy.rust.codegen.core.smithy.generators
 
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.DoubleShape
+import software.amazon.smithy.model.shapes.FloatShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.SimpleShape
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -33,7 +35,7 @@ class DefaultValueGenerator(
             is Default.RustDefault -> DefaultValue(isRustDefault = true, writable("Default::default"))
             is Default.NonZeroDefault -> {
                 val instantiation = instantiator.instantiate(target as SimpleShape, default.value)
-                DefaultValue(isRustDefault = false, writable { rust("||#T", instantiation) })
+                DefaultValue(isRustDefault = false, writable { rust("|| #T", instantiation) })
             }
         }
     }


### PR DESCRIPTION
When a floating-point shape has a default value without a decimal place, the instantiator instantiates it with an integer value, which causes compilation failure:

```
error[E0308]: mismatched types
   --> sdk/connect/src/types/_user_proficiency.rs:109:49
    |
109 |             level: self.level.unwrap_or_else(|| 1),
    |                                                 ^
    |                                                 |
    |                                                 expected `f32`, found integer
    |                                                 help: use a float literal: `1.0`
```

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
