### PR TITLE
Allow S3 Express to use CRC32 for default request checksum

### DIFF
--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -60,13 +60,15 @@ impl Storable for RequestChecksumInterceptorState {
     type Storer = StoreReplace<Self>;
 }
 
+pub(crate) type CustomDefaultFn = Box<
+    dyn Fn(Option<ChecksumAlgorithm>, &ConfigBag) -> Option<ChecksumAlgorithm>
+        + Send
+        + Sync
+        + 'static,
+>;
+
 pub(crate) struct DefaultRequestChecksumOverride {
-    custom_default: Box<
-        dyn Fn(Option<ChecksumAlgorithm>, &ConfigBag) -> Option<ChecksumAlgorithm>
-            + Send
-            + Sync
-            + 'static,
-    >,
+    custom_default: CustomDefaultFn,
 }
 impl fmt::Debug for DefaultRequestChecksumOverride {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -60,6 +60,43 @@ impl Storable for RequestChecksumInterceptorState {
     type Storer = StoreReplace<Self>;
 }
 
+pub(crate) struct DefaultRequestChecksumOverride {
+    custom_default: Box<
+        dyn Fn(Option<ChecksumAlgorithm>, &ConfigBag) -> Option<ChecksumAlgorithm>
+            + Send
+            + Sync
+            + 'static,
+    >,
+}
+impl fmt::Debug for DefaultRequestChecksumOverride {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DefaultRequestChecksumOverride").finish()
+    }
+}
+impl Storable for DefaultRequestChecksumOverride {
+    type Storer = StoreReplace<Self>;
+}
+impl DefaultRequestChecksumOverride {
+    pub(crate) fn new<F>(custom_default: F) -> Self
+    where
+        F: Fn(Option<ChecksumAlgorithm>, &ConfigBag) -> Option<ChecksumAlgorithm>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self {
+            custom_default: Box::new(custom_default),
+        }
+    }
+    pub(crate) fn custom_default(
+        &self,
+        original: Option<ChecksumAlgorithm>,
+        config_bag: &ConfigBag,
+    ) -> Option<ChecksumAlgorithm> {
+        (self.custom_default)(original, config_bag)
+    }
+}
+
 pub(crate) struct RequestChecksumInterceptor<AP> {
     algorithm_provider: AP,
 }
@@ -102,7 +139,7 @@ where
     /// Calculate a checksum and modify the request to include the checksum as a header
     /// (for in-memory request bodies) or a trailer (for streaming request bodies).
     /// Streaming bodies must be sized or this will return an error.
-    fn modify_before_retry_loop(
+    fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,
         _runtime_components: &RuntimeComponents,
@@ -112,12 +149,23 @@ where
             .load::<RequestChecksumInterceptorState>()
             .expect("set in `read_before_serialization`");
 
-        if let Some(checksum_algorithm) = state.checksum_algorithm {
+        let checksum_algorithm = incorporate_custom_default(state.checksum_algorithm, cfg);
+        if let Some(checksum_algorithm) = checksum_algorithm {
             let request = context.request_mut();
             add_checksum_for_request_body(request, checksum_algorithm, cfg)?;
         }
 
         Ok(())
+    }
+}
+
+fn incorporate_custom_default(
+    checksum: Option<ChecksumAlgorithm>,
+    cfg: &ConfigBag,
+) -> Option<ChecksumAlgorithm> {
+    match cfg.load::<DefaultRequestChecksumOverride>() {
+        Some(checksum_override) => checksum_override.custom_default(checksum, cfg),
+        None => checksum,
     }
 }
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -26,7 +26,7 @@ import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.orNull
 
-private fun RuntimeConfig.awsInlineableHttpRequestChecksum() =
+internal fun RuntimeConfig.awsInlineableHttpRequestChecksum() =
     RuntimeType.forInlineDependency(
         InlineAwsDependency.forRustFile(
             "http_request_checksum", visibility = Visibility.PUBCRATE,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
@@ -224,6 +224,8 @@ class S3ExpressRequestChecksumCustomization(
                         ${section.newLayerName}.store_put(#{DefaultRequestChecksumOverride}::new(
                             |original: #{Option}<#{ChecksumAlgorithm}>,
                             cfg: &#{ConfigBag}| {
+                                // S3 does not have the `ChecksumAlgorithm::Md5`, therefore customers cannot set it
+                                // from outside.
                                 if original != #{Some}(#{ChecksumAlgorithm}::Md5) {
                                     return original;
                                 }

--- a/aws/sdk/integration-tests/s3/tests/express.rs
+++ b/aws/sdk/integration-tests/s3/tests/express.rs
@@ -6,13 +6,28 @@
 use std::time::{Duration, SystemTime};
 
 use aws_config::Region;
+use aws_sdk_s3::config::Builder;
 use aws_sdk_s3::presigning::PresigningConfig;
 use aws_sdk_s3::primitives::SdkBody;
+use aws_sdk_s3::types::ChecksumAlgorithm;
 use aws_sdk_s3::{Client, Config};
 use aws_smithy_runtime::client::http::test_util::dvr::ReplayingClient;
 use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
 use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
 use http::Uri;
+
+async fn test_client<F>(update_builder: F) -> Client
+where
+    F: Fn(Builder) -> Builder,
+{
+    let sdk_config = aws_config::from_env()
+        .no_credentials()
+        .region("us-west-2")
+        .load()
+        .await;
+    let config = Config::from(&sdk_config).to_builder().with_test_defaults();
+    aws_sdk_s3::Client::from_conf(update_builder(config).build())
+}
 
 #[tokio::test]
 async fn list_objects_v2() {
@@ -20,17 +35,7 @@ async fn list_objects_v2() {
 
     let http_client =
         ReplayingClient::from_file("tests/data/express/list-objects-v2.json").unwrap();
-    let config = aws_config::from_env()
-        .http_client(http_client.clone())
-        .no_credentials()
-        .region("us-west-2")
-        .load()
-        .await;
-    let config = Config::from(&config)
-        .to_builder()
-        .with_test_defaults()
-        .build();
-    let client = aws_sdk_s3::Client::from_conf(config);
+    let client = test_client(|b| b.http_client(http_client.clone())).await;
 
     let result = client
         .list_objects_v2()
@@ -50,17 +55,7 @@ async fn mixed_auths() {
     let _logs = capture_test_logs();
 
     let http_client = ReplayingClient::from_file("tests/data/express/mixed-auths.json").unwrap();
-    let config = aws_config::from_env()
-        .http_client(http_client.clone())
-        .no_credentials()
-        .region("us-west-2")
-        .load()
-        .await;
-    let config = Config::from(&config)
-        .to_builder()
-        .with_test_defaults()
-        .build();
-    let client = aws_sdk_s3::Client::from_conf(config);
+    let client = test_client(|b| b.http_client(http_client.clone())).await;
 
     // A call to an S3 Express bucket where we should see two request/response pairs,
     // one for the `create_session` API and the other for `list_objects_v2` in S3 Express bucket.
@@ -186,4 +181,122 @@ async fn presigning() {
         &query_params
     );
     assert_eq!(presigned.headers().count(), 0);
+}
+
+fn operation_request_with_checksum(
+    query: &str,
+    kv: Option<(&str, &str)>,
+) -> http::Request<SdkBody> {
+    let mut b = http::Request::builder()
+        .uri(&format!("https://s3express-test-bucket--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com/{query}"))
+        .method("GET");
+    if let Some((key, value)) = kv {
+        b = b.header(key, value);
+    }
+    b.body(SdkBody::empty()).unwrap()
+}
+
+fn response_ok() -> http::Response<SdkBody> {
+    http::Response::builder()
+        .status(200)
+        .body(SdkBody::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn user_specified_checksum_should_be_respected() {
+    async fn runner(checksum: &str, value: &str) {
+        let http_client = StaticReplayClient::new(vec![
+            ReplayEvent::new(create_session_request(), create_session_response()),
+            ReplayEvent::new(
+                operation_request_with_checksum(
+                    "test?x-id=PutObject",
+                    Some((
+                        &format!("x-amz-checksum-{}", checksum.to_lowercase()),
+                        &format!("{value}"),
+                    )),
+                ),
+                response_ok(),
+            ),
+        ]);
+        let client = test_client(|b| b.http_client(http_client.clone())).await;
+
+        let _ = client
+            .put_object()
+            .bucket("s3express-test-bucket--usw2-az1--x-s3")
+            .key("test")
+            .body(SdkBody::empty().into())
+            .checksum_algorithm(ChecksumAlgorithm::from(checksum))
+            .send()
+            .await;
+
+        http_client.assert_requests_match(&[""]);
+    }
+
+    let crc32_checksum = "AAAAAA==";
+    let crc32c_checksum = "AAAAAA==";
+    let sha1_checksum = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
+    let sha256_checksum = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
+    for (checksum, value) in ChecksumAlgorithm::values().iter().zip(&[
+        crc32_checksum,
+        crc32c_checksum,
+        sha1_checksum,
+        sha256_checksum,
+    ]) {
+        runner(*checksum, *value).await;
+    }
+}
+
+#[tokio::test]
+async fn default_checksum_should_be_crc32_for_operation_requiring_checksum() {
+    let http_client = StaticReplayClient::new(vec![
+        ReplayEvent::new(create_session_request(), create_session_response()),
+        ReplayEvent::new(
+            operation_request_with_checksum(
+                "?delete&x-id=DeleteObjects",
+                Some(("x-amz-checksum-crc32", "AAAAAA==")),
+            ),
+            response_ok(),
+        ),
+    ]);
+    let client = test_client(|b| b.http_client(http_client.clone())).await;
+
+    let _ = client
+        .delete_objects()
+        .bucket("s3express-test-bucket--usw2-az1--x-s3")
+        .send()
+        .await;
+
+    http_client.assert_requests_match(&[""]);
+}
+
+#[tokio::test]
+async fn default_checksum_should_be_none() {
+    let http_client = StaticReplayClient::new(vec![
+        ReplayEvent::new(create_session_request(), create_session_response()),
+        ReplayEvent::new(
+            operation_request_with_checksum("test?x-id=PutObject", None),
+            response_ok(),
+        ),
+    ]);
+    let client = test_client(|b| b.http_client(http_client.clone())).await;
+
+    let _ = client
+        .put_object()
+        .bucket("s3express-test-bucket--usw2-az1--x-s3")
+        .key("test")
+        .body(SdkBody::empty().into())
+        .send()
+        .await;
+
+    http_client.assert_requests_match(&[""]);
+
+    let mut all_checksums = ChecksumAlgorithm::values()
+        .iter()
+        .map(|checksum| format!("amz-checksum-{}", checksum.to_lowercase()))
+        .chain(std::iter::once("content-md5".to_string()));
+
+    assert!(!all_checksums.any(|checksum| http_client
+        .actual_requests()
+        .any(|req| req.headers().iter().any(|(key, _)| key == checksum))));
 }


### PR DESCRIPTION
## Motivation and Context
Changes the default request checksum to CRC32 for S3 Express.

## Description
This PR modifies the default request checksum to CRC32 for S3 Express. Note that if a customer specifies a custom checksum algorithm via such as [checksum_algorithm](https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/operation/put_object/struct.PutObjectInput.html#structfield.checksum_algorithm), then the PR does not affect anything and respects the customer-specified checksum algorithm.

Otherwise, if an operation is annotated with a `requestChecksumRequired` trait and set to true, the default checksum becomes relevant. The default algorithm is currently `MD5` and S3 Express requires it to be `CRC32`. The code changes in this PR reflect that requirement.

Implementation details include
- `RequestChecksumInterceptor` is a single-sourced place to handle request checksum, but since it is a common place for all services we cannot add S3-Express-specific logic in there to configure the default checksum. Instead, we have introduced a slight more abstract concept of overriding the default checksum via `DefaultRequestChecksumOverride`. `RequestChecksumInterceptor` grabs it from a `ConfigBag` and uses it (if found) to configure the default checksum.
- We deferred a point of adding a checksum to a request body to `RequestChecksumInterceptor::modify_before_signing` from `RequestChecksumInterceptor::modify_before_retry_loop`. This is because we won't know whether S3 Express checksum default actually kicks until an endpoint is fully resolved. `modify_before_retry_loop` occurs before `client::orchestrator::endpoints::orchestrate_endpoint` so we need to choose a different interceptor method that runs after it.
- I abandoned having a separate S3-specific `RequestChecksumInterceptor` as it was more complicated than this approach. The wrinkle is that if we have an S3-specific `RequestChecksumInterceptor`, then it needs to either a) disable [the general RequestChecksumInterceptor](https://github.com/smithy-lang/smithy-rs/blob/f7be5f801504e7edf5cb6b731f3400c37b298abc/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs#L79-L100) entirely or b) only change the checksum default and delegate the rest to the general `RequestChecksumInterceptor`. In both cases the general `RequestChecksumInterceptor` must be disabled in runtime components, otherwise a request checksum related header will incorrectly be added twice. To disable the general `RequestChecksumInterceptor` using [disable_interceptor](https://github.com/smithy-lang/smithy-rs/blob/main/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs#L839), we need to remove a generic parameter `AP` from `RequestChecksumInterceptor` since we cannot enumerate all possible `AP` when specifying it in `disable_interceptor`.
 
## Testing
Added integration tests for S3 Express default checksum to `integration-tests/s3/tests/express.rs`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._