### PR TITLE
Resolve runtime crate versions from manifests first

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -100,8 +100,7 @@ fun generateSmithyBuild(services: AwsServices): String {
                 "plugins": {
                     "rust-client-codegen": {
                         "runtimeConfig": {
-                            "relativePath": "../",
-                            "version": "DEFAULT"
+                            "relativePath": "../"
                         },
                         "codegen": {
                             "includeFluentClient": false,

--- a/buildSrc/src/main/kotlin/ManifestPatcher.kt
+++ b/buildSrc/src/main/kotlin/ManifestPatcher.kt
@@ -15,8 +15,11 @@ fun rewriteCrateVersion(
     )
 
 /**
- * Smithy runtime crate versions in smithy-rs are all `0.0.0-smithy-rs-head`. When copying over to the AWS SDK,
- * these should be changed to the smithy-rs version.
+ * Dependently versioned Smithy runtime crate versions in smithy-rs are all `0.0.0-smithy-rs-head`.
+ * When copying over to the AWS SDK, these should be changed to the corresponding
+ * stable/unstable runtime crate version from gradle.properties.
+ *
+ * In the future when all the runtime crates are independently versioned, this can be removed.
  */
 fun rewriteRuntimeCrateVersion(
     version: String,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/Version.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/Version.kt
@@ -9,41 +9,27 @@ import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.node.Node
 
 // generated as part of the build, see codegen-core/build.gradle.kts
-private const val VERSION_FILENAME = "runtime-crate-version.txt"
+private const val VERSION_FILENAME = "runtime-crate-versions.json"
 
 data class Version(
-    val fullVersion: String,
-    val stableCrateVersion: String,
-    val unstableCrateVersion: String,
+    val gitHash: String,
     val crates: Map<String, String>,
 ) {
     companion object {
         // Version must be in the "{smithy_rs_version}\n{git_commit_hash}" format
         fun parse(content: String): Version {
             val node = Node.parse(content).expectObjectNode()
-            val githash = node.expectStringMember("githash").value
-            val stableVersion = node.expectStringMember("stableVersion").value
-            val unstableVersion = node.expectStringMember("unstableVersion").value
             return Version(
-                "$stableVersion-$githash",
-                stableCrateVersion = stableVersion,
-                unstableCrateVersion = unstableVersion,
+                node.expectStringMember("gitHash").value,
                 node.expectObjectMember("runtimeCrates").members.map {
                     it.key.value to it.value.expectStringNode().value
                 }.toMap(),
             )
         }
 
-        // Returns full version in the "{smithy_rs_version}-{git_commit_hash}" format
-        fun fullVersion(): String = fromDefaultResource().fullVersion
-
-        fun stableCrateVersion(): String = fromDefaultResource().stableCrateVersion
-
-        fun unstableCrateVersion(): String = fromDefaultResource().unstableCrateVersion
-
         fun crateVersion(crate: String): String {
             val version = fromDefaultResource()
-            return version.crates[crate] ?: version.unstableCrateVersion
+            return version.crates[crate] ?: throw CodegenException("unknown version number for runtime crate $crate")
         }
 
         fun fromDefaultResource(): Version =

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.rust.codegen.core.smithy
 
-import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
@@ -26,8 +25,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustInlineTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.Optional
-
-private const val DEFAULT_KEY = "DEFAULT"
 
 /**
  * Location of the runtime crates (aws-smithy-http, aws-smithy-types etc.)
@@ -50,14 +47,6 @@ fun RuntimeCrateLocation.crateLocation(crateName: String): DependencyLocation {
         // provide a detected version unless the user explicitly sets one via the `versions` map.
         null -> CratesIo(version)
         else -> Local(this.path)
-    }
-}
-
-fun defaultRuntimeCrateVersion(): String {
-    try {
-        return Version.stableCrateVersion()
-    } catch (ex: Exception) {
-        throw CodegenException("failed to get crate version which sets the default client-runtime version", ex)
     }
 }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGenerator.kt
@@ -94,7 +94,7 @@ class CargoTomlGenerator(
                             listOfNotNull(
                                 "smithy" to
                                     listOfNotNull(
-                                        "codegen-version" to Version.fullVersion(),
+                                        "codegen-version" to Version.fromDefaultResource().gitHash,
                                     ).toMap(),
                             ).toMap(),
                     ).toMap(),

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/VersionTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/VersionTest.kt
@@ -5,48 +5,50 @@
 
 package software.amazon.smithy.rust.codegen.core
 
-import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 
 class VersionTest {
-    @ParameterizedTest()
-    @MethodSource("versionProvider")
-    fun `parses version`(
-        content: String,
-        fullVersion: String,
-        crateVersion: String,
-    ) {
-        val version = Version.parse(content)
-        version.fullVersion shouldBe fullVersion
-        version.stableCrateVersion shouldBe crateVersion
-    }
-
-    @ParameterizedTest()
-    @MethodSource("invalidVersionProvider")
-    fun `fails to parse version`(content: String) {
-        shouldThrowAny { Version.parse(content) }
-    }
-
-    companion object {
-        @JvmStatic
-        fun versionProvider() =
-            listOf(
-                Arguments.of(
-                    """{ "stableVersion": "1.0.1", "unstableVersion": "0.60.1","githash": "0198d26096eb1af510ce24766c921ffc5e4c191e", "runtimeCrates": {} }""",
-                    "1.0.1-0198d26096eb1af510ce24766c921ffc5e4c191e",
-                    "1.0.1",
-                ),
-                Arguments.of(
-                    """{ "unstableVersion": "0.60.1", "stableVersion": "release-2022-08-04", "githash": "db48039065bec890ef387385773b37154b555b14", "runtimeCrates": {} }""",
-                    "release-2022-08-04-db48039065bec890ef387385773b37154b555b14",
-                    "release-2022-08-04",
-                ),
+    @Test
+    fun `parse versions json`() {
+        val version =
+            Version.parse(
+                """
+                {
+                  "gitHash": "30205973b951256c4c37b998e7a6e94fee2f6ecc",
+                  "runtimeCrates": {
+                    "aws-smithy-http-server": "0.60.1",
+                    "aws-smithy-runtime-api": "1.1.1",
+                    "aws-smithy-protocol-test": "0.60.1",
+                    "aws-smithy-eventstream": "0.60.1",
+                    "aws-smithy-async": "1.1.1",
+                    "aws-smithy-http-server-python": "0.60.1",
+                    "aws-smithy-types": "1.1.1",
+                    "aws-smithy-types-convert": "0.60.1",
+                    "aws-smithy-http-auth": "0.60.1",
+                    "aws-smithy-checksums": "0.60.1",
+                    "aws-smithy-runtime": "1.1.1",
+                    "aws-smithy-query": "0.60.1",
+                    "aws-smithy-xml": "0.60.1",
+                    "aws-smithy-json": "0.60.1",
+                    "aws-smithy-http-tower": "0.60.1",
+                    "aws-smithy-http": "0.60.1",
+                    "aws-smithy-client": "0.60.1",
+                    "aws-sig-auth": "0.60.1",
+                    "aws-credential-types": "1.1.1",
+                    "aws-runtime-api": "1.1.1",
+                    "aws-types": "1.1.1",
+                    "aws-sigv4": "1.1.1",
+                    "aws-runtime": "1.1.1",
+                    "aws-http": "0.60.1",
+                    "aws-endpoint": "0.60.1",
+                    "aws-config": "1.1.1",
+                    "aws-hyper": "0.60.1"  }
+                }
+                """,
             )
-
-        @JvmStatic
-        fun invalidVersionProvider() = listOf("0.0.0", "")
+        version.gitHash shouldBe "30205973b951256c4c37b998e7a6e94fee2f6ecc"
+        version.crates["aws-smithy-http-server"] shouldBe "0.60.1"
+        version.crates["aws-config"] shouldBe "1.1.1"
     }
 }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeTypeTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeTypeTest.kt
@@ -44,9 +44,9 @@ class RuntimeTypesTest {
 
         val crateLocVersioned =
             RuntimeCrateLocation(null, CrateVersionMap(mapOf("aws-smithy-runtime-api" to "999.999")))
-        crateLocVersioned.crateLocation("aws-smithy-runtime") shouldBe CratesIo(Version.stableCrateVersion())
+        crateLocVersioned.crateLocation("aws-smithy-runtime") shouldBe CratesIo(Version.crateVersion("aws-smithy-runtime"))
         crateLocVersioned.crateLocation("aws-smithy-runtime-api") shouldBe CratesIo("999.999")
-        crateLocVersioned.crateLocation("aws-smithy-http") shouldBe CratesIo(Version.unstableCrateVersion())
+        crateLocVersioned.crateLocation("aws-smithy-http") shouldBe CratesIo(Version.crateVersion("aws-smithy-http"))
     }
 
     companion object {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGeneratorTest.kt
@@ -36,7 +36,7 @@ class CargoTomlGeneratorTest {
                     .expect("missing `smithy.codegen-version` field")
                     .as_str()
                     .expect("`smithy.codegen-version` is not str");
-                assert_eq!(codegen_version, "${Version.fullVersion()}");
+                assert_eq!(codegen_version, "${Version.fromDefaultResource().gitHash}");
                 """,
             )
         }

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
@@ -240,7 +240,7 @@ class PythonServerModuleGenerator(
 
     // Render the codegeneration version as module attribute.
     private fun RustWriter.renderCodegenVersion() {
-        rust("""m.add("CODEGEN_VERSION", "${Version.stableCrateVersion()}")?;""")
+        rust("""m.add("CODEGEN_VERSION", "${Version.fromDefaultResource().gitHash}")?;""")
     }
 
     // Convert to symbol and check the namespace to figure out where they should be imported from.


### PR DESCRIPTION
This PR changes codegen-core's build-time runtime crate version resolution to pull versions from the actual runtime crate manifest files, only changing them to the version numbers in gradle.properties if they use the special `0.0.0-smithy-rs-head` version number. This is a prerequisite step in allowing independent crate versioning.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
