### PR TITLE
Fix "refusing to merge unrelated histories"

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -32,7 +32,7 @@ jobs:
         git config --local user.name "AWS SDK Rust Bot"
         git config --local user.email "aws-sdk-rust-primary@amazon.com"
 
-        git fetch
+        git fetch --unshallow
         git checkout origin/main
         backport_branch="merge-${{ env.release_branch }}-to-main-$(date +%s)"
         git checkout -b "${backport_branch}"


### PR DESCRIPTION
## Motivation and Context
Fixes the last [failed backport workflow run](https://github.com/smithy-lang/smithy-rs/actions/runs/8971718857/job/24638066793)

## Description
The error `refusing to merge unrelated histories` was caused by the same reason described in prior PRs (#3479, #3480). We need to tell git unshallow histories so that it knows they are actually related. 

## Testing
Ran the failed workflow from this branch and successfully generated a backport PR3625.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
