### PR TITLE
Fix compilation error

### DIFF
--- a/rust-runtime/aws-smithy-types/src/blob.rs
+++ b/rust-runtime/aws-smithy-types/src/blob.rs
@@ -42,7 +42,7 @@ mod serde_serialize {
             S: serde::Serializer,
         {
             if serializer.is_human_readable() {
-                serializer.serialize_str(&base64::encode(&self.inner))
+                serializer.serialize_str(&crate::base64::encode(&self.inner))
             } else {
                 serializer.serialize_bytes(&self.inner)
             }


### PR DESCRIPTION
Address #3356

## Motivation and Context
Solves compilation error mentioned in #3356 

## Description
Qualify access to `base64` module

## Testing
Trivial compilation changes has been done - `cargo build` succeeds with this change, while it doesn't without it. Provided of course that `aws_sdk_unstable` config is selected and `serde-serialize` feature is enabled.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
