### PR TITLE
Add a RuntimePlugin/Interceptor to enforce expected content length

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "Clients now enforce that the Content-Length sent by the server matches the length of the returned response body. In most cases, Hyper will enforce this behavior, however, in extremely rare circumstances where the Tokio runtime is dropped in between subsequent requests, this scenario can occur."
+references = ["smithy-rs#3491", "aws-sdk-rust#1079"]
+meta = { "breaking" = false, "bug" = true, "tada" = false }
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -271,7 +271,8 @@ where
         let fs = Fs::from_test_dir(dir.join("fs"), "/");
         let network_traffic = std::fs::read_to_string(dir.join("http-traffic.json"))
             .map_err(|e| format!("failed to load http traffic: {}", e))?;
-        let network_traffic: NetworkTraffic = serde_json::from_str(&network_traffic)?;
+        let mut network_traffic: NetworkTraffic = serde_json::from_str(&network_traffic)?;
+        network_traffic.correct_content_lengths();
 
         let metadata: Metadata<O> = serde_json::from_str(
             &std::fs::read_to_string(dir.join("test-case.json"))

--- a/aws/sdk/integration-tests/dynamodb/tests/retries-with-client-rate-limiting.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/retries-with-client-rate-limiting.rs
@@ -21,14 +21,15 @@ fn req() -> http::Request<SdkBody> {
 }
 
 fn ok() -> http::Response<SdkBody> {
+    let body = "{ \"TableNames\": [ \"Test\" ] }";
     http::Response::builder()
         .status(200)
         .header("server", "Server")
         .header("content-type", "application/x-amz-json-1.0")
-        .header("content-length", "23")
+        .header("content-length", body.len().to_string())
         .header("connection", "keep-alive")
         .header("x-amz-crc32", "2335643545")
-        .body(SdkBody::from("{ \"TableNames\": [ \"Test\" ] }"))
+        .body(SdkBody::from(body))
         .unwrap()
 }
 

--- a/aws/sdk/integration-tests/s3/tests/data/no_auth/head-object.json
+++ b/aws/sdk/integration-tests/s3/tests/data/no_auth/head-object.json
@@ -52,9 +52,6 @@
                 "server": [
                   "AmazonS3"
                 ],
-                "content-length": [
-                  "386910"
-                ],
                 "accept-ranges": [
                   "bytes"
                 ],

--- a/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
+++ b/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_smithy_runtime::client::http::test_util::dvr::ReplayingClient;
+use aws_smithy_runtime::client::http::test_util::dvr::{NetworkTraffic, ReplayingClient};
 
 #[tokio::test]
 async fn do_endpoint_discovery() {

--- a/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
+++ b/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_smithy_runtime::client::http::test_util::dvr::{NetworkTraffic, ReplayingClient};
+use aws_smithy_runtime::client::http::test_util::dvr::ReplayingClient;
 
 #[tokio::test]
 async fn do_endpoint_discovery() {

--- a/aws/sdk/integration-tests/timestreamquery/tests/traffic.json
+++ b/aws/sdk/integration-tests/timestreamquery/tests/traffic.json
@@ -61,7 +61,6 @@
           "response": {
             "Ok": {
               "status": 200,
-              "version": "HTTP/1.1",
               "headers": {
                 "x-amzn-requestid": [
                   "fcfdab03-2bb8-45e9-a284-b789cf7efb63"
@@ -73,7 +72,7 @@
                   "Wed, 24 May 2023 15:51:07 GMT"
                 ],
                 "content-length": [
-                  "104"
+                  "102"
                 ]
               }
             }
@@ -165,7 +164,6 @@
           "response": {
             "Ok": {
               "status": 200,
-              "version": "HTTP/1.1",
               "headers": {
                 "content-type": [
                   "application/x-amz-json-1.0"
@@ -246,13 +244,12 @@
           "response": {
             "Ok": {
               "status": 200,
-              "version": "HTTP/1.1",
               "headers": {
                 "content-type": [
                   "application/x-amz-json-1.0"
                 ],
                 "content-length": [
-                  "104"
+                  "102"
                 ],
                 "date": [
                   "Wed, 24 May 2023 15:51:07 GMT"
@@ -361,7 +358,6 @@
           "response": {
             "Ok": {
               "status": 200,
-              "version": "HTTP/1.1",
               "headers": {
                 "content-type": [
                   "application/x-amz-json-1.0"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.1.8"
+version = "1.2.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-client = ["aws-smithy-runtime-api/client"]
+client = ["aws-smithy-runtime-api/client", "aws-smithy-types/http-body-1-x"]
 http-auth = ["aws-smithy-runtime-api/http-auth"]
 connector-hyper-0-14-x = ["dep:hyper-0-14", "hyper-0-14?/client", "hyper-0-14?/http2", "hyper-0-14?/http1", "hyper-0-14?/tcp", "hyper-0-14?/stream", "dep:h2"]
 tls-rustls = ["dep:hyper-rustls", "dep:rustls", "connector-hyper-0-14-x"]
@@ -31,6 +31,7 @@ fastrand = "2.0.0"
 h2 = { version = "0.3", default-features = false, optional = true }
 http = { version = "0.2.8" }
 http-body-0-4 = { package = "http-body", version = "0.4.4" }
+http-body-1 = { package = "http-body", version = "1" }
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, optional = true }
 hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
 once_cell = "1.18.0"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -17,7 +17,7 @@ tls-rustls = ["dep:hyper-rustls", "dep:rustls", "connector-hyper-0-14-x"]
 rt-tokio = ["tokio/rt"]
 
 # Features for testing
-test-util = ["aws-smithy-runtime-api/test-util", "dep:aws-smithy-protocol-test", "dep:tracing-subscriber", "dep:serde", "dep:serde_json"]
+test-util = ["aws-smithy-runtime-api/test-util", "dep:aws-smithy-protocol-test", "dep:tracing-subscriber", "dep:serde", "dep:serde_json", "dep:indexmap"]
 wire-mock = ["test-util", "connector-hyper-0-14-x", "hyper-0-14?/server"]
 
 [dependencies]
@@ -39,7 +39,8 @@ pin-project-lite = "0.2.7"
 pin-utils = "0.1.0"
 rustls = { version = "0.21.8", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
+serde_json = { version = "1", features = ["preserve_order"], optional = true }
+indexmap = { version = "2", optional = true, features = ["serde"] }
 tokio = { version = "1.25", features = [] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["fmt", "json"] }

--- a/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
@@ -9,6 +9,7 @@
 //! for _your_ client, since many things can change these defaults on the way to
 //! code generating and constructing a full client.
 
+use crate::client::http::body::content_length_enforcement::EnforceContentLengthRuntimePlugin;
 use crate::client::identity::IdentityCache;
 use crate::client::retries::strategy::StandardRetryStrategy;
 use crate::client::retries::RetryPartition;
@@ -191,6 +192,10 @@ pub fn default_stalled_stream_protection_config_plugin() -> Option<SharedRuntime
     )
 }
 
+fn enforce_content_length_runtime_plugin() -> Option<SharedRuntimePlugin> {
+    Some(EnforceContentLengthRuntimePlugin::new().into_shared())
+}
+
 fn validate_stalled_stream_protection_config(
     components: &RuntimeComponentsBuilder,
     cfg: &ConfigBag,
@@ -264,6 +269,7 @@ pub fn default_plugins(
         default_time_source_plugin(),
         default_timeout_config_plugin(),
         default_stalled_stream_protection_config_plugin(),
+        enforce_content_length_runtime_plugin(),
     ]
     .into_iter()
     .flatten()

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body.rs
@@ -3,4 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pub mod content_length_enforcement;
 pub mod minimum_throughput;

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
@@ -1,0 +1,249 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! RuntimePlugin to ensure that the amount of data received matches the `Content-Length` header
+
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::runtime_components::{
+    RuntimeComponents, RuntimeComponentsBuilder,
+};
+use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::config_bag::ConfigBag;
+use bytes::Buf;
+use http_body_1::{Frame, SizeHint};
+use pin_project_lite::pin_project;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+pin_project! {
+    /// A body-wrapper that will calculate the `InnerBody`'s checksum and emit it as a trailer.
+    pub struct ContentLengthEnforcingBody<InnerBody> {
+            #[pin]
+            body: InnerBody,
+            expected_length: u64,
+            remaining_length: i64,
+    }
+}
+
+/// An error returned when a body did not have the expected content length
+#[derive(Debug)]
+pub struct ContentLengthError {
+    expected: u64,
+    received: u64,
+}
+
+impl Error for ContentLengthError {}
+
+impl Display for ContentLengthError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Invalid Content-Length: Expected {} bytes but {} bytes were received",
+            self.expected, self.received
+        )
+    }
+}
+
+impl ContentLengthEnforcingBody<SdkBody> {
+    /// Wraps an existing [`SdkBody`] in a content-length enforcement layer
+    pub fn wrap(body: SdkBody, content_length: u64) -> SdkBody {
+        body.map_preserve_contents(move |b| {
+            SdkBody::from_body_1_x(ContentLengthEnforcingBody {
+                body: b,
+                expected_length: content_length,
+                remaining_length: content_length as i64,
+            })
+        })
+    }
+}
+
+impl<
+        E: Into<aws_smithy_types::body::Error>,
+        Data: Buf,
+        InnerBody: http_body_1::Body<Error = E, Data = Data>,
+    > http_body_1::Body for ContentLengthEnforcingBody<InnerBody>
+{
+    type Data = Data;
+    type Error = aws_smithy_types::body::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.as_mut().project();
+        match ready!(this.body.poll_frame(cx)) {
+            None => {
+                if *this.remaining_length == 0 {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Ready(Some(Err(ContentLengthError {
+                        expected: *this.expected_length,
+                        received: (*this.expected_length as i64 - *this.remaining_length) as u64,
+                    }
+                    .into())))
+                }
+            }
+            Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
+            Some(Ok(frame)) => {
+                if let Some(data) = frame.data_ref() {
+                    *this.remaining_length -= data.remaining() as i64;
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.body.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.body.size_hint()
+    }
+}
+
+#[derive(Debug, Default)]
+struct EnforceContentLengthInterceptor {}
+
+impl Intercept for EnforceContentLengthInterceptor {
+    fn name(&self) -> &'static str {
+        "EnforceContentLength"
+    }
+
+    fn modify_before_deserialization(
+        &self,
+        context: &mut BeforeDeserializationInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let Some(content_length) = context.response().headers().get("content-length") else {
+            tracing::trace!("No content length header was set. Will not validate content length");
+            return Ok(());
+        };
+
+        let Ok(content_length) = content_length.parse::<u64>() else {
+            tracing::warn!(
+                "Content length was not a valid integer: {:?}",
+                content_length
+            );
+            return Ok(());
+        };
+
+        let body = context.response_mut().take_body();
+        let wrapped = body.map_preserve_contents(move |body| {
+            ContentLengthEnforcingBody::wrap(body, content_length)
+        });
+        *context.response_mut().body_mut() = wrapped;
+        Ok(())
+    }
+}
+
+/// Runtime plugin that enforces response bodies match their expected content length
+#[derive(Debug, Default)]
+pub struct EnforceContentLengthRuntimePlugin {}
+
+impl EnforceContentLengthRuntimePlugin {
+    /// Creates a runtime plugin which installs Content-Length enforcement middleware for response bodies
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl RuntimePlugin for EnforceContentLengthRuntimePlugin {
+    fn runtime_components(
+        &self,
+        _current_components: &RuntimeComponentsBuilder,
+    ) -> Cow<'_, RuntimeComponentsBuilder> {
+        Cow::Owned(
+            RuntimeComponentsBuilder::new("EnforceContentLength")
+                .with_interceptor(EnforceContentLengthInterceptor {}),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::assert_str_contains;
+    use crate::client::http::body::content_length_enforcement::ContentLengthEnforcingBody;
+    use aws_smithy_types::body::SdkBody;
+    use aws_smithy_types::byte_stream::ByteStream;
+    use aws_smithy_types::error::display::DisplayErrorContext;
+    use bytes::Bytes;
+    use http_body_0_4::Body;
+    use http_body_1::Frame;
+    use std::error::Error;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    /// Body for tests so we ensure our code works on a body split across multiple frames
+    struct ManyFrameBody {
+        data: Vec<u8>,
+    }
+
+    impl ManyFrameBody {
+        fn new(input: impl Into<String>) -> SdkBody {
+            let mut data = input.into().as_bytes().to_vec();
+            data.reverse();
+            SdkBody::from_body_1_x(Self { data })
+        }
+    }
+
+    impl http_body_1::Body for ManyFrameBody {
+        type Data = Bytes;
+        type Error = <SdkBody as Body>::Error;
+
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            match self.data.pop() {
+                Some(next) => Poll::Ready(Some(Ok(Frame::data(Bytes::from(vec![next]))))),
+                None => Poll::Ready(None),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_too_short() {
+        let body = ManyFrameBody::new("123");
+        let enforced = ContentLengthEnforcingBody::wrap(body, 10);
+        let err = expect_body_error(enforced).await;
+        assert_str_contains!(
+            format!("{}", DisplayErrorContext(err)),
+            "Expected 10 bytes but 3 bytes were received"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_too_long() {
+        let body = ManyFrameBody::new("abcdefghijk");
+        let enforced = ContentLengthEnforcingBody::wrap(body, 5);
+        let err = expect_body_error(enforced).await;
+        assert_str_contains!(
+            format!("{}", DisplayErrorContext(err)),
+            "Expected 5 bytes but 11 bytes were received"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_just_right() {
+        let body = ManyFrameBody::new("abcdefghijk");
+        let enforced = ContentLengthEnforcingBody::wrap(body, 11);
+        let data = enforced.collect().await.unwrap().to_bytes();
+        assert_eq!(b"abcdefghijk", data.as_ref());
+    }
+
+    async fn expect_body_error(body: SdkBody) -> impl Error {
+        ByteStream::new(body)
+            .collect()
+            .await
+            .expect_err("body should have failed")
+    }
+}

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
@@ -182,7 +182,7 @@ impl RuntimePlugin for EnforceContentLengthRuntimePlugin {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "test-util", test))]
 mod test {
     use crate::assert_str_contains;
     use crate::client::http::body::content_length_enforcement::{

--- a/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr.rs
@@ -43,12 +43,9 @@ impl NetworkTraffic {
     pub fn correct_content_lengths(&mut self) {
         let mut content_lengths: HashMap<(ConnectionId, Direction), usize> = HashMap::new();
         for event in &self.events {
-            match &event.action {
-                Action::Data { data, direction } => {
-                    let entry = content_lengths.entry((event.connection_id, *direction));
-                    *entry.or_default() += data.copy_to_vec().len();
-                }
-                _ => {}
+            if let Action::Data { data, direction } = &event.action {
+                let entry = content_lengths.entry((event.connection_id, *direction));
+                *entry.or_default() += data.copy_to_vec().len();
             }
         }
         for event in &mut self.events {

--- a/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr.rs
@@ -144,7 +144,7 @@ impl From<&Request> for http::Request<()> {
 impl<'a> From<&'a HttpRequest> for Request {
     fn from(req: &'a HttpRequest) -> Self {
         let uri = req.uri().to_string();
-        let headers = headers_to_map_http(req.headers()).into();
+        let headers = headers_to_map_http(req.headers());
         let method = req.method().to_string();
         Self {
             uri,

--- a/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr.rs
@@ -14,8 +14,10 @@ use aws_smithy_runtime_api::http::Headers;
 use aws_smithy_types::base64;
 use bytes::Bytes;
 use http::HeaderMap;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::Path;
 
 mod record;
 mod replay;
@@ -37,6 +39,18 @@ impl NetworkTraffic {
     /// Network events
     pub fn events(&self) -> &Vec<Event> {
         &self.events
+    }
+
+    /// Create a NetworkTraffic instance from a file
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, Box<dyn std::error::Error>> {
+        let contents = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&contents)?)
+    }
+
+    /// Create a NetworkTraffic instance from a file
+    pub fn write_to_file(&self, path: impl AsRef<Path>) -> Result<(), Box<dyn std::error::Error>> {
+        let serialized = serde_json::to_string_pretty(&self)?;
+        Ok(std::fs::write(path, serialized)?)
     }
 
     /// Update the network traffic with all `content-length` fields fixed to match the contents
@@ -101,7 +115,7 @@ pub struct Event {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Request {
     uri: String,
-    headers: HashMap<String, Vec<String>>,
+    headers: IndexMap<String, Vec<String>>,
     method: String,
 }
 
@@ -112,7 +126,7 @@ pub struct Request {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Response {
     status: u16,
-    headers: HashMap<String, Vec<String>>,
+    headers: IndexMap<String, Vec<String>>,
 }
 
 impl From<&Request> for http::Request<()> {
@@ -130,7 +144,7 @@ impl From<&Request> for http::Request<()> {
 impl<'a> From<&'a HttpRequest> for Request {
     fn from(req: &'a HttpRequest) -> Self {
         let uri = req.uri().to_string();
-        let headers = headers_to_map_http(req.headers());
+        let headers = headers_to_map_http(req.headers()).into();
         let method = req.method().to_string();
         Self {
             uri,
@@ -140,8 +154,8 @@ impl<'a> From<&'a HttpRequest> for Request {
     }
 }
 
-fn headers_to_map_http(headers: &Headers) -> HashMap<String, Vec<String>> {
-    let mut out: HashMap<_, Vec<_>> = HashMap::new();
+fn headers_to_map_http(headers: &Headers) -> IndexMap<String, Vec<String>> {
+    let mut out: IndexMap<_, Vec<_>> = IndexMap::new();
     for (header_name, header_value) in headers.iter() {
         let entry = out.entry(header_name.to_string()).or_default();
         entry.push(header_value.to_string());
@@ -149,8 +163,8 @@ fn headers_to_map_http(headers: &Headers) -> HashMap<String, Vec<String>> {
     out
 }
 
-fn headers_to_map_02x(headers: &HeaderMap) -> HashMap<String, Vec<String>> {
-    let mut out: HashMap<_, Vec<_>> = HashMap::new();
+fn headers_to_map_02x(headers: &HeaderMap) -> IndexMap<String, Vec<String>> {
+    let mut out: IndexMap<_, Vec<_>> = IndexMap::new();
     for (header_name, header_value) in headers.iter() {
         let entry = out.entry(header_name.to_string()).or_default();
         entry.push(
@@ -162,8 +176,8 @@ fn headers_to_map_02x(headers: &HeaderMap) -> HashMap<String, Vec<String>> {
     out
 }
 
-fn headers_to_map(headers: &Headers) -> HashMap<String, Vec<String>> {
-    let mut out: HashMap<_, Vec<_>> = HashMap::new();
+fn headers_to_map(headers: &Headers) -> IndexMap<String, Vec<String>> {
+    let mut out: IndexMap<_, Vec<_>> = IndexMap::new();
     for (header_name, header_value) in headers.iter() {
         let entry = out.entry(header_name.to_string()).or_default();
         entry.push(


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
There is a rarely-triggered bug (https://github.com/awslabs/aws-sdk-rust/issues/1079) that can occur when the runtime is dropped between requests. Although this is definitely the _wrong thing to do_(tm) which should still aim to at least protect the users from bad data in this case.

This adds an interceptor which validates that the body returned is the correct length.

## Description
- Adds an interceptor that computes the actual content length of the body and compares it to the actual length

## Testing
- Integration style test. Note that this is very hard to test using Hyper because Hyper will attempt to mitigate this issue.


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
