### PR TITLE
Fix S3 Express bug where SigV4 session token was incorrectly overriden

### DIFF
--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -11,7 +11,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::AuthSchemeEndpointConfig;
 use aws_smithy_runtime_api::client::identity::Identity;
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
-use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_smithy_types::Document;
 use aws_types::region::{Region, SigningRegion, SigningRegionSet};
 use aws_types::SigningName;
@@ -73,52 +73,6 @@ impl Default for SigningOptions {
             expires_in: None,
         }
     }
-}
-
-pub(crate) type SessionTokenNameOverrideFn = Box<
-    dyn Fn(&SigningSettings, &ConfigBag) -> Result<Option<&'static str>, BoxError>
-        + Send
-        + Sync
-        + 'static,
->;
-
-/// Custom config that provides the alternative session token name for [`SigningSettings`]
-pub struct SigV4SessionTokenNameOverride {
-    name_override: SessionTokenNameOverrideFn,
-}
-
-impl SigV4SessionTokenNameOverride {
-    /// Creates a new `SigV4SessionTokenNameOverride`
-    pub fn new<F>(name_override: F) -> Self
-    where
-        F: Fn(&SigningSettings, &ConfigBag) -> Result<Option<&'static str>, BoxError>
-            + Send
-            + Sync
-            + 'static,
-    {
-        Self {
-            name_override: Box::new(name_override),
-        }
-    }
-
-    /// Provides a session token name override
-    pub fn name_override(
-        &self,
-        settings: &SigningSettings,
-        config_bag: &ConfigBag,
-    ) -> Result<Option<&'static str>, BoxError> {
-        (self.name_override)(settings, config_bag)
-    }
-}
-
-impl fmt::Debug for SigV4SessionTokenNameOverride {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SessionTokenNameOverride").finish()
-    }
-}
-
-impl Storable for SigV4SessionTokenNameOverride {
-    type Storer = StoreReplace<Self>;
 }
 
 /// SigV4 signing configuration for an operation

--- a/tools/ci-cdk/lib/aws-sdk-rust/canary-stack.ts
+++ b/tools/ci-cdk/lib/aws-sdk-rust/canary-stack.ts
@@ -193,11 +193,23 @@ export class CanaryStack extends Stack {
         }));
 
         // Allow canaries to perform operations on test express bucket
+        // Unlike S3, no need to grant separate permissions for GetObject, PutObject, and so on because
+        // the session token enables access instead:
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-security-iam.html#s3-express-security-iam-actions
         this.lambdaExecutionRole.addToPolicy(
             new PolicyStatement({
-                actions: ['s3express:*'],
+                actions: ['s3express:CreateSession'],
                 effect: Effect.ALLOW,
                 resources: [`${this.canaryTestExpressBucket.attrArn}`],
+            })
+        );
+
+        // Allow canaries to list directory buckets
+        this.lambdaExecutionRole.addToPolicy(
+            new PolicyStatement({
+                actions: ['s3express:ListAllMyDirectoryBuckets'],
+                effect: Effect.ALLOW,
+                resources: ["*"],
             })
         );
 


### PR DESCRIPTION
## Description
S3 express canary exposed a bug introduced in smithy-rs#3457 where the code overwrote the regular SigV4 session token name with the S3 Expression session token name when it shouldn't.
```
    4: Error { code: "InvalidRequest", message: "CreateSession request should not include \"x-amz-s3session-token\"", aws_request_id: "01c0c8864e00018e20558a130509f37740b906e4", s3_extended_request_id: "DGTJhRqVMbZdAHQ" }
```
For APIs like `ListDirectoryBuckets` or `CreateSession`, we should not overwrite `x-amz-security-token` with `x-amz-s3session-token` in the request header.

In the said PR, `x-amz-security-token` was overwritten even in the case where an S3 client internal to `S3ExpressCredentialsProvider` made a request to `CreateSession` (should use regular SigV4 in this case). To address that issue, this PR overwrites a session token name only within a `SigV4Signer` associated with the S3 Express auth scheme.

## Testing
- Added an integration test verifying the fix (this test currently fails when run in the destination branch, `ysaito/s3express`)
- Verified all canary (including wasm, s3express) passed

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
