### PR TITLE
Fix compiling S3 crate for wasm

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,10 @@ message = "Change some credentials related info log messages to debug."
 references = ["smithy-rs#3546"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "orf"
+
+
+[[aws-sdk-rust]]
+message = "Fix an S3 crate's dependency on `ahash` so the crate can be compiled for `wasm32-unknown-unknown`."
+references = ["smithy-rs#3590", "aws-sdk-rust#1131"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "ysaito1001"

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 # Used by lru, and this forces it to be a later version that avoids
 # https://github.com/tkaitchuck/aHash/issues/200
 # when built with `cargo update -Z minimal-versions`
-ahash = "0.8.11"
+ahash = { version = "0.8.11", default-features = false }
 aws-credential-types = { path = "../aws-credential-types" }
 aws-runtime = { path = "../aws-runtime", features = ["http-02x"] }
 aws-sigv4 = { path = "../aws-sigv4" }

--- a/aws/sdk/integration-tests/test.sh
+++ b/aws/sdk/integration-tests/test.sh
@@ -16,6 +16,9 @@ for f in *; do
       else
          # The webassembly tests use a custom runner set in config.toml that
          # is not picked up when running the tests outside of the package
+         # The tests are written for `wasm32-wasi` but the manifest config also specifies
+         # `wasm32-unknown-unknown` so we can ensure the test build on that platform as well.
+         # For executing the tests, however, we explicitly choose a target `wasm32-wasi`.
          cd webassembly && cargo component test --all-features --target wasm32-wasi && cd ..
       fi
    fi

--- a/aws/sdk/integration-tests/test.sh
+++ b/aws/sdk/integration-tests/test.sh
@@ -16,7 +16,7 @@ for f in *; do
       else
          # The webassembly tests use a custom runner set in config.toml that
          # is not picked up when running the tests outside of the package
-         cd webassembly && cargo component test --all-features --all-targets && cd ..
+         cd webassembly && cargo component test --all-features --target wasm32-wasi && cd ..
       fi
    fi
 done

--- a/aws/sdk/integration-tests/webassembly/.cargo/config.toml
+++ b/aws/sdk/integration-tests/webassembly/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
+target = ["wasm32-unknown-unknown", "wasm32-wasi"]
 
 [target.wasm32-wasi]
 rustflags = ["-C", "opt-level=1"]

--- a/aws/sdk/integration-tests/webassembly/.cargo/config.toml
+++ b/aws/sdk/integration-tests/webassembly/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-target = "wasm32-wasi"
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
 
 [target.wasm32-wasi]
 rustflags = ["-C", "opt-level=1"]

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -244,7 +244,7 @@ data class CargoDependency(
     companion object {
         // Forces AHash to be a later version that avoids
         // https://github.com/tkaitchuck/aHash/issues/200
-        val AHash: CargoDependency = CargoDependency("ahash", CratesIo("0.8.11"))
+        val AHash: CargoDependency = CargoDependency("ahash", CratesIo("0.8.11"), defaultFeatures = false)
         val OnceCell: CargoDependency = CargoDependency("once_cell", CratesIo("1.16"))
         val Url: CargoDependency = CargoDependency("url", CratesIo("2.3.1"))
         val Bytes: CargoDependency = CargoDependency("bytes", CratesIo("1.0.0"))

--- a/tools/ci-scripts/check-aws-sdk-standalone-integration-tests
+++ b/tools/ci-scripts/check-aws-sdk-standalone-integration-tests
@@ -42,7 +42,7 @@ cargo check --tests --all-features
 
 # Running WebAssembly (WASI) specific integration tests
 pushd "${tmp_dir}/aws/sdk/integration-tests/webassembly" &>/dev/null
-cargo check --tests --all-features
+cargo check --tests --all-features --all-targets
 
 popd
 popd

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -16,7 +16,7 @@ cargo check --all-targets --all-features
 
 echo "## Checking the wasm32-unknown-unknown and wasm32-wasi targets for SDKs"
 for dir in sdk/*; do
-    if [[ "$(basename "${dir}")" == aws-sdk-* ]]; then
+    if [[ "$(basename "${dir}")" != aws-* ]]; then
         echo "#### Checking ${dir}..."
         cargo check --target wasm32-unknown-unknown --no-default-features --manifest-path "${dir}/Cargo.toml"
         cargo check --target wasm32-wasi --no-default-features --manifest-path "${dir}/Cargo.toml"

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -14,9 +14,14 @@ sed -i '/"examples\//d' Cargo.toml
 
 cargo check --all-targets --all-features
 
-echo "## Checking the wasm32-unknown-unknown and wasm32-wasi targets..."
-cargo check --target wasm32-unknown-unknown --no-default-features
-cargo check --target wasm32-wasi --no-default-features
+echo "## Checking the wasm32-unknown-unknown and wasm32-wasi targets for SDKs"
+for dir in sdk/*; do
+    if [[ "$(basename "${dir}")" == aws-sdk-* ]]; then
+        echo "#### Checking ${dir}..."
+        cargo check --target wasm32-unknown-unknown --no-default-features --manifest-path "${dir}/Cargo.toml"
+        cargo check --target wasm32-wasi --no-default-features --manifest-path "${dir}/Cargo.toml"
+    fi
+done
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -14,15 +14,6 @@ sed -i '/"examples\//d' Cargo.toml
 
 cargo check --all-targets --all-features
 
-echo "## Checking the wasm32-unknown-unknown and wasm32-wasi targets for SDKs"
-for dir in sdk/*; do
-    if [[ "$(basename "${dir}")" != aws-* ]]; then
-        echo "#### Checking ${dir}..."
-        cargo check --target wasm32-unknown-unknown --no-default-features --manifest-path "${dir}/Cargo.toml"
-        cargo check --target wasm32-wasi --no-default-features --manifest-path "${dir}/Cargo.toml"
-    fi
-done
-
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then
         echo "#### Checking ${test_dir}..."

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -14,6 +14,10 @@ sed -i '/"examples\//d' Cargo.toml
 
 cargo check --all-targets --all-features
 
+echo "## Checking the wasm32-unknown-unknown and wasm32-wasi targets..."
+cargo check --target wasm32-unknown-unknown --no-default-features
+cargo check --target wasm32-wasi --no-default-features
+
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then
         echo "#### Checking ${test_dir}..."


### PR DESCRIPTION
## Motivation and Context
Running `cargo build --target wasm32-unknown-unknown --no-default-features` on an S3 crate has stopped working since https://github.com/smithy-lang/smithy-rs/pull/3465 with the following error:
```
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/[REDACTED]/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.14/src/lib.rs:352:9
    |
352 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
353 | |                         default, you may need to enable the \"js\" feature. \
354 | |                         For more information see: \
355 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^
```

To address the issue, this PR updates an S3's dependency on `ahash` in a way that disables default features.

## Testing
Updated the existing test `integration-tests/webassembly` so that `check-aws-sdk-standalone-integration-tests` will run `cargo check` `aws-sdk-s3` against both `wasm32-wasi` and `wasm32-unknown-unknown` (the updated check would break if we removed `default-features = false` from the `ahash` dependency).

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
