### PR TITLE
unshallow git history prior to pushing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,11 +266,13 @@ jobs:
           # to retry a release action execution that failed due to a transient issue.
           # In that case, we expect the commit to be releasable as-is, i.e. the changelog should have already
           # been processed.
+          git pull --unshallow
           if [[ "${DRY_RUN}" == "true" ]]; then
             # During dry-runs, "git push" without "--force" can fail if smithy-rs-release-x.y.z-preview is behind
             # smithy-rs-release-x.y.z, but that does not matter much during dry-runs.
             git push --force origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
           else
+            echo "attempting to push $(git rev-parse HEAD) to $RELEASE_BRANCH_NAME $(git rev-parse $RELEASE_BRANCH_NAME)"
             git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
           fi
         fi


### PR DESCRIPTION
## Motivation and Context
I'm not sure what changed but I was able to reproduce the failure from https://github.com/smithy-lang/smithy-rs/actions/runs/8242141624/job/22564640708 with the downloaded release artifact. Because the clone was shallow, git did not attempt to push because the histories were unrelated.

Of course, they are in reality, but because the history is shallow git doesn't know that.

I verified this allowed a dry run push to succeed locally.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
