### PR TITLE
Allow manual invocation of verify TLS CI step

### DIFF
--- a/.github/workflows/ci-tls.yml
+++ b/.github/workflows/ci-tls.yml
@@ -11,6 +11,7 @@ env:
 
 name: Verify client TLS configuration
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]


### PR DESCRIPTION
The verify TLS CI step is flaky at the moment, so it would be helpful to be able to run it manually against main to see if it was the PR that broke it, or if it is its general flakiness.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
