### PR TITLE
Fix publisher check of published versions

### DIFF
--- a/tools/ci-build/publisher/src/subcommand/publish.rs
+++ b/tools/ci-build/publisher/src/subcommand/publish.rs
@@ -109,10 +109,12 @@ pub fn resolve_publish_location(location: &Path) -> PathBuf {
 }
 
 async fn is_published(index: Arc<CratesIndex>, handle: &PackageHandle) -> Result<bool> {
-    let crate_name = handle.name.clone();
-    let versions =
-        tokio::task::spawn_blocking(move || index.published_versions(&crate_name)).await??;
-    Ok(!versions.is_empty())
+    let name = handle.name.clone();
+    let version = handle.version.clone();
+    tokio::task::spawn_blocking(move || {
+        smithy_rs_tool_common::index::is_published(index.as_ref(), &name, &version)
+    })
+    .await?
 }
 
 /// Waits for the given package to show up on crates.io


### PR DESCRIPTION
## Motivation and Context
Switch to the sparse index broke the publishers check if whether or not a version was already published.

## Description
Fix check, add tests.

## Testing
- Ran test against the real sparse index.


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
