### PR TITLE
Fix resolver warning in generated cargo workspace

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -313,6 +313,7 @@ tasks.register<Copy>("relocateChangelog") {
 fun generateCargoWorkspace(services: AwsServices): String {
     return """
     |[workspace]
+    |resolver = "2"
     |exclude = [${"\n"}${services.excludedFromWorkspace().joinToString(",\n") { "|    \"$it\"" }}
     |]
     |members = [${"\n"}${services.includedInWorkspace().joinToString(",\n") { "|    \"$it\"" }}


### PR DESCRIPTION
This PR fixes the workspace resolver version warning in the SDK's generated workspace `Cargo.toml` file.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
