### PR TITLE
Run runtime crate version audit as part of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,13 @@ repos:
     language: system
     files: ^.*$
     pass_filenames: false
+  # Check that runtime crates are properly version bumped when changed
+  - id: runtime-versioner-check
+    name: runtime-versioner
+    entry: ./.pre-commit-hooks/runtime-versioner.sh
+    language: system
+    # Only run if the rust runtime files change
+    files: ^.*/?rust-runtime/.*$
+    pass_filenames: false
+    # Show the info messages from the runtime versioner that explain how things will publish
+    verbose: true

--- a/.pre-commit-hooks/runtime-versioner.sh
+++ b/.pre-commit-hooks/runtime-versioner.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+cd "$(git rev-parse --show-toplevel)/tools/ci-build/runtime-versioner" && cargo run -- audit


### PR DESCRIPTION
This PR makes the runtime-versioner run via pre-commit so that devs will know if they need to version bump a runtime crate sooner than CI would otherwise tell them.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
