### PR TITLE
bump aws-runtime to fix release infrastructure

### DIFF
--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"


### PR DESCRIPTION
## Motivation and Context
Recent changes (e.g. https://github.com/smithy-lang/smithy-rs/commit/242814cbcf617c48c354bb6d84cfd711ae5c53d7) were backported to release branch but a new smithy-rs release hasn't been made.

`runtime-versioner audit` is pulling latest release of `release-2024-04-30` which is causing it to see a diff to `aws-runtime` (which was released today with the SDK release).

```
> runtime-versioner audit
2024-05-07T22:33:45.710839Z  INFO runtime_versioner::command::audit: 'aws-config' changed and was version bumped from 1.3.0 to 1.4.0
2024-05-07T22:33:46.403927Z  INFO runtime_versioner::command::audit: 'aws-smithy-runtime' changed and was version bumped from 1.4.0 to 1.5.0
2024-05-07T22:33:46.436213Z  INFO runtime_versioner::command::audit: 'aws-smithy-runtime-api' changed and was version bumped from 1.5.0 to 1.6.0
2024-05-07T22:33:46.468490Z  INFO runtime_versioner::command::audit: 'aws-smithy-types' changed and was version bumped from 1.1.8 to 1.1.9
2024-05-07T22:33:46.588902Z  INFO runtime_versioner::command::audit: 'aws-types' changed and was version bumped from 1.2.0 to 1.2.1
aws-runtime was changed and version bumped, but the new version number (1.2.1) has already been published to crates.io. Choose a new version number.
Error: there are audit failures in the runtime crates
```

This PR bumps the version to get around this which is causing preview build failures and will cause release issues until fixed.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
