### PR TITLE
fix(awsjson): URI Result not matched correctly

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/protocol/aws_json/router.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocol/aws_json/router.rs
@@ -86,8 +86,8 @@ where
     type Error = Error;
 
     fn match_route(&self, request: &http::Request<B>) -> Result<S, Self::Error> {
-        // The URI must be root,
-        if request.uri() != "/" {
+        // The URI path must be root,
+        if request.uri().path() != "/" {
             return Err(Error::NotRootUrl);
         }
 


### PR DESCRIPTION
## Motivation and Context
When trying out the AWS Json protocol I could not get a valid 200 result. After diving into the issue the awsjson router was not matching the url correctly when running from aws lambda.
The incomming request.uri() would result into "/?" instead of "/". This would always result in a mismatch.

## Description
At this moment the fix is to use request.uri().path() != "/". This will result in correct behavior.

One downside of fixing it this way is that it will not be strict on requests against the root path with query params. It will allow any query param now. 

## Testing
Testing was now done on AWS lambda. No additional unit tests are created yet if the team finds this applicable..

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
