### PR TITLE
Bump patch version for `aws-config`

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.1.9"
+version = "1.1.10"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",


### PR DESCRIPTION
Precommit hooks and CI have started failing due to `runtime-versioner` reporting `aws-config` requires a version bump.

While the most recent change to that crate was made by [this PR](https://github.com/smithy-lang/smithy-rs/pull/3491) only updating test-related code, it does still require a version bump.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
