### PR TITLE
Revert cargo-semver-checks version due to performance regression

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -115,7 +115,7 @@ jobs:
   semver-checks:
     name: Check PR semver compliance
     runs-on: smithy_ubuntu-latest_8-core
-    timeout-minutes: 45
+    timeout-minutes: 20
     needs:
     - save-docker-login-token
     - acquire-base-image

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -113,9 +113,9 @@ jobs:
       SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}
 
   semver-checks:
-    name: check the semver status of this PR
+    name: Check PR semver compliance
     runs-on: smithy_ubuntu-latest_8-core
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs:
     - save-docker-login-token
     - acquire-base-image
@@ -153,6 +153,6 @@ jobs:
       with:
         action: check-semver
         action-arguments: ${{ github.event.pull_request.base.sha }} ${{ fromJSON(steps.check-breaking-label.outputs.result).isBreaking }}
-    - name: print help message
+    - name: Print help message
       if: failure()
-      run: echo "::error::This pull request contains breaking changes. Please add the `breaking-changes` label and a changelog entry"
+      run: echo "::error::This pull request either contains breaking changes, or has cross-crate changes that may be backwards compatible, but that cargo-semver-checks cannot verify. Please scrutinize the change for backwards compatibility."

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -115,7 +115,7 @@ jobs:
   semver-checks:
     name: Check PR semver compliance
     runs-on: smithy_ubuntu-latest_8-core
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs:
     - save-docker-login-token
     - acquire-base-image

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -131,7 +131,7 @@ ARG rust_nightly_version
 RUN cargo +${rust_nightly_version} install cargo-component --locked --version ${cargo_component_version}
 
 FROM install_rust AS cargo_semver_checks
-ARG cargo_semver_checks_version=0.30.0
+ARG cargo_semver_checks_version=0.24.1
 RUN cargo install cargo-semver-checks --locked --version ${cargo_semver_checks_version}
 
 FROM install_rust AS cargo_mdbook


### PR DESCRIPTION
It seems upgrading cargo-semver-checks to 0.30 made it take significantly longer than before (going from less than 20 minutes up to between 1-4 hours). Reverting it back to 0.24.1 for now to keep CI faster.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
