### PR TITLE
Enable S3 Express canary by default

### DIFF
--- a/tools/ci-cdk/canary-lambda/src/latest/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/latest/s3_canary.rs
@@ -205,19 +205,6 @@ pub async fn s3_express_canary(
     client: s3::Client,
     s3_express_bucket_name: String,
 ) -> anyhow::Result<()> {
-    // TODO(Post S3Express release): Delete this once S3 Express has been released and its canary is on by default
-    match std::env::var("ENABLE_S3_EXPRESS_CANARY") {
-        Ok(value) if value.eq_ignore_ascii_case("true") => {
-            println!(
-                "`ENABLE_S3_EXPRESS_CANARY` is set to `true`, proceeding with s3 express canary"
-            );
-        }
-        _ => {
-            println!("`ENABLE_S3_EXPRESS_CANARY` is not set to `true`, skipping s3 express canary");
-            return Ok(());
-        }
-    }
-
     let test_key = Uuid::new_v4().as_u128().to_string();
 
     // Test a directory bucket exists

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -372,7 +372,7 @@ async fn create_lambda_fn(
 ) -> Result<()> {
     use lambda::types::*;
 
-    let mut env_builder = match &options.expected_speech_text_by_transcribe {
+    let env_builder = match &options.expected_speech_text_by_transcribe {
         Some(expected_speech_text_by_transcribe) => Environment::builder()
             .variables("RUST_BACKTRACE", "1")
             .variables("RUST_LOG", "info")
@@ -402,11 +402,6 @@ async fn create_lambda_fn(
                 &options.lambda_test_s3_express_bucket_name,
             ),
     };
-
-    // TODO(Post S3Express release): Delete this once S3 Express has been released and its canary is on by default
-    if let Ok(value) = env::var("ENABLE_S3_EXPRESS_CANARY") {
-        env_builder = env_builder.variables("ENABLE_S3_EXPRESS_CANARY", value);
-    }
 
     lambda_client
         .create_function()


### PR DESCRIPTION
## Motivation and Context
Now that canary [passed for the last three days](https://github.com/awslabs/aws-sdk-rust/actions/runs/8335320052), we can turn s3 express canary on by default.

## Testing
Verified internally that our release pipeline passes canary with s3 express canary enabled.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
