### PR TITLE
Fix new runtime crate handling in SDK patcher tool

### DIFF
--- a/tools/ci-build/runtime-versioner/src/command/patch.rs
+++ b/tools/ci-build/runtime-versioner/src/command/patch.rs
@@ -148,11 +148,10 @@ fn crate_version_has_changed(
         .join(crate_name)
         .join("Cargo.toml");
     let to_patch_cargo_toml = runtime_crate_path.join(crate_name).join("Cargo.toml");
-    assert!(
-        sdk_cargo_toml.exists(),
-        "{:?} did not exist!",
-        sdk_cargo_toml
-    );
+    if !sdk_cargo_toml.exists() {
+        // This is a new runtime crate, so there is nothing to patch.
+        return Ok(false);
+    }
     assert!(
         to_patch_cargo_toml.exists(),
         "{:?} did not exist!",


### PR DESCRIPTION
The SDK runtime patcher tool used during smithy-rs release to detect semver breaks was breaking due to the new aws-smithy-wasm crate since it had a bad assumption in the logic to determine if a runtime crate changed. This PR corrects that logic to state the runtime crate doesn't need patching if it didn't exist previously.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
