### PR TITLE
Only create inner chain provider once in profile creds provider

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,9 @@ message = "Add `try_into_http1x` and `try_from_http1x` to Request and Response c
 references = ["aws-sdk-rust#977", "smithy-rs#3365", "smithy-rs#3373"]
 meta = { "breaking" = false, "bug" = false, "tada" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Retain the SSO token cache between calls to `provide_credentials` when using IAM Identity Center SSO via the AWS config file."
+references = ["smithy-rs#3387"]
+meta = { "breaking" = false, "bug" = true, "tada" = false }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -26,3 +26,98 @@ pub mod region;
 pub use credentials::ProfileFileCredentialsProvider;
 #[doc(inline)]
 pub use region::ProfileFileRegionProvider;
+
+mod cell {
+    use std::future::Future;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::OnceCell;
+
+    /// Once cell with a result where the error can be taken.
+    ///
+    /// The profile providers need to cache their inner provider value (specifically for SSO)
+    /// in order to preserve the SSO token cache. This wrapper around [`OnceCell`] allows
+    /// for initializing the inner provider once in a way that if it fails, the error can
+    /// be taken so that it doesn't need to implement `Clone`.
+    #[derive(Debug)]
+    pub(super) struct ErrorTakingOnceCell<T, E> {
+        cell: OnceCell<Result<Arc<T>, Mutex<E>>>,
+    }
+
+    impl<T, E> ErrorTakingOnceCell<T, E> {
+        pub(super) fn new() -> Self {
+            Self {
+                cell: OnceCell::new(),
+            }
+        }
+
+        pub(super) async fn get_or_init<F, Fut>(
+            &self,
+            init: F,
+            mut taken_error: E,
+        ) -> Result<Arc<T>, E>
+        where
+            F: FnOnce() -> Fut,
+            Fut: Future<Output = Result<T, E>>,
+        {
+            let init = || async move { (init)().await.map(Arc::new).map_err(Mutex::new) };
+            match self.cell.get_or_init(init).await {
+                Ok(value) => Ok(value.clone()),
+                Err(err) => {
+                    let mut locked = err.lock().unwrap();
+                    std::mem::swap(&mut *locked, &mut taken_error);
+                    Err(taken_error)
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::profile::cell::ErrorTakingOnceCell;
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        #[derive(Debug)]
+        enum Error {
+            InitError,
+            Taken,
+        }
+
+        #[tokio::test]
+        async fn taken_error() {
+            let cell = ErrorTakingOnceCell::new();
+            let calls = AtomicUsize::new(0);
+            let init = || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Result::<String, _>::Err(Error::InitError)
+            };
+
+            let result = cell.get_or_init(init, Error::Taken).await;
+            assert!(matches!(result, Err(Error::InitError)));
+
+            let result = cell.get_or_init(init, Error::Taken).await;
+            assert!(matches!(result, Err(Error::Taken)));
+
+            let result = cell.get_or_init(init, Error::Taken).await;
+            assert!(matches!(result, Err(Error::Taken)));
+            assert_eq!(1, calls.load(Ordering::SeqCst));
+        }
+
+        #[tokio::test]
+        async fn value_initialized_once() {
+            let cell = ErrorTakingOnceCell::new();
+            let calls = AtomicUsize::new(0);
+            let init = || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Result::<_, Error>::Ok("test".to_string())
+            };
+
+            let original = cell.get_or_init(init, Error::Taken).await.unwrap();
+            let next = cell.get_or_init(init, Error::Taken).await.unwrap();
+            assert!(Arc::ptr_eq(&original, &next));
+            assert_eq!(1, calls.load(Ordering::SeqCst));
+        }
+    }
+}

--- a/aws/rust-runtime/aws-credential-types/src/provider.rs
+++ b/aws/rust-runtime/aws-credential-types/src/provider.rs
@@ -86,7 +86,7 @@ pub mod error {
     /// Details for [`CredentialsError::CredentialsNotLoaded`]
     #[derive(Debug)]
     pub struct CredentialsNotLoaded {
-        source: Box<dyn Error + Send + Sync + 'static>,
+        source: Option<Box<dyn Error + Send + Sync + 'static>>,
     }
 
     /// Details for [`CredentialsError::ProviderTimedOut`]
@@ -160,8 +160,17 @@ pub mod error {
         /// that the provider was configured in some way, but certain settings were invalid.
         pub fn not_loaded(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
             CredentialsError::CredentialsNotLoaded(CredentialsNotLoaded {
-                source: source.into(),
+                source: Some(source.into()),
             })
+        }
+
+        /// The credentials provider did not provide credentials
+        ///
+        /// This error indicates the credentials provider was not enable or no configuration was set.
+        /// This contrasts with [`invalid_configuration`](CredentialsError::InvalidConfiguration), indicating
+        /// that the provider was configured in some way, but certain settings were invalid.
+        pub fn not_loaded_no_source() -> Self {
+            CredentialsError::CredentialsNotLoaded(CredentialsNotLoaded { source: None })
         }
 
         /// An unexpected error occurred loading credentials from this provider
@@ -227,7 +236,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn Error + 'static)> {
             match self {
                 CredentialsError::CredentialsNotLoaded(details) => {
-                    Some(details.source.as_ref() as _)
+                    details.source.as_ref().map(|s| s.as_ref() as _)
                 }
                 CredentialsError::ProviderTimedOut(_) => None,
                 CredentialsError::InvalidConfiguration(details) => {


### PR DESCRIPTION
The `SsoCredentialsProvider` maintains an in-memory expiring cache of SSO tokens, and this cache is maintained within its instance. The `ProfileFileCredentialsProvider`, which uses `SsoCredentialsProvider` as a base/inner provider, is currently reconstructing the inner provider every time it loads credentials, which discards the SSO token cache entirely.

This PR refactors the `ProfileFileCredentialsProvider` to cache the inner provider so that it is only initialized once on first load of credentials. This is done via a new `ErrorTakingOnceCell` abstraction since the same init-caching mechanism will be needed for the `ProfileFileTokenProvider` when it is implemented.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
