### PR TITLE
Fix describe tag issue when finding ancestor tag

### DIFF
--- a/tools/ci-build/runtime-versioner/src/tag.rs
+++ b/tools/ci-build/runtime-versioner/src/tag.rs
@@ -43,10 +43,11 @@ fn ancestor_tag(repo: &Repo) -> Result<ReleaseTag> {
     let tag = repo
         .git(["describe", "--tags"])
         .expect_success_output("find the current ancestor release tag")?;
-    let maybe_release_tag = ReleaseTag::from_str(&tag);
+    let tag = tag.trim();
+    let maybe_release_tag = ReleaseTag::from_str(tag);
     let release_tag = match maybe_release_tag {
         Ok(tag) => Some(tag),
-        Err(_) => strip_describe_tags_suffix(&tag)
+        Err(_) => strip_describe_tags_suffix(tag)
             .map(ReleaseTag::from_str)
             .transpose()
             .context("failed to find ancestor release tag")?,


### PR DESCRIPTION
The runtime-versioner's audit subcommand fails when the current commit is the tagged release commit due to a bug in `ancestor_tag` where it was failing to trim the output from `git describe --tags`. I fixed this earlier in #3369 since I was running into it there, but that hasn't been reviewed/merged yet. This issue is causing problems for the latest smithy-rs/SDK release, so I've pulled it out into a separate PR.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
