### PR TITLE
disable stalled stream protection on empty bodies and after read complete

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -37,3 +37,14 @@ meta = { "breaking" = false, "bug" = true, "tada" = false }
 author = "rcoh"
 
 
+[[aws-sdk-rust]]
+message = "Fixes stalled upload stream protection to not apply to empty request bodies and to stop checking for violations once the request body has been read."
+references = ["aws-sdk-rust#1141", "aws-sdk-rust#1146", "aws-sdk-rust#1148"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "aajtodd"
+
+[[smithy-rs]]
+message = "Fixes stalled upload stream protection to not apply to empty request bodies and to stop checking for violations once the request body has been read."
+references = ["aws-sdk-rust#1141", "aws-sdk-rust#1146", "aws-sdk-rust#1148"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "aajtodd"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -40,13 +40,13 @@ author = "rcoh"
 message = "Fixes stalled upload stream protection to not apply to empty request bodies and to stop checking for violations once the request body has been read."
 references = ["aws-sdk-rust#1141", "aws-sdk-rust#1146", "aws-sdk-rust#1148"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
-author = "aajtodd"
+authors = ["aajtodd", "Velfi"]
 
 [[smithy-rs]]
 message = "Fixes stalled upload stream protection to not apply to empty request bodies and to stop checking for violations once the request body has been read."
 references = ["aws-sdk-rust#1141", "aws-sdk-rust#1146", "aws-sdk-rust#1148"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
-author = "aajtodd"
+authors = ["aajtodd", "Velfi"]
 
 [[aws-sdk-rust]]
 message = "Updating the documentation for the `app_name` method on `ConfigLoader` to indicate the order of precedence for the sources of the `AppName`."

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/stalled_stream_protection.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/stalled_stream_protection.rs
@@ -13,7 +13,11 @@
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use std::time::Duration;
 
-const DEFAULT_GRACE_PERIOD: Duration = Duration::from_secs(5);
+/// The default grace period for stalled stream protection.
+///
+/// When a stream stalls for longer than this grace period, the stream will
+/// return an error.
+pub const DEFAULT_GRACE_PERIOD: Duration = Duration::from_secs(20);
 
 /// Configuration for stalled stream protection.
 ///

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.1"
+version = "1.5.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.3"
+version = "1.5.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.2"
+version = "1.5.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput.rs
@@ -136,7 +136,7 @@ impl UploadThroughput {
         self.logs.lock().unwrap().push_bytes_transferred(now, bytes);
     }
 
-    pub(crate) fn complete(&self) -> bool {
+    pub(crate) fn mark_complete(&self) -> bool {
         self.logs.lock().unwrap().mark_complete()
     }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput.rs
@@ -136,6 +136,10 @@ impl UploadThroughput {
         self.logs.lock().unwrap().push_bytes_transferred(now, bytes);
     }
 
+    pub(crate) fn complete(&self) -> bool {
+        self.logs.lock().unwrap().complete()
+    }
+
     pub(crate) fn report(&self, now: SystemTime) -> ThroughputReport {
         self.logs.lock().unwrap().report(now)
     }
@@ -177,6 +181,8 @@ trait UploadReport {
 impl UploadReport for ThroughputReport {
     fn minimum_throughput_violated(self, minimum_throughput: Throughput) -> (bool, Throughput) {
         let throughput = match self {
+            // stream has been exhausted, stop tracking violations
+            ThroughputReport::Complete => return (false, ZERO_THROUGHPUT),
             // If the report is incomplete, then we don't have enough data yet to
             // decide if minimum throughput was violated.
             ThroughputReport::Incomplete => {

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput.rs
@@ -137,7 +137,7 @@ impl UploadThroughput {
     }
 
     pub(crate) fn complete(&self) -> bool {
-        self.logs.lock().unwrap().complete()
+        self.logs.lock().unwrap().mark_complete()
     }
 
     pub(crate) fn report(&self, now: SystemTime) -> ThroughputReport {

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/http_body_0_4_x.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/http_body_0_4_x.rs
@@ -186,7 +186,7 @@ where
                 // alternative for such fringe use cases.
                 if self.is_end_stream() {
                     tracing::trace!("stream reported end of stream before Poll::Ready(None) reached; marking stream complete");
-                    self.throughput.complete();
+                    self.throughput.mark_complete();
                 }
                 Poll::Ready(Some(Ok(bytes)))
             }
@@ -197,7 +197,7 @@ where
             }
             // If we've read all the data or an error occurred, then return that result.
             res => {
-                if this.throughput.complete() {
+                if this.throughput.mark_complete() {
                     tracing::trace!("stream completed: {:?}", res);
                 }
                 res

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/http_body_0_4_x.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/http_body_0_4_x.rs
@@ -22,6 +22,7 @@ trait DownloadReport {
 impl DownloadReport for ThroughputReport {
     fn minimum_throughput_violated(self, minimum_throughput: Throughput) -> (bool, Throughput) {
         let throughput = match self {
+            ThroughputReport::Complete => return (false, ZERO_THROUGHPUT),
             // If the report is incomplete, then we don't have enough data yet to
             // decide if minimum throughput was violated.
             ThroughputReport::Incomplete => {
@@ -183,7 +184,12 @@ where
                 Poll::Pending
             }
             // If we've read all the data or an error occurred, then return that result.
-            res => res,
+            res => {
+                if this.throughput.complete() {
+                    tracing::trace!("stream completed: {:?}", res);
+                }
+                res
+            }
         }
     }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/options.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/options.rs
@@ -4,7 +4,9 @@
  */
 
 use super::Throughput;
-use aws_smithy_runtime_api::client::stalled_stream_protection::StalledStreamProtectionConfig;
+use aws_smithy_runtime_api::client::stalled_stream_protection::{
+    StalledStreamProtectionConfig, DEFAULT_GRACE_PERIOD,
+};
 use std::time::Duration;
 
 /// A collection of options for configuring a [`MinimumThroughputBody`](super::MinimumThroughputDownloadBody).
@@ -69,6 +71,13 @@ impl MinimumThroughputBodyOptions {
     }
 }
 
+const DEFAULT_MINIMUM_THROUGHPUT: Throughput = Throughput {
+    bytes_read: 1,
+    per_time_elapsed: Duration::from_secs(1),
+};
+
+const DEFAULT_CHECK_WINDOW: Duration = Duration::from_secs(1);
+
 impl Default for MinimumThroughputBodyOptions {
     fn default() -> Self {
         Self {
@@ -86,14 +95,6 @@ pub struct MinimumThroughputBodyOptionsBuilder {
     check_window: Option<Duration>,
     grace_period: Option<Duration>,
 }
-
-const DEFAULT_GRACE_PERIOD: Duration = Duration::from_secs(20);
-const DEFAULT_MINIMUM_THROUGHPUT: Throughput = Throughput {
-    bytes_read: 1,
-    per_time_elapsed: Duration::from_secs(1),
-};
-
-const DEFAULT_CHECK_WINDOW: Duration = Duration::from_secs(1);
 
 impl MinimumThroughputBodyOptionsBuilder {
     /// Create a new `MinimumThroughputBodyOptionsBuilder`.

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/options.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/options.rs
@@ -7,7 +7,7 @@ use super::Throughput;
 use aws_smithy_runtime_api::client::stalled_stream_protection::StalledStreamProtectionConfig;
 use std::time::Duration;
 
-/// A collection of options for configuring a [`MinimumThroughputBody`](super::MinimumThroughputBody).
+/// A collection of options for configuring a [`MinimumThroughputBody`](super::MinimumThroughputDownloadBody).
 #[derive(Debug, Clone)]
 pub struct MinimumThroughputBodyOptions {
     /// The minimum throughput that is acceptable.
@@ -87,7 +87,7 @@ pub struct MinimumThroughputBodyOptionsBuilder {
     grace_period: Option<Duration>,
 }
 
-const DEFAULT_GRACE_PERIOD: Duration = Duration::from_secs(0);
+const DEFAULT_GRACE_PERIOD: Duration = Duration::from_secs(20);
 const DEFAULT_MINIMUM_THROUGHPUT: Throughput = Throughput {
     bytes_read: 1,
     per_time_elapsed: Duration::from_secs(1),

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
@@ -351,7 +351,7 @@ impl ThroughputLogs {
     /// idempotent operation -- subsequent invocations of this function have no effect
     /// and return false.
     ///
-    /// After marking a stream complete [report] will forever more return
+    /// After marking a stream complete [report](#method.report) will forever more return
     /// [ThroughputReport::Complete]
     pub(super) fn complete(&mut self) -> bool {
         let prev = self.stream_complete;

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
@@ -4,6 +4,7 @@
  */
 
 use std::fmt;
+use std::sync::atomic;
 use std::time::{Duration, SystemTime};
 
 /// Throughput representation for use when configuring [`super::MinimumThroughputBody`]
@@ -260,6 +261,8 @@ pub(crate) enum ThroughputReport {
     Pending,
     /// The stream transferred this amount of throughput during the time window.
     Transferred(Throughput),
+    /// The stream has completed, no more data is expected.
+    Complete,
 }
 
 const BIN_COUNT: usize = 10;
@@ -285,6 +288,7 @@ pub(super) struct ThroughputLogs {
     resolution: Duration,
     current_tail: SystemTime,
     buffer: LogBuffer<BIN_COUNT>,
+    stream_complete: bool,
 }
 
 impl ThroughputLogs {
@@ -302,6 +306,7 @@ impl ThroughputLogs {
             resolution,
             current_tail: now,
             buffer: LogBuffer::new(),
+            stream_complete: false,
         }
     }
 
@@ -343,8 +348,24 @@ impl ThroughputLogs {
         assert!(self.current_tail >= now);
     }
 
+    /// Mark the stream complete indicating no more data is expected. This is an
+    /// idempotent operation -- subsequent invocations of this function have no effect
+    /// and return false.
+    ///
+    /// After marking a stream complete [report] will forever more return
+    /// [ThroughputReport::Complete]
+    pub(super) fn complete(&mut self) -> bool {
+        let prev = self.stream_complete;
+        self.stream_complete = true;
+        !prev
+    }
+
     /// Generates an overall report of the time window.
     pub(super) fn report(&mut self, now: SystemTime) -> ThroughputReport {
+        if self.stream_complete {
+            return ThroughputReport::Complete;
+        }
+
         self.catch_up(now);
         self.buffer.fill_gaps();
 

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
@@ -353,7 +353,7 @@ impl ThroughputLogs {
     ///
     /// After marking a stream complete [report](#method.report) will forever more return
     /// [ThroughputReport::Complete]
-    pub(super) fn complete(&mut self) -> bool {
+    pub(super) fn mark_complete(&mut self) -> bool {
         let prev = self.stream_complete;
         self.stream_complete = true;
         !prev

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/minimum_throughput/throughput.rs
@@ -4,7 +4,6 @@
  */
 
 use std::fmt;
-use std::sync::atomic;
 use std::time::{Duration, SystemTime};
 
 /// Throughput representation for use when configuring [`super::MinimumThroughputBody`]

--- a/rust-runtime/aws-smithy-runtime/src/client/stalled_stream_protection.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/stalled_stream_protection.rs
@@ -66,7 +66,6 @@ impl Intercept for StalledStreamProtectionInterceptor {
         if let Some(sspcfg) = cfg.load::<StalledStreamProtectionConfig>().cloned() {
             if sspcfg.upload_enabled() {
                 if let Some(0) = context.request().body().content_length() {
-                    // skip enabling stalled stream protection to zero length body
                     tracing::trace!(
                         "skipping stalled stream protection for zero length request body"
                     );

--- a/rust-runtime/aws-smithy-runtime/src/client/stalled_stream_protection.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/stalled_stream_protection.rs
@@ -65,6 +65,13 @@ impl Intercept for StalledStreamProtectionInterceptor {
     ) -> Result<(), BoxError> {
         if let Some(sspcfg) = cfg.load::<StalledStreamProtectionConfig>().cloned() {
             if sspcfg.upload_enabled() {
+                if let Some(0) = context.request().body().content_length() {
+                    // skip enabling stalled stream protection to zero length body
+                    tracing::trace!(
+                        "skipping stalled stream protection for zero length request body"
+                    );
+                    return Ok(());
+                }
                 let (_async_sleep, time_source) = get_runtime_component_deps(runtime_components)?;
                 let now = time_source.now();
 

--- a/rust-runtime/aws-smithy-runtime/tests/stalled_stream_upload.rs
+++ b/rust-runtime/aws-smithy-runtime/tests/stalled_stream_upload.rs
@@ -148,8 +148,7 @@ async fn complete_upload_delayed_response() {
         tick!(time, Duration::from_secs(1));
         info!("body send complete; dropping");
         drop(body_sender);
-        // advance by the grace period
-        tick!(time, Duration::from_secs(5));
+        tick!(time, DEFAULT_GRACE_PERIOD);
         info!("body stream task complete");
         // advance to unblock the stalled server
         tick!(time, Duration::from_secs(2));

--- a/rust-runtime/aws-smithy-runtime/tests/stalled_stream_upload.rs
+++ b/rust-runtime/aws-smithy-runtime/tests/stalled_stream_upload.rs
@@ -7,6 +7,8 @@
 
 #[macro_use]
 mod stalled_stream_common;
+
+use aws_smithy_runtime_api::client::stalled_stream_protection::DEFAULT_GRACE_PERIOD;
 use stalled_stream_common::*;
 
 /// Scenario: Successful upload at a rate above the minimum throughput.
@@ -179,7 +181,7 @@ async fn complete_upload_stop_polling() {
 
     tokio::spawn(async move {
         // advance past the grace period
-        tick!(time, Duration::from_secs(6));
+        tick!(time, DEFAULT_GRACE_PERIOD + Duration::from_secs(1));
         // unblock server
         tick!(time, Duration::from_secs(2));
     });

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -46,7 +46,6 @@ pin-project-lite = "0.2.9"
 pin-utils = "0.1.0"
 ryu = "1.0.5"
 time = { version = "0.3.4", features = ["parsing"] }
-tracing = "0.1.40"
 
 # ByteStream internals
 futures-core = { version = "0.3.29", optional = true }
@@ -54,7 +53,6 @@ tokio = { version = "1.23.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 base64 = "0.13.0"
 ciborium = { version = "0.2.1" }
 lazy_static = "1.4"
@@ -69,6 +67,7 @@ tokio = { version = "1.23.1", features = [
     "fs",
     "io-util",
 ] }
+# This is used in a doctest, don't listen to udeps.
 tokio-stream = "0.1.5"
 tempfile = "3.2.0"
 

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -54,6 +54,7 @@ tokio = { version = "1.23.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
 [dev-dependencies]
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 base64 = "0.13.0"
 ciborium = { version = "0.2.1" }
 lazy_static = "1.4"

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -46,6 +46,7 @@ pin-project-lite = "0.2.9"
 pin-utils = "0.1.0"
 ryu = "1.0.5"
 time = { version = "0.3.4", features = ["parsing"] }
+tracing = "0.1.40"
 
 # ByteStream internals
 futures-core = { version = "0.3.29", optional = true }

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.1.9"
+version = "1.1.10"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/body.rs
+++ b/rust-runtime/aws-smithy-types/src/body.rs
@@ -377,9 +377,11 @@ mod test {
         let mut body = SdkBody::from("hello!");
         let mut body = Pin::new(&mut body);
         let data = body.next().await;
+        assert!(!body.is_end_stream());
         assert!(data.is_some());
         let data = body.next().await;
         assert!(data.is_none());
+        assert!(body.is_end_stream());
     }
 
     #[tokio::test]

--- a/rust-runtime/aws-smithy-types/src/body.rs
+++ b/rust-runtime/aws-smithy-types/src/body.rs
@@ -376,8 +376,8 @@ mod test {
     async fn http_body_consumes_data() {
         let mut body = SdkBody::from("hello!");
         let mut body = Pin::new(&mut body);
-        let data = body.next().await;
         assert!(!body.is_end_stream());
+        let data = body.next().await;
         assert!(data.is_some());
         let data = body.next().await;
         assert!(data.is_none());

--- a/rust-runtime/aws-smithy-types/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream.rs
@@ -642,7 +642,7 @@ mod tests {
         f.write_all(b"hello").unwrap();
         let body = ByteStream::from_path(f.path()).await.unwrap();
         assert_eq!(body.inner.body.content_length(), Some(5));
-        assert_eq!(body.inner.body.is_end_stream(), false);
+        assert!(!body.inner.body.is_end_stream());
 
         assert_eq!(
             ByteStream::from_static(b"").inner.body.is_end_stream(),
@@ -652,6 +652,6 @@ mod tests {
         f.write_all(b"").unwrap();
         let body = ByteStream::from_path(f.path()).await.unwrap();
         assert_eq!(body.inner.body.content_length(), Some(0));
-        assert_eq!(body.inner.body.is_end_stream(), true);
+        assert!(body.inner.body.is_end_stream());
     }
 }

--- a/rust-runtime/aws-smithy-types/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream.rs
@@ -579,7 +579,7 @@ impl Inner {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "rt-tokio"))]
 mod tests {
     use super::{ByteStream, Inner};
     use crate::body::SdkBody;
@@ -600,7 +600,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "rt-tokio")]
     #[tokio::test]
     async fn bytestream_into_async_read() {
         use tokio::io::AsyncBufReadExt;
@@ -635,8 +634,6 @@ mod tests {
     #[allow(clippy::bool_assert_comparison)]
     #[tokio::test]
     async fn valid_eos() {
-        tracing_subscriber::fmt::init();
-
         assert_eq!(
             ByteStream::from_static(b"hello").inner.body.is_end_stream(),
             false

--- a/rust-runtime/aws-smithy-types/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream.rs
@@ -581,9 +581,11 @@ impl Inner {
 
 #[cfg(test)]
 mod tests {
+    use super::{ByteStream, Inner};
     use crate::body::SdkBody;
-    use crate::byte_stream::Inner;
     use bytes::Bytes;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[tokio::test]
     async fn read_from_string_body() {
@@ -601,7 +603,6 @@ mod tests {
     #[cfg(feature = "rt-tokio")]
     #[tokio::test]
     async fn bytestream_into_async_read() {
-        use super::ByteStream;
         use tokio::io::AsyncBufReadExt;
 
         let byte_stream = ByteStream::from_static(b"data 1\ndata 2\ndata 3");
@@ -613,5 +614,44 @@ mod tests {
         assert_eq!(lines.next_line().await.unwrap(), Some("data 2".to_owned()));
         assert_eq!(lines.next_line().await.unwrap(), Some("data 3".to_owned()));
         assert_eq!(lines.next_line().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn valid_size_hint() {
+        assert_eq!(ByteStream::from_static(b"hello").size_hint().1, Some(5));
+        assert_eq!(ByteStream::from_static(b"").size_hint().1, Some(0));
+
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"hello").unwrap();
+        let body = ByteStream::from_path(f.path()).await.unwrap();
+        assert_eq!(body.inner.size_hint().1, Some(5));
+
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"").unwrap();
+        let body = ByteStream::from_path(f.path()).await.unwrap();
+        assert_eq!(body.inner.size_hint().1, Some(0));
+    }
+
+    #[allow(clippy::bool_assert_comparison)]
+    #[tokio::test]
+    async fn valid_eos() {
+        assert_eq!(
+            ByteStream::from_static(b"hello").inner.body.is_end_stream(),
+            false
+        );
+        assert_eq!(
+            ByteStream::from_static(b"").inner.body.is_end_stream(),
+            true
+        );
+
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"hello").unwrap();
+        let body = ByteStream::from_path(f.path()).await.unwrap();
+        assert_eq!(body.inner.body.is_end_stream(), false);
+
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"").unwrap();
+        let body = ByteStream::from_path(f.path()).await.unwrap();
+        assert_eq!(body.inner.body.is_end_stream(), true);
     }
 }

--- a/rust-runtime/aws-smithy-types/src/byte_stream/bytestream_util.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream/bytestream_util.rs
@@ -44,7 +44,10 @@ impl PathBody {
 
     fn from_file(file: File, length: u64, buffer_size: usize) -> Self {
         PathBody {
-            state: State::Loaded(ReaderStream::with_capacity(file.take(length), buffer_size)),
+            state: State::Loaded {
+                stream: ReaderStream::with_capacity(file.take(length), buffer_size),
+                bytes_left: length,
+            },
             length,
             buffer_size,
             // The file used to create this `PathBody` should have already had an offset applied
@@ -230,7 +233,10 @@ impl FsBuilder {
 enum State {
     Unloaded(PathBuf),
     Loading(Pin<Box<dyn Future<Output = io::Result<File>> + Send + Sync + 'static>>),
-    Loaded(ReaderStream<io::Take<File>>),
+    Loaded {
+        stream: ReaderStream<io::Take<File>>,
+        bytes_left: u64,
+    },
 }
 
 impl http_body_0_4::Body for PathBody {
@@ -238,7 +244,7 @@ impl http_body_0_4::Body for PathBody {
     type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
     fn poll_data(
-        mut self: std::pin::Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<Self::Data, Self::Error>>> {
         use std::task::Poll;
@@ -247,6 +253,7 @@ impl http_body_0_4::Body for PathBody {
             match self.state {
                 State::Unloaded(ref path_buf) => {
                     let buf = path_buf.clone();
+                    tracing::trace!("PathBody transitioning to Loading state");
                     self.state = State::Loading(Box::pin(async move {
                         let mut file = File::open(&buf).await?;
 
@@ -260,18 +267,33 @@ impl http_body_0_4::Body for PathBody {
                 State::Loading(ref mut future) => {
                     match futures_core::ready!(Pin::new(future).poll(cx)) {
                         Ok(file) => {
-                            self.state = State::Loaded(ReaderStream::with_capacity(
-                                file.take(self.length),
-                                self.buffer_size,
-                            ));
+                            tracing::trace!("PathBody transitioning to Loaded state");
+                            self.state = State::Loaded {
+                                stream: ReaderStream::with_capacity(
+                                    file.take(self.length),
+                                    self.buffer_size,
+                                ),
+                                bytes_left: self.length,
+                            };
                         }
                         Err(e) => return Poll::Ready(Some(Err(e.into()))),
                     };
                 }
-                State::Loaded(ref mut stream) => {
+                State::Loaded {
+                    ref mut stream,
+                    ref mut bytes_left,
+                } => {
                     use futures_core::Stream;
-                    return match futures_core::ready!(std::pin::Pin::new(stream).poll_next(cx)) {
-                        Some(Ok(bytes)) => Poll::Ready(Some(Ok(bytes))),
+                    return match futures_core::ready!(Pin::new(stream).poll_next(cx)) {
+                        Some(Ok(bytes)) => {
+                            *bytes_left -= bytes.len() as u64;
+                            tracing::trace!(
+                                "read {} bytes from PathBody, {} bytes left",
+                                bytes.len(),
+                                bytes_left
+                            );
+                            Poll::Ready(Some(Ok(bytes)))
+                        }
                         None => Poll::Ready(None),
                         Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
                     };
@@ -281,15 +303,17 @@ impl http_body_0_4::Body for PathBody {
     }
 
     fn poll_trailers(
-        self: std::pin::Pin<&mut Self>,
+        self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<Option<http::HeaderMap>, Self::Error>> {
         std::task::Poll::Ready(Ok(None))
     }
 
     fn is_end_stream(&self) -> bool {
-        // fast path end-stream for empty streams
-        self.length == 0
+        match self.state {
+            State::Unloaded(_) | State::Loading(_) => false,
+            State::Loaded { bytes_left, .. } => bytes_left == 0,
+        }
     }
 
     fn size_hint(&self) -> http_body_0_4::SizeHint {
@@ -303,6 +327,7 @@ mod test {
     use super::FsBuilder;
     use crate::byte_stream::{ByteStream, Length};
     use bytes::Buf;
+    use http_body_0_4::Body;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -368,6 +393,29 @@ mod test {
             .into_inner();
 
         assert_eq!(body.content_length(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn fsbuilder_is_end_stream() {
+        let sentence = "A very long sentence that's clearly longer than a single byte.";
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(sentence.as_bytes()).unwrap();
+        // Ensure that the file was written to
+        file.flush().expect("flushing is OK");
+
+        let mut body = FsBuilder::new()
+            .path(&file)
+            .build()
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!body.is_end_stream());
+        assert_eq!(body.content_length(), Some(sentence.len() as u64));
+
+        let data = body.data().await.unwrap().unwrap();
+        assert_eq!(data.len(), sentence.len());
+        assert!(body.is_end_stream());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
* https://github.com/awslabs/aws-sdk-rust/issues/1141
* https://github.com/awslabs/aws-sdk-rust/issues/1146
* https://github.com/awslabs/aws-sdk-rust/issues/1148


## Description
* Disables stalled stream upload protection for requests with an empty/zero length body.
* Disables stalled stream upload throughput checking once the request body has been read and handed off to the HTTP layer.


## Testing
Additional integration tests added covering empty bodies and completed uploads.

Tested SQS issue against latest runtime and can see it works now. The S3 `CopyObject` issue is related to downloads and will need a different solution.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
