### PR TITLE
fix(docs: client construction): wrong type name

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
@@ -73,7 +73,7 @@ object AwsDocs {
 
                     Occasionally, SDKs may have additional service-specific values that can be set on the [`Config`] that
                     is absent from [`SdkConfig`], or slightly different settings for a specific client may be desired.
-                    The [`Config`] struct implements `From<&SdkConfig>`, so setting these specific settings can be
+                    The [`Builder`] struct implements `From<&SdkConfig>`, so setting these specific settings can be
                     done as follows:
 
                     ```rust,no_run


### PR DESCRIPTION
## Motivation and Context
Docs are wrong.

## Description
The docs are referring to the wrong type name (`Config`).
The example right below the change uses the right type name (`$crateName::config::Builder`).

## Testing
n/a

## Checklist

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
