### PR TITLE
Bump rustls and hyper-rustls versions. Replace aws-* with actuals

### DIFF
--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-client"
-version = "0.0.0-smithy-rs-head"
+version = "0.55.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Client for smithy-rs."
 edition = "2021"
@@ -15,13 +15,12 @@ rustls = ["dep:hyper-rustls", "dep:lazy_static", "dep:rustls", "client-hyper", "
 client-hyper = ["dep:hyper"]
 hyper-webpki-doctest-only = ["dep:hyper-rustls", "hyper-rustls?/webpki-roots"]
 
-
 [dependencies]
-aws-smithy-async = { path = "../aws-smithy-async" }
-aws-smithy-http = { path = "../aws-smithy-http" }
-aws-smithy-http-tower = { path = "../aws-smithy-http-tower" }
-aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test", optional = true }
-aws-smithy-types = { path = "../aws-smithy-types" }
+aws-smithy-async = "0.55.3"
+aws-smithy-http = "0.55.3"
+aws-smithy-http-tower = "0.55.3"
+aws-smithy-protocol-test = "0.55.3"
+aws-smithy-types = "0.55.3"
 bytes = "1"
 fastrand = "1.4.0"
 http = "0.2.3"
@@ -30,9 +29,9 @@ hyper = { version = "0.14.25", features = ["client", "http2", "http1", "tcp"], o
 # cargo does not support optional test dependencies, so to completely disable rustls when
 # the native-tls feature is enabled, we need to add the webpki-roots feature here.
 # https://github.com/rust-lang/cargo/issues/1596
-hyper-rustls = { version = "0.23.0", optional = true, features = ["rustls-native-certs", "http2"] }
+hyper-rustls = { version = "0.24", optional = true, features = ["rustls-native-certs", "http2"] }
 hyper-tls = { version = "0.5.0", optional = true }
-rustls = { version = "0.20", optional = true }
+rustls = { version = "0.21.11", optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project-lite = "0.2.7"
 serde = { version = "1", features = ["derive"], optional = true }
@@ -42,7 +41,7 @@ tower = { version = "0.4.6", features = ["util", "retry"] }
 tracing = "0.1"
 
 [dev-dependencies]
-aws-smithy-async = { path = "../aws-smithy-async", features = ["rt-tokio"] }
+aws-smithy-async = { version = "0.55.3", features = ["rt-tokio"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.23.1", features = ["full", "test-util"] }


### PR DESCRIPTION
There is a CVE: https://rustsec.org/advisories/RUSTSEC-2024-0336 related to `rustls`.  We want to back port the fix in `aws-smithy-client = 0.553`.