### PR TITLE
Include aws-smithy-mocks-experimental in the release

### DIFF
--- a/buildSrc/src/main/kotlin/CrateSet.kt
+++ b/buildSrc/src/main/kotlin/CrateSet.kt
@@ -63,6 +63,7 @@ object CrateSet {
             "aws-smithy-http-auth",
             "aws-smithy-http-tower",
             "aws-smithy-json",
+            "aws-smithy-mocks-experimental",
             "aws-smithy-protocol-test",
             "aws-smithy-query",
             "aws-smithy-runtime",

--- a/rust-runtime/aws-smithy-mocks-experimental/Cargo.toml
+++ b/rust-runtime/aws-smithy-mocks-experimental/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 
 [dependencies]
 aws-smithy-types = "1"
-aws-smithy-runtime-api = { version = "1", features = ["http-02x"] }
-aws-smithy-runtime = { version = "1", features = ["test-util"] }
+aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x"] }
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1", features = ["test-util"] }


### PR DESCRIPTION
We intend to include aws-smithy-mocks-experimental in the release, but it needs to be added to the CrateSet to actually be published.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
