### PR TITLE
Update Pokémon models to Smithy IDL v2

### DIFF
--- a/codegen-core/common-test-models/pokemon-awsjson.smithy
+++ b/codegen-core/common-test-models/pokemon-awsjson.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2"
 
 // TODO(https://github.com/smithy-lang/smithy-rs/issues/2215)
 // This is a temporary model to test AwsJson 1.0 with @streaming.
@@ -17,80 +17,78 @@ use com.aws.example#CheckHealth
 @title("Pokémon Service")
 @awsJson1_0
 service PokemonService {
-    version: "2021-12-01",
+    version: "2024-03-18"
     operations: [
-        GetServerStatistics,
-        DoNothing,
-        CapturePokemon,
+        GetServerStatistics
+        DoNothing
+        CapturePokemon
         CheckHealth
-    ],
+    ]
 }
 
 /// Capture Pokémons via event streams.
 operation CapturePokemon {
-    input: CapturePokemonEventsInput,
-    output: CapturePokemonEventsOutput,
-    errors: [UnsupportedRegionError, ThrottlingError, ValidationException]
-}
-
-@input
-structure CapturePokemonEventsInput {
-    events: AttemptCapturingPokemonEvent,
-}
-
-@output
-structure CapturePokemonEventsOutput {
-    events: CapturePokemonEvents,
+    input := {
+        events: AttemptCapturingPokemonEvent
+    }
+    output := {
+        events: CapturePokemonEvents
+    }
+    errors: [
+        UnsupportedRegionError
+        ThrottlingError
+        ValidationException
+    ]
 }
 
 @streaming
 union AttemptCapturingPokemonEvent {
-    event: CapturingEvent,
-    masterball_unsuccessful: MasterBallUnsuccessful,
+    event: CapturingEvent
+    masterball_unsuccessful: MasterBallUnsuccessful
 }
 
 structure CapturingEvent {
     @eventPayload
-    payload: CapturingPayload,
+    payload: CapturingPayload
 }
 
 structure CapturingPayload {
-    name: String,
-    pokeball: String,
+    name: String
+    pokeball: String
 }
 
 @streaming
 union CapturePokemonEvents {
-    event: CaptureEvent,
-    invalid_pokeball: InvalidPokeballError,
-    throttlingError: ThrottlingError,
+    event: CaptureEvent
+    invalid_pokeball: InvalidPokeballError
+    throttlingError: ThrottlingError
 }
 
 structure CaptureEvent {
     @eventHeader
-    name: String,
+    name: String
     @eventHeader
-    captured: Boolean,
+    captured: Boolean
     @eventHeader
-    shiny: Boolean,
+    shiny: Boolean
     @eventPayload
-    pokedex_update: Blob,
+    pokedex_update: Blob
 }
 
 @error("server")
 structure UnsupportedRegionError {
     @required
-    region: String,
+    region: String
 }
 
 @error("client")
 structure InvalidPokeballError {
     @required
-    pokeball: String,
+    pokeball: String
 }
 @error("server")
 structure MasterBallUnsuccessful {
-    message: String,
+    message: String
 }
 
 @error("client")

--- a/codegen-core/common-test-models/pokemon-common.smithy
+++ b/codegen-core/common-test-models/pokemon-common.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2"
 
 namespace com.aws.example
 
@@ -9,53 +9,44 @@ use smithy.framework#ValidationException
 resource PokemonSpecies {
     identifiers: {
         name: String
-    },
-    read: GetPokemonSpecies,
+    }
+    read: GetPokemonSpecies
 }
 
 /// Retrieve information about a Pokémon species.
 @readonly
 @http(uri: "/pokemon-species/{name}", method: "GET")
 operation GetPokemonSpecies {
-    input: GetPokemonSpeciesInput,
-    output: GetPokemonSpeciesOutput,
-    errors: [ResourceNotFoundException, ValidationException],
-}
+    input := {
+        @required
+        @httpLabel
+        name: String
+    }
+    output := {
+        /// The name for this resource.
+        @required
+        name: String
 
-@input
-structure GetPokemonSpeciesInput {
-    @required
-    @httpLabel
-    name: String
-}
-
-@output
-structure GetPokemonSpeciesOutput {
-    /// The name for this resource.
-    @required
-    name: String,
-
-    /// A list of flavor text entries for this Pokémon species.
-    @required
-    flavorTextEntries: FlavorTextEntries
+        /// A list of flavor text entries for this Pokémon species.
+        @required
+        flavorTextEntries: FlavorTextEntries
+    }
+    errors: [
+        ResourceNotFoundException
+        ValidationException
+    ]
 }
 
 /// Retrieve HTTP server statistiscs, such as calls count.
 @readonly
 @http(uri: "/stats", method: "GET")
 operation GetServerStatistics {
-    input: GetServerStatisticsInput,
-    output: GetServerStatisticsOutput,
-}
-
-@input
-structure GetServerStatisticsInput { }
-
-@output
-structure GetServerStatisticsOutput {
-    /// The number of calls executed by the server.
-    @required
-    calls_count: Long,
+    input := {}
+    output := {
+        /// The number of calls executed by the server.
+        @required
+        calls_count: Long
+    }
 }
 
 list FlavorTextEntries {
@@ -65,51 +56,32 @@ list FlavorTextEntries {
 structure FlavorText {
     /// The localized flavor text for an API resource in a specific language.
     @required
-    flavorText: String,
+    flavorText: String
 
     /// The language this name is in.
     @required
-    language: Language,
+    language: Language
 }
 
 /// Supported languages for FlavorText entries.
-@enum([
-    {
-        name: "ENGLISH",
-        value: "en",
-        documentation: "American English.",
-    },
-    {
-        name: "SPANISH",
-        value: "es",
-        documentation: "Español.",
-    },
-    {
-        name: "ITALIAN",
-        value: "it",
-        documentation: "Italiano.",
-    },
-    {
-        name: "JAPANESE",
-        value: "jp",
-        documentation: "日本語。",
-    },
-])
-string Language
+enum Language {
+    /// American English.
+    ENGLISH = "en"
+    /// Español.
+    SPANISH = "es"
+    /// Italiano.
+    ITALIAN = "it"
+    /// 日本語。
+    JAPANESE = "jp"
+}
 
 /// DoNothing operation, used to stress test the framework.
 @readonly
 @http(uri: "/do-nothing", method: "GET")
 operation DoNothing {
-    input: DoNothingInput,
-    output: DoNothingOutput,
+    input := {}
+    output := {}
 }
-
-@input
-structure DoNothingInput { }
-
-@output
-structure DoNothingOutput { }
 
 /// Health check operation, to check the service is up
 /// Not yet a deep check
@@ -122,5 +94,5 @@ operation CheckHealth {
 @httpError(404)
 structure ResourceNotFoundException {
     @required
-    message: String,
+    message: String
 }


### PR DESCRIPTION
## Motivation and Context
Resolves [issue 2523](https://github.com/smithy-lang/smithy-rs/issues/2523) to migrate to Smithy IDL v2

## Description

I followed the [Smithy Migration Guide](https://smithy.io/2.0/guides/model-translations/migrating-idl-1-to-2.html) to convert the models. One change was that by moving the inputs/outputs into the operation, it did result in a renaming of the CapturePokemon structures. They went from CapturePokemonEvents(Input|Output) to CapturePokemon(Input|Output). From a brief look at the commit history, it seems the API used to be named different and the inputs/outputs weren't renamed at that time. So I decided to have them match the normal naming convention (it didn't seem to break any tests).

## Testing
As this was my first commit, I ran almost every target I could discover, but I think the key ones were:
* codegen-server-test
* codegen-client-test
* examples: `make test`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
