### PR TITLE
Loosen s3 integration tests

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/s3/tests/endpoints.rs
@@ -151,8 +151,16 @@ async fn write_get_object_response() {
     );
 
     let captured_request = req.expect_request();
+    let uri_no_query = captured_request
+        .uri()
+        .splitn(2, '?')
+        .into_iter()
+        .next()
+        .unwrap()
+        .to_string();
+
     assert_eq!(
-        captured_request.uri().to_string(),
-        "https://req-route.s3-object-lambda.us-west-4.amazonaws.com/WriteGetObjectResponse?x-id=WriteGetObjectResponse"
+        uri_no_query,
+        "https://req-route.s3-object-lambda.us-west-4.amazonaws.com/WriteGetObjectResponse"
     );
 }

--- a/aws/sdk/integration-tests/s3/tests/express.rs
+++ b/aws/sdk/integration-tests/s3/tests/express.rs
@@ -270,7 +270,19 @@ async fn default_checksum_should_be_crc32_for_operation_requiring_checksum() {
         .send()
         .await;
 
-    http_client.assert_requests_match(&[""]);
+    let checksum_headers: Vec<_> = http_client
+        .actual_requests()
+        .last()
+        .unwrap()
+        .headers()
+        .iter()
+        .filter(|(key, _)| key.starts_with("x-amz-checksum"))
+        .collect();
+
+    assert_eq!(1, checksum_headers.len());
+    assert_eq!("x-amz-checksum-crc32", checksum_headers[0].0);
+    // FIXME(V1373841114): re-enable assertion after model updates
+    // http_client.assert_requests_match(&[""]);
 }
 
 #[tokio::test]

--- a/aws/sdk/integration-tests/s3/tests/select-object-content.rs
+++ b/aws/sdk/integration-tests/s3/tests/select-object-content.rs
@@ -11,9 +11,7 @@ use aws_sdk_s3::types::{
     OutputSerialization, SelectObjectContentEventStream,
 };
 use aws_sdk_s3::Client;
-use aws_smithy_protocol_test::{assert_ok, validate_body, MediaType};
 use aws_smithy_runtime::client::http::test_util::dvr::{Event, ReplayingClient};
-use std::error::Error;
 
 #[tokio::test]
 async fn test_success() {
@@ -84,16 +82,17 @@ async fn test_success() {
         received
     );
 
+    // FIXME(V1373841114): re-enable assertion after model updates
     // Validate the requests
-    replayer
-        .validate(&["content-type", "content-length"], body_validator)
-        .await
-        .unwrap();
+    // replayer
+    //     .validate(&["content-type", "content-length"], body_validator)
+    //     .await
+    //     .unwrap();
 }
 
-fn body_validator(expected_body: &[u8], actual_body: &[u8]) -> Result<(), Box<dyn Error>> {
-    let expected = std::str::from_utf8(expected_body).unwrap();
-    let actual = std::str::from_utf8(actual_body).unwrap();
-    assert_ok(validate_body(actual, expected, MediaType::Xml));
-    Ok(())
-}
+// fn body_validator(expected_body: &[u8], actual_body: &[u8]) -> Result<(), Box<dyn Error>> {
+//     let expected = std::str::from_utf8(expected_body).unwrap();
+//     let actual = std::str::from_utf8(actual_body).unwrap();
+//     assert_ok(validate_body(actual, expected, MediaType::Xml));
+//     Ok(())
+// }


### PR DESCRIPTION
## Motivation and Context

Updates integration test(s) for a pending S3 model update that would affect one of the query parameters. Where possible I've kept as much of the assertions/spirit of the test as possible as opposed to fully ignoring/disabling it until these updates are available. 

Same as https://github.com/smithy-lang/smithy-rs/pull/3628

Downloaded pending model changes and ran tests against it and current version of model to see that they pass in both states.


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
