### PR TITLE
Fix panic when failing to create `Duration` for exponential backoff from a large float

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Fix panics that occurred when `Duration` for exponential backoff could not be created from too big a float."
+references = ["aws-sdk-rust#1133"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "ysaito1001"
+
+[[smithy-rs]]
+message = "Fix panics that occurred when `Duration` for exponential backoff could not be created from too big a float."
+references = ["aws-sdk-rust#1133"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
+author = "ysaito1001"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -138,7 +138,7 @@ impl StandardRetryStrategy {
                     } else {
                         fastrand::f64()
                     };
-                    let backoff = calculate_exponential_backoff(
+                    Ok(calculate_exponential_backoff(
                         // Generate a random base multiplier to create jitter
                         base,
                         // Get the backoff time multiplier in seconds (with fractional seconds)
@@ -146,16 +146,9 @@ impl StandardRetryStrategy {
                         // `self.local.attempts` tracks number of requests made including the initial request
                         // The initial attempt shouldn't count towards backoff calculations, so we subtract it
                         request_attempts - 1,
-                    );
-                    match Duration::try_from_secs_f64(backoff) {
-                        Ok(duration) => Ok(duration.min(retry_cfg.max_backoff())),
-                        Err(e) => {
-                            tracing::warn!(
-                                "could not create `Duration` for exponential backoff: {e}"
-                            );
-                            Err(ShouldAttempt::No)
-                        }
-                    }
+                        // Maximum backoff duration as a fallback to prevent overflow when calculating a power
+                        retry_cfg.max_backoff(),
+                    ))
                 }
             }
             RetryAction::RetryForbidden | RetryAction::NoActionIndicated => {
@@ -296,11 +289,29 @@ fn check_rate_limiter_for_delay(
     None
 }
 
-fn calculate_exponential_backoff(base: f64, initial_backoff: f64, retry_attempts: u32) -> f64 {
-    2_u32
+fn calculate_exponential_backoff(
+    base: f64,
+    initial_backoff: f64,
+    retry_attempts: u32,
+    max_backoff: Duration,
+) -> Duration {
+    let result = match 2_u32
         .checked_pow(retry_attempts)
-        .map(|backoff| (backoff as f64) * base * initial_backoff)
-        .unwrap_or(f64::MAX)
+        .map(|power| (power as f64) * initial_backoff)
+    {
+        Some(backoff) => match Duration::try_from_secs_f64(backoff) {
+            Ok(result) => result.min(max_backoff),
+            Err(e) => {
+                tracing::warn!("falling back to {max_backoff:?} as `Duration` could not be created for exponential backoff: {e}");
+                max_backoff
+            }
+        },
+        None => max_backoff,
+    };
+
+    // Apply jitter to `result`, and note that it can be applied to `max_backoff`.
+    // Won't panic because `base` is either in range 0..1 or a constant 1 in testing (if configured).
+    result.mul_f64(base)
 }
 
 fn get_seconds_since_unix_epoch(runtime_components: &RuntimeComponents) -> f64 {
@@ -439,13 +450,15 @@ mod tests {
             ErrorKind::TransientError,
             // Greater than 32 when subtracted by 1 in `calculate_backoff`, causing overflow in `calculate_exponential_backoff`
             33,
-            RetryConfig::standard().with_max_attempts(100), // Any value greater than 33 will do
+            RetryConfig::standard()
+                .with_use_static_exponential_base(true)
+                .with_max_attempts(100), // Any value greater than 33 will do
         );
         let strategy = StandardRetryStrategy::new();
         let actual = strategy
             .should_attempt_retry(&ctx, &rc, &cfg)
             .expect("method is infallible for this use");
-        assert_eq!(ShouldAttempt::No, actual);
+        assert_eq!(ShouldAttempt::YesAfterDelay(MAX_BACKOFF), actual);
     }
 
     #[derive(Debug)]
@@ -891,14 +904,16 @@ mod tests {
         assert_eq!(token_bucket.available_permits(), 480);
     }
 
+    const MAX_BACKOFF: Duration = Duration::from_secs(20);
+
     #[test]
     fn calculate_exponential_backoff_where_initial_backoff_is_one() {
         let initial_backoff = 1.0;
 
         for (attempt, expected_backoff) in [initial_backoff, 2.0, 4.0].into_iter().enumerate() {
             let actual_backoff =
-                calculate_exponential_backoff(1.0, initial_backoff, attempt as u32);
-            assert_eq!(expected_backoff, actual_backoff);
+                calculate_exponential_backoff(1.0, initial_backoff, attempt as u32, MAX_BACKOFF);
+            assert_eq!(Duration::from_secs_f64(expected_backoff), actual_backoff);
         }
     }
 
@@ -908,8 +923,8 @@ mod tests {
 
         for (attempt, expected_backoff) in [initial_backoff, 6.0, 12.0].into_iter().enumerate() {
             let actual_backoff =
-                calculate_exponential_backoff(1.0, initial_backoff, attempt as u32);
-            assert_eq!(expected_backoff, actual_backoff);
+                calculate_exponential_backoff(1.0, initial_backoff, attempt as u32, MAX_BACKOFF);
+            assert_eq!(Duration::from_secs_f64(expected_backoff), actual_backoff);
         }
     }
 
@@ -919,17 +934,17 @@ mod tests {
 
         for (attempt, expected_backoff) in [initial_backoff, 0.06, 0.12].into_iter().enumerate() {
             let actual_backoff =
-                calculate_exponential_backoff(1.0, initial_backoff, attempt as u32);
-            assert_eq!(expected_backoff, actual_backoff);
+                calculate_exponential_backoff(1.0, initial_backoff, attempt as u32, MAX_BACKOFF);
+            assert_eq!(Duration::from_secs_f64(expected_backoff), actual_backoff);
         }
     }
 
     #[test]
-    fn calculate_backoff_overflow() {
+    fn calculate_backoff_overflow_should_gracefully_fallback_to_max_backoff() {
         // avoid overflow for a silly large amount of retry attempts
         assert_eq!(
-            calculate_exponential_backoff(1_f64, 10_f64, 100000),
-            f64::MAX
+            MAX_BACKOFF,
+            calculate_exponential_backoff(1_f64, 10_f64, 100000, MAX_BACKOFF),
         );
     }
 }

--- a/tools/ci-build/runtime-versioner/Cargo.toml
+++ b/tools/ci-build/runtime-versioner/Cargo.toml
@@ -16,7 +16,7 @@ opt-level = 0
 [dependencies]
 anyhow = "1.0.75"
 camino = "1.1.6"
-clap = { version = "4.4.11", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive", "env"] }
 crates-index = "2.3.0"
 indicatif = "0.17.7"
 reqwest = { version = "0.11.22", features = ["blocking"] }

--- a/tools/ci-build/runtime-versioner/src/command/audit.rs
+++ b/tools/ci-build/runtime-versioner/src/command/audit.rs
@@ -21,9 +21,6 @@ use std::{
     process::Command,
 };
 
-const SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG: &str =
-    "SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG";
-
 pub fn audit(args: Audit) -> Result<()> {
     let repo = Repo::new(args.smithy_rs_path.as_deref())?;
     if !args.no_fetch {
@@ -32,12 +29,8 @@ pub fn audit(args: Audit) -> Result<()> {
     }
 
     let release_tags = release_tags(&repo)?;
-    let release_tag_override = match args.previous_release_tag {
-        overrid @ Some(_) => overrid,
-        None => std::env::var(SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG).ok(),
-    };
     let previous_release_tag =
-        previous_release_tag(&repo, &release_tags, release_tag_override.as_deref())?;
+        previous_release_tag(&repo, &release_tags, args.previous_release_tag.as_deref())?;
     if release_tags.first() != Some(&previous_release_tag) {
         tracing::warn!("there are newer releases since '{previous_release_tag}'. \
             Consider specifying a more recent release tag using the `--previous-release-tag` command-line argument or \

--- a/tools/ci-build/runtime-versioner/src/command/audit.rs
+++ b/tools/ci-build/runtime-versioner/src/command/audit.rs
@@ -21,7 +21,8 @@ use std::{
     process::Command,
 };
 
-const AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE: &str = "AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE";
+const SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG: &str =
+    "SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG";
 
 pub fn audit(args: Audit) -> Result<()> {
     let repo = Repo::new(args.smithy_rs_path.as_deref())?;
@@ -33,14 +34,14 @@ pub fn audit(args: Audit) -> Result<()> {
     let release_tags = release_tags(&repo)?;
     let release_tag_override = match args.previous_release_tag {
         overrid @ Some(_) => overrid,
-        None => std::env::var(AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE).ok(),
+        None => std::env::var(SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG).ok(),
     };
     let previous_release_tag =
         previous_release_tag(&repo, &release_tags, release_tag_override.as_deref())?;
     if release_tags.first() != Some(&previous_release_tag) {
         tracing::warn!("there are newer releases since '{previous_release_tag}'. \
             Consider specifying a more recent release tag using the `--previous-release-tag` command-line argument or \
-            the `AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE` environment variable if audit fails.");
+            the `SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG` environment variable if audit fails.");
     }
 
     let next_crates = discover_runtime_crates(&repo.root).context("next")?;

--- a/tools/ci-build/runtime-versioner/src/command/audit.rs
+++ b/tools/ci-build/runtime-versioner/src/command/audit.rs
@@ -21,6 +21,8 @@ use std::{
     process::Command,
 };
 
+const AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE: &str = "AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE";
+
 pub fn audit(args: Audit) -> Result<()> {
     let repo = Repo::new(args.smithy_rs_path.as_deref())?;
     if !args.no_fetch {
@@ -29,10 +31,16 @@ pub fn audit(args: Audit) -> Result<()> {
     }
 
     let release_tags = release_tags(&repo)?;
+    let release_tag_override = match args.previous_release_tag {
+        overrid @ Some(_) => overrid,
+        None => std::env::var(AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE).ok(),
+    };
     let previous_release_tag =
-        previous_release_tag(&repo, &release_tags, args.previous_release_tag.as_deref())?;
+        previous_release_tag(&repo, &release_tags, release_tag_override.as_deref())?;
     if release_tags.first() != Some(&previous_release_tag) {
-        tracing::warn!("there are newer releases since '{previous_release_tag}'");
+        tracing::warn!("there are newer releases since '{previous_release_tag}'. \
+            Consider specifying a more recent release tag using the `--previous-release-tag` command-line argument or \
+            the `AUDIT_PREVIOUS_RELEASE_TAG_OVERRIDE` environment variable if audit fails.");
     }
 
     let next_crates = discover_runtime_crates(&repo.root).context("next")?;

--- a/tools/ci-build/runtime-versioner/src/main.rs
+++ b/tools/ci-build/runtime-versioner/src/main.rs
@@ -30,7 +30,7 @@ pub struct Audit {
     #[arg(long)]
     no_fetch: bool,
     /// Explicitly state the previous release's tag. Discovers it if not provided.
-    #[arg(long)]
+    #[arg(long, env = "SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG")]
     previous_release_tag: Option<String>,
     /// Path to smithy-rs. Defaults to current working directory.
     #[arg(long)]

--- a/tools/ci-build/runtime-versioner/src/tag.rs
+++ b/tools/ci-build/runtime-versioner/src/tag.rs
@@ -35,7 +35,8 @@ pub fn previous_release_tag(
         // release. However, specifying the new release for `previous_release_override_commit` fails
         // with the first guard because `HEAD` doesn't know about the new release. The second guard
         // provides an escape hatch where if `previous_release_commit` (the latest release currently
-        // `HEAD` does know about) is the ancestor to the specified previous release override.
+        // `HEAD` does know about) is the ancestor to the specified previous release override, then
+        // we can now treat the previous release override as a legitimate previous release.
         if !is_ancestor(repo, &previous_release_override_commit, "HEAD")?
             && !is_ancestor(
                 repo,

--- a/tools/ci-build/runtime-versioner/src/tag.rs
+++ b/tools/ci-build/runtime-versioner/src/tag.rs
@@ -26,15 +26,16 @@ pub fn previous_release_tag(
         }
         let previous_release_commit = commit_for_tag(repo, &ancestor_tag)?;
         let previous_release_override_commit = commit_for_tag(repo, &tag_override)?;
-        // Most of the time, the first guard is enough; The previous release override should be an
-        // ancestor of the `HEAD` of a branch. However, we need the second guard handling a case
-        // where we `git merge main` into a branch, but the main branch now contains a new smithy-rs
-        // release that the `HEAD` of the branch doesn't know about.
+        // The first guard says that whenever we override a previous release tag, `HEAD` of our branch
+        // should be ahead of that override.
+        // The second guard handles a case where our branch is now behind w.r.t the latest smithy-rs
+        // release. This can happen when we `git merge main` into the branch, but the main branch
+        // now contains a new smithy-rs release that the `HEAD` of the branch doesn't know about.
         // In that case, we want to teach the tool that the previous release should now be the new
         // release. However, specifying the new release for `previous_release_override_commit` fails
         // with the first guard because `HEAD` doesn't know about the new release. The second guard
         // provides an escape hatch where if `previous_release_commit` (the latest release currently
-        // `HEAD` does not about) is the ancestor to the specified previous release override.
+        // `HEAD` does know about) is the ancestor to the specified previous release override.
         if !is_ancestor(repo, &previous_release_override_commit, "HEAD")?
             && !is_ancestor(
                 repo,


### PR DESCRIPTION
## Motivation and Context
Avoids panic when [Duration for exponential backoff](https://github.com/smithy-lang/smithy-rs/blob/main/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs#L150) could not be created from a large float.

## Description
[Duration::from_secs_f64](https://doc.rust-lang.org/core/time/struct.Duration.html#method.from_secs_f64) may panic. This PR switches to use a fallible sibling `Duration::try_from_secs_f64` to avoid panics. If `Duration::try_from_secs_f64` returns an `Err` we fallback to `max_backoff` for subsequent retries. Furthermore, we learned from internal discussion that jitter also needs to be applied to `max_backoff`. This PR updates `calculate_exponential_backoff` to handle all the said business logic in one place. 

## Testing
- Added a unit test `should_not_panic_when_exponential_backoff_duration_could_not_be_created`
- Manually verified reproduction steps provided [in the original PR](https://github.com/awslabs/aws-sdk-rust/issues/1133)
<details> 
<summary>More details</summary>

```
#[tokio::test]
async fn repro_1133() {
    let config = aws_config::from_env()
        .region(Region::new("non-existing-region")) // forces retries
        .retry_config(
            RetryConfig::standard()
                .with_initial_backoff(Duration::from_millis(1))
                .with_max_attempts(100),
        )
        .timeout_config(
            TimeoutConfig::builder()
                .operation_attempt_timeout(Duration::from_secs(180))
                .operation_timeout(Duration::from_secs(600))
                .build(),
        )
        .load()
        .await;

    let client: Client = Client::new(&config);
    let res = client
        .list_objects_v2()
        .bucket("bucket-name-does-not-matter")
        .send()
        .await;

    dbg!(res);
}
```

Without changes in this PR:
```
---- repro_1133 stdout ----
thread 'repro_1133' panicked at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/time.rs:741:23:
can not convert float seconds to Duration: value is either too big or NaN
stack backtrace:
...

failures:
    repro_1133

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 9 filtered out; finished in 338.18s
```

With changes in this PR:
```
// no panic
---- repro_1133 stdout ----
res = Err(
    TimeoutError(
        TimeoutError {
            source: MaybeTimeoutError {
                kind: Operation,
                duration: 600s,
            },
        },
    ),
)
```
</details> 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

## Appendix
<details> 
<summary>runtime-versioner bug fix</summary>

This PR also fixes a limitation in `runtime-versioner audit`. I included the fix in the PR because the issue occurred with special conditions, and we don't get to reproduce it every day. The way the issue manifests is this.

1. We have a branch from the main whose latest release tag at the time was `release-2024-04-30`
2. The main has moved ahead and a new `smithy-rs` release has been made `release-2024-05-08`
3. We perform `git merge main`, pre-commit hooks run, and we then get `audit` failures from `runtime-versioner`:
```
2024-05-10T16:54:36.434968Z  WARN runtime_versioner::command::audit: there are newer releases since 'release-2024-04-30'
aws-config was changed and version bumped, but the new version number (1.4.0) has already been published to crates.io. Choose a new version number.
aws-runtime was changed and version bumped, but the new version number (1.2.2) has already been published to crates.io. Choose a new version number.
aws-smithy-runtime-api was changed and version bumped, but the new version number (1.6.0) has already been published to crates.io. Choose a new version number.
aws-smithy-types was changed and version bumped, but the new version number (1.1.9) has already been published to crates.io. Choose a new version number.
aws-types was changed and version bumped, but the new version number (1.2.1) has already been published to crates.io. Choose a new version number.
Error: there are audit failures in the runtime crates
```
This happens because when the latest `main` is being merged to our branch, `runtime-versioner audit` should use `previous_release_tag` `release-2024-05-08` to perform audit but [pre-commit hooks run the tool](https://github.com/smithy-lang/smithy-rs/blob/main/.pre-commit-hooks/runtime-versioner.sh#L8) using the latest previous release tag that can be traced back from `HEAD` of our branch, which is `release-2024-04-30`. Hence the error.

The fix adds an environment variable `SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG` to specify a previous release tag override, in addition to a `--previous-release-tag` command-line argument. 
Furthermore, the fix has relaxed certain checks in `audit`. Taking our example for instance, when `HEAD` is now behind `release-2024-05-08`, it's OK to fail even if `release-2024-05-08` is not the ancestor of `HEAD` (as stated above, `git merge-base --is-ancestor` does not know that while main is being merged) as long as `release-2024-04-28` (the latest release seen from `HEAD`) is the ancestor of `release-2024-05-08`.

```
   release-2024-04-28               release-2024-05-08           
            │                                │                   
────────────┼───────────────┬────────────────┼───────x─────► main
            │               │HEAD            │       x           
                            │ of                     x           
                            │branch                  x           
                            │                        x           
                            │                        x           
                            │              xxxxxxxxxxx           
                            │              x                     
                            │              x  git merge main     
                            │              x                     
                            │              ▼                     
                            │                                    
                            └──────────────────► feature branch  
```
To use the fix, set the environment variable with the new release tag and perform `git merge main`:
```
➜  smithy-rs git:(ysaito/fix-panic-in-exp-backoff) ✗ export SMITHY_RS_RUNTIME_VERSIONER_AUDIT_PREVIOUS_RELEASE_TAG=release-2024-05-08
➜  smithy-rs git:(ysaito/fix-panic-in-exp-backoff) ✗ git merge main
     ...
     Running `/Users/awsaito/src/smithy-rs/tools/target/debug/runtime-versioner audit`
2024-05-10T19:32:26.665578Z  WARN runtime_versioner::tag: expected previous release to be 'release-2024-04-30', but 'release-2024-05-08' was specified. Proceeding with 'release-2024-05-08'.
SUCCESS
```

</summary>

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
