### PR TITLE
Add CI step to release workflow to check for semver hazards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,37 @@ jobs:
       run_sdk_examples: false
       git_ref: ${{ inputs.commit_sha }}
 
+  check-semver-hazards:
+    name: Check for semver hazards
+    needs:
+    - acquire-base-image
+    # We need `always` here otherwise this job won't run if the previous job has been skipped
+    # See https://samanpavel.medium.com/github-actions-conditional-job-execution-e6aa363d2867
+    if: always()
+    runs-on: smithy_ubuntu-latest_8-core
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: smithy-rs
+        ref: ${{ inputs.commit_sha }}
+        fetch-depth: 0
+    - uses: actions/checkout@v3
+      with:
+        repository: awslabs/aws-sdk-rust
+        path: aws-sdk-rust
+        fetch-depth: 0
+    - name: Run check-semver-hazards
+      uses: ./smithy-rs/.github/actions/docker-build
+      with:
+        action: check-semver-hazards
+        action-arguments: ${{ inputs.stable_semantic_version }} ${{ inputs.unstable_semantic_version }}
+
   get-or-create-release-branch:
     name: Get or create a release branch
     needs:
-    - release-ci
     - acquire-base-image
+    - check-semver-hazards
+    - release-ci
     # We need `always` here otherwise this job won't run if the previous job has been skipped
     # See https://samanpavel.medium.com/github-actions-conditional-job-execution-e6aa363d2867
     if: |

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# This script patches the new runtime crates into an old AWS SDK and runs tests
+# to check for semver hazards, such as a `Storable` being in an unstable runtime crate.
+
+C_YELLOW='\033[1;33m'
+C_RESET='\033[0m'
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: check-semver-hazards <stable-crate-version> <unstable-crate-version>"
+  exit 1
+fi
+STABLE_CRATE_VERSION="$1"
+UNSTABLE_CRATE_VERSION="$2"
+echo "Stable crate version: ${STABLE_CRATE_VERSION}"
+echo "Unstable crate version: ${UNSTABLE_CRATE_VERSION}"
+
+# Need to allow warnings since there may be deprecations that the old SDK uses
+unset RUSTFLAGS
+
+set -eux
+
+echo -e "${C_YELLOW}# Patching SDK...${C_RESET}"
+runtime-versioner patch-runtime \
+  --sdk-path "$(pwd)/aws-sdk-rust" \
+  --smithy-rs-path "$(pwd)/smithy-rs" \
+  --stable-crate-version "${STABLE_CRATE_VERSION}" \
+  --unstable-crate-version "${UNSTABLE_CRATE_VERSION}"
+
+# Testing just a small subset of the full SDK to check for semver hazards
+echo -e "${C_YELLOW}# Testing SDK...${C_RESET}"
+for sdk in dynamodb s3; do
+  echo -e "${C_YELLOW}# Testing ${sdk}...${C_RESET}"
+  pushd "aws-sdk-rust/sdk/${sdk}" &>/dev/null
+  cargo test --all-features
+  popd &>/dev/null
+done


### PR DESCRIPTION
This CI step will check for subtle semver hazards with the `ConfigBag` during release. Once all the runtime crates are independent, then this check can be moved into normal CI.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
