### PR TITLE
Add multiple binding support to Jmespath traversal generator

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
@@ -375,6 +375,17 @@ fun RustType.isEq(): Boolean =
         else -> false
     }
 
+/** Recursively replaces lifetimes with the new lifetime */
+fun RustType.replaceLifetimes(newLifetime: String?): RustType =
+    when (this) {
+        is RustType.Option -> copy(member = member.replaceLifetimes(newLifetime))
+        is RustType.Vec -> copy(member = member.replaceLifetimes(newLifetime))
+        is RustType.HashSet -> copy(member = member.replaceLifetimes(newLifetime))
+        is RustType.HashMap -> copy(key = key.replaceLifetimes(newLifetime), member = member.replaceLifetimes(newLifetime))
+        is RustType.Reference -> copy(lifetime = newLifetime)
+        else -> this
+    }
+
 enum class Visibility {
     PRIVATE,
     PUBCRATE,


### PR DESCRIPTION
In #3526, I forgot about the existence of input/output matchers in Smithy waiters, so it only supported binding against a single global output shape. This PR revises the generator so that it supports multiple bindings so that it can generate an input/output matcher path traversal.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
