### PR TITLE
Add (S3) transfer settings

### DIFF
--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -57,3 +57,6 @@ pub mod ignore_configured_endpoint_urls;
 
 /// Default endpoint URL provider chain
 pub mod endpoint_url;
+
+/// Default transfer settings
+pub mod transfer;

--- a/aws/rust-runtime/aws-config/src/default_provider/transfer.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/transfer.rs
@@ -1,0 +1,12 @@
+// Setting names borrowed from Boto3's transfer.py
+// https://github.com/boto/boto3/blob/096e45841545f24bbd572a62504cc0dbb62e6b07/boto3/s3/transfer.py#L299-L307
+
+#[derive(Default, Debug)]
+pub(crate) struct Settings {
+    pub(crate) multipart_threshold: usize,
+    pub(crate) max_concurrency: usize,
+    pub(crate) multipart_chunksize: usize,
+    pub(crate) num_download_attempts: usize,
+    pub(crate) max_io_queue: usize,
+    pub(crate) io_chunksize: usize,
+}


### PR DESCRIPTION
## Motivation and Context

The motivation attempting to fix https://github.com/awslabs/aws-sdk-rust/issues/968 and being able to implement and test the [big files copy S3 Batch Operations strategy outlined in this AWS blogpost](https://aws.amazon.com/blogs/storage/copying-objects-greater-than-5-gb-with-amazon-s3-batch-operations/) but using a Rust runtime lambda instead of Python/Boto3.

This feature is in turn needed for [our microservices, AWS EventBus based service, OrcaBus](https://github.com/umccr/orcabus/), which is a work in progress @umccr.

## Description

Just learned about `smithy-rs` this afternoon after reading docs, code and watching the excellent @Velfi's [Rust Linz youtube intro talk](https://youtu.be/N0XMjokwTIM)... so this is very much an early draft and attempt to understand where code for this feature would fit (and to possibly inform a RFC if needed).

Learning as I go and trying to implement it [by reading similar PRs](https://github.com/smithy-lang/smithy-rs/pull/3488/files). At present I'm following [boto3's transfer.py](https://github.com/boto/boto3/blob/develop/boto3/s3/transfer.py) names... all in all, feedback and [discussion](https://github.com/awslabs/aws-sdk-rust/discussions/964)/hints/guidance is very much welcome.

## Testing

None yet.

## Checklist

<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

/cc @andrewpatto @mmalenic