### PR TITLE
Fix invalid XML root in S3 GetObjectRetention

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,3 +22,9 @@ message = "`DefaultS3ExpressIdentityProvider` now uses `BehaviorVersion` threade
 references = ["smithy-rs#3478"]
 meta = { "breaking" = false, "bug" = true, "tada" = false }
 author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "Fix invalid XML root response parsing error in S3 GetObjectRetention."
+references = ["smithy-rs#3492", "aws-sdk-rust#1065"]
+meta = { "breaking" = false, "bug" = true, "tada" = false }
+author = "jdisanti"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
@@ -58,6 +58,13 @@ class S3Decorator : ClientCodegenDecorator {
             ShapeId.from("com.amazonaws.s3#GetObjectAttributesOutput"),
             // API returns ListAllMyDirectoryBucketsResult instead of ListDirectoryBucketsOutput
             ShapeId.from("com.amazonaws.s3#ListDirectoryBucketsOutput"),
+            // API returns Retention instead of ObjectLockRetention
+            //
+            // This one is slightly weirder than the others in that it is not the output struct that is wrong,
+            // but rather, the @httpPayload member inside the output struct.
+            //
+            // https://github.com/awslabs/aws-sdk-rust/issues/1065
+            ShapeId.from("com.amazonaws.s3#ObjectLockRetention"),
         )
 
     override fun protocols(

--- a/aws/sdk/integration-tests/s3/tests/get_object_retention.json
+++ b/aws/sdk/integration-tests/s3/tests/get_object_retention.json
@@ -1,0 +1,83 @@
+{
+  "events": [
+    {
+      "connection_id": 0,
+      "action": {
+        "Request": {
+          "request": {
+            "uri": "https://test-bucket.s3.us-west-2.amazonaws.com/mathematics-bacon.png?retention",
+            "headers": {
+              "x-amz-date": [
+                "20090213T233130Z"
+              ],
+              "authorization": [
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, Signature=5893afca42a80e68a85dba55a09d961176624750d9a0f59b2fd7eece2005412f"
+              ]
+            },
+            "method": "GET"
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Response": {
+          "response": {
+            "Ok": {
+              "status": 200,
+              "headers": {
+                "x-amz-id-2": [
+                  "some-extended-request-id"
+                ],
+                "date": [
+                  "Thu, 14 Mar 2024 23:16:30 GMT"
+                ],
+                "transfer-encoding": [
+                  "chunked"
+                ],
+                "server": [
+                  "AmazonS3"
+                ],
+                "x-amz-request-id": [
+                  "some-request-id"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>GOVERNANCE</Mode><RetainUntilDate>2024-03-28T07:00:00.000Z</RetainUntilDate></Retention>"
+          },
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Response"
+        }
+      }
+    }
+  ],
+  "docs": "test data for get_object_retention.rs",
+  "version": "V0"
+}

--- a/aws/sdk/integration-tests/s3/tests/get_object_retention.rs
+++ b/aws/sdk/integration-tests/s3/tests/get_object_retention.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_sdk_s3::types::ObjectLockRetentionMode;
+use aws_smithy_runtime::client::http::test_util::dvr::ReplayingClient;
+
+/// Tests fix for https://github.com/awslabs/aws-sdk-rust/issues/1065
+///
+/// The @httpPayload "Retention" member of GetObjectRetentionOutput has
+/// the XML root "Retention" instead of "ObjectLockRetention".
+#[tokio::test]
+async fn test_get_object_retention() {
+    let http_client = ReplayingClient::from_file("tests/get_object_retention.json").unwrap();
+    let config = aws_sdk_s3::Config::builder()
+        .with_test_defaults()
+        .region(aws_sdk_s3::config::Region::from_static("us-west-2"))
+        .http_client(http_client.clone())
+        .build();
+    let s3 = aws_sdk_s3::Client::from_conf(config);
+
+    let result = s3
+        .get_object_retention()
+        .bucket("test-bucket")
+        .key("mathematics-bacon.png")
+        .send()
+        .await
+        .expect("should succeed");
+    assert_eq!(
+        ObjectLockRetentionMode::Governance,
+        result.retention.unwrap().mode.unwrap()
+    );
+    http_client
+        .validate_body_and_headers(None, "application/xml")
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
This PR fixes the invalid XML root issue reported in https://github.com/awslabs/aws-sdk-rust/issues/1065.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
