### PR TITLE
Adding impl Display for enum

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,15 @@ message = "Add `try_into_http1x` and `try_from_http1x` to Request and Response c
 references = ["aws-sdk-rust#977", "smithy-rs#3365", "smithy-rs#3373"]
 meta = { "breaking" = false, "bug" = false, "tada" = false }
 author = "rcoh"
+
+[[smithy-rs]]
+message = "Added impl `Display` to Enums."
+references = ["smithy-rs#3336","smithy-rs#3391"]
+meta = { "breaking" = false, "tada" = false, "bug" = false , "target" = "client" }
+author = "iampkmone"
+
+[[aws-sdk-rust]]
+message = "Added impl `Display` to Enums."
+references = ["smithy-rs#3336", "smithy-rs#3391"]
+meta = { "breaking" = false, "tada" = false, "bug" = false}
+author = "iampkmone"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
@@ -101,6 +101,31 @@ data class InfallibleEnumType(
                     *preludeScope,
                     "UnknownVariantError" to unknownVariantError(),
                 )
+
+                rustTemplate(
+                    """
+                    impl #{Display} for ${context.enumName} {
+                        fn fmt(&self, f: &mut #{Fmt}::Formatter) -> #{Fmt}::Result {
+                            match self {
+                                #{matchArms}
+                            }
+                        }
+                    }
+                    """,
+                    "Display" to RuntimeType.Display,
+                    "Fmt" to RuntimeType.stdFmt,
+                    "matchArms" to
+                        writable {
+                            context.sortedMembers.forEach { member ->
+                                rust(
+                                    """
+                                    ${context.enumName}::${member.derivedName()} => write!(f, ${member.value.dq()}),
+                                    """,
+                                )
+                            }
+                            rust("""${context.enumName}::Unknown(value) => write!(f, "{}", value)""")
+                        },
+                )
             }
         }
 
@@ -141,6 +166,17 @@ data class InfallibleEnumType(
                     rust("&self.0")
                 }
             }
+            rustTemplate(
+                """
+                impl #{Display} for $UnknownVariantValue {
+                    fn fmt(&self, f: &mut #{Fmt}::Formatter) -> #{Fmt}::Result {
+                        write!(f, "{}", self.0)
+                    }
+                }
+                """,
+                "Display" to RuntimeType.Display,
+                "Fmt" to RuntimeType.stdFmt,
+            )
         }
     }
 

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGeneratorTest.kt
@@ -94,6 +94,8 @@ class ClientEnumGeneratorTest {
                 """
                 assert_eq!(format!("{:?}", SomeEnum::Foo), "Foo");
                 assert_eq!(format!("{:?}", SomeEnum::Bar), "Bar");
+                assert_eq!(format!("{}", SomeEnum::Foo), "Foo");
+                assert_eq!(SomeEnum::Bar.to_string(), "Bar");
                 assert_eq!(
                     format!("{:?}", SomeEnum::from("Baz")),
                     "Unknown(UnknownVariantValue(\"Baz\"))"
@@ -161,12 +163,14 @@ class ClientEnumGeneratorTest {
                 let instance = InstanceType::T2Micro;
                 assert_eq!(instance.as_str(), "t2.micro");
                 assert_eq!(InstanceType::from("t2.nano"), InstanceType::T2Nano);
+                assert_eq!(instance.to_string(), "t2.micro");
                 // round trip unknown variants:
                 assert_eq!(
                     InstanceType::from("other"),
                     InstanceType::Unknown(crate::primitives::sealed_enum_unknown::UnknownVariantValue("other".to_owned()))
                 );
                 assert_eq!(InstanceType::from("other").as_str(), "other");
+                assert_eq!(InstanceType::from("other").to_string(), "other");
                 """,
             )
         }


### PR DESCRIPTION
## Motivation and Context
This change address the [#3335](https://github.com/smithy-lang/smithy-rs/issues/3336)

## Description
Added Display trait to the Enum. 

## Testing
Updated the [ClientEnumGeneratorTest.kt](https://github.com/smithy-lang/smithy-rs/blob/main/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGeneratorTest.kt) which test the ```impl Display``` for the enums.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
