### PR TITLE
Allow 'null' variants in unions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,11 @@ buildscript {
 }
 
 allprojects {
+    val allowLocalDeps: String by project
     repositories {
-        mavenLocal()
+        if (allowLocalDeps.toBoolean()) {
+         mavenLocal()
+        }
         mavenCentral()
         google()
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
-        // mavenLocal()
+        mavenLocal()
         mavenCentral()
         google()
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 repositories {
     mavenCentral()
     google()
-    /* mavenLocal() */
+    mavenLocal()
 }
 
 // Load properties manually to avoid hard coding smithy version

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
 repositories {
     mavenCentral()
     google()
-    mavenLocal()
 }
 
 // Load properties manually to avoid hard coding smithy version

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -114,8 +114,6 @@ val allCodegenTests = listOf(
     ),
     ClientTest("aws.protocoltests.misc#QueryCompatService", "query-compat-test", dependsOn = listOf("aws-json-query-compat.smithy")),
 ).map(ClientTest::toCodegenTest)
-// use this line to run just one test
-// .filter { it.module == "query-compat-test" }
 
 project.registerGenerateSmithyBuildTask(rootProject, pluginName, allCodegenTests)
 project.registerGenerateCargoWorkspaceTask(rootProject, pluginName, allCodegenTests, workingDirUnderBuildDir)

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -195,6 +195,15 @@ class JsonParserGeneratorTest {
             )
 
             unitTest(
+                "all_variants_null",
+                """
+                // __type field should be ignored during deserialization
+                let input = br#"{ "top": { "choice": { "blob": null, "boolean": null, "int": null, "long": null, "__type": "value-should-be-ignored-anyway" } } }"#;
+                let _err = ${format(operationGenerator)}(input, test_output::OpOutput::builder()).expect_err("invalid union");
+                """,
+            )
+
+            unitTest(
                 "empty_error",
                 """
                 // empty error

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -184,6 +184,17 @@ class JsonParserGeneratorTest {
             )
 
             unitTest(
+                "allow_null_for_variants",
+                """
+                // __type field should be ignored during deserialization
+                let input = br#"{ "top": { "choice": { "blob": null, "boolean": null, "int": 5, "long": null, "__type": "value-should-be-ignored-anyway" } } }"#;
+                let output = ${format(operationGenerator)}(input, test_output::OpOutput::builder()).unwrap().build();
+                use test_model::Choice;
+                assert_eq!(Choice::Int(5), output.top.unwrap().choice);
+                """,
+            )
+
+            unitTest(
                 "empty_error",
                 """
                 // empty error

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,7 @@ kotlin.code.style=official
 # codegen
 smithyGradlePluginVersion=0.9.0
 smithyVersion=1.45.0
+allowLocalDeps=false
 
 # kotlin
 kotlinVersion=1.9.20


### PR DESCRIPTION
## Motivation and Context
- https://github.com/awslabs/aws-sdk-rust/issues/1095

## Description
Update the JSON parser generator to allow for `null` to be set in unions. Servers can send unions like this:
```json
{
  "AmazonElasticsearchParameters": null,
  "AmazonOpenSearchParameters": null,
  "AppFlowParameters": null,
  "AthenaParameters": null,
  "AuroraParameters": null,
  "AuroraPostgreSqlParameters": null,
  "AwsIotAnalyticsParameters": null,
  "BigQueryParameters": null,
  "DatabricksParameters": null,
  "Db2Parameters": null,
  "DenodoParameters": null,
  "DocumentDBParameters": null,
  "DremioParameters": null,
  "ExasolParameters": null,
  "GoogleAnalyticsParameters": null,
  "JiraParameters": null,
  "MariaDbParameters": null,
  "MongoAtlasParameters": null,
  "MongoDBParameters": null,
  "MySqlParameters": null,
  "OracleParameters": null,
  "PostgreSqlParameters": null,
  "PrestoParameters": null,
  "RdsParameters": null,
  "RedshiftParameters": null,
  "S3Parameters": {
    "IsUploaded": false,
    "ManifestFileLocation": {
      "Bucket": "deided-bucket.prod.us-east-1",
      "Key": "sales/manifest.json"
    },
    "RoleArn": null
  },
  "SalesforceParameters": null,
  "SapHanaParameters": null,
  "ServiceNowParameters": null,
  "SnowflakeParameters": null,
  "SparkParameters": null,
  "SqlServerParameters": null,
  "StarburstParameters": null,
  "TeradataParameters": null,
  "TrinoParameters": null,
  "TwitterParameters": null
}
```

This caused our parser to fail.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] New unit test
- [x] Dry run against new [smithy protocol test](https://github.com/smithy-lang/smithy/pull/2180) 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
