### PR TITLE
create an IdentityCache by default when on latest BehaviorVersion

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,6 +10,16 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+[[aws-sdk-rust]]
+message = """
+`aws-config::loader::ConfigLoader` now creates an `IdentityCache` by default when using `BehaviorVersion::v2024_03_28()`
+or newer. If you're using `BehaviorVersion::latest()`, you will get this change automatically when updating. This
+allows clients created from `SdkConfig` to use the same cache instance by default resulting in fewer cache misses
+when using multiple clients.
+"""
+references = ["smithy-rs#3485"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "aajtodd"
 
 [[smithy-rs]]
 message = "Stalled stream protection on uploads is now enabled by default behind `BehaviorVersion::v2024_03_28()`. If you're using `BehaviorVersion::latest()`, you will get this change automatically by running `cargo update`."

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.2.1"
+version = "1.3.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -1069,6 +1069,7 @@ mod loader {
             assert!(config.credentials_provider().is_none());
         }
 
+        #[cfg(feature = "rustls")]
         #[tokio::test]
         async fn identity_cache_defaulted() {
             let config = defaults(BehaviorVersion::latest()).load().await;
@@ -1076,6 +1077,7 @@ mod loader {
             assert!(config.identity_cache().is_some());
         }
 
+        #[cfg(feature = "rustls")]
         #[allow(deprecated)]
         #[tokio::test]
         async fn identity_cache_old_behavior_version() {

--- a/aws/sdk/integration-tests/s3/tests/identity-cache.rs
+++ b/aws/sdk/integration-tests/s3/tests/identity-cache.rs
@@ -39,30 +39,6 @@ async fn test_identity_cache_reused_by_default() {
     assert_eq!(1, provider.invoke_count.load(Ordering::SeqCst));
 }
 
-#[tokio::test]
-async fn test_identity_cache_explicit_unset() {
-    let http_client =
-        infallible_client_fn(|_req| http::Response::builder().status(200).body("OK!").unwrap());
-
-    let provider = TestCredProvider::new();
-
-    let config = aws_config::defaults(BehaviorVersion::latest())
-        .http_client(http_client)
-        .credentials_provider(provider.clone())
-        .region(Region::new("us-west-2"))
-        .no_identity_cache()
-        .load()
-        .await;
-
-    let c1 = Client::new(&config);
-    let _ = c1.list_buckets().send().await;
-    assert_eq!(1, provider.invoke_count.load(Ordering::SeqCst));
-
-    let c2 = Client::new(&config);
-    let _ = c2.list_buckets().send().await;
-    assert_eq!(2, provider.invoke_count.load(Ordering::SeqCst));
-}
-
 #[allow(deprecated)] // intentionally testing an old behavior version
 #[tokio::test]
 async fn test_identity_cache_ga_behavior_version() {

--- a/aws/sdk/integration-tests/s3/tests/identity-cache.rs
+++ b/aws/sdk/integration-tests/s3/tests/identity-cache.rs
@@ -6,7 +6,7 @@
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 
-use aws_config::{identity::IdentityCache, BehaviorVersion, Region};
+use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::{
     provider::{future::ProvideCredentials as ProvideCredentialsFuture, ProvideCredentials},
     Credentials,
@@ -23,12 +23,9 @@ async fn test_identity_cache_reused_by_default() {
         infallible_client_fn(|_req| http::Response::builder().status(200).body("OK!").unwrap());
 
     let provider = TestCredProvider::new();
-    let cache = IdentityCache::lazy().build();
     let config = aws_config::defaults(BehaviorVersion::latest())
         .http_client(http_client)
         .credentials_provider(provider.clone())
-        // TODO(rfc-43) - remove adding a cache when this is the new default
-        .identity_cache(cache)
         .region(Region::new("us-west-2"))
         .load()
         .await;
@@ -42,30 +39,29 @@ async fn test_identity_cache_reused_by_default() {
     assert_eq!(1, provider.invoke_count.load(Ordering::SeqCst));
 }
 
-// TODO(rfc-43) - add no_identity_cache() to ConfigLoader and re-enable test
-// #[tokio::test]
-// async fn test_identity_cache_explicit_unset() {
-//     let http_client =
-//         infallible_client_fn(|_req| http::Response::builder().status(200).body("OK!").unwrap());
-//
-//     let provider = TestCredProvider::new();
-//
-//     let config = aws_config::defaults(BehaviorVersion::latest())
-//         .no_identity_cache()
-//         .http_client(http_client)
-//         .credentials_provider(provider.clone())
-//         .region(Region::new("us-west-2"))
-//         .load()
-//         .await;
-//
-//     let c1 = Client::new(&config);
-//     let _ = c1.list_buckets().send().await;
-//     assert_eq!(1, provider.invoke_count.load(Ordering::SeqCst));
-//
-//     let c2 = Client::new(&config);
-//     let _ = c2.list_buckets().send().await;
-//     assert_eq!(2, provider.invoke_count.load(Ordering::SeqCst));
-// }
+#[tokio::test]
+async fn test_identity_cache_explicit_unset() {
+    let http_client =
+        infallible_client_fn(|_req| http::Response::builder().status(200).body("OK!").unwrap());
+
+    let provider = TestCredProvider::new();
+
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .http_client(http_client)
+        .credentials_provider(provider.clone())
+        .region(Region::new("us-west-2"))
+        .no_identity_cache()
+        .load()
+        .await;
+
+    let c1 = Client::new(&config);
+    let _ = c1.list_buckets().send().await;
+    assert_eq!(1, provider.invoke_count.load(Ordering::SeqCst));
+
+    let c2 = Client::new(&config);
+    let _ = c2.list_buckets().send().await;
+    assert_eq!(2, provider.invoke_count.load(Ordering::SeqCst));
+}
 
 #[allow(deprecated)] // intentionally testing an old behavior version
 #[tokio::test]

--- a/design/src/rfcs/rfc0043_identity_cache_partitions.md
+++ b/design/src/rfcs/rfc0043_identity_cache_partitions.md
@@ -1,7 +1,7 @@
 RFC: Identity Cache Partitions
 ===============================
 
-> Status: Accepted
+> Status: Implemented
 >
 > Applies to: AWS SDK for Rust
 
@@ -286,10 +286,10 @@ shares a cache partition or not.
 Changes checklist
 -----------------
 
-- [ ] Add new `cache_partition()` method to `ResolveIdentity`
-- [ ] Update `SharedIdentityResolver::new` to use the new `cache_partition()` method on the `resolver` to determine if a new cache partition should be created or not
-- [ ] Claim a cache partition when `SharedCredentialsProvider` is created and override the new `ResolveIdentity` method
-- [ ] Claim a cache partition when `SharedTokenProvider` is created and override the new `ResolveIdentity` method
-- [ ] Introduce new behavior version
-- [ ] Conditionally (gated on behavior version) create a new default `IdentityCache` on `SdkConfig` if not explicitly configured
-- [ ] Add a new `no_identity_cache()` method to `ConfigLoader` that marks the identity cache as explicitly unset
+- [x] Add new `cache_partition()` method to `ResolveIdentity`
+- [x] Update `SharedIdentityResolver::new` to use the new `cache_partition()` method on the `resolver` to determine if a new cache partition should be created or not
+- [x] Claim a cache partition when `SharedCredentialsProvider` is created and override the new `ResolveIdentity` method
+- [x] Claim a cache partition when `SharedTokenProvider` is created and override the new `ResolveIdentity` method
+- [x] Introduce new behavior version
+- [x] Conditionally (gated on behavior version) create a new default `IdentityCache` on `SdkConfig` if not explicitly configured
+- [x] Add a new `no_identity_cache()` method to `ConfigLoader` that marks the identity cache as explicitly unset


### PR DESCRIPTION
## Motivation and Context
Original issue: https://github.com/smithy-lang/smithy-rs/issues/3427
RFC: https://github.com/smithy-lang/smithy-rs/pull/3544

## Description
Make `ConfigLoader` create an `IdentityCache` by default when on the latest `BehaviorVersion`. This will allow SDK clients created from `SdkConfig` to share a cache by default instead of creating one per/client. 

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
