### PR TITLE
Add a trait `SignWith` for signing HTTP requests

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,21 @@ message = "[`SdkBody`](https://docs.rs/aws-smithy-types/latest/aws_smithy_types/
 references = ["smithy-rs#3365", "aws-sdk-rust#1046"]
 meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all" }
 authors = ["cayman-amzn", "rcoh"]
+
+[[aws-sdk-rust]]
+message = """
+HTTP requests can now be signed using a method `sign_with` in a `SignWith` trait. As documented in [aws-sigv4](https://docs.rs/aws-sigv4/latest/aws_sigv4/http_request/index.html#example-signing-an-http-request), customers previously needed to go through additional steps after creating a `SigningParams`. With the new method, an HTTP request in the above example can be signed as follows:
+```
+use aws_sigv4::sign::{SigningPackage, SignWith};
+// ... same as the example
+let signing_params = ... // same as the example
+let mut my_req = http::Request::new("...");
+let signing_package = SigningPackage::builder()
+    .signing_params(&signing_params)
+    .build()
+    .expect("required fields have been set");
+my_req.sign_with(&signing_package).expect("should be signed");
+"""
+references = ["smithy-rs#3455"]
+meta = { "breaking" = false, "bug" = false, "tada" = false }
+author = "ysaito1001"

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -5,12 +5,10 @@
 
 use aws_sigv4::http_request::{
     PayloadChecksumKind, PercentEncodingMode, SessionTokenMode, SignableBody, SignatureLocation,
-    SigningInstructions, SigningSettings, UriPathNormalizationMode,
+    SigningSettings, UriPathNormalizationMode,
 };
-use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::AuthSchemeEndpointConfig;
 use aws_smithy_runtime_api::client::identity::Identity;
-use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_smithy_types::Document;
 use aws_types::region::{Region, SigningRegion, SigningRegionSet};
@@ -197,25 +195,4 @@ fn extract_field_from_endpoint_config<'a>(
         .as_document()
         .and_then(Document::as_object)
         .and_then(|config| config.get(field_name))
-}
-
-fn apply_signing_instructions(
-    instructions: SigningInstructions,
-    request: &mut HttpRequest,
-) -> Result<(), BoxError> {
-    let (new_headers, new_query) = instructions.into_parts();
-    for header in new_headers.into_iter() {
-        let mut value = http::HeaderValue::from_str(header.value()).unwrap();
-        value.set_sensitive(header.sensitive());
-        request.headers_mut().insert(header.name(), value);
-    }
-
-    if !new_query.is_empty() {
-        let mut query = aws_smithy_http::query_writer::QueryWriter::new_from_string(request.uri())?;
-        for (name, value) in new_query {
-            query.insert(name, &value);
-        }
-        request.set_uri(query.build_uri())?;
-    }
-    Ok(())
 }

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -3,16 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::auth;
 use crate::auth::{
     extract_endpoint_auth_scheme_signing_name, extract_endpoint_auth_scheme_signing_region,
     SigV4OperationSigningConfig, SigV4SigningError,
 };
 use aws_credential_types::Credentials;
-use aws_sigv4::http_request::{
-    sign, SignableBody, SignableRequest, SigningParams, SigningSettings,
-};
-use aws_sigv4::sign::v4;
+use aws_sigv4::http_request::{SigningParams, SigningSettings};
+use aws_sigv4::sign::{v4, SignWith, SigningPackage};
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::{
     AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
@@ -152,47 +149,30 @@ impl Sign for SigV4Signer {
         runtime_components: &RuntimeComponents,
         config_bag: &ConfigBag,
     ) -> Result<(), BoxError> {
-        let operation_config =
-            Self::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
-        let request_time = runtime_components.time_source().unwrap_or_default().now();
-
         if identity.data::<Credentials>().is_none() {
             return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
         };
 
+        let operation_config =
+            Self::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
+        let time_source = runtime_components.time_source().unwrap_or_default();
+
         let settings = Self::settings(&operation_config);
         let signing_params =
-            Self::signing_params(settings, identity, &operation_config, request_time)?;
+            Self::signing_params(settings, identity, &operation_config, time_source.now())?;
 
-        let (signing_instructions, _signature) = {
-            // A body that is already in memory can be signed directly. A body that is not in memory
-            // (any sort of streaming body or presigned request) will be signed via UNSIGNED-PAYLOAD.
-            let signable_body = operation_config
+        let signing_params = SigningParams::V4(signing_params);
+        let mut signing_package = SigningPackage::builder().signing_params(&signing_params);
+        signing_package.set_payload_override(
+            operation_config
                 .signing_options
                 .payload_override
                 .as_ref()
-                // the payload_override is a cheap clone because it contains either a
-                // reference or a short checksum (we're not cloning the entire body)
-                .cloned()
-                .unwrap_or_else(|| {
-                    request
-                        .body()
-                        .bytes()
-                        .map(SignableBody::Bytes)
-                        .unwrap_or(SignableBody::UnsignedPayload)
-                });
+                .cloned(),
+        );
 
-            let signable_request = SignableRequest::new(
-                request.method(),
-                request.uri(),
-                request.headers().iter(),
-                signable_body,
-            )?;
-            sign(signable_request, &SigningParams::V4(signing_params))?
-        }
-        .into_parts();
+        let (_, _signature) = request.sign_with(&signing_package.build()?)?.into_parts();
 
-        // If this is an event stream operation, set up the event stream signer
         #[cfg(feature = "event-stream")]
         {
             use aws_smithy_eventstream::frame::DeferredSignerSender;
@@ -213,7 +193,7 @@ impl Sign for SigV4Signer {
                     .expect("failed to send deferred signer");
             }
         }
-        auth::apply_signing_instructions(signing_instructions, request)?;
+
         Ok(())
     }
 }

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -5,7 +5,7 @@
 
 use crate::auth::{
     extract_endpoint_auth_scheme_signing_name, extract_endpoint_auth_scheme_signing_region,
-    SigV4OperationSigningConfig, SigV4SigningError,
+    ErrorKind, SigV4OperationSigningConfig, SigV4SigningError,
 };
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{SigningParams, SigningSettings};
@@ -81,7 +81,9 @@ impl SigV4Signer {
     ) -> Result<v4::SigningParams<'a, SigningSettings>, SigV4SigningError> {
         let creds = identity
             .data::<Credentials>()
-            .ok_or_else(|| SigV4SigningError::WrongIdentityType(identity.clone()))?;
+            .ok_or_else(|| SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            })?;
 
         if let Some(expires_in) = settings.expires_in {
             if let Some(creds_expires_time) = creds.expiry() {
@@ -98,14 +100,18 @@ impl SigV4Signer {
                 operation_config
                     .region
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningRegion)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningRegion,
+                    })?
                     .as_ref(),
             )
             .name(
                 operation_config
                     .name
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningName)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningName,
+                    })?
                     .as_ref(),
             )
             .time(request_timestamp)
@@ -118,9 +124,12 @@ impl SigV4Signer {
         auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'a>,
         config_bag: &'a ConfigBag,
     ) -> Result<Cow<'a, SigV4OperationSigningConfig>, SigV4SigningError> {
-        let operation_config = config_bag
-            .load::<SigV4OperationSigningConfig>()
-            .ok_or(SigV4SigningError::MissingOperationSigningConfig)?;
+        let operation_config =
+            config_bag
+                .load::<SigV4OperationSigningConfig>()
+                .ok_or(SigV4SigningError {
+                    kind: ErrorKind::MissingOperationSigningConfig,
+                })?;
 
         let name = extract_endpoint_auth_scheme_signing_name(&auth_scheme_endpoint_config)?
             .or(config_bag.load::<SigningName>().cloned());
@@ -150,7 +159,10 @@ impl Sign for SigV4Signer {
         config_bag: &ConfigBag,
     ) -> Result<(), BoxError> {
         if identity.data::<Credentials>().is_none() {
-            return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
+            return Err(SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            }
+            .into());
         };
 
         let operation_config =

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -185,6 +185,7 @@ impl Sign for SigV4Signer {
 
         let (_, _signature) = request.sign_with(&signing_package.build()?)?.into_parts();
 
+        // If this is an event stream operation, set up the event stream signer
         #[cfg(feature = "event-stream")]
         {
             use aws_smithy_eventstream::frame::DeferredSignerSender;

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4a.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4a.rs
@@ -4,7 +4,8 @@
  */
 
 use crate::auth::{
-    extract_endpoint_auth_scheme_signing_name, SigV4OperationSigningConfig, SigV4SigningError,
+    extract_endpoint_auth_scheme_signing_name, ErrorKind, SigV4OperationSigningConfig,
+    SigV4SigningError,
 };
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{SigningParams, SigningSettings};
@@ -94,14 +95,18 @@ impl SigV4aSigner {
                 operation_config
                     .region_set
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningRegionSet)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningRegionSet,
+                    })?
                     .as_ref(),
             )
             .name(
                 operation_config
                     .name
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningName)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningName,
+                    })?
                     .as_ref(),
             )
             .time(request_timestamp)
@@ -114,9 +119,12 @@ impl SigV4aSigner {
         auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'a>,
         config_bag: &'a ConfigBag,
     ) -> Result<Cow<'a, SigV4OperationSigningConfig>, SigV4SigningError> {
-        let operation_config = config_bag
-            .load::<SigV4OperationSigningConfig>()
-            .ok_or(SigV4SigningError::MissingOperationSigningConfig)?;
+        let operation_config =
+            config_bag
+                .load::<SigV4OperationSigningConfig>()
+                .ok_or(SigV4SigningError {
+                    kind: ErrorKind::MissingOperationSigningConfig,
+                })?;
 
         let name = extract_endpoint_auth_scheme_signing_name(&auth_scheme_endpoint_config)?
             .or(config_bag.load::<SigningName>().cloned());
@@ -141,7 +149,7 @@ fn extract_endpoint_auth_scheme_signing_region_set(
     endpoint_config: &AuthSchemeEndpointConfig<'_>,
 ) -> Result<Option<SigningRegionSet>, SigV4SigningError> {
     use aws_smithy_types::Document::Array;
-    use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
+    use ErrorKind::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
 
     match super::extract_field_from_endpoint_config("signingRegionSet", endpoint_config) {
         Some(Array(docs)) => {
@@ -152,7 +160,9 @@ fn extract_endpoint_auth_scheme_signing_region_set(
             Ok(Some(region_set))
         }
         None => Ok(None),
-        _it => Err(UnexpectedType("signingRegionSet")),
+        _it => Err(SigV4SigningError {
+            kind: UnexpectedType("signingRegionSet"),
+        }),
     }
 }
 
@@ -166,7 +176,10 @@ impl Sign for SigV4aSigner {
         config_bag: &ConfigBag,
     ) -> Result<(), BoxError> {
         if identity.data::<Credentials>().is_none() {
-            return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
+            return Err(SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            }
+            .into());
         }
 
         let operation_config =

--- a/aws/rust-runtime/aws-sigv4/external-types.toml
+++ b/aws/rust-runtime/aws-sigv4/external-types.toml
@@ -3,5 +3,6 @@ allowed_external_types = [
     "http::request::Request",
     # TODO(https://github.com/smithy-lang/smithy-rs/issues/1193): Once tooling permits it, only allow the following types in the `event-stream` feature
     "aws_smithy_types::event_stream::Message",
+    "aws_smithy_runtime_api::box_error::BoxError",
     "aws_smithy_runtime_api::client::identity::Identity"
 ]

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -148,6 +148,10 @@ impl SigningInstructions {
         (self.headers, self.params)
     }
 
+    pub(crate) fn parts(&self) -> (&Vec<Header>, &Vec<(&'static str, Cow<'static, str>)>) {
+        (&self.headers, &self.params)
+    }
+
     /// Returns a reference to the headers that should be added to the request.
     pub fn headers(&self) -> impl Iterator<Item = (&str, &str)> {
         self.headers

--- a/aws/rust-runtime/aws-sigv4/src/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign.rs
@@ -52,7 +52,11 @@ pub mod v4a;
 /// ```
 pub trait SignWith {
     /// Sign `self` with a [`SigningPackage`] and return the [`SigningOutput<SigningInstructions>`](SigningOutput)
-    /// as a result of signing
+    /// that was used during the signing process.
+    ///
+    /// Most of the time, the return value can be ignored since it has already been applied to the
+    /// given request, but there are cases where calling code needs to have access to it even after
+    /// signing is done (e.g. deferring signing for event stream).
     fn sign_with(
         &mut self,
         package: &SigningPackage<'_>,

--- a/aws/rust-runtime/aws-sigv4/src/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign.rs
@@ -51,7 +51,7 @@ pub mod v4a;
 /// # }
 /// ```
 pub trait SignWith {
-    /// Sign `self` with a [`SigningPackage`] and return the [`SigningOutput(SigningInstructions)`](SigningOutput)
+    /// Sign `self` with a [`SigningPackage`] and return the [`SigningOutput<SigningInstructions>`](SigningOutput)
     /// as a result of signing
     fn sign_with(
         &mut self,

--- a/aws/rust-runtime/aws-sigv4/src/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign.rs
@@ -5,27 +5,6 @@
 
 //! Types for creating signing keys, calculating signatures, and applying them to HTTP requests.
 
-// macro lifted from aws-smithy-runtime-api—eventually just inline these and delete macro.
-macro_rules! builder_methods {
-    ($fn_name:ident, $arg_name:ident, $ty:ty, $doc:literal, $($tail:tt)+) => {
-        builder_methods!($fn_name, $arg_name, $ty, $doc);
-        builder_methods!($($tail)+);
-    };
-    ($fn_name:ident, $arg_name:ident, $ty:ty, $doc:literal) => {
-        #[doc = $doc]
-        pub fn $fn_name(&mut self, $arg_name: Option<$ty>) -> &mut Self {
-            self.$arg_name = $arg_name;
-            self
-        }
-
-        #[doc = $doc]
-        pub fn $arg_name(mut self, $arg_name: $ty) -> Self {
-            self.$arg_name = Some($arg_name);
-            self
-        }
-    };
-}
-
 use crate::http_request::{
     sign, SignableBody, SignableRequest, SigningInstructions, SigningParams,
 };

--- a/aws/rust-runtime/aws-sigv4/src/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Functions to create signing keys and calculate signatures.
+//! Types for creating signing keys, calculating signatures, and applying them to HTTP requests.
 
 // macro lifted from aws-smithy-runtime-api—eventually just inline these and delete macro.
 macro_rules! builder_methods {
@@ -26,9 +26,176 @@ macro_rules! builder_methods {
     };
 }
 
+use crate::http_request::{
+    sign, SignableBody, SignableRequest, SigningInstructions, SigningParams,
+};
+use crate::SigningOutput;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
+
 /// Support for Sigv4 signing
 pub mod v4;
 
 /// Support for Sigv4a signing
 #[cfg(feature = "sigv4a")]
 pub mod v4a;
+
+/// Trait signing an HTTP request with a signature
+///
+/// # Examples
+/// ```rust,no_run
+/// use aws_sigv4::http_request::{SigningInstructions, SigningParams};
+/// use aws_sigv4::sign::{SigningPackage, SignWith};
+/// use aws_sigv4::SigningOutput;
+/// # use aws_smithy_runtime_api::box_error::BoxError;
+/// use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
+///
+/// fn signing_params<'a>() -> SigningParams<'a> {
+///     // --snip--
+/// #    todo!()
+/// }
+///
+/// fn request() -> HttpRequest {
+///     // --snip--
+/// #   HttpRequest::empty()
+/// }
+///
+/// # fn example() -> Result<SigningOutput<SigningInstructions>, BoxError> {
+/// let signing_params = signing_params();
+/// let signing_package = SigningPackage::builder()
+///     .signing_params(&signing_params)
+///     .build()
+///     .expect("required fields have been set");
+///
+/// let mut request = request();
+/// request.sign_with(&signing_package)
+/// # }
+/// ```
+pub trait SignWith {
+    /// Sign `self` with a [`SigningPackage`] and return the [`SigningOutput(SigningInstructions)`](SigningOutput)
+    /// as a result of signing
+    fn sign_with(
+        &mut self,
+        package: &SigningPackage<'_>,
+    ) -> Result<SigningOutput<SigningInstructions>, BoxError>;
+}
+
+impl SignWith for HttpRequest {
+    fn sign_with(
+        &mut self,
+        package: &SigningPackage<'_>,
+    ) -> Result<SigningOutput<SigningInstructions>, BoxError> {
+        let signing_output = {
+            // A body that is already in memory can be signed directly. A body that is not in memory
+            // (any sort of streaming body or presigned request) will be signed via UNSIGNED-PAYLOAD.
+            let signable_body = package
+                .payload_override
+                .as_ref()
+                // the payload_override is a cheap clone because it contains either a
+                // reference or a short checksum (we're not cloning the entire body)
+                .cloned()
+                .unwrap_or_else(|| {
+                    self.body()
+                        .bytes()
+                        .map(SignableBody::Bytes)
+                        .unwrap_or(SignableBody::UnsignedPayload)
+                });
+
+            let signable_request = SignableRequest::new(
+                self.method(),
+                self.uri(),
+                self.headers().iter(),
+                signable_body,
+            )?;
+            sign(signable_request, package.signing_params)?
+        };
+
+        apply_signing_instructions(&signing_output.output, self)?;
+
+        Ok(signing_output)
+    }
+}
+
+/// A collection of fields required for the signing process
+#[derive(Debug)]
+pub struct SigningPackage<'a> {
+    signing_params: &'a SigningParams<'a>,
+    payload_override: Option<SignableBody<'a>>,
+}
+
+impl<'a> SigningPackage<'a> {
+    /// Returns a default Builder
+    pub fn builder() -> Builder<'a> {
+        Builder::default()
+    }
+}
+
+/// Builder for [`SigningPackage`]
+#[derive(Debug, Default)]
+pub struct Builder<'a> {
+    signing_params: Option<&'a SigningParams<'a>>,
+    payload_override: Option<SignableBody<'a>>,
+}
+
+impl<'a> Builder<'a> {
+    /// Sets the [`SigningParams`] for the builder (required)
+    pub fn signing_params(mut self, signing_params: &'a SigningParams<'_>) -> Self {
+        self.set_signing_params(Some(signing_params));
+        self
+    }
+
+    /// Sets the [`SigningParams`] for the builder (required)
+    pub fn set_signing_params(
+        &mut self,
+        signing_params: Option<&'a SigningParams<'_>>,
+    ) -> &mut Self {
+        self.signing_params = signing_params;
+        self
+    }
+
+    /// Sets the [`SignableBody`] for the builder (optional)
+    pub fn payload_override(mut self, payload_override: SignableBody<'a>) -> Self {
+        self.set_payload_override(Some(payload_override));
+        self
+    }
+
+    /// Sets the [`SignableBody`] for the builder (optional)
+    pub fn set_payload_override(
+        &mut self,
+        payload_override: Option<SignableBody<'a>>,
+    ) -> &mut Self {
+        self.payload_override = payload_override;
+        self
+    }
+
+    /// Builds a [`SigningPackage`] if all required fields are provided, otherwise returns a [`BoxError`].
+    pub fn build(self) -> Result<SigningPackage<'a>, BoxError> {
+        Ok(SigningPackage {
+            signing_params: self
+                .signing_params
+                .ok_or("missing required field `signing_params`")?,
+            payload_override: self.payload_override,
+        })
+    }
+}
+
+fn apply_signing_instructions(
+    instructions: &SigningInstructions,
+    request: &mut HttpRequest,
+) -> Result<(), BoxError> {
+    let (new_headers, new_query) = instructions.parts();
+    for header in new_headers {
+        let mut value = http0::HeaderValue::from_str(header.value()).unwrap();
+        value.set_sensitive(header.sensitive());
+        request.headers_mut().insert(header.name(), value);
+    }
+
+    if !new_query.is_empty() {
+        let mut query = aws_smithy_http::query_writer::QueryWriter::new_from_string(request.uri())?;
+        for (name, value) in new_query {
+            query.insert(name, &value);
+        }
+        request.set_uri(query.build_uri())?;
+    }
+    Ok(())
+}

--- a/aws/rust-runtime/aws-sigv4/src/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign.rs
@@ -172,7 +172,7 @@ fn apply_signing_instructions(
     if !new_query.is_empty() {
         let mut query = aws_smithy_http::query_writer::QueryWriter::new_from_string(request.uri())?;
         for (name, value) in new_query {
-            query.insert(name, &value);
+            query.insert(name, value);
         }
         request.set_uri(query.build_uri())?;
     }

--- a/aws/rust-runtime/aws-sigv4/src/sign/error.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/error.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::http_request::SigningError;
+use aws_smithy_runtime_api::box_error::BoxError;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+enum SignWithErrorKind {
+    FailedToProduceSignature { source: SigningError },
+    FailedToApplySignatureToRequest { source: BoxError },
+}
+
+/// Error that occurred while producing a signature and applying it to a request
+#[derive(Debug)]
+pub struct SignWithError {
+    kind: SignWithErrorKind,
+}
+
+impl SignWithError {
+    pub(crate) fn failed_to_produce_signature(source: SigningError) -> Self {
+        Self {
+            kind: SignWithErrorKind::FailedToProduceSignature { source },
+        }
+    }
+    pub(crate) fn failed_to_apply_signature_to_request(source: BoxError) -> Self {
+        Self {
+            kind: SignWithErrorKind::FailedToApplySignatureToRequest { source },
+        }
+    }
+}
+
+impl fmt::Display for SignWithError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use SignWithErrorKind::*;
+        match self.kind {
+            FailedToProduceSignature { .. } => {
+                write!(f, "failed to produce signature")
+            }
+            FailedToApplySignatureToRequest { .. } => {
+                write!(f, "failed to apply signature to request")
+            }
+        }
+    }
+}
+
+impl Error for SignWithError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use SignWithErrorKind::*;
+        Some(match &self.kind {
+            FailedToProduceSignature { source } => source,
+            FailedToApplySignatureToRequest { source } => source.as_ref(),
+        })
+    }
+}

--- a/aws/rust-runtime/aws-sigv4/src/sign/v4.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/v4.rs
@@ -154,42 +154,42 @@ pub mod signing_params {
             self.identity = identity;
             self
         }
-        ///Sets the region (required)
+        /// Sets the region (required)
         pub fn region(mut self, region: &'a str) -> Self {
             self.set_region(Some(region));
             self
         }
-        ///Sets the region (required)
+        /// Sets the region (required)
         pub fn set_region(&mut self, region: Option<&'a str>) -> &mut Self {
             self.region = region;
             self
         }
-        ///Sets the name (required)
+        /// Sets the name (required)
         pub fn name(mut self, name: &'a str) -> Self {
             self.set_name(Some(name));
             self
         }
-        ///Sets the name (required)
+        /// Sets the name (required)
         pub fn set_name(&mut self, name: Option<&'a str>) -> &mut Self {
             self.name = name;
             self
         }
-        ///Sets the time to be used in the signature (required)
+        /// Sets the time to be used in the signature (required)
         pub fn time(mut self, time: SystemTime) -> Self {
             self.set_time(Some(time));
             self
         }
-        ///Sets the time to be used in the signature (required)
+        /// Sets the time to be used in the signature (required)
         pub fn set_time(&mut self, time: Option<SystemTime>) -> &mut Self {
             self.time = time;
             self
         }
-        ///Sets additional signing settings (required)
+        /// Sets additional signing settings (required)
         pub fn settings(mut self, settings: S) -> Self {
             self.set_settings(Some(settings));
             self
         }
-        ///Sets additional signing settings (required)
+        /// Sets additional signing settings (required)
         pub fn set_settings(&mut self, settings: Option<S>) -> &mut Self {
             self.settings = settings;
             self

--- a/aws/rust-runtime/aws-sigv4/src/sign/v4.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/v4.rs
@@ -144,29 +144,56 @@ pub mod signing_params {
     }
 
     impl<'a, S> Builder<'a, S> {
-        builder_methods!(
-            set_identity,
-            identity,
-            &'a Identity,
-            "Sets the identity (required)",
-            set_region,
-            region,
-            &'a str,
-            "Sets the region (required)",
-            set_name,
-            name,
-            &'a str,
-            "Sets the name (required)",
-            set_time,
-            time,
-            SystemTime,
-            "Sets the time to be used in the signature (required)",
-            set_settings,
-            settings,
-            S,
-            "Sets additional signing settings (required)"
-        );
-
+        /// Sets the identity (required)
+        pub fn identity(mut self, identity: &'a Identity) -> Self {
+            self.set_identity(Some(identity));
+            self
+        }
+        /// Sets the identity (required)
+        pub fn set_identity(&mut self, identity: Option<&'a Identity>) -> &mut Self {
+            self.identity = identity;
+            self
+        }
+        ///Sets the region (required)
+        pub fn region(mut self, region: &'a str) -> Self {
+            self.set_region(Some(region));
+            self
+        }
+        ///Sets the region (required)
+        pub fn set_region(&mut self, region: Option<&'a str>) -> &mut Self {
+            self.region = region;
+            self
+        }
+        ///Sets the name (required)
+        pub fn name(mut self, name: &'a str) -> Self {
+            self.set_name(Some(name));
+            self
+        }
+        ///Sets the name (required)
+        pub fn set_name(&mut self, name: Option<&'a str>) -> &mut Self {
+            self.name = name;
+            self
+        }
+        ///Sets the time to be used in the signature (required)
+        pub fn time(mut self, time: SystemTime) -> Self {
+            self.set_time(Some(time));
+            self
+        }
+        ///Sets the time to be used in the signature (required)
+        pub fn set_time(&mut self, time: Option<SystemTime>) -> &mut Self {
+            self.time = time;
+            self
+        }
+        ///Sets additional signing settings (required)
+        pub fn settings(mut self, settings: S) -> Self {
+            self.set_settings(Some(settings));
+            self
+        }
+        ///Sets additional signing settings (required)
+        pub fn set_settings(&mut self, settings: Option<S>) -> &mut Self {
+            self.settings = settings;
+            self
+        }
         /// Builds an instance of [`SigningParams`]. Will yield a [`BuildError`] if
         /// a required argument was not given.
         pub fn build(self) -> Result<SigningParams<'a, S>, BuildError> {

--- a/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
@@ -185,32 +185,32 @@ pub mod signing_params {
             self.region_set = region_set;
             self
         }
-        ///Sets the name (required)
+        /// Sets the name (required)
         pub fn name(mut self, name: &'a str) -> Self {
             self.set_name(Some(name));
             self
         }
-        ///Sets the name (required)
+        /// Sets the name (required)
         pub fn set_name(&mut self, name: Option<&'a str>) -> &mut Self {
             self.name = name;
             self
         }
-        ///Sets the time to be used in the signature (required)
+        /// Sets the time to be used in the signature (required)
         pub fn time(mut self, time: SystemTime) -> Self {
             self.set_time(Some(time));
             self
         }
-        ///Sets the time to be used in the signature (required)
+        /// Sets the time to be used in the signature (required)
         pub fn set_time(&mut self, time: Option<SystemTime>) -> &mut Self {
             self.time = time;
             self
         }
-        ///Sets additional signing settings (required)
+        /// Sets additional signing settings (required)
         pub fn settings(mut self, settings: S) -> Self {
             self.set_settings(Some(settings));
             self
         }
-        ///Sets additional signing settings (required)
+        /// Sets additional signing settings (required)
         pub fn set_settings(&mut self, settings: Option<S>) -> &mut Self {
             self.settings = settings;
             self

--- a/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
@@ -165,29 +165,56 @@ pub mod signing_params {
     }
 
     impl<'a, S> Builder<'a, S> {
-        builder_methods!(
-            set_identity,
-            identity,
-            &'a Identity,
-            "Sets the identity (required)",
-            set_region_set,
-            region_set,
-            &'a str,
-            "Sets the region set (required)",
-            set_name,
-            name,
-            &'a str,
-            "Sets the name (required)",
-            set_time,
-            time,
-            SystemTime,
-            "Sets the time to be used in the signature (required)",
-            set_settings,
-            settings,
-            S,
-            "Sets additional signing settings (required)"
-        );
-
+        /// Sets the identity (required)
+        pub fn identity(mut self, identity: &'a Identity) -> Self {
+            self.set_identity(Some(identity));
+            self
+        }
+        /// Sets the identity (required)
+        pub fn set_identity(&mut self, identity: Option<&'a Identity>) -> &mut Self {
+            self.identity = identity;
+            self
+        }
+        /// Sets the region set (required)
+        pub fn region_set(mut self, region_set: &'a str) -> Self {
+            self.set_region_set(Some(region_set));
+            self
+        }
+        /// Sets the region set (required)
+        pub fn set_region_set(&mut self, region_set: Option<&'a str>) -> &mut Self {
+            self.region_set = region_set;
+            self
+        }
+        ///Sets the name (required)
+        pub fn name(mut self, name: &'a str) -> Self {
+            self.set_name(Some(name));
+            self
+        }
+        ///Sets the name (required)
+        pub fn set_name(&mut self, name: Option<&'a str>) -> &mut Self {
+            self.name = name;
+            self
+        }
+        ///Sets the time to be used in the signature (required)
+        pub fn time(mut self, time: SystemTime) -> Self {
+            self.set_time(Some(time));
+            self
+        }
+        ///Sets the time to be used in the signature (required)
+        pub fn set_time(&mut self, time: Option<SystemTime>) -> &mut Self {
+            self.time = time;
+            self
+        }
+        ///Sets additional signing settings (required)
+        pub fn settings(mut self, settings: S) -> Self {
+            self.set_settings(Some(settings));
+            self
+        }
+        ///Sets additional signing settings (required)
+        pub fn set_settings(&mut self, settings: Option<S>) -> &mut Self {
+            self.settings = settings;
+            self
+        }
         /// Builds an instance of [`SigningParams`]. Will yield a [`BuildError`] if
         /// a required argument was not given.
         pub fn build(self) -> Result<SigningParams<'a, S>, BuildError> {

--- a/tools/ci-build/runtime-versioner/src/command/audit.rs
+++ b/tools/ci-build/runtime-versioner/src/command/audit.rs
@@ -232,8 +232,17 @@ fn fetch_smithy_rs_tags(repo: &Repo) -> Result<()> {
         .expect("valid utf-8")
         .trim()
         .to_string();
-    if origin_url != "git@github.com:smithy-lang/smithy-rs.git" {
-        bail!("smithy-rs origin must be 'git@github.com:smithy-lang/smithy-rs.git' in order to get the latest release tags");
+    if ![
+        "git@github.com:smithy-lang/smithy-rs.git",
+        "https://github.com/smithy-lang/smithy-rs.git",
+    ]
+    .iter()
+    .any(|url| *url == &origin_url)
+    {
+        bail!(
+            "smithy-rs origin must be either 'git@github.com:smithy-lang/smithy-rs.git' or \
+        'https://github.com/smithy-lang/smithy-rs.git' in order to get the latest release tags"
+        );
     }
 
     repo.git(["fetch", "--tags", "origin"])

--- a/tools/ci-build/runtime-versioner/src/command/audit.rs
+++ b/tools/ci-build/runtime-versioner/src/command/audit.rs
@@ -237,7 +237,7 @@ fn fetch_smithy_rs_tags(repo: &Repo) -> Result<()> {
         "https://github.com/smithy-lang/smithy-rs.git",
     ]
     .iter()
-    .any(|url| *url == &origin_url)
+    .any(|url| *url == origin_url)
     {
         bail!(
             "smithy-rs origin must be either 'git@github.com:smithy-lang/smithy-rs.git' or \


### PR DESCRIPTION
## Motivation and Context
https://github.com/smithy-lang/smithy-rs/pull/3388#discussion_r1480722375

## Description
This PR attempts to provide more ergonomic API for request signing. [As documented](https://docs.rs/aws-sigv4/latest/aws_sigv4/http_request/index.html#example-signing-an-http-request) in `aws_sigv4`, customers need to follow these steps after creating an `Identity` and a `SigningParams`:
```
// Convert the HTTP request into a signable request
let signable_request = SignableRequest::new(
    "GET",
    "https://some-endpoint.some-region.amazonaws.com",
    std::iter::empty(),
    SignableBody::Bytes(&[])
).expect("signable request");

let mut my_req = http::Request::new("...");
// Sign and then apply the signature to the request
let (signing_instructions, _signature) = sign(signable_request, &signing_params)?.into_parts();
signing_instructions.apply_to_request_http1x(&mut my_req);
```
This PR allows them to call `SignWith::sign_with` trait method with `SigningPackage` instead:
```
let signing_package = SigningPackage::builder()
    .signing_params(&signing_params)
    .build()
    .expect("required fields have been set");
my_req.sign_with(&signing_package);
```

## Testing
Relied on existing tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
