### PR TITLE
Add support to disable S3 Express session auth

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -63,6 +63,7 @@ class EndpointParamsInterceptorGenerator(
                 "Error" to interceptors.resolve("context::Error"),
                 "InterceptorError" to interceptors.resolve("error::InterceptorError"),
                 "Params" to endpointTypesGenerator.paramsStruct(),
+                "RuntimeComponents" to RuntimeType.runtimeComponents(rc),
             )
         }
 
@@ -83,9 +84,10 @@ class EndpointParamsInterceptorGenerator(
                     ${interceptorName.dq()}
                 }
 
-                fn read_before_execution(
+                fn read_before_serialization(
                     &self,
                     context: &#{BeforeSerializationInterceptorContextRef}<'_, #{Input}, #{Output}, #{Error}>,
+                    _runtime_components: &#{RuntimeComponents},
                     cfg: &mut #{ConfigBag},
                 ) -> #{Result}<(), #{BoxError}> {
                     let _input = context.input()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -44,9 +44,13 @@ sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
         /** Generates the code to register an interceptor */
         fun registerInterceptor(
             writer: RustWriter,
+            allow_duplicate: Boolean = true,
             interceptor: Writable,
         ) {
-            writer.rust("runtime_components.push_interceptor(#T);", interceptor)
+            when (allow_duplicate) {
+                true -> writer.rust("runtime_components.push_interceptor(#T);", interceptor)
+                false -> writer.rust("runtime_components.maybe_push_interceptor(#T);", interceptor)
+            }
         }
 
         fun registerAuthScheme(

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -717,6 +717,15 @@ impl RuntimeComponentsBuilder {
         self
     }
 
+    /// Adds an interceptor if no interceptor with the same name has been registered in the current
+    /// instance of this builder.
+    pub fn maybe_push_interceptor(&mut self, interceptor: impl Intercept + 'static) -> &mut Self {
+        if !self.interceptors().any(|i| i.name() == interceptor.name()) {
+            self.push_interceptor(interceptor);
+        }
+        self
+    }
+
     /// Adds an interceptor.
     pub fn with_interceptor(mut self, interceptor: impl Intercept + 'static) -> Self {
         self.push_interceptor(interceptor);


### PR DESCRIPTION
## Motivation and Context
Adds the ability to disable S3 Express session auth (causing it to use a regular sigv4 session auth instead).
 
## Description
S3 Express One Zone is an opt out feature, and there are three ways to disable it (with the order of precedence as listed):
- through the `disable_s3_express_session_auth` method on an S3 client
- through an environment variable `AWS_S3_DISABLE_EXPRESS_SESSION_AUTH`
- through a profile file with a key `s3_disable_express_session_auth` (won't be supported yet in this PR until https://github.com/awslabs/aws-sdk-rust/issues/1060 is implemented)
 
If one of the places is set to true/false, then the subsequent places with lower precedence will not be considered.
 
### Implementation details
#### `EndpointParamsInterceptor` now uses `read_before_serialization` instead of `read_before_execution`
This means the previous logic for `EndpointParamsInterceptor` will now kick in at a later point in the orchestrator execution. This is to support the following use case:
```
    let config = aws_config::load_from_env().await;
    let client = aws_sdk_s3::Client::new(&config);
 
    std::env::set_var("AWS_S3_DISABLE_EXPRESS_SESSION_AUTH", "true");
 
    let _ = client
        .list_objects_v2()
        .bucket("s3express-test-bucket--usw2-az1--x-s3")
        .customize()
        .config_override(Config::builder().disable_s3_express_session_auth(false))
        .send()
        .await;
```
This code should end up using the S3 Express session auth since what's passed to the S3 client method should take the highest precedence (and the one set by the environment variable should be overruled). To support this, `EndpointParamsInterceptor` needs to "hold off" on grabbing `DisableS3ExpressSessionAuth` from a config bag so that the `DisableS3ExpressSessionAuth` fully reflects all three disabling places above, which is ensured by a newly added interceptor `DisableS3ExpressSessionAuthInterceptor`. However, the new interceptor needs to run after the config bag merges service-level and operation-level configurations (because there is a chance of `config_override` like above) but before the `EndpointParamsInterceptor`'s trait method runs.

The previous execution point for `EndpointParamsInterceptor` was [here](https://github.com/smithy-lang/smithy-rs/blob/1f7d70e81b6752c5c886fe5344b9d34d52504b3e/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs#L188), but this left no room for `DisableS3ExpressSessionAuthInterceptor` to deterministically run before `EndpointParamsInterceptor` with a fully merged `ConfigBag`. Why? If `DisableS3ExpressSessionAuthInterceptor` were registered at a client level and implemented `read_before_execution`, it would run before `EndpointParamsInterceptor` but the config bag has not fully merged operation-level config. If `DisableS3ExpressSessionAuthInterceptor` were registered at an operation-level and implemented `read_before_execution`, both `EndpointParamsInterceptor` and that would be operation-level interceptors implementing the same `Intercept` trait method, no guarantee that which one runs first.

Because of this, the PR now implements `EndpointParamsInterceptor::read_before_serialization` instead of `EndpointParamsInterceptor::read_before_execution`, leaving room for `DisableS3ExpressSessionAuthInterceptor` to kick in and ensuring it has access to a fully merged `ConfigBag`.
 
#### `DisableS3ExpressSessionAuthInterceptor` is a client-level interceptor implementing `read_before_serialization`
This is because it needs to carry over a piece of information `s3_disable_express_session_auth` set by a profile file. Within `From<&SdkConfig> for Builder`, that piece of information is transferred to the interceptor (note that we don't call `builder.set_disable_s3_express_session_auth(...)` as doing so will collide with a customer setting a disable flag through the `disable_s3_express_session_auth` method on an S3 client). The interceptor then implements `read_before_serialization` so that it has access to a fully merged `ConfigBag` and runs before `EndpointParamsInterceptor::read_before_serialization`.

## Testing
Added unit tests for `DisableS3ExpressSessionAuthInterceptor` and integration tests for verifying disabling S3 Express session auth. Tests for a profile file will be TODO until the said work is implemented.
 
----
 
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._