### PR TITLE
Mark unused code as such to satisfy -D warnings in 1.78.0

### DIFF
--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/env_config/section.rs
+++ b/aws/rust-runtime/aws-runtime/src/env_config/section.rs
@@ -18,12 +18,14 @@ pub(crate) trait Section {
     fn name(&self) -> &str;
 
     /// Returns all the properties in this section
+    #[allow(dead_code)]
     fn properties(&self) -> &HashMap<String, Property>;
 
     /// Returns a reference to the property named `name`
     fn get(&self, name: &str) -> Option<&str>;
 
     /// True if there are no properties in this section.
+    #[allow(dead_code)]
     fn is_empty(&self) -> bool;
 
     /// Insert a property into a section


### PR DESCRIPTION
## Motivation and Context
Mark unused code as such for [the latest compiler](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html).

## Description
We use the latest compiler as part of our release of AWS SDKs, which ensures that 3rd party dependencies should build even if they release a new version requiring a newer MSRV than we specify within this repository. At the time of writing, the latest compiler is 1.78.0, and it is now able to detect more unused code patterns that our current MSRV 1.75.0.

The compiler 1.78.0 unfortunately caused a build failure in [check-sdk-codegen-unit-tests](https://github.com/smithy-lang/smithy-rs/blob/e8449bd152ffd6471516a125f565c63dd690c034/tools/ci-scripts/check-sdk-codegen-unit-tests) as follows
```
src/smithy-rs/aws/rust-runtime/aws-runtime/src/env_config/section.rs:21:8
       |
    16 | pub(crate) trait Section {
       |                  ------- methods in this trait
    ...
    21 |     fn properties(&self) -> &HashMap<String, Property>;
       |        ^^^^^^^^^^
    ...
    27 |     fn is_empty(&self) -> bool;
       |        ^^^^^^^^
       |
       = note: `-D dead-code` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(dead_code)]
```
We cannot eliminate this failure even if we specify `RUSTFLAGS="-D warnings"` because the generated client tests will render the following in its dot cargo directory:
```
cat .cargo/config.toml
[build]
rustflags = ["--deny","warnings"]
```
Plus, trying to eliminate `--deny warnings` contradicts what https://github.com/smithy-lang/smithy-rs/issues/3194 is trying to achieve. To fix it, we will follow what the compiler suggests to fix.

## Testing
Verified it fixed our internal release pipeline.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._