### PR TITLE
Add a new step description under `Contributing via Pull Requests`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ To send us a pull request, please:
 4. Commit to your fork using clear commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+7. Ask maintainers to manually trigger [canary](https://github.com/smithy-lang/smithy-rs/actions/workflows/manual-canary.yml) and [PR bot](https://github.com/smithy-lang/smithy-rs/actions/workflows/manual-pull-request-bot.yml) workflows using your pull request number. Those workflows cannot run in your fork and are always skipped as such.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).


### PR DESCRIPTION
## Motivation and Context
Adds a new step description for external contributors regarding running canary and PR bot workflows.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
