### PR TITLE
Read the list of identity resolvers backwards

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -1011,6 +1011,10 @@ impl GetIdentityResolver for RuntimeComponents {
     fn identity_resolver(&self, scheme_id: AuthSchemeId) -> Option<SharedIdentityResolver> {
         self.identity_resolvers
             .iter()
+            // We want the most recently added auth scheme that matches.
+            // This is so that an overriding auth scheme will be returned over one
+            // set by default
+            .rev()
             .find(|s| s.value.scheme_id() == scheme_id)
             .map(|s| s.value.identity_resolver())
     }


### PR DESCRIPTION
## Motivation and Context
- https://github.com/awslabs/aws-sdk-rust/issues/901

## Description
When merging RuntimeComponentBuilders, the vecs are appended. However, this means the most recently added auth options are at the end. If `sigv4` is provided multiple times, this means that only the original auth scheme will actually be used.


## Testing
New UT that fails without this change and passes after.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
