### PR TITLE
Make it possible to customize presigned requests

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,9 @@ message = "Add `try_into_http1x` and `try_from_http1x` to Request and Response c
 references = ["aws-sdk-rust#977", "smithy-rs#3365", "smithy-rs#3373"]
 meta = { "breaking" = false, "bug" = false, "tada" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "It is now possible to send customized presigned requests. You can now call `.customize().<customizations>.presigned(...).await`. Previously, only normal requests supported customization."
+references = ["smithy-rs#3385", "aws-sdk-rust#1031"]
+meta = { "breaking" = false, "bug" = false, "tada" = true }
+author = "rcoh"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -56,7 +56,7 @@ class AwsFluentClientDecorator : ClientCodegenDecorator {
                     AwsPresignedFluentBuilderMethod(codegenContext),
                     AwsFluentClientDocs(codegenContext),
                 ),
-        ).render(rustCrate, emptyList())
+        ).render(rustCrate)
         rustCrate.withModule(ClientRustModule.client) {
             AwsFluentClientExtensions(codegenContext, types).render(this)
         }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rustsdk
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.knowledge.HttpBindingIndex
+import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
@@ -19,8 +20,11 @@ import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.client.CustomizableOperationSection
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientSection
+import software.amazon.smithy.rust.codegen.client.smithy.generators.client.InternalTraitsModule
+import software.amazon.smithy.rust.codegen.client.smithy.generators.client.fluentBuilderType
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.RequestSerializerGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
@@ -33,13 +37,16 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.contextName
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 import software.amazon.smithy.rust.codegen.core.util.cloneOperation
 import software.amazon.smithy.rust.codegen.core.util.expectTrait
+import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
 import software.amazon.smithy.rustsdk.traits.PresignableTrait
 import kotlin.streams.toList
 
-private val presigningTypes: List<Pair<String, Any>> =
-    listOf(
+private val presigningTypes: Array<Pair<String, Any>> =
+    arrayOf(
         "PresignedRequest" to AwsRuntimeType.presigning().resolve("PresignedRequest"),
         "PresigningConfig" to AwsRuntimeType.presigning().resolve("PresigningConfig"),
     )
@@ -94,6 +101,12 @@ class AwsPresigningDecorator internal constructor(
     override val name: String = "AwsPresigning"
     override val order: Byte = ORDER
 
+    private val codegenScope =
+        arrayOf(
+            *presigningTypes,
+            *preludeScope,
+        )
+
     /**
      * Adds presignable trait to known presignable operations and creates synthetic presignable shapes for codegen
      */
@@ -128,6 +141,51 @@ class AwsPresigningDecorator internal constructor(
             }
         }.build()
     }
+
+    private fun anyPresignedShapes(ctx: ClientCodegenContext) =
+        TopDownIndex.of(ctx.model).getContainedOperations(ctx.serviceShape)
+            .any { presignableOperations.containsKey(it.id) }
+
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
+        anyPresignedShapes(codegenContext).thenSingletonListOf {
+            adhocCustomization<CustomizableOperationSection.CustomizableOperationImpl> {
+                rustTemplate(
+                    """
+                    /// Sends the request and returns the response.
+                    ##[allow(unused_mut)]
+                    pub async fn presigned(mut self, presigning_config: #{PresigningConfig}) -> #{Result}<#{PresignedRequest}, crate::error::SdkError<E>> where
+                        E: std::error::Error + #{Send} + #{Sync} + 'static,
+                        B: #{CustomizablePresigned}<E>
+                    {
+                        let mut config_override = self.config_override.unwrap_or_default();
+                        self.interceptors.into_iter().for_each(|interceptor| {
+                            config_override.push_interceptor(interceptor);
+                        });
+                        self.runtime_plugins.into_iter().for_each(|plugin| {
+                            config_override.push_runtime_plugin(plugin);
+                        });
+
+                        self.customizable_send.presign(config_override, presigning_config).await
+                    }
+                    """,
+                    *codegenScope,
+                    "CustomizablePresigned" to CustomizablePresigned,
+                )
+            }
+        }
+
+    private val CustomizablePresigned =
+        RuntimeType.forInlineFun("CustomizablePresigned", InternalTraitsModule) {
+            rustTemplate(
+                """
+                pub trait CustomizablePresigned<E> {
+                    fn presign(self, config_override: crate::config::Builder, presigning_config: #{PresigningConfig}) -> BoxFuture<SendResult<#{PresignedRequest}, E>>;
+                }
+
+                """,
+                *codegenScope,
+            )
+        }
 }
 
 class AwsPresignedFluentBuilderMethod(
@@ -135,14 +193,12 @@ class AwsPresignedFluentBuilderMethod(
 ) : FluentClientCustomization() {
     private val runtimeConfig = codegenContext.runtimeConfig
     private val codegenScope =
-        (
-            presigningTypes +
-                arrayOf(
-                    *RuntimeType.preludeScope,
-                    "Error" to AwsRuntimeType.presigning().resolve("config::Error"),
-                    "SdkError" to RuntimeType.sdkError(runtimeConfig),
-                )
-        ).toTypedArray()
+        arrayOf(
+            *presigningTypes,
+            *preludeScope,
+            "Error" to AwsRuntimeType.presigning().resolve("config::Error"),
+            "SdkError" to RuntimeType.sdkError(runtimeConfig),
+        )
 
     override fun section(section: FluentClientSection): Writable =
         writable {
@@ -159,18 +215,61 @@ class AwsPresignedFluentBuilderMethod(
                     *codegenScope,
                     "OpError" to section.operationErrorType,
                     "RawResponseType" to
-                        RuntimeType.smithyRuntimeApiClient(runtimeConfig).resolve("client::orchestrator::HttpResponse"),
+                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                            .resolve("client::orchestrator::HttpResponse"),
                 ) {
                     renderPresignedMethodBody(section)
+                    val builderName = section.operationShape.fluentBuilderType(codegenContext.symbolProvider).name
+                    addDependency(implementPresignedTrait(section, builderName).dependency!!)
                 }
             }
         }
+
+    private fun implementPresignedTrait(
+        section: FluentClientSection.FluentBuilderImpl,
+        builderName: String,
+    ): RuntimeType {
+        return RuntimeType.forInlineFun(
+            "TraitImplementation",
+            codegenContext.symbolProvider.moduleForBuilder(section.operationShape),
+        ) {
+            rustTemplate(
+                """
+                impl
+                    crate::client::customize::internal::CustomizablePresigned<
+                        #{OperationError},
+                    > for $builderName
+                {
+                    fn presign(
+                        self,
+                        config_override: crate::config::Builder,
+                        presigning_config: #{PresigningConfig}
+                    ) -> crate::client::customize::internal::BoxFuture<
+                        crate::client::customize::internal::SendResult<
+                            #{PresignedRequest},
+                            #{OperationError},
+                        >,
+                    > {
+                        #{Box}::pin(async move { self.config_override(config_override).presigned(presigning_config).await })
+                    }
+                }
+                """,
+                *preludeScope,
+                *presigningTypes,
+                "OperationError" to section.operationErrorType,
+                "SdkError" to RuntimeType.sdkError(runtimeConfig),
+            )
+        }
+    }
 
     private fun RustWriter.renderPresignedMethodBody(section: FluentClientSection.FluentBuilderImpl) {
         val presignableOp = PRESIGNABLE_OPERATIONS.getValue(section.operationShape.id)
         val operationShape =
             if (presignableOp.hasModelTransforms()) {
-                codegenContext.model.expectShape(syntheticShapeId(section.operationShape.id), OperationShape::class.java)
+                codegenContext.model.expectShape(
+                    syntheticShapeId(section.operationShape.id),
+                    OperationShape::class.java,
+                )
             } else {
                 section.operationShape
             }
@@ -262,7 +361,10 @@ class AwsPresignedFluentBuilderMethod(
             it.uppercase()
         }.let { baseName ->
             "${baseName}PresigningRequestSerializer".let { name ->
-                RuntimeType.forInlineFun(name, codegenContext.symbolProvider.moduleForShape(transformedOperationShape)) {
+                RuntimeType.forInlineFun(
+                    name,
+                    codegenContext.symbolProvider.moduleForShape(transformedOperationShape),
+                ) {
                     RequestSerializerGenerator(
                         codegenContext,
                         codegenContext.protocolImpl!!,

--- a/aws/sdk/integration-tests/polly/tests/presigning.rs
+++ b/aws/sdk/integration-tests/polly/tests/presigning.rs
@@ -58,3 +58,57 @@ async fn test_presigning() {
     );
     assert_eq!(presigned.headers().count(), 0);
 }
+
+#[tokio::test]
+async fn test_presigning_customized() {
+    let config = Config::builder()
+        .credentials_provider(Credentials::for_tests_with_session_token())
+        .region(Region::new("us-east-1"))
+        .build();
+    let client = polly::Client::from_conf(config);
+
+    let presigned = client
+        .synthesize_speech()
+        .output_format(OutputFormat::Mp3)
+        .text("hello, world")
+        .voice_id(VoiceId::Joanna)
+        .customize()
+        .config_override(Config::builder().region(Region::new("us-west-1")))
+        .mutate_request(|req| req.set_uri(req.uri().to_string() + "&test").expect("valid"))
+        .presigned(
+            PresigningConfig::builder()
+                .start_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1234567891))
+                .expires_in(Duration::from_secs(30))
+                .build()
+                .unwrap(),
+        )
+        .await
+        .expect("success");
+
+    let uri = presigned.uri().parse::<http::Uri>().unwrap();
+    let pq = uri.path_and_query().unwrap();
+    let path = pq.path();
+    let query = pq.query().unwrap();
+    let mut query_params: Vec<&str> = query.split('&').collect();
+    query_params.sort();
+
+    assert_eq!("GET", presigned.method());
+    assert_eq!("/v1/speech", path);
+    assert_eq!(
+        &[
+            "OutputFormat=mp3",
+            "Text=hello%2C%20world",
+            "VoiceId=Joanna",
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256",
+            "X-Amz-Credential=ANOTREAL%2F20090213%2Fus-west-1%2Fpolly%2Faws4_request",
+            "X-Amz-Date=20090213T233131Z",
+            "X-Amz-Expires=30",
+            "X-Amz-Security-Token=notarealsessiontoken",
+            "X-Amz-Signature=7cc39d2dfa3b8057f901b2827522790b48c6162571ed7e09c9725178c1cdd1fb",
+            "X-Amz-SignedHeaders=host",
+            "test",
+        ][..],
+        &query_params
+    );
+    assert_eq!(presigned.headers().count(), 0);
+}

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -195,3 +195,32 @@ async fn test_presigned_head_object() {
         presigned.uri().to_string(),
     );
 }
+
+#[tokio::test]
+async fn customized_presigning() {
+    let creds = Credentials::for_tests_with_session_token();
+    let config = s3::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let client = s3::Client::from_conf(config);
+    let static_ps_config = PresigningConfig::builder()
+        .start_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1234567891))
+        .expires_in(Duration::from_secs(30))
+        .build()
+        .unwrap();
+    let req = client
+        .get_object()
+        .bucket("foo")
+        .key("bar")
+        .customize()
+        .mutate_request(|req| {
+            req.set_uri(req.uri().to_string() + "&a=b")
+                .expect("failed to update URI")
+        })
+        .presigned(static_ps_config)
+        .await
+        .unwrap();
+    let expect = "https://foo.s3.us-east-1.amazonaws.com/bar?x-id=GetObject&a=b&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F20090213%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20090213T233131Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=2e1a459c206932ce53beb07028c711cf70f3a61dc876c6f9ce0aed5823f60234&X-Amz-Security-Token=notarealsessiontoken";
+    assert_eq!(req.uri(), expect);
+}

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -195,32 +195,3 @@ async fn test_presigned_head_object() {
         presigned.uri().to_string(),
     );
 }
-
-#[tokio::test]
-async fn customized_presigning() {
-    let creds = Credentials::for_tests_with_session_token();
-    let config = s3::Config::builder()
-        .credentials_provider(creds)
-        .region(Region::new("us-east-1"))
-        .build();
-    let client = s3::Client::from_conf(config);
-    let static_ps_config = PresigningConfig::builder()
-        .start_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1234567891))
-        .expires_in(Duration::from_secs(30))
-        .build()
-        .unwrap();
-    let req = client
-        .get_object()
-        .bucket("foo")
-        .key("bar")
-        .customize()
-        .mutate_request(|req| {
-            req.set_uri(req.uri().to_string() + "&a=b")
-                .expect("failed to update URI")
-        })
-        .presigned(static_ps_config)
-        .await
-        .unwrap();
-    let expect = "https://foo.s3.us-east-1.amazonaws.com/bar?x-id=GetObject&a=b&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F20090213%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20090213T233131Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=2e1a459c206932ce53beb07028c711cf70f3a61dc876c6f9ce0aed5823f60234&X-Amz-Security-Token=notarealsessiontoken";
-    assert_eq!(req.uri(), expect);
-}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationDecorator.kt
@@ -5,12 +5,9 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.generators.client
 
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
 
-sealed class CustomizableOperationSection(name: String) : Section(name) {
+sealed class CustomizableOperationSection(name: String) : AdHocSection(name) {
     /** Write custom code into a customizable operation's impl block */
     object CustomizableOperationImpl : CustomizableOperationSection("CustomizableOperationImpl")
 }
-
-abstract class CustomizableOperationCustomization : NamedCustomization<CustomizableOperationSection>()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -89,14 +89,10 @@ class FluentClientGenerator(
     private val runtimeConfig = codegenContext.runtimeConfig
     private val core = FluentClientCore(model)
 
-    fun render(
-        crate: RustCrate,
-        customizableOperationCustomizations: List<CustomizableOperationCustomization> = emptyList(),
-    ) {
+    fun render(crate: RustCrate) {
         renderFluentClient(crate)
 
-        val customizableOperationGenerator =
-            CustomizableOperationGenerator(codegenContext, customizableOperationCustomizations)
+        val customizableOperationGenerator = CustomizableOperationGenerator(codegenContext)
         operations.forEach { operation ->
             crate.withModule(symbolProvider.moduleForBuilder(operation)) {
                 renderFluentBuilder(operation)
@@ -594,7 +590,7 @@ private fun generateShapeMemberDocs(
     }
 }
 
-internal fun OperationShape.fluentBuilderType(symbolProvider: RustSymbolProvider): RuntimeType =
+fun OperationShape.fluentBuilderType(symbolProvider: RustSymbolProvider): RuntimeType =
     symbolProvider.moduleForBuilder(this).toType()
         .resolve(symbolProvider.toSymbol(this).name + "FluentBuilder")
 


### PR DESCRIPTION
## Motivation and Context
This enables the following code:
```rust
    let req = client
        .get_object()
        .bucket("foo")
        .key("bar")
        .customize()
        .mutate_request(|req| {
            req.set_uri(req.uri().to_string() + "&a=b")
                .expect("failed to update URI")
        })
        .presigned(static_ps_config)
        .await
```
Previously, it wasn't possible to presign a request once customization had begun.


## Description
- Follow the same pattern as send by introducing an additional trait, CustomizeablePresign
- change InvokeWithStopPoint to actually _return_ the error if there is one.

## Testing
New integration test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates
- [x] Conditionally generate the presign method

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
