### PR TITLE
Updating timeout logic in the WASI HTTP client

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -40,3 +40,9 @@ message = "Add support for Lambda's `InvokeWithResponseStreaming` and Bedrock Ag
 references = ["aws-sdk-rust#1075", "aws-sdk-rust#1080", "smithy-rs#3451"]
 meta = { "breaking" = false, "bug" = false, "tada" = true }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Updating timeout logic in the WASI HTTP client"
+references = ["smithy-rs#3463"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+authors = ["landonxjames"]

--- a/rust-runtime/aws-smithy-wasm/src/wasi.rs
+++ b/rust-runtime/aws-smithy-wasm/src/wasi.rs
@@ -160,16 +160,12 @@ impl From<&HttpConnectorSettings> for WasiRequestOptions {
             .read_timeout()
             .map(|dur| u64::try_from(dur.as_nanos()).unwrap_or(u64::MAX));
 
-        //Note: these only fail if setting this particular type of timeout is not
-        //supported. Spec compliant runtimes should always support these so it is
-        //unlikely to be an issue.
+        //Note: setting these timeouts fails if the particular type of timeout is not
+        //supported by the WASI environment. If the timeout is not supported we are
+        //stuck with the default timeout set by that env and so we just move on.
         let wasi_http_opts = wasi_http::RequestOptions::new();
-        wasi_http_opts
-            .set_connect_timeout(connect_timeout)
-            .expect("Connect timeout not supported");
-        wasi_http_opts
-            .set_first_byte_timeout(read_timeout)
-            .expect("Read timeout not supported");
+        let _ = wasi_http_opts.set_connect_timeout(connect_timeout);
+        let _ = wasi_http_opts.set_first_byte_timeout(read_timeout);
 
         WasiRequestOptions(Some(wasi_http_opts))
     }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Previously it was panicing if the timeouts were not correctly set. But one major environment where WASM/WASI is run (Node), currently doesn't support setting that timeout. So for the time being we now continue with the default timeout if setting it fails

## Description
<!--- Describe your changes in detail -->
Removed the `expect` from the `set_*_timeout` calls so that execution can continue with the default timeouts in environments where setting them is not supported. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested locally by running a WASM binary in Node, an environment that does not yet support setting these timeouts.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
