### PR TITLE
Update credentials-verification.yml

### DIFF
--- a/.github/workflows/credentials-verification.yml
+++ b/.github/workflows/credentials-verification.yml
@@ -16,9 +16,8 @@ jobs:
     - name: Verify Crates.io Token
       shell: bash
       env:
-        RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
       run: |
-        cargo login "${RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN}"
         echo "Checking cargo auth token..."
         # "cargo login" only saves a token and does not actually use it, so we use "cargo yank" to verify the token.
         # This version has already been yanked, so it is safe to execute the command below repeatedly.


### PR DESCRIPTION
According to [these docs](https://doc.rust-lang.org/cargo/reference/config.html?highlight=CARGO_REGISTRY_TOKEN#credentials), we should be able to just set an env var instead of calling `cargo login`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
