### PR TITLE
- Uncommented several lines of commented-out code to make the example…

### DIFF
--- a/aws/rust-runtime/aws-sigv4/src/http_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request.rs
@@ -10,10 +10,9 @@
 //! **Note**: This requires `http0-compat` to be enabled.
 //!
 //! ```rust
-//! # use aws_credential_types::Credentials;
+//! use aws_credential_types::Credentials;
 //! use aws_smithy_runtime_api::client::identity::Identity;
-//! # use aws_sigv4::http_request::SignableBody;
-//! #[cfg(feature = "http0-compat")]
+//! use aws_sigv4::http_request::SignableBody;
 //! fn test() -> Result<(), aws_sigv4::http_request::SigningError> {
 //! use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest};
 //! use aws_sigv4::sign::v4;
@@ -50,8 +49,8 @@
 //! // Sign and then apply the signature to the request
 //! let (signing_instructions, _signature) = sign(signable_request, &signing_params)?.into_parts();
 //! signing_instructions.apply_to_request_http0x(&mut my_req);
-//! # Ok(())
-//! # }
+//! Ok(())
+//! }
 //! ```
 
 mod canonical_request;


### PR DESCRIPTION
- Uncommented several lines of commented-out code to make the example…

- I removed #[cfg(feature = "http0-compat")]. It's only useful if an example is built as part of the aws-sigv4 crate (that has a definition of this feature). However, there is no value in it when you copy it into a client app.

## Motivation and Context

I was trying to use aws-sigv4 for request signing and found an example of how to use it here.
https://docs.rs/aws-sigv4/1.1.1/aws_sigv4/http_request/index.html

The example needed to be completed (it didn't build).

I checked the code and found out that it looked like a formatting error (when somebody was converting it from commented-out code to documentation.

The change makes the example complete and buildable. 

## Description

The change
- Uncommented accidentally commented code
- Removes unnecessary #[cfg()] check 

## Testing

I included the sample in my client app and ensured it builds. 

Since the change in documentation of example, it can't affect any other areas of the code.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
