### PR TITLE
Bumping version of `wasi` crate dependency

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -12,7 +12,7 @@
 # author = "rcoh"
 
 [[smithy-rs]]
-message = "Bumping version of wasi crate dependency in aws-smithy-wasm."
+message = "Increased minimum version of wasi crate dependency in aws-smithy-wasm to 0.12.1."
 references = ["smithy-rs#3476"]
-meta = { "breaking" = false, "tada" = true, "bug" = false }
+meta = { "breaking" = false, "tada" = false, "bug" = false }
 authors = ["landonxjames"]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,68 +11,8 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
-[[aws-sdk-rust]]
-message = "EKS Pod Identity is now supported as part of the default ECS credential provider."
-references = ["smithy-rs#3416"]
-meta = { "breaking" = false, "bug" = false, "tada" = true }
-author = "jackkleeman"
-
 [[smithy-rs]]
-message = "Added aws-smithy-wasm crate to enable SDK use in WASI compliant environments"
-references = ["smithy-rs#2087", "smithy-rs#2520", "smithy-rs#3409", "aws-sdk-rust#59", "smithy-rs#3476"]
+message = "Bumping version of wasi crate dependency in aws-smithy-wasm."
+references = ["smithy-rs#3476"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
-authors = ["landonxjames", "eduardomourar"]
-
-[[smithy-rs]]
-message = "Added aws-smithy-wasm crate to enable SDK use in WASI compliant environments"
-references = ["smithy-rs#2087", "smithy-rs#2520", "smithy-rs#3409", "smithy-rs#3476"]
-meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "client"}
-authors = ["landonxjames", "eduardomourar"]
-
-[[smithy-rs]]
-message = "[`SdkBody`](https://docs.rs/aws-smithy-types/latest/aws_smithy_types/body/struct.SdkBody.html) now implements the 1.0 version of the `http_body::Body` trait."
-references = ["smithy-rs#3365", "aws-sdk-rust#1046"]
-meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all" }
-authors = ["cayman-amzn", "rcoh"]
-
-[[aws-sdk-rust]]
-message = "Add support for Lambda's `InvokeWithResponseStreaming` and Bedrock Agent Runtime's `InvokeAgent` operations."
-references = ["aws-sdk-rust#1075", "aws-sdk-rust#1080", "smithy-rs#3451"]
-meta = { "breaking" = false, "bug" = false, "tada" = true }
-author = "jdisanti"
-
-[[aws-sdk-rust]]
-message = "Added support for SSO bearer token authentication. The aws-sdk-codecatalyst crate can now send requests without erroring."
-references = ["aws-sdk-rust#703", "smithy-rs#3453"]
-meta = { "breaking" = false, "bug" = false, "tada" = true }
-author = "jdisanti"
-
-[[smithy-rs]]
-message = "Upgrade Smithy to 1.45."
-references = ["smithy-rs#3470"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
-authors = ["jdisanti"]
-
-[[aws-sdk-rust]]
-message = "Add support for S3 Express One Zone. See [the user guide](https://github.com/awslabs/aws-sdk-rust/discussions/1091) for more details."
-references = ["aws-sdk-rust#992", "smithy-rs#3465"]
-meta = { "breaking" = false, "bug" = false, "tada" = true }
-author = "ysaito1001"
-
-[[smithy-rs]]
-message = "The `ResolveIdentity` trait is now aware of its `IdentityCache` location."
-references = ["smithy-rs#3465", "smithy-rs#3477"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
-author = "ysaito1001"
-
-[[smithy-rs]]
-message = "`RuntimeComponents` can now be converted back to a `RuntimeComponentsBuilder`, using `.to_builder()`."
-references = ["smithy-rs#3465", "smithy-rs#3477"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
-authors = "ysaito1001"
-
-[[aws-sdk-rust]]
-message = "`aws_sigv4::http_request::settigns::SigningSettings` adds a new setting `session_token_name_override` to allow for an alternative session token name for SigV4 signing."
-references = ["smithy-rs#3465", "smithy-rs#3477"]
-meta = { "breaking" = false, "bug" = false, "tada" = false }
-author = "ysaito1001"
+authors = ["landonxjames"]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -19,7 +19,7 @@ author = "jackkleeman"
 
 [[smithy-rs]]
 message = "Added aws-smithy-wasm crate to enable SDK use in WASI compliant environments"
-references = ["smithy-rs#2087", "smithy-rs#2520", "smithy-rs#3409", "aws-sdk-rust#59"]
+references = ["smithy-rs#2087", "smithy-rs#2520", "smithy-rs#3409", "aws-sdk-rust#59", "smithy-rs#3476"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 authors = ["landonxjames", "eduardomourar"]
 

--- a/rust-runtime/aws-smithy-wasm/Cargo.toml
+++ b/rust-runtime/aws-smithy-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-wasm"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Eduardo Rodrigues <16357187+eduardomourar@users.noreply.github.com>",

--- a/rust-runtime/aws-smithy-wasm/Cargo.toml
+++ b/rust-runtime/aws-smithy-wasm/Cargo.toml
@@ -19,7 +19,7 @@ http = "1.0.0"
 tracing = "0.1.40"
 # Note the wasi crate will only build for target wasm32-wasi, but having a target
 # statement here breaks some of the CI tests, so we leave it with the rest of the deps
-wasi = "0.12.0" # This is build on wasi-0.2.0
+wasi = "0.12.1" # This is build on wasi-0.2.0
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Motivation and Context
The `0.12.0` version of `wasi` suffered from a bug the could impact users using lower versions of `wit-bindgen` dependencies. Mixed versions of `wit-bindgen` generated bindings in a single project would cause a symbol collision. This is fixed by newer versions of `wit-bindgen` and `wasi = 0.12.1` contains bindings generated by one of these newer versions. See this issue for details: https://github.com/bytecodealliance/wit-bindgen/issues/849 and a longer discussion of the issue on Zulip [here](https://bytecodealliance.zulipchat.com/#narrow/stream/327223-wit-bindgen/topic/Component.20failing.20to.20compile.20with.20mixed.20wit-bindgen.20versions/near/422068264).

## Description
<!--- Describe your changes in detail -->
Bumped version of `wasi` dependency in `aws-amithy-wasm` from `0.12.0` -> `0.12.1`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
