### PR TITLE
bug: Fix comparison between Throughput with and without duration

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,10 @@ message = "Make `BehaviorVersion` be future-proof by disallowing it to be constr
 references = ["aws-sdk-rust#1111", "smithy-rs#3513"]
 meta = { "breaking" = true, "tada" = false, "bug" = true, "target" = "client" }
 author = "Ten0"
+
+[[smithy-rs]]
+message = "Fixed comparison of Throughput when one or both have zero duration; prevents false positive Err for stalled stream detection"
+references = ["smithy-rs#3464"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client"}
+authors = ["iamjpotts"]
+


### PR DESCRIPTION
## Motivation and Context

I observed a failure during a download from a bucket where the stalled stream detection complained that a throughput measurement of about 400kb over zero nanoseconds was below the minimum threshold of one byte per second.

Debug string of Err value:

```
ThroughputBelowMinimum { expected: Throughput { bytes_read: 1, per_time_elapsed: 1s }, actual: Throughput { bytes_read: 417792, per_time_elapsed: 0ns } }
```

The 417792 bytes read over a very short period of time shows that the stream is not stalled and that Err should not have been returned from the S3 api.

## Description

When a `Throughput` has a zero `Duration` but a non-zero `bytes_read` it should always compare `Ord::Greater` than any `Throughput` with a non-zero `Duration`.

## Testing

Added unit tests for `PartialEq` and `Eq` behavior.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
