### PR TITLE
Add empty workflow for running canary in `aws-sdk-rust` from `smithy-rs` CI

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Canary
+on:
+  workflow_dispatch:
+
+jobs:
+  canary:
+    name: Canary
+    runs-on: ubuntu-latest
+    steps:
+    - name: Invoke canary in aws-sdk-rust
+      run: echo "Hello World"


### PR DESCRIPTION
## Motivation and Context
Add a skeletal workflow file for later invoking canary in `aws-sdk-rust` from within `smithy-rs` CI. GitHub actions do not allow us to manually trigger them unless they are first checked-in to the main branch.

(**Disclaimer**: we may end up executing `canary-runner` from a smithy-rs CI step without invoking canary in `aws-sdk-rust`, but for the sake of illustration, assume we invoke canary in `aws-sdk-rust` for the rest of the PR description)

## Description
To briefly explain where we're going, a diagram below illustrates how relevant workflow files look like when we run canary in `smithy-rs` CI (in the context of this PR, it will check-in a file that says `canary.yml` in red).

<p align="center">
<img width="600" alt="Screen Shot 2023-02-08 at 3 47 05 PM" src="https://github.com/smithy-lang/smithy-rs/assets/15333866/4a336f7b-8d41-42e4-b59d-4aa87ab91093">
</p>

We will add a new CI step that runs canary in `aws-sdk-rust` from within `smithy-rs`. It will work when run as part of `cr-pr.yml` but it won't when run from `cr-pr-forks.yml` (i.e. for external contributors) because their forked repos do not have a necessary repository secret to invoke canary in `aws-sdk-rust`. To work around, we will manually run `smithy-lang/smithy-rs/.github/workflows/canary.yml` on their behalf with the name of a fork and a commit hash.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
