### PR TITLE
Allow only patch-level bumps for `fastrand` in testing

### DIFF
--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -27,6 +27,8 @@ aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test", optional = tr
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-0-4-x"] }
 bytes = "1"
+# Make sure to update `fastrand` in [dev-dependencies] if we bump the major version
+# We probably need to update unit tests using the `fastrand` crate when that happens
 fastrand = "2.0.0"
 h2 = { version = "0.3", default-features = false, optional = true }
 http = { version = "0.2.8" }
@@ -50,6 +52,9 @@ approx = "0.5.1"
 aws-smithy-async = { path = "../aws-smithy-async", features = ["rt-tokio", "test-util"] }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["test-util"] }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["test-util"] }
+# Allow only patch-level bumps since major-level or minor-level bumps can cause seed-value-breaking changes
+# https://github.com/smol-rs/fastrand/issues/20
+fastrand = "~2.0.0"
 futures-util = "0.3.29"
 pretty_assertions = "1.4.0"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "test-util", "full"] }


### PR DESCRIPTION
## Motivation and Context
Pins major and minor versions for `fastrand` during testing in `aws-smithy-runtime`

## Description
`aws-smithy-runtime` uses the `fastrand` crate in a waiters' [unit test](https://github.com/smithy-lang/smithy-rs/blob/eac52eb69c89d78c1844e9e2b0f0c3413031fc58/rust-runtime/aws-smithy-runtime/src/client/waiters/backoff.rs#L137). Two days ago, `fastrand` of version 2.1.0 got released (previously 2.0.2). According to [this PR](https://github.com/smol-rs/fastrand/issues/20), a minor version bump can cause seed-value-breaking changes.

This PR will only allow patch-level bumps for `fastrand` in `[dev-dependencies]`.

## Testing
Relies on testing in CI (since CI in the main branch currently fails, if CI passes in this PR we're good).

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
