### PR TITLE
Add empty workflow for manually running canary in smithy-rs on behalf of external contributors

### DIFF
--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -1,0 +1,18 @@
+# This workflow allows maintainers to manually run the canary given an external contributor's pull request created from
+# a forked repository, which does not have required repository secrets to execute the canary.
+name: Invoke Canary as Maintainer
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: The PR number to invoke the canary for.
+        required: true
+        type: string
+
+jobs:
+  canary:
+    name: Canary
+    runs-on: ubuntu-latest
+    steps:
+    - name: Invoke canary
+      run: echo "Hello World"


### PR DESCRIPTION
## Motivation and Context
The same reason for #3500, which is GitHub actions do not allow us to manually trigger them unless they are first checked-in to the main branch.

## Description
This PR adds a skeletal workflow file for manually invoking canary within `smithy-lang/smithy-rs` on behalf of external contributors. Forked repositories will be missing repository secrets to run the canary in CI so it will always fail for external contributors. As a workaround, maintainers will manually trigger `manual-canary.yml`, given a PR number from an external contributor as input.

A subsequent PR will fill in the blank.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
