### PR TITLE
Drop `S3ExpressSigner` and override session token name via `RuntimePlugin`

### DIFF
--- a/aws/rust-runtime/aws-inlineable/src/s3_express.rs
+++ b/aws/rust-runtime/aws-inlineable/src/s3_express.rs
@@ -617,7 +617,7 @@ pub(crate) mod identity_provider {
 
 /// Supporting code for S3 Express runtime plugin
 pub(crate) mod runtime_plugin {
-    use aws_runtime::auth::SessionTokenNameOverride;
+    use aws_runtime::auth::SigV4SessionTokenNameOverride;
     use aws_sigv4::http_request::{SignatureLocation, SigningSettings};
     use aws_smithy_runtime_api::{box_error::BoxError, client::runtime_plugin::RuntimePlugin};
     use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Layer};
@@ -669,7 +669,7 @@ pub(crate) mod runtime_plugin {
                 }
             }
 
-            let session_token_name_override = SessionTokenNameOverride::new(
+            let session_token_name_override = SigV4SessionTokenNameOverride::new(
                 |settings: &SigningSettings, cfg: &ConfigBag| {
                     // Not configured for S3 express, use the original session token name override
                     if !crate::s3_express::utils::for_s3_express(cfg) {

--- a/aws/rust-runtime/aws-inlineable/src/s3_express.rs
+++ b/aws/rust-runtime/aws-inlineable/src/s3_express.rs
@@ -5,11 +5,8 @@
 
 /// Supporting code for S3 Express auth
 pub(crate) mod auth {
-    use aws_runtime::auth::apply_signing_instructions;
     use aws_runtime::auth::sigv4::SigV4Signer;
-    use aws_sigv4::http_request::{
-        sign, SignableBody, SignableRequest, SignatureLocation, SigningParams, SigningSettings,
-    };
+    use aws_sigv4::http_request::{SignatureLocation, SigningSettings};
     use aws_smithy_runtime_api::box_error::BoxError;
     use aws_smithy_runtime_api::client::auth::{
         AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
@@ -69,43 +66,17 @@ pub(crate) mod auth {
         ) -> Result<(), BoxError> {
             let operation_config =
                 SigV4Signer::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
-            let request_time = runtime_components.time_source().unwrap_or_default().now();
             let mut settings = SigV4Signer::signing_settings(&operation_config);
             override_session_token_name(&mut settings)?;
 
-            let signing_params =
-                SigV4Signer::signing_params(settings, identity, &operation_config, request_time)?;
-
-            let (signing_instructions, _signature) = {
-                // A body that is already in memory can be signed directly. A body that is not in memory
-                // (any sort of streaming body or presigned request) will be signed via UNSIGNED-PAYLOAD.
-                let signable_body = operation_config
-                    .signing_options
-                    .payload_override
-                    .as_ref()
-                    // the payload_override is a cheap clone because it contains either a
-                    // reference or a short checksum (we're not cloning the entire body)
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        request
-                            .body()
-                            .bytes()
-                            .map(SignableBody::Bytes)
-                            .unwrap_or(SignableBody::UnsignedPayload)
-                    });
-
-                let signable_request = SignableRequest::new(
-                    request.method(),
-                    request.uri(),
-                    request.headers().iter(),
-                    signable_body,
-                )?;
-                sign(signable_request, &SigningParams::V4(signing_params))?
-            }
-            .into_parts();
-
-            apply_signing_instructions(signing_instructions, request)?;
-            Ok(())
+            SigV4Signer.sign_http_request(
+                request,
+                identity,
+                settings,
+                &operation_config,
+                runtime_components,
+                config_bag,
+            )
         }
     }
 

--- a/aws/rust-runtime/aws-inlineable/src/s3_express.rs
+++ b/aws/rust-runtime/aws-inlineable/src/s3_express.rs
@@ -6,17 +6,9 @@
 /// Supporting code for S3 Express auth
 pub(crate) mod auth {
     use aws_runtime::auth::sigv4::SigV4Signer;
-    use aws_sigv4::http_request::{SignatureLocation, SigningSettings};
-    use aws_smithy_runtime_api::box_error::BoxError;
-    use aws_smithy_runtime_api::client::auth::{
-        AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
-    };
-    use aws_smithy_runtime_api::client::identity::{Identity, SharedIdentityResolver};
-    use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
-    use aws_smithy_runtime_api::client::runtime_components::{
-        GetIdentityResolver, RuntimeComponents,
-    };
-    use aws_smithy_types::config_bag::ConfigBag;
+    use aws_smithy_runtime_api::client::auth::{AuthScheme, AuthSchemeId, Sign};
+    use aws_smithy_runtime_api::client::identity::SharedIdentityResolver;
+    use aws_smithy_runtime_api::client::runtime_components::GetIdentityResolver;
 
     /// Auth scheme ID for S3 Express.
     pub(crate) const SCHEME_ID: AuthSchemeId = AuthSchemeId::new("sigv4-s3express");
@@ -24,7 +16,7 @@ pub(crate) mod auth {
     /// S3 Express auth scheme.
     #[derive(Debug, Default)]
     pub(crate) struct S3ExpressAuthScheme {
-        signer: S3ExpressSigner,
+        signer: SigV4Signer,
     }
 
     impl S3ExpressAuthScheme {
@@ -49,45 +41,6 @@ pub(crate) mod auth {
         fn signer(&self) -> &dyn Sign {
             &self.signer
         }
-    }
-
-    /// S3 Express signer.
-    #[derive(Debug, Default)]
-    pub(crate) struct S3ExpressSigner;
-
-    impl Sign for S3ExpressSigner {
-        fn sign_http_request(
-            &self,
-            request: &mut HttpRequest,
-            identity: &Identity,
-            auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'_>,
-            runtime_components: &RuntimeComponents,
-            config_bag: &ConfigBag,
-        ) -> Result<(), BoxError> {
-            let operation_config =
-                SigV4Signer::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
-            let mut settings = SigV4Signer::signing_settings(&operation_config);
-            override_session_token_name(&mut settings)?;
-
-            SigV4Signer.sign_http_request(
-                request,
-                identity,
-                settings,
-                &operation_config,
-                runtime_components,
-                config_bag,
-            )
-        }
-    }
-
-    fn override_session_token_name(settings: &mut SigningSettings) -> Result<(), BoxError> {
-        let session_token_name_override = match settings.signature_location {
-            SignatureLocation::Headers => Some("x-amz-s3session-token"),
-            SignatureLocation::QueryParams => Some("X-Amz-S3session-Token"),
-            _ => { return Err(BoxError::from("`SignatureLocation` adds a new variant, which needs to be handled in a separate match arm")) },
-        };
-        settings.session_token_name_override = session_token_name_override;
-        Ok(())
     }
 }
 
@@ -664,8 +617,10 @@ pub(crate) mod identity_provider {
 
 /// Supporting code for S3 Express runtime plugin
 pub(crate) mod runtime_plugin {
-    use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
-    use aws_smithy_types::config_bag::{FrozenLayer, Layer};
+    use aws_runtime::auth::SessionTokenNameOverride;
+    use aws_sigv4::http_request::{SignatureLocation, SigningSettings};
+    use aws_smithy_runtime_api::{box_error::BoxError, client::runtime_plugin::RuntimePlugin};
+    use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Layer};
     use aws_types::os_shim_internal::Env;
 
     mod env {
@@ -713,6 +668,27 @@ pub(crate) mod runtime_plugin {
                     }
                 }
             }
+
+            let session_token_name_override = SessionTokenNameOverride::new(
+                |settings: &SigningSettings, cfg: &ConfigBag| {
+                    // Not configured for S3 express, use the original session token name override
+                    if !crate::s3_express::utils::for_s3_express(cfg) {
+                        return Ok(settings.session_token_name_override);
+                    }
+
+                    let session_token_name_override = Some(match settings.signature_location {
+                    SignatureLocation::Headers => "x-amz-s3session-token",
+                    SignatureLocation::QueryParams => "X-Amz-S3session-Token",
+                    _ => {
+                        return Err(BoxError::from(
+                            "`SignatureLocation` adds a new variant, which needs to be handled in a separate match arm",
+                        ))
+                    }
+                });
+                    Ok(session_token_name_override)
+                },
+            );
+            layer.store_or_unset(Some(session_token_name_override));
 
             Self {
                 config: layer.freeze(),
@@ -789,6 +765,22 @@ pub(crate) mod runtime_plugin {
             assert!(cfg
                 .load::<crate::config::DisableS3ExpressSessionAuth>()
                 .is_none());
+        }
+    }
+}
+
+pub(crate) mod utils {
+    use aws_smithy_types::{config_bag::ConfigBag, Document};
+
+    pub(crate) fn for_s3_express(cfg: &ConfigBag) -> bool {
+        let endpoint = cfg
+            .load::<crate::config::endpoint::Endpoint>()
+            .expect("endpoint added to config bag by endpoint orchestrator");
+
+        if let Some(Document::String(backend)) = endpoint.properties().get("backend") {
+            backend.as_str() == "S3Express"
+        } else {
+            false
         }
     }
 }

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -209,8 +209,7 @@ fn extract_field_from_endpoint_config<'a>(
         .and_then(|config| config.get(field_name))
 }
 
-/// Applies the instructions to the given `request`.
-pub fn apply_signing_instructions(
+fn apply_signing_instructions(
     instructions: SigningInstructions,
     request: &mut HttpRequest,
 ) -> Result<(), BoxError> {

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -11,7 +11,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::AuthSchemeEndpointConfig;
 use aws_smithy_runtime_api::client::identity::Identity;
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
-use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::Document;
 use aws_types::region::{Region, SigningRegion, SigningRegionSet};
 use aws_types::SigningName;
@@ -73,6 +73,52 @@ impl Default for SigningOptions {
             expires_in: None,
         }
     }
+}
+
+pub(crate) type SessionTokenNameOverrideFn = Box<
+    dyn Fn(&SigningSettings, &ConfigBag) -> Result<Option<&'static str>, BoxError>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+/// Custom config that provides the alternative session token name for [`SigningSettings`]
+pub struct SessionTokenNameOverride {
+    name_override: SessionTokenNameOverrideFn,
+}
+
+impl SessionTokenNameOverride {
+    /// Creates a new `SessionTokenNameOverride`
+    pub fn new<F>(name_override: F) -> Self
+    where
+        F: Fn(&SigningSettings, &ConfigBag) -> Result<Option<&'static str>, BoxError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self {
+            name_override: Box::new(name_override),
+        }
+    }
+
+    /// Provides a session token name override
+    pub fn name_override(
+        &self,
+        settings: &SigningSettings,
+        config_bag: &ConfigBag,
+    ) -> Result<Option<&'static str>, BoxError> {
+        (self.name_override)(settings, config_bag)
+    }
+}
+
+impl fmt::Debug for SessionTokenNameOverride {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionTokenNameOverride").finish()
+    }
+}
+
+impl Storable for SessionTokenNameOverride {
+    type Storer = StoreReplace<Self>;
 }
 
 /// SigV4 signing configuration for an operation

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -209,7 +209,8 @@ fn extract_field_from_endpoint_config<'a>(
         .and_then(|config| config.get(field_name))
 }
 
-fn apply_signing_instructions(
+/// Applies the instructions to the given `request`.
+pub fn apply_signing_instructions(
     instructions: SigningInstructions,
     request: &mut HttpRequest,
 ) -> Result<(), BoxError> {

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -83,12 +83,12 @@ pub(crate) type SessionTokenNameOverrideFn = Box<
 >;
 
 /// Custom config that provides the alternative session token name for [`SigningSettings`]
-pub struct SessionTokenNameOverride {
+pub struct SigV4SessionTokenNameOverride {
     name_override: SessionTokenNameOverrideFn,
 }
 
-impl SessionTokenNameOverride {
-    /// Creates a new `SessionTokenNameOverride`
+impl SigV4SessionTokenNameOverride {
+    /// Creates a new `SigV4SessionTokenNameOverride`
     pub fn new<F>(name_override: F) -> Self
     where
         F: Fn(&SigningSettings, &ConfigBag) -> Result<Option<&'static str>, BoxError>
@@ -111,13 +111,13 @@ impl SessionTokenNameOverride {
     }
 }
 
-impl fmt::Debug for SessionTokenNameOverride {
+impl fmt::Debug for SigV4SessionTokenNameOverride {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SessionTokenNameOverride").finish()
     }
 }
 
-impl Storable for SessionTokenNameOverride {
+impl Storable for SigV4SessionTokenNameOverride {
     type Storer = StoreReplace<Self>;
 }
 

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -129,8 +129,14 @@ fn settings(operation_config: &SigV4OperationSigningConfig) -> SigningSettings {
     settings
 }
 
+/// Errors that can occur while signing with SigV4.
 #[derive(Debug)]
-enum SigV4SigningError {
+pub struct SigV4SigningError {
+    kind: ErrorKind,
+}
+
+#[derive(Debug)]
+pub(crate) enum ErrorKind {
     MissingOperationSigningConfig,
     MissingSigningRegion,
     #[cfg(feature = "sigv4a")]
@@ -142,9 +148,9 @@ enum SigV4SigningError {
 
 impl fmt::Display for SigV4SigningError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use SigV4SigningError::*;
+        use ErrorKind::*;
         let mut w = |s| f.write_str(s);
-        match self {
+        match &self.kind {
             MissingOperationSigningConfig => w("missing operation signing config"),
             MissingSigningRegion => w("missing signing region"),
             #[cfg(feature = "sigv4a")]
@@ -168,24 +174,28 @@ impl StdError for SigV4SigningError {}
 fn extract_endpoint_auth_scheme_signing_name(
     endpoint_config: &AuthSchemeEndpointConfig<'_>,
 ) -> Result<Option<SigningName>, SigV4SigningError> {
-    use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
+    use ErrorKind::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
 
     match extract_field_from_endpoint_config("signingName", endpoint_config) {
         Some(Document::String(s)) => Ok(Some(SigningName::from(s.to_string()))),
         None => Ok(None),
-        _ => Err(UnexpectedType("signingName")),
+        _ => Err(SigV4SigningError {
+            kind: UnexpectedType("signingName"),
+        }),
     }
 }
 
 fn extract_endpoint_auth_scheme_signing_region(
     endpoint_config: &AuthSchemeEndpointConfig<'_>,
 ) -> Result<Option<SigningRegion>, SigV4SigningError> {
-    use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
+    use ErrorKind::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
 
     match extract_field_from_endpoint_config("signingRegion", endpoint_config) {
         Some(Document::String(s)) => Ok(Some(SigningRegion::from(Region::new(s.clone())))),
         None => Ok(None),
-        _ => Err(UnexpectedType("signingRegion")),
+        _ => Err(SigV4SigningError {
+            kind: UnexpectedType("signingRegion"),
+        }),
     }
 }
 

--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -129,14 +129,8 @@ fn settings(operation_config: &SigV4OperationSigningConfig) -> SigningSettings {
     settings
 }
 
-/// Errors that can occur while signing with SigV4.
 #[derive(Debug)]
-pub struct SigV4SigningError {
-    kind: ErrorKind,
-}
-
-#[derive(Debug)]
-pub(crate) enum ErrorKind {
+enum SigV4SigningError {
     MissingOperationSigningConfig,
     MissingSigningRegion,
     #[cfg(feature = "sigv4a")]
@@ -148,9 +142,9 @@ pub(crate) enum ErrorKind {
 
 impl fmt::Display for SigV4SigningError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ErrorKind::*;
+        use SigV4SigningError::*;
         let mut w = |s| f.write_str(s);
-        match &self.kind {
+        match self {
             MissingOperationSigningConfig => w("missing operation signing config"),
             MissingSigningRegion => w("missing signing region"),
             #[cfg(feature = "sigv4a")]
@@ -174,28 +168,24 @@ impl StdError for SigV4SigningError {}
 fn extract_endpoint_auth_scheme_signing_name(
     endpoint_config: &AuthSchemeEndpointConfig<'_>,
 ) -> Result<Option<SigningName>, SigV4SigningError> {
-    use ErrorKind::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
+    use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
 
     match extract_field_from_endpoint_config("signingName", endpoint_config) {
         Some(Document::String(s)) => Ok(Some(SigningName::from(s.to_string()))),
         None => Ok(None),
-        _ => Err(SigV4SigningError {
-            kind: UnexpectedType("signingName"),
-        }),
+        _ => Err(UnexpectedType("signingName")),
     }
 }
 
 fn extract_endpoint_auth_scheme_signing_region(
     endpoint_config: &AuthSchemeEndpointConfig<'_>,
 ) -> Result<Option<SigningRegion>, SigV4SigningError> {
-    use ErrorKind::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
+    use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
 
     match extract_field_from_endpoint_config("signingRegion", endpoint_config) {
         Some(Document::String(s)) => Ok(Some(SigningRegion::from(Region::new(s.clone())))),
         None => Ok(None),
-        _ => Err(SigV4SigningError {
-            kind: UnexpectedType("signingRegion"),
-        }),
+        _ => Err(UnexpectedType("signingRegion")),
     }
 }
 

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -6,7 +6,7 @@
 use crate::auth;
 use crate::auth::{
     extract_endpoint_auth_scheme_signing_name, extract_endpoint_auth_scheme_signing_region,
-    SessionTokenNameOverride, SigV4OperationSigningConfig, SigV4SigningError,
+    SigV4OperationSigningConfig, SigV4SessionTokenNameOverride, SigV4SigningError,
 };
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{
@@ -162,7 +162,7 @@ impl Sign for SigV4Signer {
         let request_time = runtime_components.time_source().unwrap_or_default().now();
 
         let settings = if let Some(session_token_name_override) =
-            config_bag.load::<SessionTokenNameOverride>()
+            config_bag.load::<SigV4SessionTokenNameOverride>()
         {
             let mut settings = Self::settings(&operation_config);
             let name_override = session_token_name_override.name_override(&settings, config_bag)?;

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -6,7 +6,7 @@
 use crate::auth;
 use crate::auth::{
     extract_endpoint_auth_scheme_signing_name, extract_endpoint_auth_scheme_signing_region,
-    SigV4OperationSigningConfig, SigV4SigningError,
+    SessionTokenNameOverride, SigV4OperationSigningConfig, SigV4SigningError,
 };
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{
@@ -72,8 +72,7 @@ impl SigV4Signer {
         Self
     }
 
-    /// Creates a [`SigningSettings`] from the given `operation_config`.
-    pub fn signing_settings(operation_config: &SigV4OperationSigningConfig) -> SigningSettings {
+    fn settings(operation_config: &SigV4OperationSigningConfig) -> SigningSettings {
         super::settings(operation_config)
     }
 
@@ -143,27 +142,38 @@ impl SigV4Signer {
             }
         }
     }
+}
 
-    /// Signs the given `request`.
-    ///
-    /// This is a helper used by [`Sign::sign_http_request`] and will be useful if calling code
-    /// needs to pass a configured `settings`.
-    ///
-    /// TODO(S3Express): Make this method more user friendly, possibly returning a builder
-    ///  instead of taking these input parameters. The builder will have a `sign` method that
-    ///  does what this method body currently does.
-    pub fn sign_http_request(
+impl Sign for SigV4Signer {
+    fn sign_http_request(
         &self,
         request: &mut HttpRequest,
         identity: &Identity,
-        settings: SigningSettings,
-        operation_config: &SigV4OperationSigningConfig,
+        auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'_>,
         runtime_components: &RuntimeComponents,
-        #[allow(unused_variables)] config_bag: &ConfigBag,
+        config_bag: &ConfigBag,
     ) -> Result<(), BoxError> {
+        if identity.data::<Credentials>().is_none() {
+            return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
+        };
+
+        let operation_config =
+            Self::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
         let request_time = runtime_components.time_source().unwrap_or_default().now();
+
+        let settings = if let Some(session_token_name_override) =
+            config_bag.load::<SessionTokenNameOverride>()
+        {
+            let mut settings = Self::settings(&operation_config);
+            let name_override = session_token_name_override.name_override(&settings, config_bag)?;
+            settings.session_token_name_override = name_override;
+            settings
+        } else {
+            Self::settings(&operation_config)
+        };
+
         let signing_params =
-            Self::signing_params(settings, identity, operation_config, request_time)?;
+            Self::signing_params(settings, identity, &operation_config, request_time)?;
 
         let (signing_instructions, _signature) = {
             // A body that is already in memory can be signed directly. A body that is not in memory
@@ -216,35 +226,6 @@ impl SigV4Signer {
         }
         auth::apply_signing_instructions(signing_instructions, request)?;
         Ok(())
-    }
-}
-
-impl Sign for SigV4Signer {
-    fn sign_http_request(
-        &self,
-        request: &mut HttpRequest,
-        identity: &Identity,
-        auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'_>,
-        runtime_components: &RuntimeComponents,
-        config_bag: &ConfigBag,
-    ) -> Result<(), BoxError> {
-        if identity.data::<Credentials>().is_none() {
-            return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
-        };
-
-        let operation_config =
-            Self::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
-
-        let settings = Self::signing_settings(&operation_config);
-
-        self.sign_http_request(
-            request,
-            identity,
-            settings,
-            &operation_config,
-            runtime_components,
-            config_bag,
-        )
     }
 }
 

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -77,8 +77,7 @@ impl SigV4Signer {
         super::settings(operation_config)
     }
 
-    /// Creates a [`SigningParams`] from the given arguments.
-    pub fn signing_params<'a>(
+    fn signing_params<'a>(
         settings: SigningSettings,
         identity: &'a Identity,
         operation_config: &'a SigV4OperationSigningConfig,
@@ -153,31 +152,27 @@ impl SigV4Signer {
             }
         }
     }
-}
 
-impl Sign for SigV4Signer {
-    fn sign_http_request(
+    /// Signs the given `request`.
+    ///
+    /// This is a helper used by [`Sign::sign_http_request`] and will be useful if calling code
+    /// needs to pass a configured `settings`.
+    ///
+    /// TODO(S3Express): Make this method more user friendly, possibly returning a builder
+    ///  instead of taking these input parameters. The builder will have a `sign` method that
+    ///  does what this method body currently does.
+    pub fn sign_http_request(
         &self,
         request: &mut HttpRequest,
         identity: &Identity,
-        auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'_>,
+        settings: SigningSettings,
+        operation_config: &SigV4OperationSigningConfig,
         runtime_components: &RuntimeComponents,
-        config_bag: &ConfigBag,
+        #[allow(unused_variables)] config_bag: &ConfigBag,
     ) -> Result<(), BoxError> {
-        let operation_config =
-            Self::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
         let request_time = runtime_components.time_source().unwrap_or_default().now();
-
-        if identity.data::<Credentials>().is_none() {
-            return Err(SigV4SigningError {
-                kind: ErrorKind::WrongIdentityType(identity.clone()),
-            }
-            .into());
-        };
-
-        let settings = Self::signing_settings(&operation_config);
         let signing_params =
-            Self::signing_params(settings, identity, &operation_config, request_time)?;
+            Self::signing_params(settings, identity, operation_config, request_time)?;
 
         let (signing_instructions, _signature) = {
             // A body that is already in memory can be signed directly. A body that is not in memory
@@ -230,6 +225,38 @@ impl Sign for SigV4Signer {
         }
         auth::apply_signing_instructions(signing_instructions, request)?;
         Ok(())
+    }
+}
+
+impl Sign for SigV4Signer {
+    fn sign_http_request(
+        &self,
+        request: &mut HttpRequest,
+        identity: &Identity,
+        auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'_>,
+        runtime_components: &RuntimeComponents,
+        config_bag: &ConfigBag,
+    ) -> Result<(), BoxError> {
+        if identity.data::<Credentials>().is_none() {
+            return Err(SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            }
+            .into());
+        };
+
+        let operation_config =
+            Self::extract_operation_config(auth_scheme_endpoint_config, config_bag)?;
+
+        let settings = Self::signing_settings(&operation_config);
+
+        self.sign_http_request(
+            request,
+            identity,
+            settings,
+            &operation_config,
+            runtime_components,
+            config_bag,
+        )
     }
 }
 

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -6,7 +6,7 @@
 use crate::auth;
 use crate::auth::{
     extract_endpoint_auth_scheme_signing_name, extract_endpoint_auth_scheme_signing_region,
-    SigV4OperationSigningConfig, SigV4SigningError,
+    ErrorKind, SigV4OperationSigningConfig, SigV4SigningError,
 };
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{
@@ -85,7 +85,9 @@ impl SigV4Signer {
     ) -> Result<v4::SigningParams<'a, SigningSettings>, SigV4SigningError> {
         let creds = identity
             .data::<Credentials>()
-            .ok_or_else(|| SigV4SigningError::WrongIdentityType(identity.clone()))?;
+            .ok_or_else(|| SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            })?;
 
         if let Some(expires_in) = settings.expires_in {
             if let Some(creds_expires_time) = creds.expiry() {
@@ -102,14 +104,18 @@ impl SigV4Signer {
                 operation_config
                     .region
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningRegion)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningRegion,
+                    })?
                     .as_ref(),
             )
             .name(
                 operation_config
                     .name
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningName)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningName,
+                    })?
                     .as_ref(),
             )
             .time(request_timestamp)
@@ -122,10 +128,13 @@ impl SigV4Signer {
     pub fn extract_operation_config<'a>(
         auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'a>,
         config_bag: &'a ConfigBag,
-    ) -> Result<Cow<'a, SigV4OperationSigningConfig>, BoxError> {
-        let operation_config = config_bag
-            .load::<SigV4OperationSigningConfig>()
-            .ok_or(SigV4SigningError::MissingOperationSigningConfig)?;
+    ) -> Result<Cow<'a, SigV4OperationSigningConfig>, SigV4SigningError> {
+        let operation_config =
+            config_bag
+                .load::<SigV4OperationSigningConfig>()
+                .ok_or(SigV4SigningError {
+                    kind: ErrorKind::MissingOperationSigningConfig,
+                })?;
 
         let name = extract_endpoint_auth_scheme_signing_name(&auth_scheme_endpoint_config)?
             .or(config_bag.load::<SigningName>().cloned());
@@ -229,7 +238,10 @@ impl Sign for SigV4Signer {
         config_bag: &ConfigBag,
     ) -> Result<(), BoxError> {
         if identity.data::<Credentials>().is_none() {
-            return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
+            return Err(SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            }
+            .into());
         };
 
         let operation_config =

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4a.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4a.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::auth::{
-    apply_signing_instructions, extract_endpoint_auth_scheme_signing_name,
+    apply_signing_instructions, extract_endpoint_auth_scheme_signing_name, ErrorKind,
     SigV4OperationSigningConfig, SigV4SigningError,
 };
 use aws_credential_types::Credentials;
@@ -95,14 +95,18 @@ impl SigV4aSigner {
                 operation_config
                     .region_set
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningRegionSet)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningRegionSet,
+                    })?
                     .as_ref(),
             )
             .name(
                 operation_config
                     .name
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningName)?
+                    .ok_or(SigV4SigningError {
+                        kind: ErrorKind::MissingSigningName,
+                    })?
                     .as_ref(),
             )
             .time(request_timestamp)
@@ -115,9 +119,12 @@ impl SigV4aSigner {
         auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'a>,
         config_bag: &'a ConfigBag,
     ) -> Result<Cow<'a, SigV4OperationSigningConfig>, SigV4SigningError> {
-        let operation_config = config_bag
-            .load::<SigV4OperationSigningConfig>()
-            .ok_or(SigV4SigningError::MissingOperationSigningConfig)?;
+        let operation_config =
+            config_bag
+                .load::<SigV4OperationSigningConfig>()
+                .ok_or(SigV4SigningError {
+                    kind: ErrorKind::MissingOperationSigningConfig,
+                })?;
 
         let name = extract_endpoint_auth_scheme_signing_name(&auth_scheme_endpoint_config)?
             .or(config_bag.load::<SigningName>().cloned());
@@ -142,7 +149,7 @@ fn extract_endpoint_auth_scheme_signing_region_set(
     endpoint_config: &AuthSchemeEndpointConfig<'_>,
 ) -> Result<Option<SigningRegionSet>, SigV4SigningError> {
     use aws_smithy_types::Document::Array;
-    use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
+    use ErrorKind::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
 
     match super::extract_field_from_endpoint_config("signingRegionSet", endpoint_config) {
         Some(Array(docs)) => {
@@ -153,7 +160,9 @@ fn extract_endpoint_auth_scheme_signing_region_set(
             Ok(Some(region_set))
         }
         None => Ok(None),
-        _it => Err(UnexpectedType("signingRegionSet")),
+        _it => Err(SigV4SigningError {
+            kind: UnexpectedType("signingRegionSet"),
+        }),
     }
 }
 
@@ -171,7 +180,10 @@ impl Sign for SigV4aSigner {
         let request_time = runtime_components.time_source().unwrap_or_default().now();
 
         if identity.data::<Credentials>().is_none() {
-            return Err(SigV4SigningError::WrongIdentityType(identity.clone()).into());
+            return Err(SigV4SigningError {
+                kind: ErrorKind::WrongIdentityType(identity.clone()),
+            }
+            .into());
         }
 
         let settings = Self::settings(&operation_config);


### PR DESCRIPTION
## Motivation and Context
In response to https://github.com/smithy-lang/smithy-rs/pull/3455#issuecomment-1973771991, it's clear that we need to iterate more on the potential signing API.

This PR takes a different approach where `S3ExpressSigner` is dropped and a session token name override, if any, is placed into and retrieved from `ConfigBag`, which is used within `SigV4Signer::sign_http_request`.

## Testing
Existing tests in CI

A semver failure in CI can be ignored; A public API SigV4Signer::sign_http_request has been removed that only existed in the branch.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
