### PR TITLE
Allow runtime-versioner's audit to accept HTTP remote

### DIFF
--- a/tools/ci-build/runtime-versioner/src/command/audit.rs
+++ b/tools/ci-build/runtime-versioner/src/command/audit.rs
@@ -232,8 +232,17 @@ fn fetch_smithy_rs_tags(repo: &Repo) -> Result<()> {
         .expect("valid utf-8")
         .trim()
         .to_string();
-    if origin_url != "git@github.com:smithy-lang/smithy-rs.git" {
-        bail!("smithy-rs origin must be 'git@github.com:smithy-lang/smithy-rs.git' in order to get the latest release tags");
+    if ![
+        "git@github.com:smithy-lang/smithy-rs.git",
+        "https://github.com/smithy-lang/smithy-rs.git",
+    ]
+    .iter()
+    .any(|url| *url == origin_url)
+    {
+        bail!(
+            "smithy-rs origin must be either 'git@github.com:smithy-lang/smithy-rs.git' or \
+        'https://github.com/smithy-lang/smithy-rs.git' in order to get the latest release tags"
+        );
     }
 
     repo.git(["fetch", "--tags", "origin"])


### PR DESCRIPTION
## Motivation and Context
Fixes the following error when a pre-commit hook `runtime-versioner` runs in a repo created from HTTP remote:
```
Error: smithy-rs origin must be 'git@github.com:smithy-lang/smithy-rs.git' in order to get the latest release tags
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
