### PR TITLE
Fix `sigv4-s3express` position in `auth_scheme_options`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -38,3 +38,9 @@ Users may also ignore endpoint URLs sourced from the env and profile files:
 references = ["smithy-rs#3488"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 authors = ["Velfi"]
+
+[[aws-sdk-rust]]
+message = "Fix a bug where a `sigv4-s3express` auth scheme was incorrectly positioned at the front of `auth_scheme_options` and was used when no auth schemes were available for an endpoint."
+references = ["smithy-rs#3498"]
+meta = { "breaking" = false, "bug" = true, "tada" = false }
+author = "ysaito1001"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -39,6 +39,7 @@ import software.amazon.smithy.rust.codegen.core.util.hasEventStreamOperations
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
 import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
+import software.amazon.smithy.rustsdk.customize.s3.S3ExpressDecorator
 
 internal fun ClientCodegenContext.usesSigAuth(): Boolean =
     ServiceIndex.of(model).getEffectiveAuthSchemes(serviceShape).containsKey(SigV4Trait.ID) ||
@@ -61,7 +62,9 @@ class SigV4AuthDecorator : ConditionalDecorator(
     delegateTo =
         object : ClientCodegenDecorator {
             override val name: String get() = "SigV4AuthDecorator"
-            override val order: Byte = 0
+
+            // This decorator must decorate before S3ExpressDecorator so that sigv4 appears before sigv4-s3express within auth_scheme_options
+            override val order: Byte = (S3ExpressDecorator.ORDER + 1).toByte()
 
             private val sigv4a = "sigv4a"
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -39,7 +39,6 @@ import software.amazon.smithy.rust.codegen.core.util.hasEventStreamOperations
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
 import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
-import software.amazon.smithy.rustsdk.customize.s3.S3ExpressDecorator
 
 internal fun ClientCodegenContext.usesSigAuth(): Boolean =
     ServiceIndex.of(model).getEffectiveAuthSchemes(serviceShape).containsKey(SigV4Trait.ID) ||
@@ -62,9 +61,7 @@ class SigV4AuthDecorator : ConditionalDecorator(
     delegateTo =
         object : ClientCodegenDecorator {
             override val name: String get() = "SigV4AuthDecorator"
-
-            // This decorator must decorate before S3ExpressDecorator so that sigv4 appears before sigv4-s3express within auth_scheme_options
-            override val order: Byte = (S3ExpressDecorator.ORDER + 1).toByte()
+            override val order: Byte = ORDER
 
             private val sigv4a = "sigv4a"
 
@@ -124,7 +121,11 @@ class SigV4AuthDecorator : ConditionalDecorator(
                 }
             }
         },
-)
+) {
+    companion object {
+        const val ORDER: Byte = 0
+    }
+}
 
 private class SigV4SigningConfig(
     runtimeConfig: RuntimeConfig,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
@@ -36,7 +36,12 @@ import software.amazon.smithy.rustsdk.InlineAwsDependency
 
 class S3ExpressDecorator : ClientCodegenDecorator {
     override val name: String = "S3ExpressDecorator"
-    override val order: Byte = 0
+
+    companion object {
+        const val ORDER: Byte = 0
+    }
+
+    override val order: Byte = ORDER
 
     private fun sigv4S3Express(runtimeConfig: RuntimeConfig) =
         writable {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
@@ -38,10 +38,6 @@ import software.amazon.smithy.rustsdk.SigV4AuthDecorator
 class S3ExpressDecorator : ClientCodegenDecorator {
     override val name: String = "S3ExpressDecorator"
 
-    companion object {
-        const val ORDER: Byte = 0
-    }
-
     // This decorator must decorate after SigV4AuthDecorator so that sigv4 appears before sigv4-s3express within auth_scheme_options
     override val order: Byte = (SigV4AuthDecorator.ORDER - 1).toByte()
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
@@ -33,6 +33,7 @@ import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rustsdk.AwsCargoDependency
 import software.amazon.smithy.rustsdk.AwsRuntimeType
 import software.amazon.smithy.rustsdk.InlineAwsDependency
+import software.amazon.smithy.rustsdk.SigV4AuthDecorator
 
 class S3ExpressDecorator : ClientCodegenDecorator {
     override val name: String = "S3ExpressDecorator"
@@ -41,7 +42,8 @@ class S3ExpressDecorator : ClientCodegenDecorator {
         const val ORDER: Byte = 0
     }
 
-    override val order: Byte = ORDER
+    // This decorator must decorate after SigV4AuthDecorator so that sigv4 appears before sigv4-s3express within auth_scheme_options
+    override val order: Byte = (SigV4AuthDecorator.ORDER - 1).toByte()
 
     private fun sigv4S3Express(runtimeConfig: RuntimeConfig) =
         writable {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -30,7 +30,10 @@ interface CoreCodegenDecorator<CodegenContext, CodegenSettings> {
     val name: String
 
     /**
-     * Enable a deterministic ordering to be applied, with the lowest numbered integrations being applied first
+     * Enable a deterministic ordering to be applied
+     *
+     * Lowest numbered integrations are applied last since they are applied in reverse order of their positions
+     * in the list of decorators.
      */
     val order: Byte
 


### PR DESCRIPTION
## Motivation and Context
Fixes an S3-related bug introduced when s3 Express was added

## Description
This PR fixes a bug where s3 Express auth flow was incorrectly used when no auth schemes were available for an endpoint. This use case was observed in test settings and manifested itself as a confusing behavior.

To address this issue, the fix ensures that an auth scheme for S3 express will be registered after that for sigv4 has been registered.

## Testing
Added an integration test `s3_express_auth_flow_should_not_be_reached_with_no_auth_schemes`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
