### PR TITLE
Bump minor for some runtime crates as part of S3 Express

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -58,3 +58,21 @@ message = "Add support for S3 Express One Zone. See [the user guide](https://git
 references = ["aws-sdk-rust#992", "smithy-rs#3465"]
 meta = { "breaking" = false, "bug" = false, "tada" = true }
 author = "ysaito1001"
+
+[[smithy-rs]]
+message = "The `ResolveIdentity` trait is now aware of its `IdentityCache` location."
+references = ["smithy-rs#3465", "smithy-rs#3477"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+author = "ysaito1001"
+
+[[smithy-rs]]
+message = "`RuntimeComponents` can now be converted back to a `RuntimeComponentsBuilder`, using `.to_builder()`."
+references = ["smithy-rs#3465", "smithy-rs#3477"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+authors = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "`aws_sigv4::http_request::settigns::SigningSettings` adds a new setting `session_token_name_override` to allow for an alternative session token name for SigV4 signing."
+references = ["smithy-rs#3465", "smithy-rs#3477"]
+meta = { "breaking" = false, "bug" = false, "tada" = false }
+author = "ysaito1001"

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.1.9"
+version = "1.2.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.1.8"
+version = "1.2.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"


### PR DESCRIPTION
## Description
- Bump minor for `aws-sigv4` for [these changes](https://github.com/smithy-lang/smithy-rs/pull/3465/files#diff-154d03aaceb2d08722c365acf156e47c523638765a8a645c350cff72550c80dd)
- Bump minor for `aws-smithy-runtime-api` for [these changes](https://github.com/smithy-lang/smithy-rs/pull/3465/files#diff-daa7b9cc6f272b9b914593b1ce032b87af4fe17c351fee5608d621bdac091040)

## Testing
Existing tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
