### PR TITLE
Create backport PRs automatically

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -27,13 +27,14 @@ jobs:
     - name: Prepare backport branch
       id: backport-branch
       run: |
+        # This step assumes the merge runs cleanly without conflicts, which should be the case when
+        # this workflow is called by the release workflow right after a release tag has been created.
+
         git fetch
         git checkout origin/main
         backport_branch="merge-${{ env.release_branch }}-to-main-$(date +%s)"
         git checkout -b "${backport_branch}"
 
-        # This assumes the merge runs cleanly without conflicts, which should be the case when
-        # this workflow is called by the release workflow right after a release tag has been created.
         git merge "origin/${{ env.release_branch }}" -m 'Merge remote-tracking branch "origin/${{ env.release_branch }}" into "merge-${{ env.release_branch }}-to-main"'
         git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' push origin HEAD
 

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Open a backport PR to merge the release branch into main
+
+on:
+  # automatically called by release.yml
+  workflow_dispatch:
+  # can also be manually triggered when a patch fix is merged into the release branch and needs to be back-ported
+  workflow_call:
+    secrets:
+      RELEASE_AUTOMATION_BOT_PAT:
+        required: true
+
+env:
+  release_branch: smithy-rs-release-1.x.y
+
+jobs:
+  create-backport-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
+
+    - name: Prepare backport branch
+      id: backport-branch
+      run: |
+        git fetch
+        git checkout origin/main
+        backport_branch="merge-${{ env.release_branch }}-to-main-$(date +%s)"
+        git checkout -b "${backport_branch}"
+
+        # This assumes the merge runs cleanly without conflicts, which should be the case when
+        # this workflow is called by the release workflow right after a release tag has been created.
+        git merge "origin/${{ env.release_branch }}" -m 'Merge remote-tracking branch "origin/${{ env.release_branch }}" into "merge-${{ env.release_branch }}-to-main"'
+        git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' push origin HEAD
+
+        echo "branch_name=${backport_branch}" > $GITHUB_OUTPUT
+
+    - name: Create pull request
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
+        script: |
+          const { repo, owner } = context.repo;
+          const result = await github.rest.pulls.create({
+            title: 'Merge ${{ env.release_branch }} into main',
+            owner,
+            repo,
+            head: '${{ steps.backport-branch.outputs.branch_name }}',
+            base: 'main',
+            body: [
+              "Merge it with `gh pr merge --admin --merge` or manually merge it with the merge commit (not squash merge).",
+              "",
+              "_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._"
+            ].join('\n'),
+            draft: true
+          });
+
+          github.rest.issues.addLabels({
+            owner,
+            repo,
+            issue_number: result.data.number,
+            labels: ['needs-sdk-review']
+          });

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         # This step assumes the merge runs cleanly without conflicts, which should be the case when
         # this workflow is called by the release workflow right after a release tag has been created.
+        git config --local user.name "AWS SDK Rust Bot"
+        git config --local user.email "aws-sdk-rust-primary@amazon.com"
 
         git fetch
         git checkout origin/main
@@ -36,7 +38,7 @@ jobs:
         git checkout -b "${backport_branch}"
 
         git merge "origin/${{ env.release_branch }}" -m 'Merge remote-tracking branch "origin/${{ env.release_branch }}" into "merge-${{ env.release_branch }}-to-main"'
-        git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' push origin HEAD
+        git push origin HEAD
 
         echo "branch_name=${backport_branch}" > $GITHUB_OUTPUT
 

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -40,28 +40,13 @@ jobs:
         echo "branch_name=${backport_branch}" > $GITHUB_OUTPUT
 
     - name: Create pull request
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
-        script: |
-          const { repo, owner } = context.repo;
-          const result = await github.rest.pulls.create({
-            title: 'Merge ${{ env.release_branch }} into main',
-            owner,
-            repo,
-            head: '${{ steps.backport-branch.outputs.branch_name }}',
-            base: 'main',
-            body: [
-              "Merge it with `gh pr merge --admin --merge` or manually merge it with the merge commit (not squash merge).",
-              "",
-              "_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._"
-            ].join('\n'),
-            draft: true
-          });
-
-          github.rest.issues.addLabels({
-            owner,
-            repo,
-            issue_number: result.data.number,
-            labels: ['needs-sdk-review']
-          });
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
+      run: |
+        gh pr create \
+          --title "Merge ${{ env.release_branch }} into main" \
+          --body "Merge it with \`gh pr merge --admin --merge\` or manually merge it with the merge commit (not squash merge)." \
+          --base main \
+          --head ${{ steps.backport-branch.outputs.branch_name }} \
+          --label "needs-sdk-review" \
+          --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,10 +272,9 @@ jobs:
   open-backport-pull-request:
     name: Open backport pull request to merge the release branch back to main
     needs:
-    - release
     - trim-changelog-next-on-main
     # See https://github.com/actions/runner/issues/2205#issuecomment-1381988186 for details on the workaround
-    if: inputs.dry_run == false && always() && contains(needs.*.result, 'success')
+    if: inputs.dry_run == false && always() && needs.trim-changelog-next-on-main.result == 'success'
     uses: ./.github/workflows/backport-pull-request.yml
     secrets:
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,3 +268,14 @@ jobs:
         # a manual PR to edit the current CHANGELOG.next.toml file and remove the released entries.
         git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit CHANGELOG.next.toml --message "Remove released entries from \`CHANGELOG.next.toml\`"
         git push origin main
+
+  open-backport-pull-request:
+    name: Open backport pull request to merge the release branch back to main
+    needs:
+    - release
+    - trim-changelog-next-on-main
+    # See https://github.com/actions/runner/issues/2205#issuecomment-1381988186 for details on the workaround
+    if: inputs.dry_run == false && always() && contains(needs.*.result, 'success')
+    uses: ./.github/workflows/backport-pull-request.yml
+    secrets:
+      RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}


### PR DESCRIPTION
## Motivation and Context
Automatically opens backport PRs merging `smithy-rs-release-1.x.y-release` to `main`.

## Description
A workflow `backport-pull-request.yml` can be called in two ways:
- called automatically when a prod release runs
- called manually when a patch fix has been made to `smithy-rs-release-1.x.y-release` and needs to be back-ported

## Testing
- Triggered the workflow manually and confirmed [this (dummy) PR](https://github.com/smithy-lang/smithy-rs/pull/3556) got created
- Triggered the workflow automatically and confirmed [this (dummy) PR](https://github.com/smithy-lang/smithy-rs/pull/3557) got created

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
