### PR TITLE
Improve logging for the credentials cache

### DIFF
--- a/rust-runtime/aws-smithy-runtime/src/expiring_cache.rs
+++ b/rust-runtime/aws-smithy-runtime/src/expiring_cache.rs
@@ -80,6 +80,8 @@ where
         if let Some((value, expiry)) = self.value.read().await.get() {
             if !expired(*expiry, self.buffer_time, now) {
                 return Some(value.clone());
+            } else {
+                tracing::debug!(expiry = ?expiry, delta= ?now.duration_since(*expiry), "An item existed but it expired.")
             }
         }
 


### PR DESCRIPTION
## Motivation and Context
Make it easier to understand why credentials are expired. New log example:

```
2024-02-19T17:47:31.769924Z  INFO lazy_load_identity: aws_smithy_runtime::client::identity::cache::lazy: identity cache miss occurred; added new identity (took 861.893ms) new_expiration=2024-02-19T18:47:31Z valid_for=3599.230108s partition=IdentityCachePartition(1)
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
