### PR TITLE
re-enable content length enforcement

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,6 +11,7 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
+
 [[aws-sdk-rust]]
 message = "Fix panics that occurred when `Duration` for exponential backoff could not be created from too big a float."
 references = ["aws-sdk-rust#1133"]
@@ -22,3 +23,17 @@ message = "Fix panics that occurred when `Duration` for exponential backoff coul
 references = ["aws-sdk-rust#1133"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "ysaito1001"
+
+[[smithy-rs]]
+message = "Clients now enforce that the Content-Length sent by the server matches the length of the returned response body. In most cases, Hyper will enforce this behavior, however, in extremely rare circumstances where the Tokio runtime is dropped in between subsequent requests, this scenario can occur."
+references = ["smithy-rs#3491", "aws-sdk-rust#1079"]
+meta = { "breaking" = false, "bug" = true, "tada" = false }
+author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Clients now enforce that the Content-Length sent by the server matches the length of the returned response body. In most cases, Hyper will enforce this behavior, however, in extremely rare circumstances where the Tokio runtime is dropped in between subsequent requests, this scenario can occur."
+references = ["aws-sdk-rust#1079"]
+meta = { "breaking" = false, "bug" = true, "tada" = false }
+author = "rcoh"
+
+

--- a/aws/sdk/integration-tests/s3/tests/streaming-response.rs
+++ b/aws/sdk/integration-tests/s3/tests/streaming-response.rs
@@ -18,9 +18,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use tracing::debug;
 
-// TODO(https://github.com/smithy-lang/smithy-rs/issues/3523): Unignore this test
 #[tokio::test]
-#[ignore]
 async fn test_too_short_body_causes_an_error() {
     // this is almost impossible to reproduce with Hyper—you need to do stuff like run each request
     // in its own async runtime. But there's no reason a customer couldn't run their _own_ HttpClient

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
@@ -204,8 +204,6 @@ fn default_stalled_stream_protection_config_plugin_v2(
     )
 }
 
-// TODO(https://github.com/smithy-lang/smithy-rs/issues/3523)
-#[allow(dead_code)]
 fn enforce_content_length_runtime_plugin() -> Option<SharedRuntimePlugin> {
     Some(EnforceContentLengthRuntimePlugin::new().into_shared())
 }
@@ -286,8 +284,7 @@ pub fn default_plugins(
         default_sleep_impl_plugin(),
         default_time_source_plugin(),
         default_timeout_config_plugin(),
-        // TODO(https://github.com/smithy-lang/smithy-rs/issues/3523): Reenable this
-        /* enforce_content_length_runtime_plugin(), */
+        enforce_content_length_runtime_plugin(),
         default_stalled_stream_protection_config_plugin_v2(behavior_version),
     ]
     .into_iter()


### PR DESCRIPTION
## Motivation and Context
This PR re-enables content-length runtime plugin that was previously disabled due to some erroneous tests. Those [tests](https://github.com/awslabs/aws-sdk-rust/blob/main/sdk/dynamodb/tests/retries-with-client-rate-limiting.rs#L29) appear to be fixed.
 
Original PR: https://github.com/smithy-lang/smithy-rs/pull/3491
Tracking issue: https://github.com/smithy-lang/smithy-rs/issues/3523


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
