### PR TITLE
Change timeout settings to merge them when configuration is merged

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -37,14 +37,14 @@ author = "rcoh"
 
 [[smithy-rs]]
 message = "Added impl `Display` to Enums."
-references = ["smithy-rs#3336","smithy-rs#3391"]
-meta = { "breaking" = false, "tada" = false, "bug" = false , "target" = "client" }
+references = ["smithy-rs#3336", "smithy-rs#3391"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "iampkmone"
 
 [[aws-sdk-rust]]
 message = "Added impl `Display` to Enums."
 references = ["smithy-rs#3336", "smithy-rs#3391"]
-meta = { "breaking" = false, "tada" = false, "bug" = false}
+meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "iampkmone"
 
 [[aws-sdk-rust]]
@@ -104,3 +104,21 @@ message = "Retain the SSO token cache between calls to `provide_credentials` whe
 references = ["smithy-rs#3387"]
 meta = { "breaking" = false, "bug" = true, "tada" = false }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = """Fix bug where timeout settings where not merged properly. This will add a default connect timeout of 3.1s seconds for most clients.
+
+[**For more details see the long-form changelog discussion**](https://github.com/smithy-lang/smithy-rs/discussions/3408)."""
+
+references = ["smithy-rs#3405", "smithy-rs#3400", "smithy-rs#3258"]
+meta = { "bug" = true, "breaking" = true, tada = false, target = "client" }
+author = "rcoh"
+
+[[aws-sdk-rust]]
+message = """Fix bug where timeout settings where not merged properly. This will add a default connect timeout of 3.1s seconds for most clients.
+
+[**For more details see the long-form changelog discussion**](https://github.com/smithy-lang/smithy-rs/discussions/3408)."""
+
+references = ["smithy-rs#3405", "smithy-rs#3400", "smithy-rs#3258"]
+meta = { "bug" = true, "breaking" = true, tada = false }
+author = "rcoh"

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TestUtil.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TestUtil.kt
@@ -51,7 +51,7 @@ fun awsSdkIntegrationTest(
 
 fun awsIntegrationTestParams() =
     IntegrationTestParams(
-        cargoCommand = "cargo test --features test-util behavior-version-latest",
+        cargoCommand = "cargo test --features test-util,behavior-version-latest --tests --lib",
         runtimeConfig = AwsTestRuntimeConfig,
         additionalSettings =
             ObjectNode.builder().withMember(

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TimeoutConfigMergingTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TimeoutConfigMergingTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import SdkCodegenIntegrationTest
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+
+class TimeoutConfigMergingTest {
+    @Test
+    fun testTimeoutSettingsProperlyMerged() {
+        // for monday: these tests don't seem to be running
+        awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { ctx, crate ->
+            val name = ctx.moduleUseName()
+            crate.integrationTest("timeout_settings_properly_merged") {
+                rustTemplate(
+                    """
+
+                    use $name::Client;
+                    use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
+                    use aws_smithy_runtime_api::box_error::BoxError;
+                    use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextRef;
+                    use aws_smithy_runtime_api::client::interceptors::Intercept;
+                    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+                    use aws_smithy_runtime::client::http::test_util::infallible_client_fn;
+                    use aws_smithy_types::config_bag::ConfigBag;
+                    use aws_smithy_types::timeout::TimeoutConfig;
+                    use aws_smithy_types::body::SdkBody;
+                    use aws_types::SdkConfig;
+                    use std::sync::Arc;
+                    use std::sync::Mutex;
+                    use std::time::Duration;
+
+                    ##[derive(Debug, Clone)]
+                    struct CaptureConfigInterceptor {
+                        timeout_config: Arc<Mutex<Option<TimeoutConfig>>>,
+                    }
+
+                    impl Intercept for CaptureConfigInterceptor {
+                        fn name(&self) -> &'static str {
+                            "capture config interceptor"
+                        }
+
+                        fn read_before_attempt(
+                            &self,
+                            _context: &BeforeTransmitInterceptorContextRef<'_>,
+                            _runtime_components: &RuntimeComponents,
+                            cfg: &mut ConfigBag,
+                        ) -> Result<(), BoxError> {
+                            *self.timeout_config.lock().unwrap() = cfg.load::<TimeoutConfig>().cloned();
+                            Ok(())
+                        }
+                    }
+                    #{tokio_test}
+                    async fn test_all_timeouts() {
+                        let (_logs, _guard) = capture_test_logs();
+                        let connect_timeout = Duration::from_secs(1);
+                        let read_timeout = Duration::from_secs(2);
+                        let operation_attempt = Duration::from_secs(3);
+                        let operation = Duration::from_secs(4);
+                        let http_client = infallible_client_fn(|_req| http::Response::builder().body(SdkBody::empty()).unwrap());
+                        let sdk_config = SdkConfig::builder()
+                            .timeout_config(
+                                TimeoutConfig::builder()
+                                    .connect_timeout(connect_timeout)
+                                    .build(),
+                            )
+                            .http_client(http_client)
+                            .build();
+                        let client_config = $name::config::Builder::from(&sdk_config)
+                            .timeout_config(TimeoutConfig::builder().read_timeout(read_timeout).build())
+                            .build();
+                        let client = Client::from_conf(client_config);
+                        let interceptor = CaptureConfigInterceptor {
+                            timeout_config: Default::default(),
+                        };
+                        let _err = client
+                            .some_operation()
+                            .customize()
+                            .config_override(
+                                $name::Config::builder().timeout_config(
+                                    TimeoutConfig::builder()
+                                        .operation_attempt_timeout(operation_attempt)
+                                        .operation_timeout(operation)
+                                        .build(),
+                                ),
+                            )
+                            .interceptor(interceptor.clone())
+                            .send()
+                            .await;
+                        let _ = dbg!(_err);
+                        assert_eq!(
+                            interceptor
+                                .timeout_config
+                                .lock()
+                                .unwrap()
+                                .as_ref()
+                                .expect("timeout config not set"),
+                            &TimeoutConfig::builder()
+                                .operation_timeout(operation)
+                                .operation_attempt_timeout(operation_attempt)
+                                .read_timeout(read_timeout)
+                                .connect_timeout(connect_timeout)
+                                .build(),
+                            "full set of timeouts set from all three sources."
+                        );
+
+                        // disable timeouts
+                        let _err = client
+                            .some_operation()
+                            .customize()
+                            .config_override(
+                                $name::Config::builder().timeout_config(
+                                    TimeoutConfig::disabled(),
+                                ),
+                            )
+                            .interceptor(interceptor.clone())
+                            .send()
+                            .await;
+                        let _ = dbg!(_err);
+                        assert_eq!(
+                            interceptor
+                                .timeout_config
+                                .lock()
+                                .unwrap()
+                                .as_ref()
+                                .expect("timeout config not set"),
+                            &TimeoutConfig::disabled(),
+                            "timeouts disabled by config override"
+                        );
+
+                        // override one field
+                        let _err = client
+                            .some_operation()
+                            .customize()
+                            .config_override(
+                                $name::Config::builder().timeout_config(
+                                    TimeoutConfig::builder().read_timeout(Duration::from_secs(10)).build(),
+                                ),
+                            )
+                            .interceptor(interceptor.clone())
+                            .send()
+                            .await;
+                        let _ = dbg!(_err);
+                        assert_eq!(
+                            interceptor
+                                .timeout_config
+                                .lock()
+                                .unwrap()
+                                .as_ref()
+                                .expect("timeout config not set"),
+                            &TimeoutConfig::builder()
+                                .read_timeout(Duration::from_secs(10))
+                                .connect_timeout(connect_timeout)
+                                .disable_operation_attempt_timeout()
+                                .disable_operation_timeout()
+                                .build(),
+                            "read timeout overridden"
+                        );
+                    }
+                    """,
+                    "tokio_test" to writable { Attribute.TokioTest.render(this) },
+                )
+            }
+        }
+    }
+}

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TimeoutConfigMergingTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TimeoutConfigMergingTest.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
 class TimeoutConfigMergingTest {
     @Test
     fun testTimeoutSettingsProperlyMerged() {
-        // for monday: these tests don't seem to be running
         awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { ctx, crate ->
             val name = ctx.moduleUseName()
             crate.integrationTest("timeout_settings_properly_merged") {

--- a/aws/sdk/integration-tests/s3/tests/service_timeout_overrides.rs
+++ b/aws/sdk/integration-tests/s3/tests/service_timeout_overrides.rs
@@ -80,7 +80,6 @@ async fn default_connect_timeout_set() {
                 .build(),
         )
         .retry_config(RetryConfig::disabled())
-        //.http_client(NeverClient::new())
         // ip that
         .endpoint_url(
             // Emulate a connect timeout error by hitting an unroutable IP

--- a/aws/sdk/integration-tests/s3/tests/service_timeout_overrides.rs
+++ b/aws/sdk/integration-tests/s3/tests/service_timeout_overrides.rs
@@ -5,10 +5,13 @@
 
 use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::Credentials;
+use aws_smithy_async::assert_elapsed;
 use aws_smithy_async::rt::sleep::{SharedAsyncSleep, TokioSleep};
 use aws_smithy_runtime::client::http::test_util::NeverClient;
 use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
+use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
 use aws_smithy_runtime_api::client::result::SdkError;
+use aws_smithy_types::retry::RetryConfig;
 use aws_smithy_types::timeout::TimeoutConfig;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
@@ -23,9 +26,11 @@ async fn timeouts_can_be_set_by_service() {
         .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::from_static("us-east-1"))
         .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+        .retry_config(RetryConfig::disabled())
         .timeout_config(
             TimeoutConfig::builder()
                 .operation_timeout(Duration::from_secs(5))
+                .read_timeout(Duration::from_secs(1))
                 .build(),
         )
         .http_client(NeverClient::new())
@@ -42,6 +47,7 @@ async fn timeouts_can_be_set_by_service() {
                 .build(),
         )
         .build();
+
     let client = aws_sdk_s3::Client::from_conf(config);
     let start = Instant::now();
     let err = client
@@ -59,4 +65,61 @@ async fn timeouts_can_be_set_by_service() {
     // there should be a 0ms timeout, we gotta set some stuff up. Just want to make sure
     // it's shorter than the 5 second timeout if the test is broken
     assert!(start.elapsed() < Duration::from_millis(500));
+}
+
+/// Use a 5 second operation timeout on SdkConfig and a 0ms operation timeout on the service config
+#[tokio::test]
+async fn default_connect_timeout_set() {
+    let (_guard, _) = capture_test_logs();
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .test_credentials()
+        .region(Region::from_static("us-east-1"))
+        .timeout_config(
+            TimeoutConfig::builder()
+                .operation_timeout(Duration::from_secs(5))
+                .build(),
+        )
+        .retry_config(RetryConfig::disabled())
+        //.http_client(NeverClient::new())
+        // ip that
+        .endpoint_url(
+            // Emulate a connect timeout error by hitting an unroutable IP
+            "http://172.255.255.0:18104",
+        )
+        .load()
+        .await;
+    assert_eq!(
+        sdk_config.timeout_config(),
+        Some(
+            &TimeoutConfig::builder()
+                .connect_timeout(Duration::from_millis(3100))
+                .operation_timeout(Duration::from_secs(5))
+                .build()
+        )
+    );
+    let config = aws_sdk_s3::config::Builder::from(&sdk_config)
+        .timeout_config(
+            TimeoutConfig::builder()
+                .operation_attempt_timeout(Duration::from_secs(4))
+                .build(),
+        )
+        .build();
+
+    let client = aws_sdk_s3::Client::from_conf(config);
+    let start = Instant::now();
+    let err = client
+        .get_object()
+        .key("foo")
+        .bucket("bar")
+        .send()
+        .await
+        .expect_err("unroutable IP should timeout");
+    assert!(
+        matches!(err, SdkError::DispatchFailure { .. }),
+        "expected DispatchFailure got {}",
+        err
+    );
+    // there should be a 0ms timeout, we gotta set some stuff up. Just want to make sure
+    // it's shorter than the 5 second timeout if the test is broken
+    assert_elapsed!(start, Duration::from_millis(3100));
 }

--- a/aws/sdk/integration-tests/s3/tests/service_timeout_overrides.rs
+++ b/aws/sdk/integration-tests/s3/tests/service_timeout_overrides.rs
@@ -67,7 +67,8 @@ async fn timeouts_can_be_set_by_service() {
     assert!(start.elapsed() < Duration::from_millis(500));
 }
 
-/// Use a 5 second operation timeout on SdkConfig and a 0ms operation timeout on the service config
+/// Ensures that a default timeout from aws-config is still persisted even if an operation_timeout
+/// is set.
 #[tokio::test]
 async fn default_connect_timeout_set() {
     let (_guard, _) = capture_test_logs();
@@ -118,7 +119,6 @@ async fn default_connect_timeout_set() {
         "expected DispatchFailure got {}",
         err
     );
-    // there should be a 0ms timeout, we gotta set some stuff up. Just want to make sure
-    // it's shorter than the 5 second timeout if the test is broken
+    // ensure that of the three timeouts, the one we hit is connect timeout.
     assert_elapsed!(start, Duration::from_millis(3100));
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -244,7 +244,7 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                     rustTemplate(
                         """
                         pub fn set_timeout_config(&mut self, timeout_config: #{Option}<#{TimeoutConfig}>) -> &mut Self {
-                            let mut timeout_config = timeout_config.unwrap_or_else(||#{TimeoutConfig}::disabled());
+                            let mut timeout_config = timeout_config.unwrap_or_else(#{TimeoutConfig}::disabled);
                             if let Some(base) = self.config.load::<#{TimeoutConfig}>() {
                                 timeout_config.take_defaults_from(base);
                             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -213,7 +213,11 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                             self
                         }
 
-                        /// Set the timeout_config for the builder
+                        /// Set the timeout_config for the builder.
+                        ///
+                        /// Setting this to `None` has no effect if another source of configuration has set timeouts. If you
+                        /// are attempting to disable timeouts, use [`TimeoutConfig::disabled`](#{TimeoutConfig}::disabled)
+                        ///
                         ///
                         /// ## Examples
                         ///
@@ -244,7 +248,11 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                     rustTemplate(
                         """
                         pub fn set_timeout_config(&mut self, timeout_config: #{Option}<#{TimeoutConfig}>) -> &mut Self {
-                            let mut timeout_config = timeout_config.unwrap_or_else(#{TimeoutConfig}::disabled);
+                            // passing None has no impact.
+                            let Some(mut timeout_config) = timeout_config else {
+                                return self
+                            };
+
                             if let Some(base) = self.config.load::<#{TimeoutConfig}>() {
                                 timeout_config.take_defaults_from(base);
                             }

--- a/rust-runtime/aws-smithy-types/src/config_bag.rs
+++ b/rust-runtime/aws-smithy-types/src/config_bag.rs
@@ -264,9 +264,10 @@ impl CloneableLayer {
     where
         T::StoredType: Clone,
     {
-        self.0
-            .props
-            .insert(TypeId::of::<T>(), TypeErasedBox::new_with_clone(value));
+        self.0.props.insert(
+            TypeId::of::<T::StoredType>(),
+            TypeErasedBox::new_with_clone(value),
+        );
         self
     }
 
@@ -320,7 +321,7 @@ impl CloneableLayer {
     {
         self.0
             .props
-            .entry(TypeId::of::<T>())
+            .entry(TypeId::of::<T::StoredType>())
             .or_insert_with(|| TypeErasedBox::new_with_clone(T::StoredType::default()))
             .downcast_mut()
             .expect("typechecked")
@@ -371,7 +372,7 @@ impl Layer {
     /// Inserts `value` into the layer directly
     fn put_directly<T: Store>(&mut self, value: T::StoredType) -> &mut Self {
         self.props
-            .insert(TypeId::of::<T>(), TypeErasedBox::new(value));
+            .insert(TypeId::of::<T::StoredType>(), TypeErasedBox::new(value));
         self
     }
 
@@ -490,14 +491,14 @@ impl Layer {
     /// Retrieves the value of type `T` from this layer if exists
     fn get<T: Send + Sync + Store + 'static>(&self) -> Option<&T::StoredType> {
         self.props
-            .get(&TypeId::of::<T>())
+            .get(&TypeId::of::<T::StoredType>())
             .map(|t| t.downcast_ref().expect("typechecked"))
     }
 
     /// Returns a mutable reference to `T` if it is stored in this layer
     fn get_mut<T: Send + Sync + Store + 'static>(&mut self) -> Option<&mut T::StoredType> {
         self.props
-            .get_mut(&TypeId::of::<T>())
+            .get_mut(&TypeId::of::<T::StoredType>())
             .map(|t| t.downcast_mut().expect("typechecked"))
     }
 
@@ -508,7 +509,7 @@ impl Layer {
         T::StoredType: Default,
     {
         self.props
-            .entry(TypeId::of::<T>())
+            .entry(TypeId::of::<T::StoredType>())
             .or_insert_with(|| TypeErasedBox::new(T::StoredType::default()))
             .downcast_mut()
             .expect("typechecked")


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
For context, see https://github.com/smithy-lang/smithy-rs/discussions/3408

## Description
<!--- Describe your changes in detail -->
- During `invoke`, load all timeout configs and merge them via a custom loader.
- Fix config bag bugs that prevented using a Stored type that differed from `T`.
- Add new e2e and codegen integration test validating that timeout settings are properly merged.
- Add fallback for an empty timeout config being equivalent to `TimeoutConfig::disabled`.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
