### PR TITLE
Allow artifacts of the same name to be overwritten

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -66,3 +66,4 @@ runs:
       path: artifacts-${{ inputs.action }}.tar.gz
       if-no-files-found: error
       retention-days: 3
+      overwrite: true


### PR DESCRIPTION
## Motivation and Context


## Description
After [upgrading to actions/upload-artifact@v4](https://github.com/smithy-lang/smithy-rs/pull/3497), it seems to have brought a behavior change where an artifact with the same name is [disallowed by default](https://github.com/smithy-lang/smithy-rs/actions/runs/8423689643/job/23067178393#step:4:639) within a workflow run.

This happened during a [release](https://github.com/smithy-lang/smithy-rs/blob/main/.github/workflows/release.yml) workflow where it first invoked ci.yml (which then called `generate-smithy-rs-release` and created an artifact with that action name) and then called `generate-smithy-rs-release` by itself (attempted to create an artifact with that action name again, leading to the error above). This was not a problem previously when we were using `actions/upload-artifact@v3`.

This PR explicitly sets `overwrite: true` to bring back the old behavior for a place that's affected.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
