### PR TITLE
Make runtime versioner ignore any additional flags

### DIFF
--- a/tools/ci-build/runtime-versioner/src/main.rs
+++ b/tools/ci-build/runtime-versioner/src/main.rs
@@ -59,11 +59,15 @@ pub struct PatchRuntime {
     #[arg(long)]
     previous_release_tag: Option<String>,
     /// Version number for stable crates.
+    ///
+    /// Deprecated: this argument is ignored
     #[arg(long)]
-    stable_crate_version: String,
+    stable_crate_version: Option<String>,
     /// Version number for unstable crates.
+    ///
+    /// Deprecated: this argument is ignored
     #[arg(long)]
-    unstable_crate_version: String,
+    unstable_crate_version: Option<String>,
 }
 
 #[derive(clap::Args, Clone)]

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -10,14 +10,9 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: check-semver-hazards <stable-crate-version> <unstable-crate-version>"
-  exit 1
+if [ "$#" -ne 0 ]; then
+  echo "Unexpected arguments ignored"
 fi
-STABLE_CRATE_VERSION="$1"
-UNSTABLE_CRATE_VERSION="$2"
-echo "Stable crate version: ${STABLE_CRATE_VERSION}"
-echo "Unstable crate version: ${UNSTABLE_CRATE_VERSION}"
 
 # Need to allow warnings since there may be deprecations that the old SDK uses
 unset RUSTFLAGS
@@ -28,8 +23,6 @@ echo -e "${C_YELLOW}# Patching SDK...${C_RESET}"
 runtime-versioner patch-runtime \
   --sdk-path "$(pwd)/aws-sdk-rust" \
   --smithy-rs-path "$(pwd)/smithy-rs" \
-  --stable-crate-version "${STABLE_CRATE_VERSION}" \
-  --unstable-crate-version "${UNSTABLE_CRATE_VERSION}"
 
 # Testing just a small subset of the full SDK to check for semver hazards
 echo -e "${C_YELLOW}# Testing SDK...${C_RESET}"

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -22,7 +22,7 @@ set -eux
 echo -e "${C_YELLOW}# Patching SDK...${C_RESET}"
 runtime-versioner patch-runtime \
   --sdk-path "$(pwd)/aws-sdk-rust" \
-  --smithy-rs-path "$(pwd)/smithy-rs" \
+  --smithy-rs-path "$(pwd)/smithy-rs"
 
 # Testing just a small subset of the full SDK to check for semver hazards
 echo -e "${C_YELLOW}# Testing SDK...${C_RESET}"


### PR DESCRIPTION
## Motivation and Context
This is the first of two PRs to remove the concept of stable/unstable versions from the release process. This PR will cause a full docker rebuild, so I'm splitting it out to merge first to make iterating on the second PR easier.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
