### PR TITLE
Add MSRV to generated SDK Cargo.toml files

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -116,6 +116,7 @@ fun generateSmithyBuild(services: AwsServices): String {
                         ${service.examplesUri(project)?.let { """"examples": "$it",""" } ?: ""}
                         "moduleRepository": "https://github.com/awslabs/aws-sdk-rust",
                         "license": "Apache-2.0",
+                        "minimumSupportedRustVersion": "${getRustMSRV()}",
                         "customizationConfig": {
                             "awsSdk": {
                                 "awsSdkBuild": true,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
@@ -37,6 +37,7 @@ data class ClientRustSettings(
     override val codegenConfig: ClientCodegenConfig,
     override val license: String?,
     override val examplesUri: String?,
+    override val minimumSupportedRustVersion: String? = null,
     override val customizationConfig: ObjectNode?,
 ) : CoreRustSettings(
         service,
@@ -49,6 +50,7 @@ data class ClientRustSettings(
         codegenConfig,
         license,
         examplesUri,
+        minimumSupportedRustVersion,
         customizationConfig,
     ) {
     companion object {
@@ -70,6 +72,7 @@ data class ClientRustSettings(
                 codegenConfig = ClientCodegenConfig.fromCodegenConfigAndNode(coreCodegenConfig, codegenSettingsNode),
                 license = coreRustSettings.license,
                 examplesUri = coreRustSettings.examplesUri,
+                minimumSupportedRustVersion = coreRustSettings.minimumSupportedRustVersion,
                 customizationConfig = coreRustSettings.customizationConfig,
             )
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
@@ -36,6 +36,7 @@ fun testClientRustSettings(
     codegenConfig: ClientCodegenConfig = ClientCodegenConfig(),
     license: String? = null,
     examplesUri: String? = null,
+    minimumSupportedRustVersion: String? = null,
     customizationConfig: ObjectNode? = null,
 ) = ClientRustSettings(
     service,
@@ -48,6 +49,7 @@ fun testClientRustSettings(
     codegenConfig,
     license,
     examplesUri,
+    minimumSupportedRustVersion,
     customizationConfig,
 )
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CoreRustSettings.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CoreRustSettings.kt
@@ -15,18 +15,18 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.Optional
 import java.util.logging.Logger
-import kotlin.streams.toList
 
-const val SERVICE = "service"
-const val MODULE_NAME = "module"
-const val MODULE_DESCRIPTION = "moduleDescription"
-const val MODULE_VERSION = "moduleVersion"
-const val MODULE_AUTHORS = "moduleAuthors"
-const val MODULE_REPOSITORY = "moduleRepository"
-const val RUNTIME_CONFIG = "runtimeConfig"
-const val LICENSE = "license"
-const val EXAMPLES = "examples"
-const val CUSTOMIZATION_CONFIG = "customizationConfig"
+private const val SERVICE = "service"
+private const val MODULE_NAME = "module"
+private const val MODULE_DESCRIPTION = "moduleDescription"
+private const val MODULE_VERSION = "moduleVersion"
+private const val MODULE_AUTHORS = "moduleAuthors"
+private const val MODULE_REPOSITORY = "moduleRepository"
+private const val RUNTIME_CONFIG = "runtimeConfig"
+private const val LICENSE = "license"
+private const val EXAMPLES = "examples"
+private const val MINIMUM_SUPPORTED_RUST_VERSION = "minimumSupportedRustVersion"
+private const val CUSTOMIZATION_CONFIG = "customizationConfig"
 const val CODEGEN_SETTINGS = "codegen"
 
 /**
@@ -88,6 +88,7 @@ open class CoreRustSettings(
     open val codegenConfig: CoreCodegenConfig,
     open val license: String?,
     open val examplesUri: String? = null,
+    open val minimumSupportedRustVersion: String? = null,
     open val customizationConfig: ObjectNode? = null,
 ) {
     /**
@@ -177,6 +178,7 @@ open class CoreRustSettings(
                     CODEGEN_SETTINGS,
                     EXAMPLES,
                     LICENSE,
+                    MINIMUM_SUPPORTED_RUST_VERSION,
                     CUSTOMIZATION_CONFIG,
                 ),
             )
@@ -198,6 +200,7 @@ open class CoreRustSettings(
                 codegenConfig = coreCodegenConfig,
                 license = config.getStringMember(LICENSE).orNull()?.value,
                 examplesUri = config.getStringMember(EXAMPLES).orNull()?.value,
+                minimumSupportedRustVersion = config.getStringMember(MINIMUM_SUPPORTED_RUST_VERSION).orNull()?.value,
                 customizationConfig = config.getObjectMember(CUSTOMIZATION_CONFIG).orNull(),
             )
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGenerator.kt
@@ -49,6 +49,7 @@ class CargoTomlGenerator(
     private val moduleDescription: String?,
     private val moduleLicense: String?,
     private val moduleRepository: String?,
+    private val minimumSupportedRustVersion: String?,
     private val writer: RustWriter,
     private val manifestCustomizations: ManifestCustomizations = emptyMap(),
     private val dependencies: List<CargoDependency> = emptyList(),
@@ -67,6 +68,7 @@ class CargoTomlGenerator(
         settings.moduleDescription,
         settings.license,
         settings.moduleRepository,
+        settings.minimumSupportedRustVersion,
         writer,
         manifestCustomizations,
         dependencies,
@@ -90,6 +92,7 @@ class CargoTomlGenerator(
                         "edition" to "2021",
                         "license" to moduleLicense,
                         "repository" to moduleRepository,
+                        "rust-version" to minimumSupportedRustVersion,
                         "metadata" to
                             listOfNotNull(
                                 "smithy" to

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -466,6 +466,7 @@ private fun String.intoCrate(
                 moduleDescription = null,
                 moduleLicense = null,
                 moduleRepository = null,
+                minimumSupportedRustVersion = null,
                 writer = this,
                 dependencies = deps,
             ).render()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -38,6 +38,7 @@ data class ServerRustSettings(
     override val codegenConfig: ServerCodegenConfig,
     override val license: String?,
     override val examplesUri: String?,
+    override val minimumSupportedRustVersion: String? = null,
     override val customizationConfig: ObjectNode?,
 ) : CoreRustSettings(
         service,
@@ -50,6 +51,7 @@ data class ServerRustSettings(
         codegenConfig,
         license,
         examplesUri,
+        minimumSupportedRustVersion,
         customizationConfig,
     ) {
     companion object {
@@ -71,6 +73,7 @@ data class ServerRustSettings(
                 codegenConfig = ServerCodegenConfig.fromCodegenConfigAndNode(coreCodegenConfig, codegenSettingsNode),
                 license = coreRustSettings.license,
                 examplesUri = coreRustSettings.examplesUri,
+                minimumSupportedRustVersion = coreRustSettings.minimumSupportedRustVersion,
                 customizationConfig = coreRustSettings.customizationConfig,
             )
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
@@ -81,6 +81,7 @@ fun serverTestRustSettings(
     codegenConfig: ServerCodegenConfig = ServerCodegenConfig(),
     license: String? = null,
     examplesUri: String? = null,
+    minimumSupportedRustVersion: String? = null,
     customizationConfig: ObjectNode? = null,
 ) = ServerRustSettings(
     service,
@@ -93,6 +94,7 @@ fun serverTestRustSettings(
     codegenConfig,
     license,
     examplesUri,
+    minimumSupportedRustVersion,
     customizationConfig,
 )
 


### PR DESCRIPTION
This PR sets the `rust-version` property on generated Cargo.toml files for the AWS SDK crates. It doesn't attempt to place the property on the runtime crates for now since that will either require manual updating, or more machinery to automate.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
