### PR TITLE
Make BehaviorVersion as future-proof as the documentation and RFC specify

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Make `BehaviorVersion` be future-proof by disallowing it to be constructed via the `BehaviorVersion {}` syntax."
+references = ["aws-sdk-rust#1111", "smithy-rs#3513"]
+meta = { "breaking" = true, "tada" = false, "bug" = true }
+author = "Ten0"
+
+[[smithy-rs]]
+message = "Make `BehaviorVersion` be future-proof by disallowing it to be constructed via the `BehaviorVersion {}` syntax."
+references = ["aws-sdk-rust#1111", "smithy-rs#3513"]
+meta = { "breaking" = true, "tada" = false, "bug" = true, "target" = "client" }
+author = "Ten0"

--- a/design/src/rfcs/rfc0040_behavior_versions.md
+++ b/design/src/rfcs/rfc0040_behavior_versions.md
@@ -60,6 +60,7 @@ In order to implement this feature, we need to create a `BehaviorVersion` struct
 #[derive(Debug, Clone)]
 pub struct BehaviorVersion {
     // currently there is only 1 MV so we don't actually need anything in here.
+    _private: (),
 }
 ```
 

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
@@ -7,31 +7,42 @@
 
 /// Behavior major-version of the client
 ///
-/// Over time, new best-practice behaviors are introduced. However, these behaviors might not be backwards
-/// compatible. For example, a change which introduces new default timeouts or a new retry-mode for
-/// all operations might be the ideal behavior but could break existing applications.
-#[derive(Debug, Clone)]
-pub struct BehaviorVersion {}
+/// Over time, new best-practice behaviors are introduced. However, these behaviors might not be
+/// backwards compatible. For example, a change which introduces new default timeouts or a new
+/// retry-mode for all operations might be the ideal behavior but could break existing applications.
+#[derive(Clone)]
+pub struct BehaviorVersion {
+    // currently there is only 1 MV so we don't actually need anything in here.
+    _private: (),
+}
 
 impl BehaviorVersion {
     /// This method will always return the latest major version.
     ///
     /// This is the recommend choice for customers who aren't reliant on extremely specific behavior
-    /// characteristics. For example, if you are writing a CLI app, the latest behavior major version
-    /// is probably the best setting for you.
+    /// characteristics. For example, if you are writing a CLI app, the latest behavior major
+    /// version is probably the best setting for you.
     ///
     /// If, however, you're writing a service that is very latency sensitive, or that has written
     /// code to tune Rust SDK behaviors, consider pinning to a specific major version.
     ///
     /// The latest version is currently [`BehaviorVersion::v2023_11_09`]
     pub fn latest() -> Self {
-        Self {}
+        Self::v2023_11_09()
     }
 
     /// This method returns the behavior configuration for November 9th, 2023
     ///
     /// When a new behavior major version is released, this method will be deprecated.
     pub fn v2023_11_09() -> Self {
-        Self {}
+        Self { _private: () }
+    }
+}
+
+impl std::fmt::Debug for BehaviorVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BehaviorVersion")
+            .field("name", &"v2023_11_09")
+            .finish()
     }
 }


### PR DESCRIPTION
Fixes aws-sdk-rust#1111

This is *technically* a breaking change but since this was released recently and it's documented that this API shouldn't be used, this can probably be considered a bug, which is better fixed now than later.
