### PR TITLE
Retro compatible for p256 0.10.0

### DIFF
--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -29,7 +29,7 @@ hmac = "0.12"
 http0 = { version = "0.2", optional = true, package = "http" }
 http = { version = "1", optional = true }
 once_cell = "1.8"
-p256 = { version = "0.11", features = ["ecdsa"], optional = true }
+p256 = { version = "0.10", features = ["ecdsa"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 ring = { version = "0.17.5", optional = true }
 sha2 = "0.10"

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"


### PR DESCRIPTION
## Motivation and Context

Keeping it retro compatible with solana-sdk 1.16

## Description

Updating `p256` version from `0.11` to `0.10` will still allow version `0.11` but will include `0.10` which is necessary when building something that includes `solana-sdk` version `1.16`.

- solana-sdk https://crates.io/crates/solana-sdk/1.16.27/dependencies
  - curve25519-dalek https://crates.io/crates/curve25519-dalek/4.1.2/dependencies
    - zeroize ^1
-  p256 https://crates.io/crates/p256/0.10.1/dependencies
  - elliptic-curve https://crates.io/crates/elliptic-curve/0.11.12/dependencies
    - zeroize ^1
  
`p256 0.11` has another version of `zeroize` which is incompatible
-  p256 https://crates.io/crates/p256/0.11.0/dependencies
  - elliptic-curve https://crates.io/crates/elliptic-curve/0.12.3/dependencies
    - zeroize ^1.5
