### PR TITLE
Fix release-mode warnings in aws-smithy-runtime-api

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/retries/classifiers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/retries/classifiers.rs
@@ -279,14 +279,14 @@ impl ClassifyRetry for SharedRetryClassifier {
 impl ValidateConfig for SharedRetryClassifier {
     fn validate_final_config(
         &self,
-        runtime_components: &RuntimeComponents,
+        _runtime_components: &RuntimeComponents,
         _cfg: &ConfigBag,
     ) -> Result<(), BoxError> {
         #[cfg(debug_assertions)]
         {
             // Because this is validating that the implementation is correct rather
             // than validating user input, we only want to run this in debug builds.
-            let retry_classifiers = runtime_components.retry_classifiers_slice();
+            let retry_classifiers = _runtime_components.retry_classifiers_slice();
             let out_of_order: Vec<_> = retry_classifiers
                 .windows(2)
                 .filter(|&w| w[0].value().priority() > w[1].value().priority())

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -425,6 +425,7 @@ impl RuntimeComponents {
     }
 
     // Needed for `impl ValidateConfig for SharedRetryClassifier {`
+    #[cfg(debug_assertions)]
     pub(crate) fn retry_classifiers_slice(&self) -> &[Tracked<SharedRetryClassifier>] {
         self.retry_classifiers.as_slice()
     }
@@ -883,6 +884,7 @@ impl<T> Tracked<T> {
         }
     }
 
+    #[cfg(debug_assertions)]
     pub(crate) fn value(&self) -> &T {
         &self.value
     }


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
