### PR TITLE
Add Code Catalyst model to smoke test

### DIFF
--- a/aws/sdk/aws-models/codecatalyst.json
+++ b/aws/sdk/aws-models/codecatalyst.json
@@ -1,0 +1,5574 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.amazonaws.codecatalyst#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied because you don't have sufficient access to perform this action. Verify that you are a member of a role that allows this action.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.codecatalyst#AccessToken": {
+            "type": "resource",
+            "identifiers": {
+                "accessTokenId": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenId"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.codecatalyst#CreateAccessToken"
+            },
+            "delete": {
+                "target": "com.amazonaws.codecatalyst#DeleteAccessToken"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListAccessTokens"
+            }
+        },
+        "com.amazonaws.codecatalyst#AccessTokenId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 36
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#AccessTokenName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#AccessTokenSecret": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 4000
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#AccessTokenSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#AccessTokenSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#AccessTokenSummary": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated ID of the personal access token.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "accessTokenId"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the personal access token.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "expiresTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time when the personal access token will expire, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a specified personal access token (PAT).</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ClientToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CodeCatalyst": {
+            "type": "service",
+            "version": "2022-09-28",
+            "operations": [
+                {
+                    "target": "com.amazonaws.codecatalyst#GetUserDetails"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#VerifySession"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "com.amazonaws.codecatalyst#AccessToken"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#Space"
+                }
+            ],
+            "errors": [
+                {
+                    "target": "com.amazonaws.codecatalyst#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "CodeCatalyst",
+                    "endpointPrefix": "codecatalyst"
+                },
+                "aws.protocols#restJson1": {},
+                "smithy.api#documentation": "<p>Welcome to the Amazon CodeCatalyst API reference. This reference provides descriptions of operations and data types for Amazon CodeCatalyst. You can use the Amazon CodeCatalyst \n      API to work with the following objects. </p>\n         <p>Spaces, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>DeleteSpace</a>, which deletes a space.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetSpace</a>, which returns information about a space.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetSubscription</a>, which returns information about the Amazon Web Services account used for billing purposes \n        and the billing plan for the space.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListSpaces</a>, which retrieves a list of spaces.</p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateSpace</a>, which changes one or more values for a space.</p>\n            </li>\n         </ul>\n         <p>Projects, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateProject</a> which creates a project in a specified space.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetProject</a>, which returns information about a project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListProjects</a>, which retrieves a list of projects in a space.</p>\n            </li>\n         </ul>\n         <p>Users, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetUserDetails</a>, which returns information about a user in Amazon CodeCatalyst.</p>\n            </li>\n         </ul>\n         <p>Source repositories, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateSourceRepository</a>, which creates an empty Git-based source repository in a specified project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>CreateSourceRepositoryBranch</a>, which creates a branch in a specified repository where you can work on code.</p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteSourceRepository</a>, which deletes a source repository.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetSourceRepository</a>, which returns information about a source repository.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetSourceRepositoryCloneUrls</a>, which returns information about the URLs that can be used with a Git client to clone a source\n        repository.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListSourceRepositories</a>, which retrieves a list of source repositories in a project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListSourceRepositoryBranches</a>, which retrieves a list of branches in a source repository.</p>\n            </li>\n         </ul>\n         <p>Dev Environments and the Amazon Web Services Toolkits, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateDevEnvironment</a>, which creates a Dev Environment, \n       where you can quickly work on the code stored in the source repositories of your project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteDevEnvironment</a>, which deletes a Dev Environment.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetDevEnvironment</a>, which returns information about a Dev Environment.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListDevEnvironments</a>, which retrieves a list of Dev Environments in a project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListDevEnvironmentSessions</a>, which retrieves a list of active Dev Environment sessions in a project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>StartDevEnvironment</a>, which starts a specified Dev Environment and puts it into an active state.</p>\n            </li>\n            <li>\n               <p>\n                  <a>StartDevEnvironmentSession</a>, which starts a session to a specified Dev Environment.</p>\n            </li>\n            <li>\n               <p>\n                  <a>StopDevEnvironment</a>, which stops a specified Dev Environment and puts it into an stopped state.</p>\n            </li>\n            <li>\n               <p>\n                  <a>StopDevEnvironmentSession</a>, which stops a session for a specified Dev Environment.</p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateDevEnvironment</a>, which changes one or more values for a Dev Environment.</p>\n            </li>\n         </ul>\n         <p>Workflows, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetWorkflow</a>, which returns information about a workflow.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetWorkflowRun</a>, which returns information about a specified run of a workflow.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListWorkflowRuns</a>, which retrieves a list of runs of a specified workflow.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListWorkflows</a>, which retrieves a list of workflows in a specified project.</p>\n            </li>\n            <li>\n               <p>\n                  <a>StartWorkflowRun</a>, which starts a run of a specified workflow.</p>\n            </li>\n         </ul>\n         <p>Security, activity, and resource management in Amazon CodeCatalyst, by calling the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateAccessToken</a>, which creates a personal access token (PAT) for the current user.</p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteAccessToken</a>, which deletes a specified personal access token (PAT).</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAccessTokens</a>, which lists all personal access tokens (PATs) associated with a user.</p>\n            </li>\n            <li>\n               <p>\n                  <a>ListEventLogs</a>, which retrieves a list of events that occurred during a specified time period in a space.</p>\n            </li>\n            <li>\n               <p>\n                  <a>VerifySession</a>, which verifies whether the calling user has a valid Amazon CodeCatalyst login and session.</p>\n            </li>\n         </ul>\n         <note>\n            <p>If you are using the Amazon CodeCatalyst APIs with an SDK or the CLI, you must configure your computer to work with Amazon CodeCatalyst and single sign-on (SSO).\n        For more information, see <a href=\"https://docs.aws.amazon.com/codecatalyst/latest/userguide/set-up-cli.html\">Setting up to use the CLI with Amazon CodeCatalyst</a>\n      and the SSO documentation for your SDK.</p>\n         </note>",
+                "smithy.api#httpBearerAuth": {},
+                "smithy.api#title": "Amazon CodeCatalyst",
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "not",
+                                    "argv": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "fn": "aws.partition",
+                                    "argv": [
+                                        "us-west-2"
+                                    ],
+                                    "assign": "PartitionResult"
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "supportsFIPS"
+                                                            ]
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Partition does not support FIPS.",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": "https://codecatalyst-fips.global.{PartitionResult#dualStackDnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": "https://codecatalyst.global.{PartitionResult#dualStackDnsSuffix}",
+                                        "properties": {},
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "fn": "aws.partition",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ],
+                                    "assign": "PartitionResult"
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "supportsFIPS"
+                                                            ]
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Partition does not support FIPS.",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": "https://codecatalyst-fips.global.{PartitionResult#dualStackDnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": "https://codecatalyst.global.{PartitionResult#dualStackDnsSuffix}",
+                                        "properties": {},
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ],
+                            "type": "tree"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "version": "1",
+                    "testCases": [
+                        {
+                            "documentation": "Override endpoint",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://test.codecatalyst.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Endpoint": "https://test.codecatalyst.global.api.aws"
+                            }
+                        },
+                        {
+                            "documentation": "Default endpoint (region not set)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst.global.api.aws"
+                                }
+                            },
+                            "params": {}
+                        },
+                        {
+                            "documentation": "Default FIPS endpoint (region not set)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst-fips.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "Default endpoint (region: aws-global)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-global"
+                            }
+                        },
+                        {
+                            "documentation": "Default FIPS endpoint (region: aws-global)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst-fips.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-global",
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "Default endpoint for a valid home region (region: us-west-2)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "Default FIPS endpoint for a valid home region (region: us-west-2)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst-fips.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "Default endpoint for an unavailable home region (region: us-east-1)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "Default FIPS endpoint for an unavailable home region (region: us-east-1)",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://codecatalyst-fips.global.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ComparisonOperator": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "EQUALS",
+                        "value": "EQ"
+                    },
+                    {
+                        "name": "GREATER_THAN",
+                        "value": "GT"
+                    },
+                    {
+                        "name": "GREATER_THAN_OR_EQUALS",
+                        "value": "GE"
+                    },
+                    {
+                        "name": "LESS_THAN",
+                        "value": "LT"
+                    },
+                    {
+                        "name": "LESS_THAN_OR_EQUALS",
+                        "value": "LE"
+                    },
+                    {
+                        "name": "BEGINS_WITH",
+                        "value": "BEGINS_WITH"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#ConflictException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied because the requested operation would cause a conflict with the current state of a service resource associated with the request. \n       Another user might have updated the resource. Reload, make sure you have the latest data, and then try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateAccessToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#CreateAccessTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#CreateAccessTokenResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a personal access token (PAT) for the current user. A personal access token (PAT) is similar to a password. \n      It is associated with your user identity for use across all spaces and projects in Amazon CodeCatalyst. You use PATs to access CodeCatalyst \n      from resources that include integrated development environments (IDEs) and Git-based source repositories.  \n      PATs represent you in Amazon CodeCatalyst and you can manage them in your user settings.For more information, see \n      <a href=\"https://docs.aws.amazon.com/codecatalyst/latest/userguide/ipa-tokens-keys.html\">Managing personal access tokens in Amazon CodeCatalyst</a>.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/accessTokens",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateAccessTokenRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the personal access token.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "expiresTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the personal access token expires, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateAccessTokenResponse": {
+            "type": "structure",
+            "members": {
+                "secret": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenSecret",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The secret value of the personal access token.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the personal access token.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "expiresTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the personal access token expires, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>. If not specified, the default is one year from creation.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "accessTokenId": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the access token.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateDevEnvironment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#CreateDevEnvironmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#CreateDevEnvironmentResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a Dev Environment in Amazon CodeCatalyst, a cloud-based development environment that you can use to quickly work on the code stored \n      in the source repositories of your project.       </p>\n         <note>\n            <p>When created in the Amazon CodeCatalyst console, by default a Dev Environment is configured to have a 2 core processor, 4GB of RAM, and 16GB of persistent storage. None of these\n      defaults apply to a Dev Environment created programmatically.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments",
+                    "code": 201
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateDevEnvironmentRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "repositories": {
+                    "target": "com.amazonaws.codecatalyst#RepositoriesInput",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source repository that contains the branch to clone into the Dev Environment. </p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.codecatalyst#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A user-specified idempotency token.  Idempotency ensures that an API request completes only once. \n       With an idempotent request, if the original request completes successfully, the subsequent retries return the result from the original successful request and have no additional effect.</p>"
+                    }
+                },
+                "alias": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-defined alias for a Dev Environment.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        },
+                        "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_\\.][a-zA-Z0-9]+)*$"
+                    }
+                },
+                "ides": {
+                    "target": "com.amazonaws.codecatalyst#IdeConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the integrated development environment (IDE) configured for a\n      Dev Environment.</p>\n         <note>\n            <p>An IDE is required to create a Dev Environment. For Dev Environment creation, this field\n        contains configuration information and must be provided. </p>\n         </note>"
+                    }
+                },
+                "instanceType": {
+                    "target": "com.amazonaws.codecatalyst#InstanceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon EC2 instace type to use for the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "inactivityTimeoutMinutes": {
+                    "target": "com.amazonaws.codecatalyst#InactivityTimeoutMinutes",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of time the Dev Environment will run without any activity detected before stopping, in minutes. Only whole integers are allowed. Dev Environments consume compute minutes when running.</p>"
+                    }
+                },
+                "persistentStorage": {
+                    "target": "com.amazonaws.codecatalyst#PersistentStorageConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the amount of storage allocated to the Dev Environment. </p>\n         <note>\n            <p>By default, a Dev Environment is configured to have 16GB of persistent storage when created from the Amazon CodeCatalyst console, but there is no default when programmatically\n        creating a Dev Environment. \n        Valid values for persistent storage are based on memory sizes in 16GB increments. Valid\n        values are 16, 32, and 64.</p>\n         </note>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "vpcConnectionName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the connection to use connect to a Amazon VPC.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateDevEnvironmentResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "vpcConnectionName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the connection used to connect to Amazon VPC used when the Dev Environment was created, if any.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateProject": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#CreateProjectRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#CreateProjectResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a project in a specified space.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects",
+                    "code": 201
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateProjectRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "com.amazonaws.codecatalyst#ProjectDisplayName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the project that will be displayed to users.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#ProjectDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the project. This description will be displayed to all users of the project. We recommend providing a brief description of the project and its intended purpose.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateProjectResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "projectName"
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the project.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the project.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateSourceRepository": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#CreateSourceRepositoryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#CreateSourceRepositoryResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates an empty Git-based source repository in a specified project. The repository is\n      created with an initial empty commit with a default branch named <code>main</code>.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories/{name}",
+                    "code": 201
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateSourceRepositoryBranch": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#CreateSourceRepositoryBranchRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#CreateSourceRepositoryBranchResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a branch in a specified source repository in Amazon CodeCatalyst. </p>\n         <note>\n            <p>This API only creates a branch in a source repository hosted in Amazon CodeCatalyst. You cannot use this API to create a branch in a linked repository.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories/{sourceRepositoryName}/branches/{name}",
+                    "code": 201
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateSourceRepositoryBranchRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the repository where you want to create a branch.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name for the branch you're creating.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "sourceRepositoryBranchName"
+                    }
+                },
+                "headCommitId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The commit ID in an existing branch from which you want to create the new branch.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateSourceRepositoryBranchResponse": {
+            "type": "structure",
+            "members": {
+                "ref": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchRefString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Git reference name of the branch.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the newly created branch.</p>"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the branch was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "headCommitId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The commit ID of the tip of the newly created branch.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateSourceRepositoryRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository. For more information about name requirements, see <a href=\"https://docs.aws.amazon.com/codecatalyst/latest/userguide/source-quotas.html\">Quotas for source repositories</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "sourceRepositoryName"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryDescriptionString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the source repository.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#CreateSourceRepositoryResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryDescriptionString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the source repository.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteAccessToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#DeleteAccessTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#DeleteAccessTokenResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a specified personal access token (PAT). A personal access token can only be deleted by the user who created it.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/accessTokens/{id}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteAccessTokenRequest": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the personal access token to delete. You can find the IDs of all PATs associated with your Amazon Web Services Builder ID in a space by calling <a>ListAccessTokens</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "accessTokenId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteAccessTokenResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteDevEnvironment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#DeleteDevEnvironmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#DeleteDevEnvironmentResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a Dev Environment.  </p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteDevEnvironmentRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment you want to delete. To retrieve a list of Dev Environment IDs, use <a>ListDevEnvironments</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteDevEnvironmentResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the deleted Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteProject": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#DeleteProjectRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#DeleteProjectResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a project in a space.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/spaces/{spaceName}/projects/{name}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteProjectRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space. To retrieve a list of project names, use <a>ListProjects</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "projectName"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteProjectResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "projectName"
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name displayed to users of the project in Amazon CodeCatalyst.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteSourceRepository": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#DeleteSourceRepositoryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#DeleteSourceRepositoryResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a source repository in Amazon CodeCatalyst. You cannot use this API to delete a linked repository. It can only be used to delete a Amazon CodeCatalyst source repository.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories/{name}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteSourceRepositoryRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "sourceRepositoryName"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteSourceRepositoryResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteSpace": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#DeleteSpaceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#DeleteSpaceResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a space.</p>\n         <important>\n            <p>Deleting a space cannot be undone. Additionally, since space names must be unique across Amazon CodeCatalyst, you cannot reuse names of deleted spaces.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/spaces/{name}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteSpaceRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.  To retrieve a list of space names, use <a>ListSpaces</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "spaceName"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DeleteSpaceResponse": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "spaceName"
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the space displayed to users of the space in Amazon CodeCatalyst.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironment": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "devEnvironmentId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.codecatalyst#CreateDevEnvironment"
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetDevEnvironment"
+            },
+            "update": {
+                "target": "com.amazonaws.codecatalyst#UpdateDevEnvironment"
+            },
+            "delete": {
+                "target": "com.amazonaws.codecatalyst#DeleteDevEnvironment"
+            },
+            "operations": [
+                {
+                    "target": "com.amazonaws.codecatalyst#ListDevEnvironmentSessions"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#StartDevEnvironment"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#StartDevEnvironmentSession"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#StopDevEnvironment"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#StopDevEnvironmentSession"
+                }
+            ]
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentAccessDetails": {
+            "type": "structure",
+            "members": {
+                "streamUrl": {
+                    "target": "com.amazonaws.codecatalyst#SensitiveString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL used to send commands to and from the Dev Environment.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tokenValue": {
+                    "target": "com.amazonaws.codecatalyst#SensitiveString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An encrypted token value that contains session and caller information used to authenticate the connection.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about connection details for a Dev Environment.</p>",
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentRepositorySummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#DevEnvironmentRepositorySummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentRepositorySummary": {
+            "type": "structure",
+            "members": {
+                "repositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "branchName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the branch in a source repository cloned into the Dev Environment. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the source repsitory for a Dev Environment. </p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentSessionConfiguration": {
+            "type": "structure",
+            "members": {
+                "sessionType": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentSessionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the session.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "executeCommandSessionConfiguration": {
+                    "target": "com.amazonaws.codecatalyst#ExecuteCommandSessionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about optional commands that will be run on the Dev Environment when the SSH session begins.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the configuration of a Dev Environment session.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentSessionSummary": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "devEnvironmentId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "startedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the session started, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "id": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment session.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 96
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about active sessions for a Dev Environment.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentSessionType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "SSM",
+                        "value": "SSM"
+                    },
+                    {
+                        "name": "SSH",
+                        "value": "SSH"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentSessionsSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#DevEnvironmentSessionSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentStatus": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "PENDING",
+                        "value": "PENDING"
+                    },
+                    {
+                        "name": "RUNNING",
+                        "value": "RUNNING"
+                    },
+                    {
+                        "name": "STARTING",
+                        "value": "STARTING"
+                    },
+                    {
+                        "name": "STOPPING",
+                        "value": "STOPPING"
+                    },
+                    {
+                        "name": "STOPPED",
+                        "value": "STOPPED"
+                    },
+                    {
+                        "name": "FAILED",
+                        "value": "FAILED"
+                    },
+                    {
+                        "name": "DELETING",
+                        "value": "DELETING"
+                    },
+                    {
+                        "name": "DELETED",
+                        "value": "DELETED"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentSummary": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>"
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>"
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID for the Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Dev Environment was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "creatorId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the user who created the Dev Environment. </p>",
+                        "smithy.api#length": {
+                            "max": 1024
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusReason": {
+                    "target": "com.amazonaws.codecatalyst#StatusReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the status.</p>"
+                    }
+                },
+                "repositories": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentRepositorySummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the repositories that will be cloned into the Dev Environment. If no rvalue is specified, no repository is cloned.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "alias": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-specified alias for the Dev Environment.</p>",
+                        "smithy.api#length": {
+                            "max": 128
+                        }
+                    }
+                },
+                "ides": {
+                    "target": "com.amazonaws.codecatalyst#Ides",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the integrated development environment (IDE) configured for a Dev Environment.</p>"
+                    }
+                },
+                "instanceType": {
+                    "target": "com.amazonaws.codecatalyst#InstanceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon EC2 instace type used for the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "inactivityTimeoutMinutes": {
+                    "target": "com.amazonaws.codecatalyst#InactivityTimeoutMinutes",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of time the Dev Environment will run without any activity detected before stopping, in minutes. Dev Environments consume compute minutes when running.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "persistentStorage": {
+                    "target": "com.amazonaws.codecatalyst#PersistentStorage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the configuration of persistent storage for the Dev Environment.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "vpcConnectionName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the connection used to connect to Amazon VPC used when the Dev Environment was created, if any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a Dev Environment. </p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#DevEnvironmentSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#DevEnvironmentSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#EmailAddress": {
+            "type": "structure",
+            "members": {
+                "email": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The email address.</p>"
+                    }
+                },
+                "verified": {
+                    "target": "smithy.api#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Whether the email address has been verified.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about an email address.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#EventLogEntries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#EventLogEntry"
+            }
+        },
+        "com.amazonaws.codecatalyst#EventLogEntry": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "eventName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "eventType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "eventCategory": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The category for the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "eventSource": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source of the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "eventTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the event took place, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "operationType": {
+                    "target": "com.amazonaws.codecatalyst#OperationType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "userIdentity": {
+                    "target": "com.amazonaws.codecatalyst#UserIdentity",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the user whose actions are recorded in the event.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectInformation": {
+                    "target": "com.amazonaws.codecatalyst#ProjectInformation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the project where the event occurred.</p>"
+                    }
+                },
+                "requestId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the request.</p>"
+                    }
+                },
+                "requestPayload": {
+                    "target": "com.amazonaws.codecatalyst#EventPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the payload of the request.</p>"
+                    }
+                },
+                "responsePayload": {
+                    "target": "com.amazonaws.codecatalyst#EventPayload",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the payload of the response, if any.</p>"
+                    }
+                },
+                "errorCode": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The code of the error, if any.</p>"
+                    }
+                },
+                "sourceIpAddress": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The IP address of the user whose actions are recorded in the event.</p>"
+                    }
+                },
+                "userAgent": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user agent whose actions are recorded in the event.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about an entry in an event log of Amazon CodeCatalyst activity.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#EventLogResource": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "eventLogId": {
+                    "target": "smithy.api#String"
+                }
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListEventLogs"
+            }
+        },
+        "com.amazonaws.codecatalyst#EventPayload": {
+            "type": "structure",
+            "members": {
+                "contentType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of content in the event payload.</p>"
+                    }
+                },
+                "data": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data included in the event payload.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the payload of an event recording Amazon CodeCatalyst activity.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ExecuteCommandSessionConfiguration": {
+            "type": "structure",
+            "members": {
+                "command": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The command used at the beginning of the SSH session to a Dev Environment.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 255
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "arguments": {
+                    "target": "com.amazonaws.codecatalyst#ExecuteCommandSessionConfigurationArguments",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of arguments containing arguments and members.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the commands that will be run on a Dev Environment when an SSH session begins.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ExecuteCommandSessionConfigurationArguments": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String",
+                "traits": {
+                    "smithy.api#length": {
+                        "min": 1,
+                        "max": 255
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#Filter": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key that can be used to sort results.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "values": {
+                    "target": "com.amazonaws.codecatalyst#StringList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The values of the key.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "comparisonOperator": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The operator used to compare the fields.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a filter used to limit results of a query.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#FilterKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "HAS_ACCESS_TO",
+                        "value": "hasAccessTo"
+                    },
+                    {
+                        "name": "NAME",
+                        "value": "name"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#Filters": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#Filter"
+            }
+        },
+        "com.amazonaws.codecatalyst#GetDevEnvironment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetDevEnvironmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetDevEnvironmentResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about a Dev Environment for a source repository in a project. Dev Environments are specific to the user who creates them.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetDevEnvironmentRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment for which you want to view information. To retrieve a list of Dev Environment IDs, use <a>ListDevEnvironments</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetDevEnvironmentResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Dev Environment was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "creatorId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the user who created the Dev Environment. </p>",
+                        "smithy.api#length": {
+                            "max": 1024
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current status of the Dev Environment.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusReason": {
+                    "target": "com.amazonaws.codecatalyst#StatusReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason for the status.</p>"
+                    }
+                },
+                "repositories": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentRepositorySummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source repository that contains the branch cloned into the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "alias": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-specified alias for the Dev Environment. </p>",
+                        "smithy.api#length": {
+                            "max": 128
+                        }
+                    }
+                },
+                "ides": {
+                    "target": "com.amazonaws.codecatalyst#Ides",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the integrated development environment (IDE) configured for the Dev Environment. </p>"
+                    }
+                },
+                "instanceType": {
+                    "target": "com.amazonaws.codecatalyst#InstanceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon EC2 instace type to use for the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "inactivityTimeoutMinutes": {
+                    "target": "com.amazonaws.codecatalyst#InactivityTimeoutMinutes",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of time the Dev Environment will run without any activity detected before stopping, in minutes.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "persistentStorage": {
+                    "target": "com.amazonaws.codecatalyst#PersistentStorage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the amount of storage allocated to the Dev Environment.  By default, a Dev Environment is configured to have 16GB of persistent storage.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "vpcConnectionName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the connection used to connect to Amazon VPC used when the Dev Environment was created, if any.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetProject": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetProjectRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetProjectResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about a project.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/projects/{name}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetProjectRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "projectName"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetProjectResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>"
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the project displayed to users in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the project.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSourceRepository": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetSourceRepositoryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetSourceRepositoryResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about a source repository.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories/{name}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSourceRepositoryCloneUrls": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetSourceRepositoryCloneUrlsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetSourceRepositoryCloneUrlsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about the URLs that can be used with a Git client to clone a source\n      repository.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories/{sourceRepositoryName}/cloneUrls",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSourceRepositoryCloneUrlsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSourceRepositoryCloneUrlsResponse": {
+            "type": "structure",
+            "members": {
+                "https": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTPS URL to use when cloning the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSourceRepositoryRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "sourceRepositoryName"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSourceRepositoryResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryDescriptionString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the source repository.</p>"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the source repository was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the source repository was created, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSpace": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetSpaceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetSpaceResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about an space.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{name}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSpaceRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "spaceName"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSpaceResponse": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "regionName": {
+                    "target": "com.amazonaws.codecatalyst#RegionString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services Region where the space exists.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the space displayed to users.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the space.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSubscription": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetSubscriptionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetSubscriptionResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about the Amazon Web Services account used for billing purposes \n      and the billing plan for the space.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/subscription",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSubscriptionRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetSubscriptionResponse": {
+            "type": "structure",
+            "members": {
+                "subscriptionType": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the billing plan for the space.</p>"
+                    }
+                },
+                "awsAccountName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The display name of the Amazon Web Services account used for billing for the space.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetUserDetails": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetUserDetailsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetUserDetailsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about a user. </p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/userDetails",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetUserDetailsRequest": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the user. </p>",
+                        "smithy.api#httpQuery": "id",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 256
+                        }
+                    }
+                },
+                "userName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the user as displayed in Amazon CodeCatalyst.</p>",
+                        "smithy.api#httpQuery": "userName",
+                        "smithy.api#length": {
+                            "min": 3,
+                            "max": 100
+                        },
+                        "smithy.api#pattern": "^[a-zA-Z0-9]{3,100}$"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetUserDetailsResponse": {
+            "type": "structure",
+            "members": {
+                "userId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the user.</p>"
+                    }
+                },
+                "userName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the user as displayed in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name displayed for the user in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "primaryEmail": {
+                    "target": "com.amazonaws.codecatalyst#EmailAddress",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The email address provided by the user when they signed up.</p>"
+                    }
+                },
+                "version": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p/>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#GetWorkflow": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetWorkflowRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetWorkflowResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about a workflow.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/workflows/{id}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetWorkflowRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the workflow. To rerieve a list of workflow IDs, use <a>ListWorkflows</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "workflowId"
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetWorkflowResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the workflow.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "workflowId"
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository where the workflow YAML is stored.</p>"
+                    }
+                },
+                "sourceBranchName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the branch that contains the workflow YAML.</p>"
+                    }
+                },
+                "definition": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowDefinition",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the workflow definition file for the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow was created, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "runMode": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The behavior to use when multiple workflows occur at the same time. For more information, see \n      <a href=\"https://docs.aws.amazon.com/codecatalyst/latest/userguide/workflows-configure-runs.html\">https://docs.aws.amazon.com/codecatalyst/latest/userguide/workflows-configure-runs.html</a> in the Amazon CodeCatalyst User Guide.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetWorkflowRun": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#GetWorkflowRunRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#GetWorkflowRunResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns information about a specified run of a workflow.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/workflowRuns/{id}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetWorkflowRunRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the workflow run. To retrieve a list of workflow run IDs, use <a>ListWorkflowRuns</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "workflowRunId"
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#GetWorkflowRunResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the workflow run.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "workflowRunId"
+                    }
+                },
+                "workflowId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the workflow run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusReasons": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunStatusReasons",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the reasons for the status of the workflow run.</p>"
+                    }
+                },
+                "startTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow run began, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow run ended, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow run status was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#Ide": {
+            "type": "structure",
+            "members": {
+                "runtime": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A link to the IDE runtime image.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 400
+                        }
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the IDE.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about an integrated development environment (IDE) used in a Dev Environment.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#IdeConfiguration": {
+            "type": "structure",
+            "members": {
+                "runtime": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A link to the IDE runtime image. </p>\n         <note>\n            <p>This parameter is not required for <code>VSCode</code>.</p>\n         </note>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 400
+                        }
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the IDE. Valid values include <code>Cloud9</code>, <code>IntelliJ</code>, <code>PyCharm</code>, <code>GoLand</code>, and <code>VSCode</code>.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the configuration of an integrated development environment (IDE) for a Dev Environment.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#IdeConfigurationList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#IdeConfiguration"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#Ides": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#Ide"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#InactivityTimeoutMinutes": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0,
+                "smithy.api#range": {
+                    "min": 0,
+                    "max": 1200
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#InstanceType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "DEV_STANDARD1_SMALL",
+                        "value": "dev.standard1.small"
+                    },
+                    {
+                        "name": "DEV_STANDARD1_MEDIUM",
+                        "value": "dev.standard1.medium"
+                    },
+                    {
+                        "name": "DEV_STANDARD1_LARGE",
+                        "value": "dev.standard1.large"
+                    },
+                    {
+                        "name": "DEV_STANDARD1_XLARGE",
+                        "value": "dev.standard1.xlarge"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#ListAccessTokens": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListAccessTokensRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListAccessTokensResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Lists all personal access tokens (PATs) associated with the user who calls the API. You can only list PATs associated with your Amazon Web Services Builder ID.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/accessTokens",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListAccessTokensRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "max": 10
+                        }
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListAccessTokensResponse": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#AccessTokenSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of personal access tokens (PATs) associated with the calling user identity.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListDevEnvironmentSessions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListDevEnvironmentSessionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListDevEnvironmentSessionsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of active sessions for a Dev Environment in a project.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{devEnvironmentId}/sessions",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListDevEnvironmentSessionsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "devEnvironmentId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 200
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListDevEnvironmentSessionsResponse": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentSessionsSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about each session retrieved in the list.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListDevEnvironments": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListDevEnvironmentsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListDevEnvironmentsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of Dev Environments in a project.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/devEnvironments",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListDevEnvironmentsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>"
+                    }
+                },
+                "filters": {
+                    "target": "com.amazonaws.codecatalyst#Filters",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about filters to apply to narrow the results returned in the list.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListDevEnvironmentsResponse": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the Dev Environments in a project.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListEventLogs": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListEventLogsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListEventLogsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of events that occurred during a specific time in a space. You can\n      use these events to audit user and system activity in a space. For more information, see\n        <a href=\"https://docs.aws.amazon.com/codecatalyst/latest/userguide/ipa-monitoring.html\">Monitoring</a> in the <i>Amazon CodeCatalyst User Guide</i>.</p>\n         <note>\n            <p>ListEventLogs guarantees events for the last 30 days in a given space. You can also\n        view and retrieve a list of management events over the last 90 days for Amazon CodeCatalyst in the\n          CloudTrail console by viewing Event history, or by creating a trail to create\n        and maintain a record of events that extends past 90 days. For more information, see <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-cloudtrail-events.html\">Working with CloudTrail Event History</a> and <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-getting-started.html\">Working with\n          CloudTrail trails</a>.</p>\n         </note>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/eventLogs",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListEventLogsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "startTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time when you want to start retrieving events, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time after which you do not want any events retrieved, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "eventName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the event.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 250
+                        }
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListEventLogsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#EventLogEntries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about each event retrieved in the list.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListProjects": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListProjectsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListProjectsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of projects.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/projects",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListProjectsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 100
+                        }
+                    }
+                },
+                "filters": {
+                    "target": "com.amazonaws.codecatalyst#ProjectListFilters",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about filters to apply to narrow the results returned in the list.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListProjectsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#ProjectSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the projects.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositories": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoriesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoriesResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of source repositories in a project.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoriesItem": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryIdString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryDescriptionString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the repository, if any.</p>"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the source repository was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the source repository was created, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a source repository returned in a list of source repositories.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoriesItems": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoriesItem"
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoriesRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 200
+                        }
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoriesResponse": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#ListSourceRepositoriesItems",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the source repositories.</p>"
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoryBranches": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of branches in a specified source repository.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/sourceRepositories/{sourceRepositoryName}/branches",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesItem": {
+            "type": "structure",
+            "members": {
+                "ref": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchRefString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Git reference name of the branch.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the branch.</p>"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time the branch was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "headCommitId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The commit ID of the tip of the branch at the time of the request, also known as the head commit.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a branch of a source repository returned in a list of branches.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesItems": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesItem"
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#ListSourceRepositoryBranchesItems",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the source branches.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSpaces": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListSpacesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListSpacesResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of spaces.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSpacesRequest": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 10000
+                        }
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListSpacesResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#SpaceSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the spaces. </p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#ListWorkflowRuns": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListWorkflowRunsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListWorkflowRunsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of workflow runs of a specified workflow.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/workflowRuns",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListWorkflowRunsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "workflowId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the workflow. To retrieve a list of workflow IDs, use <a>ListWorkflows</a>.</p>",
+                        "smithy.api#httpQuery": "workflowId"
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#httpQuery": "nextToken",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 2048
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 50
+                        }
+                    }
+                },
+                "sortBy": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunSortCriteriaList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information used to sort the items in the returned list.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListWorkflowRunsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the runs of a workflow.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListWorkflows": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#ListWorkflowsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#ListWorkflowsResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a list of workflows in a specified project.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/workflows",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "nextToken",
+                    "outputToken": "nextToken",
+                    "pageSize": "maxResults",
+                    "items": "items"
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListWorkflowsRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>",
+                        "smithy.api#httpQuery": "nextToken",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 2048
+                        }
+                    }
+                },
+                "maxResults": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of results to show in a single call to this API. If the number of results is larger than the number you specified, the response will include a <code>NextToken</code> element, which you can use to obtain additional results.</p>",
+                        "smithy.api#httpQuery": "maxResults",
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 100
+                        }
+                    }
+                },
+                "sortBy": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowSortCriteriaList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information used to sort the items in the returned list.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ListWorkflowsResponse": {
+            "type": "structure",
+            "members": {
+                "nextToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token returned from a call to this API to indicate the next batch of results to return, if any.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowSummaries",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the workflows in a project.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#NameString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 63
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_\\.][a-zA-Z0-9]+)*$"
+            }
+        },
+        "com.amazonaws.codecatalyst#OperationType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "READONLY",
+                        "value": "READONLY"
+                    },
+                    {
+                        "name": "MUTATION",
+                        "value": "MUTATION"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#PersistentStorage": {
+            "type": "structure",
+            "members": {
+                "sizeInGiB": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the persistent storage in gigabytes (specifically GiB).</p>\n         <note>\n            <p>Valid values for storage are based on memory sizes in 16GB increments. Valid values are\n        16, 32, and 64.</p>\n         </note>",
+                        "smithy.api#range": {
+                            "min": 0,
+                            "max": 64
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the persistent storage for a Dev Environment.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#PersistentStorageConfiguration": {
+            "type": "structure",
+            "members": {
+                "sizeInGiB": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the persistent storage in gigabytes (specifically GiB).</p>\n         <note>\n            <p>Valid values for storage are based on memory sizes in 16GB increments. Valid values are\n        16, 32, and 64.</p>\n         </note>",
+                        "smithy.api#range": {
+                            "min": 0,
+                            "max": 64
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the configuration of persistent storage for a Dev Environment. </p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#Project": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.codecatalyst#CreateProject"
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetProject"
+            },
+            "update": {
+                "target": "com.amazonaws.codecatalyst#UpdateProject"
+            },
+            "delete": {
+                "target": "com.amazonaws.codecatalyst#DeleteProject"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListProjects"
+            },
+            "resources": [
+                {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironment"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#SourceRepository"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#Workflow"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRun"
+                }
+            ]
+        },
+        "com.amazonaws.codecatalyst#ProjectDescription": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_a-zA-Z0-9.,;:/\\+=?&$% \n\t\r])*$"
+            }
+        },
+        "com.amazonaws.codecatalyst#ProjectDisplayName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 63
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_\\. ][a-zA-Z0-9]+)*$"
+            }
+        },
+        "com.amazonaws.codecatalyst#ProjectInformation": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>"
+                    }
+                },
+                "projectId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the project.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a project in a space.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ProjectListFilter": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "target": "com.amazonaws.codecatalyst#FilterKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key that can be used to sort results.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "values": {
+                    "target": "com.amazonaws.codecatalyst#StringList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The values of the key.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "comparisonOperator": {
+                    "target": "com.amazonaws.codecatalyst#ComparisonOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The operator used to compare the fields.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>nformation about the filter used to narrow the results returned in a list of projects.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ProjectListFilters": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#ProjectListFilter"
+            }
+        },
+        "com.amazonaws.codecatalyst#ProjectSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#ProjectSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#ProjectSummary": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name displayed to users of the project in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the project.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a project.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#RegionString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 16
+                },
+                "smithy.api#pattern": "^(us(?:-gov)?|af|ap|ca|cn|eu|sa)-(central|(?:north|south)?(?:east|west)?)-(\\d+)$"
+            }
+        },
+        "com.amazonaws.codecatalyst#RepositoriesInput": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#RepositoryInput"
+            }
+        },
+        "com.amazonaws.codecatalyst#RepositoryInput": {
+            "type": "structure",
+            "members": {
+                "repositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "branchName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the branch in a source repository.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a repository that will be cloned to a Dev Environment.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied because the specified resource was not found. Verify that the spelling is correct and that you have access to the resource.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.codecatalyst#SensitiveString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied because one or more resources has reached its limits for the tier the space belongs to. Either reduce\n      the number of resources, or change the tier if applicable.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepository": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString"
+                }
+            },
+            "put": {
+                "target": "com.amazonaws.codecatalyst#CreateSourceRepository"
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetSourceRepository"
+            },
+            "delete": {
+                "target": "com.amazonaws.codecatalyst#DeleteSourceRepository"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositories"
+            },
+            "operations": [
+                {
+                    "target": "com.amazonaws.codecatalyst#GetSourceRepositoryCloneUrls"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranch"
+                }
+            ],
+            "traits": {
+                "smithy.api#noReplace": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepositoryBranch": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString"
+                },
+                "sourceRepositoryBranchName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString"
+                }
+            },
+            "put": {
+                "target": "com.amazonaws.codecatalyst#CreateSourceRepositoryBranch"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListSourceRepositoryBranches"
+            },
+            "traits": {
+                "smithy.api#noReplace": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepositoryBranchRefString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepositoryBranchString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepositoryDescriptionString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 255
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepositoryIdString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            }
+        },
+        "com.amazonaws.codecatalyst#SourceRepositoryNameString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                },
+                "smithy.api#pattern": "^(?!.*[.]git$)[\\w\\-.]*$"
+            }
+        },
+        "com.amazonaws.codecatalyst#Space": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                }
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetSpace"
+            },
+            "update": {
+                "target": "com.amazonaws.codecatalyst#UpdateSpace"
+            },
+            "delete": {
+                "target": "com.amazonaws.codecatalyst#DeleteSpace"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListSpaces"
+            },
+            "operations": [
+                {
+                    "target": "com.amazonaws.codecatalyst#ListDevEnvironments"
+                }
+            ],
+            "resources": [
+                {
+                    "target": "com.amazonaws.codecatalyst#EventLogResource"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#Project"
+                },
+                {
+                    "target": "com.amazonaws.codecatalyst#Subscription"
+                }
+            ]
+        },
+        "com.amazonaws.codecatalyst#SpaceDescription": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_a-zA-Z0-9.,;:/\\+=?&$% \n\t\r])*$"
+            }
+        },
+        "com.amazonaws.codecatalyst#SpaceSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#SpaceSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#SpaceSummary": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "regionName": {
+                    "target": "com.amazonaws.codecatalyst#RegionString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services Region\n      where the space exists.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the space displayed to users.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the space.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about an space.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#StartDevEnvironment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#StartDevEnvironmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#StartDevEnvironmentResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Starts a specified Dev Environment and puts it into an active state. </p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}/start",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#StartDevEnvironmentRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "ides": {
+                    "target": "com.amazonaws.codecatalyst#IdeConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the integrated development environment (IDE) configured for a Dev Environment. </p>"
+                    }
+                },
+                "instanceType": {
+                    "target": "com.amazonaws.codecatalyst#InstanceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon EC2 instace type to use for the Dev Environment. </p>"
+                    }
+                },
+                "inactivityTimeoutMinutes": {
+                    "target": "com.amazonaws.codecatalyst#InactivityTimeoutMinutes",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of time the Dev Environment will run without any activity detected before stopping, in minutes. Only whole integers are allowed. Dev Environments consume compute minutes when running.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StartDevEnvironmentResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StartDevEnvironmentSession": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#StartDevEnvironmentSessionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#StartDevEnvironmentSessionResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Starts a session for a specified Dev Environment.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}/session",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StartDevEnvironmentSessionRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "sessionConfiguration": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentSessionConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StartDevEnvironmentSessionResponse": {
+            "type": "structure",
+            "members": {
+                "accessDetails": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentAccessDetails",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "sessionId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment session.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 96
+                        }
+                    }
+                },
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StartWorkflowRun": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#StartWorkflowRunRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#StartWorkflowRunResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Begins a run of a specified workflow.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/workflowRuns",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#StartWorkflowRunRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1
+                        },
+                        "smithy.api#required": {}
+                    }
+                },
+                "workflowId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the workflow. To retrieve a list of workflow IDs, use <a>ListWorkflows</a>.</p>",
+                        "smithy.api#httpQuery": "workflowId",
+                        "smithy.api#required": {}
+                    }
+                },
+                "clientToken": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A user-specified idempotency token.  Idempotency ensures that an API request completes only once. \n       With an idempotent request, if the original request completes successfully, the subsequent retries return the result from the original successful request and have no additional effect.</p>",
+                        "smithy.api#idempotencyToken": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 64
+                        },
+                        "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_\\.][a-zA-Z0-9]+)*$"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#StartWorkflowRunResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the workflow run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "workflowId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#StatusReason": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 1024
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StopDevEnvironment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#StopDevEnvironmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#StopDevEnvironmentResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Pauses a specified Dev Environment and places it in a non-running state. Stopped Dev Environments do not consume compute minutes.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}/stop",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#StopDevEnvironmentRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StopDevEnvironmentResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#DevEnvironmentStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the Dev Environment. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StopDevEnvironmentSession": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#StopDevEnvironmentSessionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#StopDevEnvironmentSessionResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Stops a session for a specified Dev Environment.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}/session/{sessionId}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#StopDevEnvironmentSessionRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. To obtain this ID, use <a>ListDevEnvironments</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "sessionId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment session. This ID is returned by <a>StartDevEnvironmentSession</a>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 96
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StopDevEnvironmentSessionResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "sessionId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment session.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 96
+                        },
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#StringList": {
+            "type": "list",
+            "member": {
+                "target": "smithy.api#String"
+            }
+        },
+        "com.amazonaws.codecatalyst#Subscription": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                }
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetSubscription"
+            }
+        },
+        "com.amazonaws.codecatalyst#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied due to request throttling.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429,
+                "smithy.api#retryable": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#Timestamp": {
+            "type": "timestamp",
+            "traits": {
+                "smithy.api#timestampFormat": "date-time"
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateDevEnvironment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#UpdateDevEnvironmentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#UpdateDevEnvironmentResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Changes one or more values for a Dev Environment. Updating certain values of the Dev Environment will cause a restart.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/v1/spaces/{spaceName}/projects/{projectName}/devEnvironments/{id}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateDevEnvironmentRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "alias": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-specified alias for the Dev Environment. Changing this value will not cause a restart.</p>",
+                        "smithy.api#length": {
+                            "max": 128
+                        },
+                        "smithy.api#pattern": "^$|^[a-zA-Z0-9]+(?:[-_\\.][a-zA-Z0-9]+)*$"
+                    }
+                },
+                "ides": {
+                    "target": "com.amazonaws.codecatalyst#IdeConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the integrated development environment (IDE) configured for a Dev Environment.</p>"
+                    }
+                },
+                "instanceType": {
+                    "target": "com.amazonaws.codecatalyst#InstanceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon EC2 instace type to use for the Dev Environment. </p>\n         <note>\n            <p>Changing this value will cause a restart of the Dev Environment if it is running.</p>\n         </note>"
+                    }
+                },
+                "inactivityTimeoutMinutes": {
+                    "target": "com.amazonaws.codecatalyst#InactivityTimeoutMinutes",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of time the Dev Environment will run without any activity detected before stopping, in minutes. \n      Only whole integers are allowed. Dev Environments consume compute minutes when running.</p>\n         <note>\n            <p>Changing this value will cause a restart of the Dev Environment if it is running.</p>\n         </note>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.codecatalyst#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A user-specified idempotency token.  Idempotency ensures that an API request completes only once. \n       With an idempotent request, if the original request completes successfully, the subsequent retries return the result from the original successful request and have no additional effect.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateDevEnvironmentResponse": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the Dev Environment. </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "devEnvironmentId"
+                    }
+                },
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project in the space.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "alias": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-specified alias for the Dev Environment.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 128
+                        },
+                        "smithy.api#pattern": "^[a-zA-Z0-9]+(?:[-_\\.][a-zA-Z0-9]+)*$"
+                    }
+                },
+                "ides": {
+                    "target": "com.amazonaws.codecatalyst#IdeConfigurationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the integrated development environment (IDE) configured for the Dev Environment.</p>"
+                    }
+                },
+                "instanceType": {
+                    "target": "com.amazonaws.codecatalyst#InstanceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon EC2 instace type to use for the Dev Environment. </p>"
+                    }
+                },
+                "inactivityTimeoutMinutes": {
+                    "target": "com.amazonaws.codecatalyst#InactivityTimeoutMinutes",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of time the Dev Environment will run without any activity detected before stopping, in minutes. </p>"
+                    }
+                },
+                "clientToken": {
+                    "target": "com.amazonaws.codecatalyst#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A user-specified idempotency token.  Idempotency ensures that an API request completes only once. \n       With an idempotent request, if the original request completes successfully, the subsequent retries return the result from the original successful request and have no additional effect.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateProject": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#UpdateProjectRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#UpdateProjectResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Changes one or more values for a project.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/v1/spaces/{spaceName}/projects/{name}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateProjectRequest": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "projectName"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#ProjectDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the project.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateProjectResponse": {
+            "type": "structure",
+            "members": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the project.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the project displayed to users in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the project.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateSpace": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.codecatalyst#UpdateSpaceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#UpdateSpaceResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Changes one or more values for a space.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/v1/spaces/{name}",
+                    "code": 200
+                },
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateSpaceRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "spaceName"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.codecatalyst#SpaceDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the space.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UpdateSpaceResponse": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.codecatalyst#NameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the space.</p>"
+                    }
+                },
+                "displayName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The friendly name of the space displayed to users in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the space.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#UserIdentity": {
+            "type": "structure",
+            "members": {
+                "userType": {
+                    "target": "com.amazonaws.codecatalyst#UserType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The role assigned to the user in a Amazon CodeCatalyst space or project when the event occurred.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "principalId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the Amazon CodeCatalyst service principal.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "userName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The display name of the user in Amazon CodeCatalyst.</p>"
+                    }
+                },
+                "awsAccountId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account number of the user in Amazon Web Services, if any.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a user whose activity is recorded in an event for a space.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#UserType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "USER",
+                        "value": "USER"
+                    },
+                    {
+                        "name": "AWS_ACCOUNT",
+                        "value": "AWS_ACCOUNT"
+                    },
+                    {
+                        "name": "UNKNOWN",
+                        "value": "UNKNOWN"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#Uuid": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            }
+        },
+        "com.amazonaws.codecatalyst#ValidationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied because an input failed to satisfy the constraints specified by the service. Check the spelling and input requirements, and then try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.codecatalyst#VerifySession": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.api#Unit"
+            },
+            "output": {
+                "target": "com.amazonaws.codecatalyst#VerifySessionResponse"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Verifies whether the calling user has a valid Amazon CodeCatalyst login and session.  If successful, this returns the ID of the user in Amazon CodeCatalyst.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/session",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.amazonaws.codecatalyst#VerifySessionResponse": {
+            "type": "structure",
+            "members": {
+                "identity": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the user in Amazon CodeCatalyst.</p>",
+                        "smithy.api#length": {
+                            "min": 1,
+                            "max": 256
+                        }
+                    }
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#Workflow": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "workflowId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid"
+                }
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetWorkflow"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListWorkflows"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowDefinition": {
+            "type": "structure",
+            "members": {
+                "path": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The path to the workflow definition file stored in the source repository for the project, including the file name.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a workflow definition file.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowDefinitionSummary": {
+            "type": "structure",
+            "members": {
+                "path": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The path to the workflow definition file stored in the source repository for the project, including the file name.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a workflow definition.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRun": {
+            "type": "resource",
+            "identifiers": {
+                "spaceName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "projectName": {
+                    "target": "com.amazonaws.codecatalyst#NameString"
+                },
+                "workflowRunId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid"
+                }
+            },
+            "create": {
+                "target": "com.amazonaws.codecatalyst#StartWorkflowRun"
+            },
+            "read": {
+                "target": "com.amazonaws.codecatalyst#GetWorkflowRun"
+            },
+            "list": {
+                "target": "com.amazonaws.codecatalyst#ListWorkflowRuns"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunMode": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "QUEUED",
+                        "value": "QUEUED"
+                    },
+                    {
+                        "name": "PARALLEL",
+                        "value": "PARALLEL"
+                    },
+                    {
+                        "name": "SUPERSEDED",
+                        "value": "SUPERSEDED"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunSortCriteria": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Information used to sort workflow runs in the returned list.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunSortCriteriaList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#WorkflowRunSortCriteria"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunStatus": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "SUCCEEDED",
+                        "value": "SUCCEEDED"
+                    },
+                    {
+                        "name": "FAILED",
+                        "value": "FAILED"
+                    },
+                    {
+                        "name": "STOPPED",
+                        "value": "STOPPED"
+                    },
+                    {
+                        "name": "SUPERSEDED",
+                        "value": "SUPERSEDED"
+                    },
+                    {
+                        "name": "CANCELLED",
+                        "value": "CANCELLED"
+                    },
+                    {
+                        "name": "NOT_RUN",
+                        "value": "NOT_RUN"
+                    },
+                    {
+                        "name": "VALIDATING",
+                        "value": "VALIDATING"
+                    },
+                    {
+                        "name": "PROVISIONING",
+                        "value": "PROVISIONING"
+                    },
+                    {
+                        "name": "IN_PROGRESS",
+                        "value": "IN_PROGRESS"
+                    },
+                    {
+                        "name": "STOPPING",
+                        "value": "STOPPING"
+                    },
+                    {
+                        "name": "ABANDONED",
+                        "value": "ABANDONED"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunStatusReason": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the status of a workflow run.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunStatusReasons": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#WorkflowRunStatusReason"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#WorkflowRunSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowRunSummary": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the workflow run.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "workflowRunId"
+                    }
+                },
+                "workflowId": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "workflowName": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the workflow run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusReasons": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunStatusReasons",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reasons for the workflow run status.</p>"
+                    }
+                },
+                "startTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow run began, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "endTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow run ended, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a workflow run.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowSortCriteria": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Information used to sort workflows in the returned list.</p>"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowSortCriteriaList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#WorkflowSortCriteria"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowStatus": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "name": "INVALID",
+                        "value": "INVALID"
+                    },
+                    {
+                        "name": "ACTIVE",
+                        "value": "ACTIVE"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowSummaries": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.codecatalyst#WorkflowSummary"
+            }
+        },
+        "com.amazonaws.codecatalyst#WorkflowSummary": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.codecatalyst#Uuid",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The system-generated unique ID of a workflow.</p>",
+                        "smithy.api#required": {},
+                        "smithy.api#resourceIdentifier": "workflowId"
+                    }
+                },
+                "name": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sourceRepositoryName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryNameString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the source repository where the workflow definition file is stored.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sourceBranchName": {
+                    "target": "com.amazonaws.codecatalyst#SourceRepositoryBranchString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the branch of the source repository where the workflow definition file is stored.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "definition": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowDefinitionSummary",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the workflow definition file.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "createdTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow was created, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "lastUpdatedTime": {
+                    "target": "com.amazonaws.codecatalyst#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the workflow was last updated, in coordinated universal time (UTC) timestamp format as specified in <a href=\"https://www.rfc-editor.org/rfc/rfc3339#section-5.6\">RFC 3339</a>\n         </p>",
+                        "smithy.api#required": {},
+                        "smithy.api#timestampFormat": "date-time"
+                    }
+                },
+                "runMode": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowRunMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The run mode of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.codecatalyst#WorkflowStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the workflow.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a workflow.</p>"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the Code Catalyst service to the smoke test models, which is already done as part of #3453, but having it as a separate commit that merges before #3453 will allow us to see a codegen diff on the Code Catalyst service during review of that feature.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
