### PR TITLE
[3161] Implement Debug for DateTime

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,10 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+
+[[smithy-rs]]
+message = "Implement Debug for DateTime"
+references = ["smithy-rs#3161"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
+author = "mnissenb"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,10 +10,3 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
-
-
-[[smithy-rs]]
-message = "Implement Debug for DateTime"
-references = ["smithy-rs#3161"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
-author = "mnissenb"

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.1.8"
+version = "1.1.9"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.1.9"
+version = "1.1.8"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -55,7 +55,7 @@ const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 /// The [`aws-smithy-types-convert`](https://crates.io/crates/aws-smithy-types-convert) crate
 /// can be used for conversions to/from other libraries, such as
 /// [`time`](https://crates.io/crates/time) or [`chrono`](https://crates.io/crates/chrono).
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
 pub struct DateTime {
     pub(crate) seconds: i64,
     /// Subsecond nanos always advances the wallclock time, even for times where seconds is negative
@@ -336,6 +336,12 @@ impl Display for DateTime {
         write!(f, "{}", date)
     }
 }
+
+impl fmt::Debug for DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
 /// Failure to convert a `DateTime` to or from another type.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -392,6 +398,21 @@ mod test {
 
         let date_time = DateTime::from_secs(16995123);
         assert_eq!(format!("{}", date_time), "1970-07-16T16:52:03Z");
+    }
+
+    #[test]
+    fn test_debug_date_time() {
+        let date_time = DateTime::from_secs(1576540098);
+        assert_eq!(format!("{:?}", date_time), "2019-12-16T23:48:18Z");
+
+        let date_time = DateTime::from_fractional_secs(1576540098, 0.52);
+        assert_eq!(format!("{:?}", date_time), "2019-12-16T23:48:18.52Z");
+
+        let date_time = DateTime::from_secs(1699942527);
+        assert_eq!(format!("{:?}", date_time), "2023-11-14T06:15:27Z");
+
+        let date_time = DateTime::from_secs(16995123);
+        assert_eq!(format!("{:?}", date_time), "1970-07-16T16:52:03Z");
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -55,7 +55,7 @@ const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 /// The [`aws-smithy-types-convert`](https://crates.io/crates/aws-smithy-types-convert) crate
 /// can be used for conversions to/from other libraries, such as
 /// [`time`](https://crates.io/crates/time) or [`chrono`](https://crates.io/crates/chrono).
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct DateTime {
     pub(crate) seconds: i64,
     /// Subsecond nanos always advances the wallclock time, even for times where seconds is negative
@@ -336,12 +336,6 @@ impl Display for DateTime {
         write!(f, "{}", date)
     }
 }
-
-impl fmt::Debug for DateTime {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
 /// Failure to convert a `DateTime` to or from another type.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -398,21 +392,6 @@ mod test {
 
         let date_time = DateTime::from_secs(16995123);
         assert_eq!(format!("{}", date_time), "1970-07-16T16:52:03Z");
-    }
-
-    #[test]
-    fn test_debug_date_time() {
-        let date_time = DateTime::from_secs(1576540098);
-        assert_eq!(format!("{:?}", date_time), "2019-12-16T23:48:18Z");
-
-        let date_time = DateTime::from_fractional_secs(1576540098, 0.52);
-        assert_eq!(format!("{:?}", date_time), "2019-12-16T23:48:18.52Z");
-
-        let date_time = DateTime::from_secs(1699942527);
-        assert_eq!(format!("{:?}", date_time), "2023-11-14T06:15:27Z");
-
-        let date_time = DateTime::from_secs(16995123);
-        assert_eq!(format!("{:?}", date_time), "1970-07-16T16:52:03Z");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
According to #3161 , the Debug output was in a marginally legible format. 

<!--- If it fixes an open issue, please link to the issue here -->
#3161 

## Description
<!--- Describe your changes in detail -->
Since there's no expected difference between `Debug` and `Display` for date_time, the `fmt::Debug` for `date_time` calls the already implemented `Display`. 

## Testing
<!--- Please describe in detail how you tested your changes -->
I added unit tests, and ran `cargo test` within the `rust-runtime` directory. 
<!--- Include details of your testing environment, and the tests you ran to -->
Aarch64 mac terminal - `$ cd rust-runtime && cargo test`
<!--- see how your change affects other areas of the code, etc. -->
A single test failed:  `client::waiters::backoff::tests::backoff_with_seeded_jitter` at first. After rebasing on upstream, the failure went away. Thanks for the fix. 



## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
