### PR TITLE
Add timeouts to CI jobs

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -23,6 +23,7 @@ jobs:
   acquire-base-image:
     runs-on: smithy_ubuntu-latest_8-core
     name: Acquire Base Image
+    timeout-minutes: 60
     outputs:
       docker-login-password: ${{ steps.set-token.outputs.docker-login-password }}
     permissions:

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -22,6 +22,7 @@ jobs:
   # The login password is encrypted with the repo secret DOCKER_LOGIN_TOKEN_PASSPHRASE
   save-docker-login-token:
     name: Save a docker login token
+    timeout-minutes: 10
     outputs:
       docker-login-password: ${{ steps.set-token.outputs.docker-login-password }}
     permissions:
@@ -51,6 +52,7 @@ jobs:
     name: Acquire Base Image
     needs: save-docker-login-token
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
       DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -52,7 +52,7 @@ jobs:
     name: Acquire Base Image
     needs: save-docker-login-token
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     env:
       ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
       DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/ci-pr-forks.yml
+++ b/.github/workflows/ci-pr-forks.yml
@@ -20,6 +20,7 @@ jobs:
     name: Acquire Base Image
     if: ${{ github.event.pull_request.head.repo.full_name != 'smithy-lang/smithy-rs' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -101,7 +101,6 @@ jobs:
   # The PR bot requires a Docker build image, so make it depend on the `acquire-base-image` job.
   pr_bot:
     name: PR Bot
-    timeout-minutes: 30
     if: ${{ github.event.pull_request.head.repo.full_name == 'smithy-lang/smithy-rs' }}
     needs: acquire-base-image
     uses: ./.github/workflows/pull-request-bot.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -21,6 +21,7 @@ jobs:
   # The login password is encrypted with the repo secret DOCKER_LOGIN_TOKEN_PASSPHRASE
   save-docker-login-token:
     name: Save a docker login token
+    timeout-minutes: 10
     if: ${{ github.event.pull_request.head.repo.full_name == 'smithy-lang/smithy-rs' }}
     outputs:
       docker-login-password: ${{ steps.set-token.outputs.docker-login-password }}
@@ -50,6 +51,7 @@ jobs:
   # it uploads the image as a build artifact for other jobs to download and use.
   acquire-base-image:
     name: Acquire Base Image
+    timeout-minutes: 60
     needs: save-docker-login-token
     if: ${{ github.event.pull_request.head.repo.full_name == 'smithy-lang/smithy-rs' }}
     runs-on: smithy_ubuntu-latest_8-core
@@ -99,6 +101,7 @@ jobs:
   # The PR bot requires a Docker build image, so make it depend on the `acquire-base-image` job.
   pr_bot:
     name: PR Bot
+    timeout-minutes: 30
     if: ${{ github.event.pull_request.head.repo.full_name == 'smithy-lang/smithy-rs' }}
     needs: acquire-base-image
     uses: ./.github/workflows/pull-request-bot.yml
@@ -113,6 +116,7 @@ jobs:
   semver-checks:
     name: check the semver status of this PR
     runs-on: smithy_ubuntu-latest_8-core
+    timeout-minutes: 20
     needs:
     - save-docker-login-token
     - acquire-base-image

--- a/.github/workflows/ci-tls.yml
+++ b/.github/workflows/ci-tls.yml
@@ -19,6 +19,7 @@ jobs:
   verify-tls-config:
     name: Verify TLS configuration
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Install packages
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
   # and also runs some checks/lints so that those are run sooner rather than later.
   generate:
     name: Generate
+    timeout-minutes: 25
     runs-on: smithy_ubuntu-latest_8-core
     # To avoid repeating setup boilerplate, we have the actual commands
     # in a matrix strategy. These commands get run in the steps after all the setup.
@@ -84,6 +85,7 @@ jobs:
   test-codegen:
     name: Test Codegen
     runs-on: ${{ matrix.test.runner }}
+    timeout-minutes: 30
     # To avoid repeating setup boilerplate, we have the actual test commands
     # in a matrix strategy. These commands get run in the steps after all the setup.
     strategy:
@@ -140,6 +142,7 @@ jobs:
   check-semver-hazards:
     name: Check for semver hazards
     runs-on: smithy_ubuntu-latest_8-core
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
       with:
@@ -162,6 +165,7 @@ jobs:
     name: Test the SDK
     needs: generate
     runs-on: ${{ matrix.test.runner }}
+    timeout-minutes: 20
     # To avoid repeating setup boilerplate, we have the actual test commands
     # in a matrix strategy. These commands get run in the steps after all the setup.
     strategy:
@@ -193,11 +197,10 @@ jobs:
       with:
         action: ${{ matrix.test.action }}
 
-
-
   test-rust-windows:
     name: Rust Tests on Windows
     runs-on: windows-latest
+    timeout-minutes: 20
     env:
       # Disable incremental compilation to reduce disk space use
       CARGO_INCREMENTAL: 0
@@ -232,6 +235,7 @@ jobs:
   test-exotic-platform-support:
     name: Exotic platform support
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -335,6 +339,7 @@ jobs:
     if: ${{ inputs.run_canary }}
     needs: generate
     runs-on: smithy_ubuntu-latest_8-core
+    timeout-minutes: 20
     permissions:
       id-token: write
       contents: read
@@ -373,6 +378,7 @@ jobs:
     if: ${{ inputs.run_sdk_examples }}
     needs: generate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This PR adds reasonable timeouts to each CI job so that a PR isn't held up for six hours by a hung runner.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
