### PR TITLE
fix the `./gradlew :aws:sdk:assemble` command and aws-config tests on Windows

### DIFF
--- a/aws/rust-runtime/aws-config/src/credential_process.rs
+++ b/aws/rust-runtime/aws-config/src/credential_process.rs
@@ -231,7 +231,7 @@ mod test {
     use time::OffsetDateTime;
     use tokio::time::timeout;
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
     #[cfg_attr(windows, ignore)]
     async fn test_credential_process() {
@@ -254,7 +254,7 @@ mod test {
         );
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
     #[cfg_attr(windows, ignore)]
     async fn test_credential_process_no_expiry() {

--- a/aws/rust-runtime/aws-config/src/credential_process.rs
+++ b/aws/rust-runtime/aws-config/src/credential_process.rs
@@ -231,7 +231,9 @@ mod test {
     use time::OffsetDateTime;
     use tokio::time::timeout;
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
+    #[cfg_attr(windows, ignore)]
     async fn test_credential_process() {
         let provider = CredentialProcessProvider::new(String::from(
             r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "SessionToken": "TESTSESSIONTOKEN", "Expiration": "2022-05-02T18:36:00+00:00" }'"#,
@@ -252,7 +254,9 @@ mod test {
         );
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
+    #[cfg_attr(windows, ignore)]
     async fn test_credential_process_no_expiry() {
         let provider = CredentialProcessProvider::new(String::from(
             r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY" }'"#,

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -299,20 +299,20 @@ mod test {
     make_test!(ecs_credentials_invalid_profile);
 
     make_test!(eks_pod_identity_credentials);
-    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is disabled on Windows because it uses Unix-style paths
     #[cfg(not(windows))]
     make_test!(eks_pod_identity_no_token_file);
 
     #[cfg(not(feature = "sso"))]
     make_test!(sso_assume_role #[should_panic(expected = "This behavior requires following cargo feature(s) enabled: sso")]);
-    
+
     #[cfg(feature = "sso")]
     make_test!(sso_assume_role);
-    
-    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is disabled on Windows because it uses Unix-style paths
     #[cfg(not(any(feature = "sso", windows)))]
     make_test!(sso_no_token_file #[should_panic(expected = "This behavior requires following cargo feature(s) enabled: sso")]);
-    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is disabled on Windows because it uses Unix-style paths
     #[cfg(all(feature = "sso", not(windows)))]
     make_test!(sso_no_token_file);
 

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -299,17 +299,21 @@ mod test {
     make_test!(ecs_credentials_invalid_profile);
 
     make_test!(eks_pod_identity_credentials);
+    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    #[cfg(not(windows))]
     make_test!(eks_pod_identity_no_token_file);
 
     #[cfg(not(feature = "sso"))]
     make_test!(sso_assume_role #[should_panic(expected = "This behavior requires following cargo feature(s) enabled: sso")]);
-    #[cfg(not(feature = "sso"))]
-    make_test!(sso_no_token_file #[should_panic(expected = "This behavior requires following cargo feature(s) enabled: sso")]);
-
+    
     #[cfg(feature = "sso")]
     make_test!(sso_assume_role);
-
-    #[cfg(feature = "sso")]
+    
+    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    #[cfg(not(any(feature = "sso", windows)))]
+    make_test!(sso_no_token_file #[should_panic(expected = "This behavior requires following cargo feature(s) enabled: sso")]);
+    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    #[cfg(all(feature = "sso", not(windows)))]
     make_test!(sso_no_token_file);
 
     #[cfg(feature = "credentials-sso")]

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -982,6 +982,8 @@ pub(crate) mod test {
         http_client.assert_requests_match(&[]);
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     /// Verify that the end-to-end real client has a 1-second connect timeout
     #[tokio::test]
     #[cfg(feature = "rustls")]

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -982,7 +982,7 @@ pub(crate) mod test {
         http_client.assert_requests_match(&[]);
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     /// Verify that the end-to-end real client has a 1-second connect timeout
     #[tokio::test]

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -454,7 +454,7 @@ mod test {
         );
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     #[cfg(feature = "rustls")]

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -454,6 +454,8 @@ mod test {
         );
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     #[cfg(feature = "rustls")]
     async fn external_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials() {

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -594,10 +594,10 @@ mod test {
     make_test!(retry_on_error);
     make_test!(invalid_config);
     make_test!(region_override);
-    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is disabled on Windows because it uses Unix-style paths
     #[cfg(all(feature = "credentials-process", not(windows)))]
     make_test!(credential_process);
-    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is disabled on Windows because it uses Unix-style paths
     #[cfg(all(feature = "credentials-process", not(windows)))]
     make_test!(credential_process_failure);
     #[cfg(feature = "credentials-process")]
@@ -624,7 +624,7 @@ mod sso_tests {
     use aws_types::os_shim_internal::{Env, Fs};
     use std::collections::HashMap;
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     // In order to preserve the SSO token cache, the inner provider must only
     // be created once, rather than once per credential resolution.

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -594,9 +594,11 @@ mod test {
     make_test!(retry_on_error);
     make_test!(invalid_config);
     make_test!(region_override);
-    #[cfg(feature = "credentials-process")]
+    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    #[cfg(all(feature = "credentials-process", not(windows)))]
     make_test!(credential_process);
-    #[cfg(feature = "credentials-process")]
+    // (TODO aws-sdk-rust#1117) This test is disabled on Windows because it uses Unix-style paths
+    #[cfg(all(feature = "credentials-process", not(windows)))]
     make_test!(credential_process_failure);
     #[cfg(feature = "credentials-process")]
     make_test!(credential_process_invalid);
@@ -622,6 +624,8 @@ mod sso_tests {
     use aws_types::os_shim_internal::{Env, Fs};
     use std::collections::HashMap;
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     // In order to preserve the SSO token cache, the inner provider must only
     // be created once, rather than once per credential resolution.
     #[tokio::test]

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -413,7 +413,9 @@ mod tests {
         assert_eq!(contents, source.files[0].contents);
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
+    #[cfg_attr(windows, ignore)]
     async fn programmatically_include_default_files() {
         let config_contents = "[default]\nregion = us-east-1";
         let credentials_contents = "[default]\n\

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(contents, source.files[0].contents);
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
     #[cfg_attr(windows, ignore)]
     async fn programmatically_include_default_files() {

--- a/aws/rust-runtime/aws-config/src/sso/cache.rs
+++ b/aws/rust-runtime/aws-config/src/sso/cache.rs
@@ -514,6 +514,8 @@ mod tests {
         );
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[test]
     fn determine_correct_cache_filenames() {
         assert_eq!(
@@ -534,6 +536,8 @@ mod tests {
         );
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn save_cached_token() {
         let expires_at = SystemTime::UNIX_EPOCH + Duration::from_secs(50_000_000);

--- a/aws/rust-runtime/aws-config/src/sso/cache.rs
+++ b/aws/rust-runtime/aws-config/src/sso/cache.rs
@@ -514,7 +514,7 @@ mod tests {
         );
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[test]
     fn determine_correct_cache_filenames() {
@@ -536,7 +536,7 @@ mod tests {
         );
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn save_cached_token() {

--- a/aws/rust-runtime/aws-config/src/sso/token.rs
+++ b/aws/rust-runtime/aws-config/src/sso/token.rs
@@ -513,6 +513,8 @@ mod tests {
         }
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn use_unexpired_cached_token() {
         let fs = Fs::from_slice(&[(
@@ -536,6 +538,8 @@ mod tests {
         req_rx.expect_no_request();
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_cached_token() {
         let fs = Fs::from_slice(&[(
@@ -557,6 +561,8 @@ mod tests {
         req_rx.expect_no_request();
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_token_and_expired_client_registration() {
         let fs = Fs::from_slice(&[(
@@ -584,6 +590,8 @@ mod tests {
         req_rx.expect_no_request();
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_token_refresh_with_refresh_token() {
         let fs = Fs::from_slice(&[(
@@ -666,6 +674,8 @@ mod tests {
         );
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_token_refresh_fails() {
         let fs = Fs::from_slice(&[(
@@ -705,6 +715,8 @@ mod tests {
         let _ = req_rx.expect_request();
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     // Expired token refresh without new refresh token
     #[tokio::test]
     async fn expired_token_refresh_without_new_refresh_token() {
@@ -755,6 +767,8 @@ mod tests {
         let _ = req_rx.expect_request();
     }
 
+    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn refresh_timings() {
         let _logs = capture_test_logs();

--- a/aws/rust-runtime/aws-config/src/sso/token.rs
+++ b/aws/rust-runtime/aws-config/src/sso/token.rs
@@ -513,7 +513,7 @@ mod tests {
         }
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn use_unexpired_cached_token() {
@@ -538,7 +538,7 @@ mod tests {
         req_rx.expect_no_request();
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_cached_token() {
@@ -561,7 +561,7 @@ mod tests {
         req_rx.expect_no_request();
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_token_and_expired_client_registration() {
@@ -590,7 +590,7 @@ mod tests {
         req_rx.expect_no_request();
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_token_refresh_with_refresh_token() {
@@ -674,7 +674,7 @@ mod tests {
         );
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn expired_token_refresh_fails() {
@@ -715,7 +715,7 @@ mod tests {
         let _ = req_rx.expect_request();
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     // Expired token refresh without new refresh token
     #[tokio::test]
@@ -767,7 +767,7 @@ mod tests {
         let _ = req_rx.expect_request();
     }
 
-    // (TODO aws-sdk-rust#1117) This test is ignored on Windows because it uses Unix-style paths
+    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
     async fn refresh_timings() {

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -87,6 +87,9 @@ fun generateSmithyBuild(services: AwsServices): String {
         }
         val moduleName = "aws-sdk-${service.module}"
         val eventStreamAllowListMembers = eventStreamAllowList.joinToString(", ") { "\"$it\"" }
+        val defaultConfigPath = services.defaultConfigPath.let { software.amazon.smithy.utils.StringUtils.escapeJavaString(it, "") }
+        val partitionsConfigPath = services.partitionsConfigPath.let { software.amazon.smithy.utils.StringUtils.escapeJavaString(it, "") }
+        val integrationTestPath = project.projectDir.resolve("integration-tests").let { software.amazon.smithy.utils.StringUtils.escapeJavaString(it, "") }
         """
             "${service.module}": {
                 "imports": [${files.joinToString()}],
@@ -117,9 +120,9 @@ fun generateSmithyBuild(services: AwsServices): String {
                             "awsSdk": {
                                 "awsSdkBuild": true,
                                 "awsConfigVersion": "$awsConfigVersion",
-                                "defaultConfigPath": "${services.defaultConfigPath}",
-                                "partitionsConfigPath": "${services.partitionsConfigPath}",
-                                "integrationTestPath": "${project.projectDir.resolve("integration-tests")}"
+                                "defaultConfigPath": $defaultConfigPath,
+                                "partitionsConfigPath": $partitionsConfigPath,
+                                "integrationTestPath": $integrationTestPath
                             }
                         }
                         ${service.extraConfig ?: ""}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -626,11 +626,12 @@ class RustWriter private constructor(
             if (filename.endsWith(".rs")) {
                 require(
                     namespace.startsWith("crate") ||
-                    // Unix systems
-                    filename.startsWith("tests/") ||
-                    // Windows systems
-                    filename.startsWith("tests\\") ||
-                    filename == "build.rs") {
+                        // Unix systems
+                        filename.startsWith("tests/") ||
+                        // Windows systems
+                        filename.startsWith("tests\\") ||
+                        filename == "build.rs",
+                ) {
                     "We can only write into files in the crate (got $namespace)"
                 }
             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -624,7 +624,13 @@ class RustWriter private constructor(
         init {
             expressionStart = '#'
             if (filename.endsWith(".rs")) {
-                require(namespace.startsWith("crate") || filename.startsWith("tests/") || filename == "build.rs") {
+                require(
+                    namespace.startsWith("crate") ||
+                    // Unix systems
+                    filename.startsWith("tests/") ||
+                    // Windows systems
+                    filename.startsWith("tests\\") ||
+                    filename == "build.rs") {
                     "We can only write into files in the crate (got $namespace)"
                 }
             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -626,10 +626,7 @@ class RustWriter private constructor(
             if (filename.endsWith(".rs")) {
                 require(
                     namespace.startsWith("crate") ||
-                        // Unix systems
-                        filename.startsWith("tests/") ||
-                        // Windows systems
-                        filename.startsWith("tests\\") ||
+                        filename.startsWith("tests${File.separator}") ||
                         filename == "build.rs",
                 ) {
                     "We can only write into files in the crate (got $namespace)"

--- a/tools/ci-build/crate-hasher/src/file_list.rs
+++ b/tools/ci-build/crate-hasher/src/file_list.rs
@@ -96,7 +96,7 @@ impl FileMetadata {
 }
 
 /// Returns the file mode (permissions) for the given path.
-/// 
+///
 /// On Windows, this returns the file attributes instead of the permissions.
 fn file_mode(path: &Path, metadata: &Metadata) -> Result<u32> {
     #[cfg(windows)]
@@ -110,15 +110,16 @@ fn file_mode(path: &Path, metadata: &Metadata) -> Result<u32> {
 
     #[cfg(unix)]
     {
-    use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::PermissionsExt;
 
-    if metadata.file_type().is_symlink() {
-        let actual_path = std::fs::read_link(path).context("follow symlink")?;
-        let actual_metadata = std::fs::metadata(&actual_path).context("file metadata")?;
-        file_mode(&actual_path, &actual_metadata)
-    } else {
-        Ok(metadata.permissions().mode())
-    }}
+        if metadata.file_type().is_symlink() {
+            let actual_path = std::fs::read_link(path).context("follow symlink")?;
+            let actual_metadata = std::fs::metadata(&actual_path).context("file metadata")?;
+            file_mode(&actual_path, &actual_metadata)
+        } else {
+            Ok(metadata.permissions().mode())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tools/ci-build/crate-hasher/src/file_list.rs
+++ b/tools/ci-build/crate-hasher/src/file_list.rs
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use anyhow::{Context, Result};
 use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::fs::Metadata;
 use std::path::Path;
-
-use anyhow::{bail, Context, Result};
 
 #[derive(Debug, Default)]
 pub struct FileList(BTreeSet<FileMetadata>);

--- a/tools/ci-scripts/test-windows.sh
+++ b/tools/ci-scripts/test-windows.sh
@@ -16,6 +16,6 @@ for runtime_path in "rust-runtime" "aws/rust-runtime"; do
   cargo doc --no-deps --document-private-items --all-features --workspace "${exclusions[@]}"
   popd &>/dev/null
 done
-# (TODO aws-sdk-rust#1117) We don't have a way to codegen the deps needed by the aws-config crate
+# TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) We don't have a way to codegen the deps needed by the aws-config crate
 # (cd aws/rust-runtime/aws-config && cargo test --all-features) # aws-config is not part of the workspace so we have to test it separately
 (cd rust-runtime && cargo test -p aws-smithy-experimental --features crypto-ring) # only ring works on windows

--- a/tools/ci-scripts/test-windows.sh
+++ b/tools/ci-scripts/test-windows.sh
@@ -16,5 +16,6 @@ for runtime_path in "rust-runtime" "aws/rust-runtime"; do
   cargo doc --no-deps --document-private-items --all-features --workspace "${exclusions[@]}"
   popd &>/dev/null
 done
-(cd aws/rust-runtime/aws-config && cargo test) # aws-config is not part of the workspace so we have to test it separately
+# (TODO aws-sdk-rust#1117) We don't have a way to codegen the deps needed by the aws-config crate
+# (cd aws/rust-runtime/aws-config && cargo test --all-features) # aws-config is not part of the workspace so we have to test it separately
 (cd rust-runtime && cargo test -p aws-smithy-experimental --features crypto-ring) # only ring works on windows

--- a/tools/ci-scripts/test-windows.sh
+++ b/tools/ci-scripts/test-windows.sh
@@ -16,4 +16,5 @@ for runtime_path in "rust-runtime" "aws/rust-runtime"; do
   cargo doc --no-deps --document-private-items --all-features --workspace "${exclusions[@]}"
   popd &>/dev/null
 done
+(cd aws/rust-runtime/aws-config && cargo test) # aws-config is not part of the workspace so we have to test it separately
 (cd rust-runtime && cargo test -p aws-smithy-experimental --features crypto-ring) # only ring works on windows


### PR DESCRIPTION
tracked in issue #3518 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
