### PR TITLE
sdk-lints was using a yanked verion of 'cargo_toml'

### DIFF
--- a/tools/ci-build/sdk-lints/Cargo.lock
+++ b/tools/ci-build/sdk-lints/Cargo.lock
@@ -107,13 +107,12 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cargo_toml"
-version = "0.10.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363c7cfaa15f101415c4ac9e68706ca4a2277773932828b33f96e59d28c68e62"
+checksum = "802b755090e39835a4b0440fb0bbee0df7495a8b337f63db21e616f7821c7e8c"
 dependencies = [
  "serde",
- "serde_derive",
- "toml",
+ "toml 0.8.8",
 ]
 
 [[package]]
@@ -138,7 +137,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "strsim",
  "termcolor",
@@ -191,6 +190,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -306,7 +311,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -318,6 +323,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -422,7 +433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -770,7 +791,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "smithy-rs-tool-common",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -834,6 +855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,7 +896,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -997,8 +1027,42 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1276,6 +1340,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/tools/ci-build/sdk-lints/Cargo.toml
+++ b/tools/ci-build/sdk-lints/Cargo.toml
@@ -12,7 +12,7 @@ opt-level = 0
 
 [dependencies]
 anyhow = "1"
-cargo_toml = "0.10.1"
+cargo_toml = "0.18.0"
 clap = { version = "~3.1.18", features = ["derive"]}
 lazy_static = "1.4.0"
 serde = { version = "1", features = ["derive"]}

--- a/tools/ci-build/sdk-lints/src/lint_cargo_toml.rs
+++ b/tools/ci-build/sdk-lints/src/lint_cargo_toml.rs
@@ -89,7 +89,7 @@ impl Check for CrateLicense {
 fn check_crate_license(package: Package, path: impl AsRef<Path>) -> Result<Vec<LintError>> {
     let mut errors = vec![];
     match package.license {
-        Some(license) if license == "Apache-2.0" => {}
+        Some(license) if license.as_ref().unwrap() == "Apache-2.0" => {}
         incorrect_license => errors.push(LintError::new(format!(
             "invalid license: {:?}",
             incorrect_license
@@ -145,7 +145,13 @@ fn check_crate_author(package: Package) -> Result<Vec<LintError>> {
     } else {
         RUST_SDK_TEAM
     };
-    if !package.authors.iter().any(|s| s == expected_author) {
+    if !package
+        .authors
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|s| s == expected_author)
+    {
         errors.push(LintError::new(format!(
             "missing `{}` in package author list ({:?})",
             expected_author, package.authors


### PR DESCRIPTION
## Motivation and Context
update version of cargo_toml used by sdk-lints


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
