### PR TITLE
Upgrade Smithy to 1.47

### DIFF
--- a/codegen-core/common-test-models/rest-json-extras.smithy
+++ b/codegen-core/common-test-models/rest-json-extras.smithy
@@ -8,30 +8,6 @@ use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 use smithy.framework#ValidationException
 
-// TODO(https://github.com/smithy-lang/smithy/pull/2167): Remove this test once it's fixed in Smithy
-apply AllQueryStringTypes @httpRequestTests([
-    {
-        id: "RestJsonZeroAndFalseQueryValuesFixed"
-        documentation: "Query values of 0 and false are serialized"
-        protocol: restJson1
-        method: "GET"
-        uri: "/AllQueryStringTypesInput"
-        body: ""
-        queryParams: [
-            "Integer=0"
-            "Boolean=false"
-        ]
-        params: {
-            queryInteger: 0
-            queryBoolean: false
-            queryParamsMapOfStringList: {
-                Integer: ["0"]
-                Boolean: ["false"]
-            }
-        }
-    }
-])
-
 apply QueryPrecedence @httpRequestTests([
     {
         id: "UrlParamsKeyEncoding",
@@ -90,8 +66,6 @@ service RestJsonExtras {
         CaseInsensitiveErrorOperation,
         EmptyStructWithContentOnWireOp,
         QueryPrecedence,
-        // TODO(https://github.com/smithy-lang/smithy/pull/2167): Remove this test once it's fixed in Smithy
-        AllQueryStringTypes,
     ],
     errors: [ExtraError]
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -813,10 +813,6 @@ class ServerProtocolTestGenerator(
                 FailingTest(RestJson, "RestJsonEndpointTrait", TestType.Request),
                 FailingTest(RestJson, "RestJsonEndpointTraitWithHostLabel", TestType.Request),
                 FailingTest(RestJson, "RestJsonOmitsEmptyListQueryValues", TestType.Request),
-                // TODO(https://github.com/smithy-lang/smithy/pull/2167): BEGIN Remove this failing test once it's fixed in Smithy
-                FailingTest(RestJson, "RestJsonZeroAndFalseQueryValues", TestType.Request),
-                FailingTest(RestJsonExtras, "RestJsonZeroAndFalseQueryValues", TestType.Request),
-                // TODO(https://github.com/smithy-lang/smithy/pull/2167): END Remove this failing test once it's fixed in Smithy
                 // Tests involving `@range` on floats.
                 // Pending resolution from the Smithy team, see https://github.com/smithy-lang/smithy-rs/issues/2007.
                 FailingTest(RestJsonValidation, "RestJsonMalformedRangeFloat_case0", TestType.MalformedRequest),
@@ -915,6 +911,8 @@ class ServerProtocolTestGenerator(
                 // RestXml S3 tests that fail to compile
                 "S3EscapeObjectKeyInUriLabel",
                 "S3EscapePathObjectKeyInUriLabel",
+                "S3PreservesLeadingDotSegmentInUriLabel",
+                "S3PreservesEmbeddedDotSegmentInUriLabel",
             )
 
         // TODO(https://github.com/awslabs/smithy/issues/1506)

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ kotlin.code.style=official
 
 # codegen
 smithyGradlePluginVersion=0.9.0
-smithyVersion=1.45.0
+smithyVersion=1.47.0
 allowLocalDeps=false
 
 # kotlin


### PR DESCRIPTION
This PR upgrades Smithy to 1.47.0. The new S3 tests needed to be excluded in the server tests since they fail to compile for the same reason as the other ones that are excluded.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
