### PR TITLE
Support for accessing arbitrary profile config data

### DIFF
--- a/aws/rust-runtime/aws-config/src/default_provider/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/retry_config.rs
@@ -173,8 +173,8 @@ mod test {
         let expected_retry_config = RetryConfig::standard();
 
         assert_eq!(actual_retry_config, expected_retry_config);
-        // This is redundant but it's really important to make sure that
-        // we're setting these exact values by default so we check twice
+        // This is redundant, but it's really important to make sure that
+        // we're setting these exact values by default, so we check twice
         assert_eq!(actual_retry_config.max_attempts(), 3);
         assert_eq!(actual_retry_config.mode(), RetryMode::Standard);
     }

--- a/aws/rust-runtime/aws-config/src/profile/parser/parse.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/parse.rs
@@ -59,8 +59,8 @@ impl Error for ProfileParseError {}
 
 /// Validate that a line represents a valid subproperty
 ///
-/// - Subproperties looks like regular properties (`k=v`) that are nested within an existing property.
-/// - Subproperties must be validated for compatibility with other SDKs, but they are not actually
+/// - Sub-properties looks like regular properties (`k=v`) that are nested within an existing property.
+/// - Sub-properties must be validated for compatibility with other SDKs, but they are not actually
 /// parsed into structured data.
 fn validate_subproperty(value: &str, location: Location) -> Result<(), ProfileParseError> {
     if value.trim_matches(WHITESPACE).is_empty() {


### PR DESCRIPTION
I still have some TODOs and naming to think about but the main functionality is all there for review

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This is required to enable an upcoming service-specific env config feature

## Description
<!--- Describe your changes in detail -->
This PR adds support for accessing profile config data defined in any sort of section. It also supports sub-properties.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
