### PR TITLE
Disable formatter

### DIFF
--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -29,6 +29,11 @@ dependencies {
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
 }
 
+// Disabled because the formatter was remove formatting from our `body` sections.
+smithy {
+    format.set(false)
+}
+
 data class ClientTest(
     val serviceShapeName: String,
     val moduleName: String,

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
     implementation("software.amazon.smithy:smithy-validation-model:$smithyVersion")
 }
 
+smithy {
+    format.set(false)
+}
+
 val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
     listOf(
         CodegenTest("crate#Config", "naming_test_ops", imports = listOf("$commonModels/naming-obstacle-course-ops.smithy")),


### PR DESCRIPTION
## Motivation and Context
running codegen tests produces a diff you need to ignore

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
