### PR TITLE
Allow AggregatedBytes to be constructed directly from segmented bytes

### DIFF
--- a/rust-runtime/aws-smithy-types/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream.rs
@@ -492,6 +492,11 @@ impl From<Vec<u8>> for ByteStream {
 pub struct AggregatedBytes(SegmentedBuf<Bytes>);
 
 impl AggregatedBytes {
+    /// Construct a new instance from a segmented buffer of `Bytes`.
+    pub fn from_segmented(segments: SegmentedBuf<Bytes>) -> Self {
+        Self(segments)
+    }
+
     /// Convert this buffer into [`Bytes`].
     ///
     /// # Why does this consume `self`?


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This is useful for cases where I already have a segmented buffer of bytes, and I need to stream them to S3 as a single object.

## Description
<!--- Describe your changes in detail -->
Internal to this crate, the AggregatedBytes struct can be constructed directly from a SegmentedBytes buffer. 

There are cases where folks would like to perform this same thing. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I am currently using this for a project where a segmented buffer of bytes is streamed to S3 as a single object.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
