### PR TITLE
Update sigv4 to allow applying signature to http1x URIs

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,9 @@ message = "Fix bug where overriding the credentials at the operation level faile
 references = ["aws-sdk-rust#901", "smithy-rs#3363"]
 meta = { "breaking" = false, "bug" = true, "tada" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Add `apply_to_request_http1x` to `aws-sigv4` to enable signing http = 1.0 requests."
+references = ["aws-sdk-rust#1041", "smithy-rs#3366"]
+meta = { "breaking" = false, "bug" = false, "tada" = true }
+author = "rcoh"

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 
 [features]
 default = ["sign-http", "http1"]
-http0-compat = ["dep:http"]
-http1 = ["dep:http1"]
-sign-http = ["dep:http", "dep:percent-encoding", "dep:form_urlencoded"]
+http0-compat = ["dep:http0"]
+http1 = ["dep:http"]
+sign-http = ["dep:http0", "dep:percent-encoding", "dep:form_urlencoded"]
 sign-eventstream = ["dep:aws-smithy-eventstream"]
 sigv4a = ["dep:p256", "dep:crypto-bigint", "dep:subtle", "dep:zeroize", "dep:ring"]
 
@@ -26,8 +26,8 @@ bytes = "1"
 form_urlencoded = { version = "1.0", optional = true }
 hex = "0.4"
 hmac = "0.12"
-http = { version = "0.2", optional = true }
-http1 = { package = "http", version = "1", optional = true }
+http0 = { version = "0.2", optional = true, package = "http" }
+http = { version = "1", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
 once_cell = "1.8"
 p256 = { version = "0.11", features = ["ecdsa"], optional = true }

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -9,8 +9,9 @@ license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
 
 [features]
-default = ["sign-http"]
+default = ["sign-http", "http1"]
 http0-compat = ["dep:http"]
+http1 = ["dep:http1"]
 sign-http = ["dep:http", "dep:percent-encoding", "dep:form_urlencoded"]
 sign-eventstream = ["dep:aws-smithy-eventstream"]
 sigv4a = ["dep:p256", "dep:crypto-bigint", "dep:subtle", "dep:zeroize", "dep:ring"]
@@ -26,6 +27,7 @@ form_urlencoded = { version = "1.0", optional = true }
 hex = "0.4"
 hmac = "0.12"
 http = { version = "0.2", optional = true }
+http1 = { package = "http", version = "1", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
 once_cell = "1.8"
 p256 = { version = "0.11", features = ["ecdsa"], optional = true }

--- a/aws/rust-runtime/aws-sigv4/src/http_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request.rs
@@ -13,14 +13,15 @@
 //! # use aws_credential_types::Credentials;
 //! use aws_smithy_runtime_api::client::identity::Identity;
 //! # use aws_sigv4::http_request::SignableBody;
-//! #[cfg(feature = "http0-compat")]
+//! #[cfg(feature = "http1")]
 //! fn test() -> Result<(), aws_sigv4::http_request::SigningError> {
 //! use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest};
 //! use aws_sigv4::sign::v4;
-//! use http;
+//! use http0;
 //! use std::time::SystemTime;
 //!
 //! // Set up information and settings for the signing
+//! // You can obtain credentials from `SdkConfig`.
 //! let identity = Credentials::new(
 //!     "AKIDEXAMPLE",
 //!     "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
@@ -49,7 +50,7 @@
 //! let mut my_req = http::Request::new("...");
 //! // Sign and then apply the signature to the request
 //! let (signing_instructions, _signature) = sign(signable_request, &signing_params)?.into_parts();
-//! signing_instructions.apply_to_request_http0x(&mut my_req);
+//! signing_instructions.apply_to_request_http1x(&mut my_req);
 //! # Ok(())
 //! # }
 //! ```

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -15,8 +15,8 @@ use crate::http_request::{PayloadChecksumKind, SignableBody, SignatureLocation, 
 use crate::sign::v4::sha256_hex_string;
 use crate::SignatureVersion;
 use aws_smithy_http::query_writer::QueryWriter;
-use http::header::{AsHeaderName, HeaderName, HOST};
-use http::{HeaderMap, HeaderValue, Uri};
+use http0::header::{AsHeaderName, HeaderName, HOST};
+use http0::{HeaderMap, HeaderValue, Uri};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::convert::TryFrom;
@@ -626,7 +626,7 @@ mod tests {
     use aws_credential_types::Credentials;
     use aws_smithy_http::query_writer::QueryWriter;
     use aws_smithy_runtime_api::client::identity::Identity;
-    use http::{HeaderValue, Uri};
+    use http0::{HeaderValue, Uri};
     use pretty_assertions::assert_eq;
     use proptest::{prelude::*, proptest};
     use std::borrow::Cow;
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_tilde_in_uri() {
-        let req = http::Request::builder()
+        let req = http0::Request::builder()
             .uri("https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix&single&k=&unreserved=-_.~").body("").unwrap().into();
         let req = SignableRequest::from(&req);
         let identity = Credentials::for_tests().into();
@@ -815,7 +815,7 @@ mod tests {
         query_writer.insert("list-type", "2");
         query_writer.insert("prefix", &all_printable_ascii_chars);
 
-        let req = http::Request::builder()
+        let req = http0::Request::builder()
             .uri(query_writer.build_uri())
             .body("")
             .unwrap()
@@ -863,7 +863,7 @@ mod tests {
     // It should exclude authorization, user-agent, x-amzn-trace-id headers from presigning
     #[test]
     fn non_presigning_header_exclusion() {
-        let request = http::Request::builder()
+        let request = http0::Request::builder()
             .uri("https://some-endpoint.some-region.amazonaws.com")
             .header("authorization", "test-authorization")
             .header("content-type", "application/xml")
@@ -895,7 +895,7 @@ mod tests {
     // It should exclude authorization, user-agent, x-amz-user-agent, x-amzn-trace-id headers from presigning
     #[test]
     fn presigning_header_exclusion() {
-        let request = http::Request::builder()
+        let request = http0::Request::builder()
             .uri("https://some-endpoint.some-region.amazonaws.com")
             .header("authorization", "test-authorization")
             .header("content-type", "application/xml")
@@ -944,7 +944,7 @@ mod tests {
                 valid_input,
             )
         ) {
-            let mut request_builder = http::Request::builder()
+            let mut request_builder = http0::Request::builder()
                 .uri("https://some-endpoint.some-region.amazonaws.com")
                 .header("content-type", "application/xml")
                 .header("content-length", "0");

--- a/aws/rust-runtime/aws-sigv4/src/http_request/error.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/error.rs
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use http::header::{InvalidHeaderName, InvalidHeaderValue};
-use http::uri::InvalidUri;
+use http0::header::{InvalidHeaderName, InvalidHeaderValue};
+use http0::uri::InvalidUri;
 use std::error::Error;
 use std::fmt;
 

--- a/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use http::header::{AUTHORIZATION, USER_AGENT};
+use http0::header::{AUTHORIZATION, USER_AGENT};
 use std::borrow::Cow;
 use std::time::Duration;
 

--- a/aws/rust-runtime/aws-sigv4/src/http_request/test.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/test.rs
@@ -6,7 +6,7 @@
 //! Functions shared between the tests of several modules.
 
 use crate::http_request::{SignableBody, SignableRequest};
-use http::{Method, Uri};
+use http0::{Method, Uri};
 use std::error::Error as StdError;
 
 pub(crate) mod v4 {
@@ -258,8 +258,8 @@ impl TestRequest {
         self.body = TestSignedBody::Signable(body);
     }
 
-    pub(crate) fn as_http_request(&self) -> http::Request<&'static str> {
-        let mut builder = http::Request::builder()
+    pub(crate) fn as_http_request(&self) -> http0::Request<&'static str> {
+        let mut builder = http0::Request::builder()
             .uri(&self.uri)
             .method(Method::from_bytes(self.method.as_bytes()).unwrap());
         for (k, v) in &self.headers {
@@ -269,8 +269,8 @@ impl TestRequest {
     }
 }
 
-impl<B: AsRef<[u8]>> From<http::Request<B>> for TestRequest {
-    fn from(value: http::Request<B>) -> Self {
+impl<B: AsRef<[u8]>> From<http0::Request<B>> for TestRequest {
+    fn from(value: http0::Request<B>) -> Self {
         let invalid = value
             .headers()
             .values()

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -21,6 +21,7 @@ aws-smithy-types = { path = "../aws-smithy-types", features = ["byte-stream-poll
 bytes = "1"
 bytes-utils = "0.1"
 http = "0.2.3"
+http1 = { package = "http", version = "1" }
 http-body = "0.4.4"
 once_cell = "1.10"
 percent-encoding = "2.1.0"

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -21,7 +21,6 @@ aws-smithy-types = { path = "../aws-smithy-types", features = ["byte-stream-poll
 bytes = "1"
 bytes-utils = "0.1"
 http = "0.2.3"
-http1 = { package = "http", version = "1" }
 http-body = "0.4.4"
 once_cell = "1.10"
 percent-encoding = "2.1.0"


### PR DESCRIPTION
## Motivation and Context
- https://github.com/awslabs/aws-sdk-rust/issues/1041

## Description
Enable signing Http 1x requests.

## Testing
Unit tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
