### PR TITLE
Fix canary execution during prod release

### DIFF
--- a/.github/workflows/dry-run-release-scheduled.yml
+++ b/.github/workflows/dry-run-release-scheduled.yml
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow performs a scheduled dry-run for smithy-rs release.
+# When run, it only produces release artifacts, but will not cut a release tag in GitHub or publish to crates.io.
+
+name: Scheduled smithy-rs dry run release
+run-name: ${{ github.workflow }}
+on:
+  schedule:
+    # Runs 00:00 UTC every day
+  - cron: 0 0 * * *
+
+jobs:
+  smithy-rs-scheduled-dry-run-release:
+    name: Scheduled dry-run release
+    uses: ./.github/workflows/release.yml
+    with:
+      commit_sha: main
+      dry_run: true
+      skip_ci: true
+    secrets:
+      RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
+      RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}

--- a/.github/workflows/dry-run-release-scheduled.yml
+++ b/.github/workflows/dry-run-release-scheduled.yml
@@ -4,7 +4,7 @@
 # This workflow performs a scheduled dry-run for smithy-rs release.
 # When run, it only produces release artifacts, but will not cut a release tag in GitHub or publish to crates.io.
 
-name: Scheduled smithy-rs dry run release
+name: Scheduled smithy-rs dry-run release
 run-name: ${{ github.workflow }}
 on:
   schedule:

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -1,15 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow performs a dry run for smithy-rs release. It can be triggered via either cron or manually.
-# When ran, it only produces release artifacts, but will not cut a release tag in GitHub or publish to crates.io.
+# This workflow performs a manual dry-run for smithy-rs release.
+# When run, it only produces release artifacts, but will not cut a release tag in GitHub or publish to crates.io.
 
 name: Smithy-rs dry run release
-run-name: ${{ github.workflow }} ${{ inputs.commit_sha == ''  && 'scheduled' || (inputs.commit_sha) }}
+run-name: ${{ github.workflow }}-${{ inputs.commit_sha }}
 on:
-  schedule:
-    # Runs 00:00 UTC every day
-  - cron: 0 0 * * *
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -34,20 +31,6 @@ jobs:
       commit_sha: ${{ inputs.commit_sha }}
       dry_run: true
       skip_ci: ${{ inputs.skip_ci }}
-    secrets:
-      RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
-      RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
-      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
-      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}
-
-  smithy-rs-scheduled-dry-run-release:
-    name: Scheduled dry run release
-    if: ${{ github.event_name == 'schedule' }}
-    uses: ./.github/workflows/release.yml
-    with:
-      commit_sha: main
-      dry_run: true
-      skip_ci: true
     secrets:
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
       RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -19,6 +19,11 @@ on:
           Alternatively, you can use the name of a branch.
         required: true
         type: string
+      skip_ci:
+        description: Skip CI
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   smithy-rs-manual-dry-run-release:
@@ -28,9 +33,12 @@ jobs:
     with:
       commit_sha: ${{ inputs.commit_sha }}
       dry_run: true
+      skip_ci: ${{ inputs.skip_ci }}
     secrets:
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
       RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}
 
   smithy-rs-scheduled-dry-run-release:
     name: Scheduled dry run release
@@ -39,6 +47,9 @@ jobs:
     with:
       commit_sha: main
       dry_run: true
+      skip_ci: true
     secrets:
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
       RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -4,7 +4,7 @@
 # This workflow performs a manual dry-run for smithy-rs release.
 # When run, it only produces release artifacts, but will not cut a release tag in GitHub or publish to crates.io.
 
-name: Smithy-rs dry run release
+name: Smithy-rs dry-run release
 run-name: ${{ github.workflow }}-${{ inputs.commit_sha }}
 on:
   workflow_dispatch:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -24,6 +24,9 @@ jobs:
     with:
       commit_sha: ${{ inputs.commit_sha }}
       dry_run: false
+      skip_ci: false
     secrets:
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
       RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
+      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,18 @@ on:
         description: When true, it only produces release artifacts, but will not cut a release tag in GitHub or publish to crates.io.
         required: true
         type: boolean
+      skip_ci:
+        description: Skip CI when executing a release
+        required: true
+        type: boolean
     secrets:
       RELEASE_AUTOMATION_BOT_PAT:
         required: true
       RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN:
+        required: true
+      CANARY_GITHUB_ACTIONS_ROLE_ARN:
+        required: true
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME:
         required: true
 
 jobs:
@@ -81,13 +89,16 @@ jobs:
 
   release-ci:
     name: Prerelease checks
-    if: inputs.dry_run == false
+    if: inputs.skip_ci == false
     needs:
     - acquire-base-image
     uses: ./.github/workflows/ci.yml
     with:
       run_sdk_examples: false
       git_ref: ${{ inputs.commit_sha }}
+    secrets:
+      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}
 
   check-semver-hazards:
     name: Check for semver hazards

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,10 @@ jobs:
         retention-days: 1
 
   release-ci:
-    name: Prerelease checks
-    if: inputs.skip_ci == false
+    name: Pre-release checks
+    # We need `always` here otherwise this job won't run if the previous job has been skipped
+    # See https://samanpavel.medium.com/github-actions-conditional-job-execution-e6aa363d2867
+    if: always() && inputs.skip_ci == false
     needs:
     - acquire-base-image
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
The new canary secrets weren't being propagated from the root prod release workflow into the CI workflow, so the canary was failing. This PR propagates those secrets, and also makes it possible to run the full CI workflow in a dry-run release so that it's possible to test in the future.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
