### PR TITLE
Independently version deprecated runtime crates

### DIFF
--- a/aws/rust-runtime/aws-endpoint/Cargo.toml
+++ b/aws/rust-runtime/aws-endpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-endpoint"
-version = "0.0.0-smithy-rs-head"
+version = "0.60.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "This crate is no longer used by the AWS SDK and is deprecated."
 edition = "2021"

--- a/aws/rust-runtime/aws-hyper/Cargo.toml
+++ b/aws/rust-runtime/aws-hyper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-hyper"
-version = "0.0.0-smithy-rs-head"
+version = "0.60.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "This crate has been removed and is deprecated."
 edition = "2021"

--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sig-auth"
-version = "0.0.0-smithy-rs-head"
+version = "0.60.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "This crate is no longer used by the AWS SDK and is deprecated."
 edition = "2021"

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-client"
-version = "0.0.0-smithy-rs-head"
+version = "0.60.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "This crate is no longer used by smithy-rs and is deprecated."
 edition = "2021"

--- a/rust-runtime/aws-smithy-http-auth/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-auth"
-version = "0.0.0-smithy-rs-head"
+version = "0.60.3"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Eduardo Rodrigues <16357187+eduardomourar@users.noreply.github.com>",

--- a/rust-runtime/aws-smithy-http-tower/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-tower"
-version = "0.0.0-smithy-rs-head"
+version = "0.60.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "This crate is no longer used by smithy-rs and is deprecated."
 edition = "2021"


### PR DESCRIPTION
This PR sets independent versions for the deprecated runtime crates so that they won't publish new version numbers with every release anymore.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
