### PR TITLE
Make when expression non exhaustive in EndpointBuiltInsDecorator.kt

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -109,10 +109,12 @@ fun Model.sdkConfigSetter(
     val builtIn = loadBuiltIn(serviceId, builtInSrc) ?: return null
     val fieldName = configParameterNameOverride ?: builtIn.name.rustName()
 
+    val builtinType = builtIn.type!!
     val map =
-        when (builtIn.type!!) {
+        when (builtinType) {
             ParameterType.STRING -> writable { rust("|s|s.to_string()") }
             ParameterType.BOOLEAN -> null
+            else -> PANIC("needs to handle unimplemented endpoint parameter builtin type: $builtinType")
         }
 
     return if (fieldName == "endpoint_url") {


### PR DESCRIPTION
## Motivation and Context
Updates handling matching on endpoint parameter type in `EndpointBuiltInsDecorator.kt`

## Description
Smithy 1.48.0 will introduce `ParameterType.STRING_ARRAY` for the endpoint parameter type and exhaustive matching like what we have today makes lint unhappy.
```
codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt: (113, 9): 'when' expression must be exhaustive, add necessary 'STRING_ARRAY' branch or 'else' branch instead 
```

For now, we will fail out loud for anything other than `string` or `boolean` since we most likely don't have services that support `ParameterType.STRING_ARRAY` today. The panic will let us know during internal preview when a service supports `ParameterType.STRING_ARRAY`.

## Testing
Relies on tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
