### PR TITLE
Update GitHub actions to fix deprecation warning

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     name: Gradle Cache
     with:
       path: |
@@ -24,8 +24,8 @@ runs:
       key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/caches/**/*', 'gradle/wrapper/**/*') }}
       restore-keys: |
         ${{ runner.os }}-gradle-
-    # Pinned to the commit hash of v2.1.0
-  - uses: Swatinem/rust-cache@b894d59a8d236e2979b247b80dac8d053ab340dd
+    # Pinned to the commit hash of v2.7.3
+  - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:
       shared-key: ${{ runner.os }}-${{ github.job }}
       workspaces: |
@@ -60,7 +60,7 @@ runs:
       ./smithy-rs/tools/ci-build/ci-action ${{ inputs.action }} ${{ inputs.action-arguments}}
       tar cfz artifacts-${{ inputs.action }}.tar.gz -C artifacts .
   - name: Upload artifacts
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: artifacts-${{ inputs.action }}
       path: artifacts-${{ inputs.action }}.tar.gz

--- a/.github/actions/download-all-artifacts/action.yml
+++ b/.github/actions/download-all-artifacts/action.yml
@@ -7,7 +7,7 @@ runs:
   using: composite
   steps:
   - name: Download artifacts
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
   - name: Untar artifacts
     shell: bash
     run: find . -maxdepth 2 -iname 'artifacts-*.tar.gz' -print -exec tar xfz {} \;

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Acquire credentials
-      uses: aws-actions/configure-aws-credentials@v2.2.0
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Acquire credentials
       uses: aws-actions/configure-aws-credentials@v2.2.0
       with:

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -58,7 +58,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
     - name: Acquire base image

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Attempt to load a docker login password
-      uses: aws-actions/configure-aws-credentials@v2.2.0
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions
@@ -67,7 +67,7 @@ jobs:
         DOCKER_BUILDKIT: 1
       run: ./smithy-rs/.github/scripts/acquire-build-image
     - name: Acquire credentials
-      uses: aws-actions/configure-aws-credentials@v2.2.0
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions

--- a/.github/workflows/ci-pr-forks.yml
+++ b/.github/workflows/ci-pr-forks.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name != 'smithy-lang/smithy-rs' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
     - name: Acquire base image
@@ -30,7 +30,7 @@ jobs:
         DOCKER_BUILDKIT: 1
       run: ./smithy-rs/.github/scripts/acquire-build-image
     - name: Upload base image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: smithy-rs-base-image
         path: smithy-rs-base-image

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -60,7 +60,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
     - name: Acquire base image
@@ -121,7 +121,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Attempt to load a docker login password
-      uses: aws-actions/configure-aws-credentials@v2.2.0
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions
@@ -69,7 +69,7 @@ jobs:
         DOCKER_BUILDKIT: 1
       run: ./smithy-rs/.github/scripts/acquire-build-image
     - name: Acquire credentials
-      uses: aws-actions/configure-aws-credentials@v2.2.0
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions
@@ -127,7 +127,7 @@ jobs:
         ref: ${{ inputs.git_ref }}
     - name: Get PR info
       id: check-breaking-label
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const response = await github.rest.pulls.get({

--- a/.github/workflows/ci-tls.yml
+++ b/.github/workflows/ci-tls.yml
@@ -29,21 +29,21 @@ jobs:
     - name: Stop nginx
       run: sudo systemctl stop nginx
     - name: Checkout smithy-rs
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ./smithy-rs
     - name: Checkout trytls
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ouspg/trytls
         path: ./trytls
     - name: Checkout badtls
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: wbond/badtls.io
         path: ./badtls.io
     - name: Checkout badssl
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: chromium/badssl.com
         path: ./badssl.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,17 @@ jobs:
         - action: generate-aws-sdk-smoketest
         - action: generate-smithy-rs-release
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.git_ref }}
     # The models from aws-sdk-rust are needed to generate the full SDK for CI
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: awslabs/aws-sdk-rust
         path: aws-sdk-rust
     # The examples from aws-doc-sdk-examples are needed to see if smithy-rs changes break examples
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: awsdocs/aws-doc-sdk-examples
         path: aws-doc-sdk-examples
@@ -116,7 +116,7 @@ jobs:
         - action: check-deterministic-codegen
           runner: smithy_ubuntu-latest_8-core
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.git_ref }}
@@ -155,7 +155,7 @@ jobs:
         - action: check-aws-sdk-standalone-integration-tests
           runner: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.git_ref }}
@@ -175,11 +175,11 @@ jobs:
       RUSTDOCFLAGS: -D warnings
       RUSTFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.git_ref }}
-      # Pinned to the commit hash of v2.1.0
-    - uses: Swatinem/rust-cache@b894d59a8d236e2979b247b80dac8d053ab340dd
+      # Pinned to the commit hash of v2.7.3
+    - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
       with:
         shared-key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
         workspaces: |
@@ -234,11 +234,11 @@ jobs:
       CROSS_CONFIG: Cross.toml
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.git_ref }}
-      # Pinned to the commit hash of v2.1.0
-    - uses: Swatinem/rust-cache@b894d59a8d236e2979b247b80dac8d053ab340dd
+      # Pinned to the commit hash of v2.7.3
+    - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
       with:
         shared-key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ matrix.target }}
         workspaces: |
@@ -302,7 +302,7 @@ jobs:
     needs: generate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Main branch check
       if: ${{ github.ref_name != 'main' }}
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           core.setFailed("This workflow can only be ran on main (current branch: ${{ github.ref_name }})")

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -39,7 +39,7 @@ jobs:
     - main-branch-check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
       id: acquire
       run: ./smithy-rs/.github/scripts/acquire-build-image
     - name: Upload base image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: smithy-rs-base-image
         path: smithy-rs-base-image
@@ -65,11 +65,11 @@ jobs:
       with:
         toolchain: ${{ env.rust_version }}
     - name: Checkout smithy-rs
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Publish to crates.io
       shell: bash
       env:
-         CARGO_REGISTRY_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
       run: |
         cargo install --path tools/ci-build/publisher
         # Verify the publisher tool installed successfully

--- a/.github/workflows/credentials-verification.yml
+++ b/.github/workflows/credentials-verification.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout smithy-rs
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Verify Crates.io Token
       shell: bash
       env:
@@ -38,7 +38,7 @@ jobs:
     steps:
     - name: Checkout smithy-rs
         # To test the validity of the personal access token, we only need to perform checkout with the specified token.
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
     - name: Notify Slack on Failure

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -42,7 +42,7 @@ jobs:
     - get-pr-info
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         # The ref used needs to match the HEAD revision of the PR being diffed, or else
@@ -55,7 +55,7 @@ jobs:
       id: acquire
       run: ./smithy-rs/.github/scripts/acquire-build-image
     - name: Upload base image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: smithy-rs-base-image
         path: smithy-rs-base-image

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Get PR info
       id: get-pr-info
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const response = await github.rest.pulls.get({

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -46,7 +46,7 @@ jobs:
     outputs:
       bot-message: ${{ steps.generate-diff.outputs.bot-message }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.head_revision }}
@@ -81,8 +81,8 @@ jobs:
     outputs:
       bot-message: ${{ steps.generate-preview.outputs.bot-message }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       name: Gradle Cache
       with:
         path: |
@@ -147,7 +147,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
     - name: Download all artifacts

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         action: generate-codegen-diff
         action-arguments: ${{ inputs.base_revision }}
-    - uses: aws-actions/configure-aws-credentials@v2.2.0
+    - uses: aws-actions/configure-aws-credentials@v4
       name: Acquire credentials for uploading to S3
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}
@@ -93,7 +93,7 @@ jobs:
           ${{ runner.os }}-gradle-
       # JDK is needed to generate code
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: corretto
         java-package: jdk
@@ -126,7 +126,7 @@ jobs:
         ./tools/ci-scripts/generate-doc-preview-index.sh ${{ inputs.base_revision }}
 
         echo 'bot-message=A [new doc preview](https://d2luzm2xt3nokh.cloudfront.net/docs/'${{ inputs.head_revision }}'/index.html) is ready to view.' >> "${GITHUB_OUTPUT}"
-    - uses: aws-actions/configure-aws-credentials@v2.2.0
+    - uses: aws-actions/configure-aws-credentials@v4
       name: Acquire credentials for uploading to S3
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}
@@ -158,7 +158,7 @@ jobs:
         set -eux
         echo "codegen-diff=$(cat ./bot-message-codegen-diff)" >> "${GITHUB_OUTPUT}"
     - name: Post bot comment
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           await github.rest.issues.createComment({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       (needs.check-actor-for-prod-run.result == 'success' || needs.check-actor-for-prod-run.result == 'skipped')
     runs-on: smithy_ubuntu-latest_16-core
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.commit_sha }}
@@ -83,7 +83,7 @@ jobs:
       id: acquire
       run: ./smithy-rs/.github/scripts/acquire-build-image
     - name: Upload base image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: smithy-rs-base-image
         path: smithy-rs-base-image
@@ -108,12 +108,12 @@ jobs:
     if: always()
     runs-on: smithy_ubuntu-latest_8-core
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: smithy-rs
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: awslabs/aws-sdk-rust
         path: aws-sdk-rust
@@ -141,7 +141,7 @@ jobs:
       release_branch: ${{ steps.branch-push.outputs.release_branch }}
       new_release_series: ${{ steps.branch-push.outputs.new_release_series }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
@@ -173,7 +173,7 @@ jobs:
       release_branch: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
       commit_sha: ${{ steps.gradle-push.outputs.commit_sha }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
         path: smithy-rs
@@ -240,7 +240,7 @@ jobs:
       with:
         toolchain: ${{ env.rust_version }}
     - name: Checkout smithy-rs
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ needs.upgrade-gradle-properties.outputs.commit_sha }}
         path: smithy-rs
@@ -321,7 +321,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout smithy-rs
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
         path: smithy-rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
         fi
         echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
     - name: Tag release
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
         script: |

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out `smithy-rs`
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: smithy-lang/smithy-rs
         ref: ${{ inputs.generate_ref }}
         path: smithy-rs
     - name: Check out `aws-sdk-rust`
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: awslabs/aws-sdk-rust
         ref: main

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -36,7 +36,7 @@ jobs:
         path: aws-sdk-rust
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: corretto
         java-package: jdk


### PR DESCRIPTION
Our workflows used outdated actions and that was causing deprecation warnings for Node v16. Those annoyed me so I updated everything. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
