### PR TITLE
fix const names in codegen

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -214,7 +214,7 @@ class RegionProviderConfig(codegenContext: ClientCodegenContext) : ConfigCustomi
                 }
 
                 is ServiceConfig.BuilderFromConfigBag -> {
-                    rustTemplate("${section.builder}.set_region(${section.config_bag}.load::<#{Region}>().cloned());", *codegenScope)
+                    rustTemplate("${section.builder}.set_region(${section.configBag}.load::<#{Region}>().cloned());", *codegenScope)
                 }
 
                 else -> emptySection

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -147,7 +147,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
 
                 is ServiceConfig.BuilderFromConfigBag ->
                     writable {
-                        rustTemplate("${section.builder}.set_app_name(${section.config_bag}.load::<#{AppName}>().cloned());", *codegenScope)
+                        rustTemplate("${section.builder}.set_app_name(${section.configBag}.load::<#{AppName}>().cloned());", *codegenScope)
                     }
 
                 is ServiceConfig.BuilderBuild ->

--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -174,7 +174,7 @@ fun Project.registerGenerateSmithyBuildTask(
 
             // If this is a rebuild, cache all the hashes of the generated Rust files. These are later used by the
             // `modifyMtime` task.
-            project.extra[previousBuildHashesKey] =
+            project.extra[PREVIOUS_BUILD_HASHES_KEY] =
                 project.buildDir.walk()
                     .filter { it.isFile }
                     .map {
@@ -217,7 +217,7 @@ fun Project.registerGenerateCargoConfigTomlTask(outputDir: File) {
     }
 }
 
-const val previousBuildHashesKey = "previousBuildHashes"
+const val PREVIOUS_BUILD_HASHES_KEY = "previousBuildHashes"
 
 fun Project.registerModifyMtimeTask() {
     // Cargo uses `mtime` (among other factors) to determine whether a compilation unit needs a rebuild. While developing,
@@ -232,11 +232,11 @@ fun Project.registerModifyMtimeTask() {
         dependsOn("generateSmithyBuild")
 
         doFirst {
-            if (!project.extra.has(previousBuildHashesKey)) {
+            if (!project.extra.has(PREVIOUS_BUILD_HASHES_KEY)) {
                 println("No hashes from a previous build exist because `generateSmithyBuild` is up to date, skipping `mtime` fixups")
             } else {
                 @Suppress("UNCHECKED_CAST")
-                val previousBuildHashes: Map<String, Long> = project.extra[previousBuildHashesKey] as Map<String, Long>
+                val previousBuildHashes: Map<String, Long> = project.extra[PREVIOUS_BUILD_HASHES_KEY] as Map<String, Long>
 
                 project.buildDir.walk()
                     .filter { it.isFile }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientReservedWords.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientReservedWords.kt
@@ -26,8 +26,8 @@ val ClientReservedWords =
             mapOf(
                 // Unions contain an `Unknown` variant. This exists to support parsing data returned from the server
                 // that represent union variants that have been added since this SDK was generated.
-                UnionGenerator.UnknownVariantName to "${UnionGenerator.UnknownVariantName}Value",
-                "${UnionGenerator.UnknownVariantName}Value" to "${UnionGenerator.UnknownVariantName}Value_",
+                UnionGenerator.UNKNOWN_VARIANT_NAME to "${UnionGenerator.UNKNOWN_VARIANT_NAME}Value",
+                "${UnionGenerator.UNKNOWN_VARIANT_NAME}Value" to "${UnionGenerator.UNKNOWN_VARIANT_NAME}Value_",
             ),
         enumMemberMap =
             mapOf(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
@@ -86,32 +86,32 @@ data class ClientRustSettings(
  * [addMessageToErrors]: Adds a `message` field automatically to all error shapes
  */
 data class ClientCodegenConfig(
-    override val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
-    override val debugMode: Boolean = defaultDebugMode,
-    override val flattenCollectionAccessors: Boolean = defaultFlattenAccessors,
+    override val formatTimeoutSeconds: Int = DEFAULT_FORMAT_TIMEOUT_SECONDS,
+    override val debugMode: Boolean = DEFAULT_DEBUG_MODE,
+    override val flattenCollectionAccessors: Boolean = DEFAULT_FLATTEN_ACCESSORS,
     val nullabilityCheckMode: NullableIndex.CheckMode = NullableIndex.CheckMode.CLIENT,
-    val renameExceptions: Boolean = defaultRenameExceptions,
-    val includeFluentClient: Boolean = defaultIncludeFluentClient,
-    val addMessageToErrors: Boolean = defaultAddMessageToErrors,
+    val renameExceptions: Boolean = DEFAULT_RENAME_EXCEPTIONS,
+    val includeFluentClient: Boolean = DEFAULT_INCLUDE_FLUENT_CLIENT,
+    val addMessageToErrors: Boolean = DEFAULT_ADD_MESSAGE_TO_ERRORS,
     // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
-    val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
+    val eventStreamAllowList: Set<String> = DEFAULT_EVENT_STREAM_ALLOW_LIST,
     /** If true, adds `endpoint_url`/`set_endpoint_url` methods to the service config */
-    val includeEndpointUrlConfig: Boolean = defaultIncludeEndpointUrlConfig,
-    val enableUserConfigurableRuntimePlugins: Boolean = defaultEnableUserConfigurableRuntimePlugins,
+    val includeEndpointUrlConfig: Boolean = DEFAULT_INCLUDE_ENDPOINT_URL_CONFIG,
+    val enableUserConfigurableRuntimePlugins: Boolean = DEFAULT_ENABLE_USER_CONFIGURABLE_RUNTIME_PLUGINS,
 ) : CoreCodegenConfig(
-        formatTimeoutSeconds, debugMode, defaultFlattenAccessors,
+        formatTimeoutSeconds, debugMode, DEFAULT_FLATTEN_ACCESSORS,
     ) {
     companion object {
-        private const val defaultRenameExceptions = true
-        private const val defaultIncludeFluentClient = true
-        private const val defaultAddMessageToErrors = true
-        private val defaultEventStreamAllowList: Set<String> = emptySet()
-        private const val defaultIncludeEndpointUrlConfig = true
-        private const val defaultEnableUserConfigurableRuntimePlugins = true
-        private const val defaultNullabilityCheckMode = "CLIENT"
+        private const val DEFAULT_RENAME_EXCEPTIONS = true
+        private const val DEFAULT_INCLUDE_FLUENT_CLIENT = true
+        private const val DEFAULT_ADD_MESSAGE_TO_ERRORS = true
+        private val DEFAULT_EVENT_STREAM_ALLOW_LIST: Set<String> = emptySet()
+        private const val DEFAULT_INCLUDE_ENDPOINT_URL_CONFIG = true
+        private const val DEFAULT_ENABLE_USER_CONFIGURABLE_RUNTIME_PLUGINS = true
+        private const val DEFAULT_NULLABILITY_CHECK_MODE = "CLIENT"
 
         // Note: only clients default to true, servers default to false
-        private const val defaultFlattenAccessors = true
+        private const val DEFAULT_FLATTEN_ACCESSORS = true
 
         fun fromCodegenConfigAndNode(
             coreCodegenConfig: CoreCodegenConfig,
@@ -119,26 +119,26 @@ data class ClientCodegenConfig(
         ) = if (node.isPresent) {
             ClientCodegenConfig(
                 formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
-                flattenCollectionAccessors = node.get().getBooleanMemberOrDefault("flattenCollectionAccessors", defaultFlattenAccessors),
+                flattenCollectionAccessors = node.get().getBooleanMemberOrDefault("flattenCollectionAccessors", DEFAULT_FLATTEN_ACCESSORS),
                 debugMode = coreCodegenConfig.debugMode,
                 eventStreamAllowList =
                     node.get().getArrayMember("eventStreamAllowList").map { array ->
                         array.toList().mapNotNull { node ->
                             node.asStringNode().orNull()?.value
                         }
-                    }.orNull()?.toSet() ?: defaultEventStreamAllowList,
-                renameExceptions = node.get().getBooleanMemberOrDefault("renameErrors", defaultRenameExceptions),
-                includeFluentClient = node.get().getBooleanMemberOrDefault("includeFluentClient", defaultIncludeFluentClient),
-                addMessageToErrors = node.get().getBooleanMemberOrDefault("addMessageToErrors", defaultAddMessageToErrors),
-                includeEndpointUrlConfig = node.get().getBooleanMemberOrDefault("includeEndpointUrlConfig", defaultIncludeEndpointUrlConfig),
-                enableUserConfigurableRuntimePlugins = node.get().getBooleanMemberOrDefault("enableUserConfigurableRuntimePlugins", defaultEnableUserConfigurableRuntimePlugins),
-                nullabilityCheckMode = NullableIndex.CheckMode.valueOf(node.get().getStringMemberOrDefault("nullabilityCheckMode", defaultNullabilityCheckMode)),
+                    }.orNull()?.toSet() ?: DEFAULT_EVENT_STREAM_ALLOW_LIST,
+                renameExceptions = node.get().getBooleanMemberOrDefault("renameErrors", DEFAULT_RENAME_EXCEPTIONS),
+                includeFluentClient = node.get().getBooleanMemberOrDefault("includeFluentClient", DEFAULT_INCLUDE_FLUENT_CLIENT),
+                addMessageToErrors = node.get().getBooleanMemberOrDefault("addMessageToErrors", DEFAULT_ADD_MESSAGE_TO_ERRORS),
+                includeEndpointUrlConfig = node.get().getBooleanMemberOrDefault("includeEndpointUrlConfig", DEFAULT_INCLUDE_ENDPOINT_URL_CONFIG),
+                enableUserConfigurableRuntimePlugins = node.get().getBooleanMemberOrDefault("enableUserConfigurableRuntimePlugins", DEFAULT_ENABLE_USER_CONFIGURABLE_RUNTIME_PLUGINS),
+                nullabilityCheckMode = NullableIndex.CheckMode.valueOf(node.get().getStringMemberOrDefault("nullabilityCheckMode", DEFAULT_NULLABILITY_CHECK_MODE)),
             )
         } else {
             ClientCodegenConfig(
                 formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                 debugMode = coreCodegenConfig.debugMode,
-                nullabilityCheckMode = NullableIndex.CheckMode.valueOf(defaultNullabilityCheckMode),
+                nullabilityCheckMode = NullableIndex.CheckMode.valueOf(DEFAULT_NULLABILITY_CHECK_MODE),
             )
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -292,15 +292,15 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
 
                 is ServiceConfig.BuilderFromConfigBag -> {
                     rustTemplate(
-                        "${section.builder}.set_retry_config(${section.config_bag}.load::<#{RetryConfig}>().cloned());",
+                        "${section.builder}.set_retry_config(${section.configBag}.load::<#{RetryConfig}>().cloned());",
                         *codegenScope,
                     )
                     rustTemplate(
-                        "${section.builder}.set_timeout_config(${section.config_bag}.load::<#{TimeoutConfig}>().cloned());",
+                        "${section.builder}.set_timeout_config(${section.configBag}.load::<#{TimeoutConfig}>().cloned());",
                         *codegenScope,
                     )
                     rustTemplate(
-                        "${section.builder}.set_retry_partition(${section.config_bag}.load::<#{RetryPartition}>().cloned());",
+                        "${section.builder}.set_retry_partition(${section.configBag}.load::<#{RetryPartition}>().cloned());",
                         *codegenScope,
                     )
                 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
@@ -158,8 +158,8 @@ internal class EndpointResolverGenerator(
     private val context = Context(registry, runtimeConfig)
 
     companion object {
-        const val DiagnosticCollector = "_diagnostic_collector"
-        private const val ParamsName = "_params"
+        const val DIAGNOSTIC_COLLECTOR = "_diagnostic_collector"
+        private const val PARAMS_NAME = "_params"
     }
 
     /**
@@ -224,7 +224,7 @@ internal class EndpointResolverGenerator(
             Attribute(allow(allowLintsForResolver)).render(this)
             rustTemplate(
                 """
-                pub(super) fn resolve_endpoint($ParamsName: &#{Params}, $DiagnosticCollector: &mut #{DiagnosticCollector}, #{additional_args}) -> #{endpoint}::Result {
+                pub(super) fn resolve_endpoint($PARAMS_NAME: &#{Params}, $DIAGNOSTIC_COLLECTOR: &mut #{DiagnosticCollector}, #{additional_args}) -> #{endpoint}::Result {
                   #{body:W}
                 }
 
@@ -241,7 +241,7 @@ internal class EndpointResolverGenerator(
         writable {
             endpointRuleSet.parameters.toList().forEach {
                 Attribute.AllowUnusedVariables.render(this)
-                rust("let ${it.memberName()} = &$ParamsName.${it.memberName()};")
+                rust("let ${it.memberName()} = &$PARAMS_NAME.${it.memberName()};")
             }
             generateRulesList(endpointRuleSet.rules)(this)
         }
@@ -256,7 +256,7 @@ internal class EndpointResolverGenerator(
                 // it's hard to figure out if these are always needed or not
                 Attribute.AllowUnreachableCode.render(this)
                 rustTemplate(
-                    """return Err(#{EndpointError}::message(format!("No rules matched these parameters. This is a bug. {:?}", $ParamsName)));""",
+                    """return Err(#{EndpointError}::message(format!("No rules matched these parameters. This is a bug. {:?}", $PARAMS_NAME)));""",
                     *codegenScope,
                 )
             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGenerator.kt
@@ -130,7 +130,7 @@ class ExpressionGenerator(
                 val expressionGenerator = ExpressionGenerator(Ownership.Borrowed, context)
                 val argWritables = args.map { expressionGenerator.generate(it) }
                 rustTemplate(
-                    "#{fn}(#{args}, ${EndpointResolverGenerator.DiagnosticCollector})",
+                    "#{fn}(#{args}, ${EndpointResolverGenerator.DIAGNOSTIC_COLLECTOR})",
                     "fn" to fnDefinition.usage(),
                     "args" to argWritables.join(","),
                 )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
@@ -31,10 +31,10 @@ data class InfallibleEnumType(
 ) : EnumType() {
     companion object {
         /** Name of the generated unknown enum member name for enums with named members. */
-        const val UnknownVariant = "Unknown"
+        const val UNKNOWN_VARIANT = "Unknown"
 
-        /** Name of the opaque struct that is inner data for the generated [UnknownVariant]. */
-        const val UnknownVariantValue = "UnknownVariantValue"
+        /** Name of the opaque struct that is inner data for the generated [UNKNOWN_VARIANT]. */
+        const val UNKNOWN_VARIANT_VALUE = "UnknownVariantValue"
     }
 
     override fun implFromForStr(context: EnumGeneratorContext): Writable =
@@ -56,7 +56,7 @@ data class InfallibleEnumType(
                             rust("${member.value.dq()} => ${context.enumName}::${member.derivedName()},")
                         }
                         rust(
-                            "other => ${context.enumName}::$UnknownVariant(#T(other.to_owned()))",
+                            "other => ${context.enumName}::$UNKNOWN_VARIANT(#T(other.to_owned()))",
                             unknownVariantValue(context),
                         )
                     },
@@ -131,25 +131,25 @@ data class InfallibleEnumType(
 
     override fun additionalDocs(context: EnumGeneratorContext): Writable =
         writable {
-            renderForwardCompatibilityNote(context.enumName, context.sortedMembers, UnknownVariant, UnknownVariantValue)
+            renderForwardCompatibilityNote(context.enumName, context.sortedMembers, UNKNOWN_VARIANT, UNKNOWN_VARIANT_VALUE)
         }
 
     override fun additionalEnumMembers(context: EnumGeneratorContext): Writable =
         writable {
-            docs("`$UnknownVariant` contains new variants that have been added since this code was generated.")
+            docs("`$UNKNOWN_VARIANT` contains new variants that have been added since this code was generated.")
             rust(
-                """##[deprecated(note = "Don't directly match on `$UnknownVariant`. See the docs on this enum for the correct way to handle unknown variants.")]""",
+                """##[deprecated(note = "Don't directly match on `$UNKNOWN_VARIANT`. See the docs on this enum for the correct way to handle unknown variants.")]""",
             )
-            rust("$UnknownVariant(#T)", unknownVariantValue(context))
+            rust("$UNKNOWN_VARIANT(#T)", unknownVariantValue(context))
         }
 
     override fun additionalAsStrMatchArms(context: EnumGeneratorContext): Writable =
         writable {
-            rust("${context.enumName}::$UnknownVariant(value) => value.as_str()")
+            rust("${context.enumName}::$UNKNOWN_VARIANT(value) => value.as_str()")
         }
 
     private fun unknownVariantValue(context: EnumGeneratorContext): RuntimeType {
-        return RuntimeType.forInlineFun(UnknownVariantValue, unknownVariantModule) {
+        return RuntimeType.forInlineFun(UNKNOWN_VARIANT_VALUE, unknownVariantModule) {
             docs(
                 """
                 Opaque struct used as inner data for the `Unknown` variant defined in enums in
@@ -159,8 +159,8 @@ data class InfallibleEnumType(
                 """.trimIndent(),
             )
             context.enumMeta.render(this)
-            rustTemplate("struct $UnknownVariantValue(pub(crate) #{String});", *preludeScope)
-            rustBlock("impl $UnknownVariantValue") {
+            rustTemplate("struct $UNKNOWN_VARIANT_VALUE(pub(crate) #{String});", *preludeScope)
+            rustBlock("impl $UNKNOWN_VARIANT_VALUE") {
                 // The generated as_str is not pub as we need to prevent users from calling it on this opaque struct.
                 rustBlock("pub(crate) fn as_str(&self) -> &str") {
                     rust("&self.0")
@@ -168,7 +168,7 @@ data class InfallibleEnumType(
             }
             rustTemplate(
                 """
-                impl #{Display} for $UnknownVariantValue {
+                impl #{Display} for $UNKNOWN_VARIANT_VALUE {
                     fn fmt(&self, f: &mut #{Fmt}::Formatter) -> #{Fmt}::Result {
                         write!(f, "{}", self.0)
                     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceGenerator.kt
@@ -48,7 +48,7 @@ class ServiceGenerator(
                 )
             serviceConfigGenerator.render(this)
 
-            // Enable users to opt in to the test-utils in the runtime crate
+            // Enable users to opt in to the `test-util` feature in the runtime crate
             rustCrate.mergeFeature(TestUtilFeature.copy(deps = listOf("aws-smithy-runtime/test-util")))
 
             ServiceRuntimePluginGenerator(codegenContext)

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -58,12 +58,12 @@ sealed class ServiceConfig(name: String) : Section(name) {
     /**
      * Additional documentation comments for the `Config` struct.
      */
-    object ConfigStructAdditionalDocs : ServiceConfig("ConfigStructAdditionalDocs")
+    data object ConfigStructAdditionalDocs : ServiceConfig("ConfigStructAdditionalDocs")
 
     /**
      * Struct definition of `Config`. Fields should end with `,` (e.g. `foo: Box<u64>,`)
      */
-    object ConfigStruct : ServiceConfig("ConfigStruct")
+    data object ConfigStruct : ServiceConfig("ConfigStruct")
 
     /**
      * impl block of `Config`. (e.g. to add functions)
@@ -72,13 +72,13 @@ sealed class ServiceConfig(name: String) : Section(name) {
      * rust("pub fn is_cross_region() -> bool { true }")
      * ```
      */
-    object ConfigImpl : ServiceConfig("ConfigImpl")
+    data object ConfigImpl : ServiceConfig("ConfigImpl")
 
     /** Struct definition of `ConfigBuilder` **/
-    object BuilderStruct : ServiceConfig("BuilderStruct")
+    data object BuilderStruct : ServiceConfig("BuilderStruct")
 
     /** impl block of `ConfigBuilder` **/
-    object BuilderImpl : ServiceConfig("BuilderImpl")
+    data object BuilderImpl : ServiceConfig("BuilderImpl")
 
     // It is important to ensure through type system that each field added to config implements this injection,
     // tracked by smithy-rs#3419
@@ -90,7 +90,7 @@ sealed class ServiceConfig(name: String) : Section(name) {
      *  rust("""builder.set_field(config_bag.load::<FieldType>().cloned())""")
      *  ```
      */
-    data class BuilderFromConfigBag(val builder: String, val config_bag: String) : ServiceConfig("BuilderFromConfigBag")
+    data class BuilderFromConfigBag(val builder: String, val configBag: String) : ServiceConfig("BuilderFromConfigBag")
 
     /**
      * Convert from a field in the builder to the final field in config
@@ -99,7 +99,7 @@ sealed class ServiceConfig(name: String) : Section(name) {
      *  rust("""my_field: my_field.unwrap_or_else(||"default")""")
      *  ```
      */
-    object BuilderBuild : ServiceConfig("BuilderBuild")
+    data object BuilderBuild : ServiceConfig("BuilderBuild")
 
     /**
      * A section for setting up a field to be used by ConfigOverrideRuntimePlugin
@@ -109,7 +109,7 @@ sealed class ServiceConfig(name: String) : Section(name) {
     /**
      * A section for extra functionality that needs to be defined with the config module
      */
-    object Extras : ServiceConfig("Extras")
+    data object Extras : ServiceConfig("Extras")
 
     /**
      * The set default value of a field for use in tests, e.g `${configBuilderRef}.set_credentials(Credentials::for_tests())`
@@ -243,7 +243,7 @@ fun standardConfigParam(param: ConfigParam): ConfigCustomization =
                     writable {
                         rustTemplate(
                             """
-                            ${section.builder}.set_${param.name}(${section.config_bag}.#{load_from_config_bag});
+                            ${section.builder}.set_${param.name}(${section.configBag}.#{load_from_config_bag});
                             """,
                             "load_from_config_bag" to loadFromConfigBag(param.type.name, param.newtype!!),
                         )
@@ -335,7 +335,7 @@ class ServiceConfigGenerator(
                 customizations.forEach {
                     it.section(ServiceConfig.BuilderFromConfigBag(builderVar, configBagVar))(this)
                 }
-                rust("$builderVar")
+                rust(builderVar)
             }
         }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/StalledStreamProtectionConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/StalledStreamProtectionConfigCustomization.kt
@@ -99,7 +99,7 @@ class StalledStreamProtectionConfigCustomization(codegenContext: ClientCodegenCo
             is ServiceConfig.BuilderFromConfigBag ->
                 writable {
                     rustTemplate(
-                        "${section.builder}.set_stalled_stream_protection(${section.config_bag}.load::<#{StalledStreamProtectionConfig}>().cloned());",
+                        "${section.builder}.set_stalled_stream_protection(${section.configBag}.load::<#{StalledStreamProtectionConfig}>().cloned());",
                         *codegenScope,
                     )
                 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGeneratorTest.kt
@@ -134,7 +134,7 @@ internal class ServiceConfigGeneratorTest {
                         writable {
                             rustTemplate(
                                 """
-                                ${section.builder} = ${section.builder}.config_field(${section.config_bag}.load::<#{T}>().map(|u| u.0).unwrap());
+                                ${section.builder} = ${section.builder}.config_field(${section.configBag}.load::<#{T}>().map(|u| u.0).unwrap());
                                 """,
                                 "T" to
                                     configParamNewtype(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -37,15 +37,15 @@ sealed class RustDependency(open val name: String) : SymbolDependencyContainer {
                 .builder()
                 .packageName(name).version(version())
                 // We rely on retrieving the structured dependency from the symbol later
-                .putProperty(PropertyKey, this).build(),
+                .putProperty(PROPERTY_KEY, this).build(),
         ) + dependencies().flatMap { it.dependencies }
     }
 
     companion object {
-        private const val PropertyKey = "rustdep"
+        private const val PROPERTY_KEY = "rustdep"
 
         fun fromSymbolDependency(symbolDependency: SymbolDependency) =
-            symbolDependency.getProperty(PropertyKey, RustDependency::class.java).get()
+            symbolDependency.getProperty(PROPERTY_KEY, RustDependency::class.java).get()
     }
 }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CoreRustSettings.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CoreRustSettings.kt
@@ -39,26 +39,26 @@ const val CODEGEN_SETTINGS = "codegen"
  * [debugMode]: Generate comments in the generated code indicating where code was generated from
  */
 open class CoreCodegenConfig(
-    open val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
-    open val debugMode: Boolean = defaultDebugMode,
-    open val flattenCollectionAccessors: Boolean = defaultFlattenMode,
+    open val formatTimeoutSeconds: Int = DEFAULT_FORMAT_TIMEOUT_SECONDS,
+    open val debugMode: Boolean = DEFAULT_DEBUG_MODE,
+    open val flattenCollectionAccessors: Boolean = DEFAULT_FLATTEN_MODE,
 ) {
     companion object {
-        const val defaultFormatTimeoutSeconds = 20
-        const val defaultDebugMode = false
-        const val defaultFlattenMode = false
+        const val DEFAULT_FORMAT_TIMEOUT_SECONDS = 20
+        const val DEFAULT_DEBUG_MODE = false
+        const val DEFAULT_FLATTEN_MODE = false
 
         fun fromNode(node: Optional<ObjectNode>): CoreCodegenConfig =
             if (node.isPresent) {
                 CoreCodegenConfig(
-                    formatTimeoutSeconds = node.get().getNumberMemberOrDefault("formatTimeoutSeconds", defaultFormatTimeoutSeconds).toInt(),
-                    debugMode = node.get().getBooleanMemberOrDefault("debugMode", defaultDebugMode),
-                    flattenCollectionAccessors = node.get().getBooleanMemberOrDefault("flattenCollectionAccessors", defaultFlattenMode),
+                    formatTimeoutSeconds = node.get().getNumberMemberOrDefault("formatTimeoutSeconds", DEFAULT_FORMAT_TIMEOUT_SECONDS).toInt(),
+                    debugMode = node.get().getBooleanMemberOrDefault("debugMode", DEFAULT_DEBUG_MODE),
+                    flattenCollectionAccessors = node.get().getBooleanMemberOrDefault("flattenCollectionAccessors", DEFAULT_FLATTEN_MODE),
                 )
             } else {
                 CoreCodegenConfig(
-                    formatTimeoutSeconds = defaultFormatTimeoutSeconds,
-                    debugMode = defaultDebugMode,
+                    formatTimeoutSeconds = DEFAULT_FORMAT_TIMEOUT_SECONDS,
+                    debugMode = DEFAULT_DEBUG_MODE,
                 )
             }
     }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
@@ -164,7 +164,7 @@ open class EnumGenerator(
 ) {
     companion object {
         /** Name of the function on the enum impl to get a vec of value names */
-        const val Values = "values"
+        const val VALUES = "values"
     }
 
     private val enumTrait: EnumTrait = shape.expectTrait()
@@ -295,7 +295,7 @@ open class EnumGenerator(
                     #{asStrImpl:W}
                 }
                 /// Returns all the `&str` representations of the enum members.
-                pub const fn $Values() -> &'static [&'static str] {
+                pub const fn $VALUES() -> &'static [&'static str] {
                     &[#{Values:W}]
                 }
             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
@@ -161,7 +161,7 @@ open class UnionGenerator(
                         }
                     }
                     if (renderUnknownVariant) {
-                        rust("${unionSymbol.name}::$UnknownVariantName => f.debug_tuple(${UnknownVariantName.dq()}).finish(),")
+                        rust("${unionSymbol.name}::$UNKNOWN_VARIANT_NAME => f.debug_tuple(${UNKNOWN_VARIANT_NAME.dq()}).finish(),")
                     }
                 }
             }
@@ -169,12 +169,12 @@ open class UnionGenerator(
     }
 
     companion object {
-        const val UnknownVariantName = "Unknown"
+        const val UNKNOWN_VARIANT_NAME = "Unknown"
     }
 }
 
 fun unknownVariantError(union: String) =
-    "Cannot serialize `$union::${UnionGenerator.UnknownVariantName}` for the request. " +
+    "Cannot serialize `$union::${UnionGenerator.UNKNOWN_VARIANT_NAME}` for the request. " +
         "The `Unknown` variant is intended for responses only. " +
         "It occurs when an outdated client is used after a new enum variant was added on the server side."
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
@@ -163,7 +163,7 @@ class EventStreamUnmarshallerGenerator(
                 when (codegenTarget.renderUnknownVariant()) {
                     true ->
                         rustTemplate(
-                            "Ok(#{UnmarshalledMessage}::Event(#{Output}::${UnionGenerator.UnknownVariantName}))",
+                            "Ok(#{UnmarshalledMessage}::Event(#{Output}::${UnionGenerator.UNKNOWN_VARIANT_NAME}))",
                             "Output" to unionSymbol,
                             *codegenScope,
                         )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -611,7 +611,7 @@ class JsonParserGenerator(
                                                 """
                                                 _ => {
                                                   #{skip_value}(tokens)?;
-                                                  Some(#{Union}::${UnionGenerator.UnknownVariantName})
+                                                  Some(#{Union}::${UnionGenerator.UNKNOWN_VARIANT_NAME})
                                                 }
                                                 """,
                                                 "Union" to returnSymbolToParse.symbol,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -464,7 +464,7 @@ class XmlBindingTraitParserGenerator(
                             }
                         }
                         when (target.renderUnknownVariant()) {
-                            true -> rust("_unknown => base = Some(#T::${UnionGenerator.UnknownVariantName}),", symbol)
+                            true -> rust("_unknown => base = Some(#T::${UnionGenerator.UNKNOWN_VARIANT_NAME}),", symbol)
                             false ->
                                 rustTemplate(
                                     """variant => return Err(#{XmlDecodeError}::custom(format!("unexpected union variant: {:?}", variant)))""",

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
@@ -125,7 +125,7 @@ open class EventStreamMarshallerGenerator(
                     if (target.renderUnknownVariant()) {
                         rustTemplate(
                             """
-                            Self::Input::${UnionGenerator.UnknownVariantName} => return Err(
+                            Self::Input::${UnionGenerator.UNKNOWN_VARIANT_NAME} => return Err(
                                 #{Error}::marshalling(${unknownVariantError(unionSymbol.rustType().name).dq()}.to_owned())
                             )
                             """,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -548,7 +548,7 @@ class JsonSerializerGenerator(
                         }
                         if (codegenTarget.renderUnknownVariant()) {
                             rustTemplate(
-                                "#{Union}::${UnionGenerator.UnknownVariantName} => return Err(#{Error}::unknown_variant(${unionSymbol.name.dq()}))",
+                                "#{Union}::${UnionGenerator.UNKNOWN_VARIANT_NAME} => return Err(#{Error}::unknown_variant(${unionSymbol.name.dq()}))",
                                 "Union" to unionSymbol,
                                 *codegenScope,
                             )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/QuerySerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/QuerySerializerGenerator.kt
@@ -366,7 +366,7 @@ abstract class QuerySerializerGenerator(private val codegenContext: CodegenConte
                         }
                         if (target.renderUnknownVariant()) {
                             rustTemplate(
-                                "#{Union}::${UnionGenerator.UnknownVariantName} => return Err(#{Error}::unknown_variant(${unionSymbol.name.dq()}))",
+                                "#{Union}::${UnionGenerator.UNKNOWN_VARIANT_NAME} => return Err(#{Error}::unknown_variant(${unionSymbol.name.dq()}))",
                                 "Union" to unionSymbol,
                                 *codegenScope,
                             )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -469,7 +469,7 @@ class XmlBindingTraitSerializerGenerator(
 
                         if (codegenTarget.renderUnknownVariant()) {
                             rustTemplate(
-                                "#{Union}::${UnionGenerator.UnknownVariantName} => return Err(#{Error}::unknown_variant(${unionSymbol.name.dq()}))",
+                                "#{Union}::${UnionGenerator.UNKNOWN_VARIANT_NAME} => return Err(#{Error}::unknown_variant(${unionSymbol.name.dq()}))",
                                 "Union" to unionSymbol,
                                 *codegenScope,
                             )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
@@ -143,11 +143,11 @@ fun testRustSettings(
     examplesUri,
 )
 
-private const val SmithyVersion = "1.0"
+private const val SMITHY_VERSION = "1.0"
 
 fun String.asSmithyModel(
     sourceLocation: String? = null,
-    smithyVersion: String = SmithyVersion,
+    smithyVersion: String = SMITHY_VERSION,
     disableValidation: Boolean = false,
 ): Model {
     val processed = letIf(!this.trimStart().startsWith("\$version")) { "\$version: ${smithyVersion.dq()}\n$it" }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGeneratorTest.kt
@@ -269,7 +269,7 @@ class EnumGeneratorTest {
                     "it_generates_unnamed_enums",
                     """
                     // Values should be sorted
-                    assert_eq!(FooEnum::${EnumGenerator.Values}(), ["0", "1", "Bar", "Baz", "Foo"]);
+                    assert_eq!(FooEnum::${EnumGenerator.VALUES}(), ["0", "1", "Bar", "Baz", "Foo"]);
                     """.trimIndent(),
                 )
             }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -85,10 +85,10 @@ data class ServerRustSettings(
  * [ignoreUnsupportedConstraints]: Generate model even though unsupported constraints are present
  */
 data class ServerCodegenConfig(
-    override val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
-    override val debugMode: Boolean = defaultDebugMode,
-    val publicConstrainedTypes: Boolean = defaultPublicConstrainedTypes,
-    val ignoreUnsupportedConstraints: Boolean = defaultIgnoreUnsupportedConstraints,
+    override val formatTimeoutSeconds: Int = DEFAULT_FORMAT_TIMEOUT_SECONDS,
+    override val debugMode: Boolean = DEFAULT_DEBUG_MODE,
+    val publicConstrainedTypes: Boolean = DEFAULT_PUBLIC_CONSTRAINED_TYPES,
+    val ignoreUnsupportedConstraints: Boolean = DEFAULT_IGNORE_UNSUPPORTED_CONSTRAINTS,
     /**
      * A flag to enable _experimental_ support for custom validation exceptions via the
      * [CustomValidationExceptionWithReasonDecorator] decorator.
@@ -100,8 +100,8 @@ data class ServerCodegenConfig(
         formatTimeoutSeconds, debugMode,
     ) {
     companion object {
-        private const val defaultPublicConstrainedTypes = true
-        private const val defaultIgnoreUnsupportedConstraints = false
+        private const val DEFAULT_PUBLIC_CONSTRAINED_TYPES = true
+        private const val DEFAULT_IGNORE_UNSUPPORTED_CONSTRAINTS = false
         private val defaultExperimentalCustomValidationExceptionWithReasonPleaseDoNotUse = null
 
         fun fromCodegenConfigAndNode(
@@ -111,8 +111,8 @@ data class ServerCodegenConfig(
             ServerCodegenConfig(
                 formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                 debugMode = coreCodegenConfig.debugMode,
-                publicConstrainedTypes = node.get().getBooleanMemberOrDefault("publicConstrainedTypes", defaultPublicConstrainedTypes),
-                ignoreUnsupportedConstraints = node.get().getBooleanMemberOrDefault("ignoreUnsupportedConstraints", defaultIgnoreUnsupportedConstraints),
+                publicConstrainedTypes = node.get().getBooleanMemberOrDefault("publicConstrainedTypes", DEFAULT_PUBLIC_CONSTRAINED_TYPES),
+                ignoreUnsupportedConstraints = node.get().getBooleanMemberOrDefault("ignoreUnsupportedConstraints", DEFAULT_IGNORE_UNSUPPORTED_CONSTRAINTS),
                 experimentalCustomValidationExceptionWithReasonPleaseDoNotUse = node.get().getStringMemberOrDefault("experimentalCustomValidationExceptionWithReasonPleaseDoNotUse", defaultExperimentalCustomValidationExceptionWithReasonPleaseDoNotUse),
             )
         } else {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -802,28 +802,27 @@ class ServerProtocolTestGenerator(
         // These could be configured via runtime configuration, but since this won't be long-lasting,
         // it makes sense to do the simplest thing for now.
         // The test will _fail_ if these pass, so we will discover & remove if we fix them by accident
-        private const val AwsJson11 = "aws.protocoltests.json#JsonProtocol"
-        private const val AwsJson10 = "aws.protocoltests.json10#JsonRpc10"
-        private const val RestJson = "aws.protocoltests.restjson#RestJson"
-        private const val RestJsonExtras = "aws.protocoltests.restjson#RestJsonExtras"
-        private const val RestJsonValidation = "aws.protocoltests.restjson.validation#RestJsonValidation"
+        private const val AWS_JSON11 = "aws.protocoltests.json#JsonProtocol"
+        private const val AWS_JSON10 = "aws.protocoltests.json10#JsonRpc10"
+        private const val REST_JSON = "aws.protocoltests.restjson#RestJson"
+        private const val REST_JSON_VALIDATION = "aws.protocoltests.restjson.validation#RestJsonValidation"
         private val ExpectFail: Set<FailingTest> =
             setOf(
                 // Endpoint trait is not implemented yet, see https://github.com/smithy-lang/smithy-rs/issues/950.
-                FailingTest(RestJson, "RestJsonEndpointTrait", TestType.Request),
-                FailingTest(RestJson, "RestJsonEndpointTraitWithHostLabel", TestType.Request),
-                FailingTest(RestJson, "RestJsonOmitsEmptyListQueryValues", TestType.Request),
+                FailingTest(REST_JSON, "RestJsonEndpointTrait", TestType.Request),
+                FailingTest(REST_JSON, "RestJsonEndpointTraitWithHostLabel", TestType.Request),
+                FailingTest(REST_JSON, "RestJsonOmitsEmptyListQueryValues", TestType.Request),
                 // Tests involving `@range` on floats.
                 // Pending resolution from the Smithy team, see https://github.com/smithy-lang/smithy-rs/issues/2007.
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeFloat_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeFloat_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeMaxFloat", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeMinFloat", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeFloat_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeFloat_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeMaxFloat", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeMinFloat", TestType.MalformedRequest),
                 // Tests involving floating point shapes and the `@range` trait; see https://github.com/smithy-lang/smithy-rs/issues/2007
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeFloatOverride_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeFloatOverride_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeMaxFloatOverride", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedRangeMinFloatOverride", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeFloatOverride_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeFloatOverride_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeMaxFloatOverride", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedRangeMinFloatOverride", TestType.MalformedRequest),
                 // Some tests for the S3 service (restXml).
                 FailingTest("com.amazonaws.s3#AmazonS3", "GetBucketLocationUnwrappedOutput", TestType.Response),
                 FailingTest("com.amazonaws.s3#AmazonS3", "S3DefaultAddressing", TestType.Request),
@@ -838,56 +837,56 @@ class ServerProtocolTestGenerator(
                 FailingTest("aws.protocoltests.json10#JsonRpc10", "AwsJson10EndpointTraitWithHostLabel", TestType.Request),
                 FailingTest("aws.protocoltests.json10#JsonRpc10", "AwsJson10EndpointTrait", TestType.Request),
                 // AwsJson1.1 failing tests.
-                FailingTest(AwsJson11, "AwsJson11EndpointTraitWithHostLabel", TestType.Request),
-                FailingTest(AwsJson11, "AwsJson11EndpointTrait", TestType.Request),
-                FailingTest(AwsJson11, "parses_the_request_id_from_the_response", TestType.Response),
+                FailingTest(AWS_JSON11, "AwsJson11EndpointTraitWithHostLabel", TestType.Request),
+                FailingTest(AWS_JSON11, "AwsJson11EndpointTrait", TestType.Request),
+                FailingTest(AWS_JSON11, "parses_the_request_id_from_the_response", TestType.Response),
                 // TODO(https://github.com/awslabs/smithy/issues/1683): This has been marked as failing until resolution of said issue
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsBlobList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsBooleanList_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsBooleanList_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsStringList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsByteList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsShortList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsIntegerList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsLongList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsTimestampList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsDateTimeList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsBlobList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsBooleanList_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsBooleanList_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsStringList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsByteList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsShortList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsIntegerList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsLongList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsTimestampList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsDateTimeList", TestType.MalformedRequest),
                 FailingTest(
-                    RestJsonValidation,
+                    REST_JSON_VALIDATION,
                     "RestJsonMalformedUniqueItemsHttpDateList_case0",
                     TestType.MalformedRequest,
                 ),
                 FailingTest(
-                    RestJsonValidation,
+                    REST_JSON_VALIDATION,
                     "RestJsonMalformedUniqueItemsHttpDateList_case1",
                     TestType.MalformedRequest,
                 ),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsEnumList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsIntEnumList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsListList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsStructureList", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsUnionList_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedUniqueItemsUnionList_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsEnumList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsIntEnumList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsListList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsStructureList", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsUnionList_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedUniqueItemsUnionList_case1", TestType.MalformedRequest),
                 // TODO(https://github.com/smithy-lang/smithy-rs/issues/2472): We don't respect the `@internal` trait
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumList_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumList_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumMapKey_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumMapKey_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumMapValue_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumMapValue_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumString_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumString_case1", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumUnion_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumUnion_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumList_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumList_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumMapKey_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumMapKey_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumMapValue_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumMapValue_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumString_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumString_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumUnion_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumUnion_case1", TestType.MalformedRequest),
                 // TODO(https://github.com/awslabs/smithy/issues/1737): Specs on @internal, @tags, and enum values need to be clarified
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumTraitString_case0", TestType.MalformedRequest),
-                FailingTest(RestJsonValidation, "RestJsonMalformedEnumTraitString_case1", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumTraitString_case0", TestType.MalformedRequest),
+                FailingTest(REST_JSON_VALIDATION, "RestJsonMalformedEnumTraitString_case1", TestType.MalformedRequest),
                 // These tests are broken because they are missing a target header
-                FailingTest(AwsJson10, "AwsJson10ServerPopulatesNestedDefaultsWhenMissingInRequestBody", TestType.Request),
-                FailingTest(AwsJson10, "AwsJson10ServerPopulatesDefaultsWhenMissingInRequestBody", TestType.Request),
+                FailingTest(AWS_JSON10, "AwsJson10ServerPopulatesNestedDefaultsWhenMissingInRequestBody", TestType.Request),
+                FailingTest(AWS_JSON10, "AwsJson10ServerPopulatesDefaultsWhenMissingInRequestBody", TestType.Request),
                 // Response defaults are not set when builders are not used https://github.com/smithy-lang/smithy-rs/issues/3339
-                FailingTest(AwsJson10, "AwsJson10ServerPopulatesDefaultsInResponseWhenMissingInParams", TestType.Response),
-                FailingTest(AwsJson10, "AwsJson10ServerPopulatesNestedDefaultValuesWhenMissingInInResponseParams", TestType.Response),
+                FailingTest(AWS_JSON10, "AwsJson10ServerPopulatesDefaultsInResponseWhenMissingInParams", TestType.Response),
+                FailingTest(AWS_JSON10, "AwsJson10ServerPopulatesNestedDefaultValuesWhenMissingInInResponseParams", TestType.Response),
             )
         private val RunOnly: Set<String>? = null
 
@@ -949,7 +948,7 @@ class ServerProtocolTestGenerator(
             // TODO(https://github.com/awslabs/smithy/issues/1506)
             mapOf(
                 Pair(
-                    RestJsonValidation,
+                    REST_JSON_VALIDATION,
                     "RestJsonMalformedPatternReDOSString",
                 ) to ::fixRestJsonMalformedPatternReDOSString,
             )

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolProviderTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolProviderTest.kt
@@ -26,7 +26,7 @@ import software.amazon.smithy.rust.codegen.core.util.lookup
 import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverTestSymbolProvider
 import java.util.stream.Stream
 
-const val baseModelString =
+const val BASE_MODEL_STRING =
     """
     namespace test
 
@@ -87,7 +87,7 @@ const val baseModelString =
     """
 
 class ConstrainedShapeSymbolProviderTest {
-    private val model = baseModelString.asSmithyModel()
+    private val model = BASE_MODEL_STRING.asSmithyModel()
     private val serviceShape = model.lookup<ServiceShape>("test#TestService")
     private val symbolProvider = serverTestSymbolProvider(model, serviceShape)
     private val constrainedShapeSymbolProvider = ConstrainedShapeSymbolProvider(symbolProvider, serviceShape, true)

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PubCrateConstrainedShapeSymbolProviderTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PubCrateConstrainedShapeSymbolProviderTest.kt
@@ -23,7 +23,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverTestSymb
 class PubCrateConstrainedShapeSymbolProviderTest {
     private val model =
         """
-        $baseModelString
+        $BASE_MODEL_STRING
 
         structure NonTransitivelyConstrainedStructureShape {
             constrainedString: ConstrainedString,


### PR DESCRIPTION
This renames stuff in codegen based on IntelliJ lints.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
