### PR TITLE
Updating docs for app_name on ConfigLoader

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -36,4 +36,8 @@ references = ["aws-sdk-rust#1079"]
 meta = { "breaking" = false, "bug" = true, "tada" = false }
 author = "rcoh"
 
-
+[[aws-sdk-rust]]
+message = "Updating the documentation for the app_name method on ConfigLoader to indicate the order of precedence for the sources of the AppName."
+references = ["smithy-rs#3645"]
+meta = { "breaking" = false, "bug" = false, "tada" = false }
+author = "landonxjames"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -37,7 +37,7 @@ meta = { "breaking" = false, "bug" = true, "tada" = false }
 author = "rcoh"
 
 [[aws-sdk-rust]]
-message = "Updating the documentation for the app_name method on ConfigLoader to indicate the order of precedence for the sources of the AppName."
+message = "Updating the documentation for the `app_name` method on `ConfigLoader` to indicate the order of precedence for the sources of the `AppName`."
 references = ["smithy-rs#3645"]
 meta = { "breaking" = false, "bug" = false, "tada" = false }
 author = "landonxjames"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -532,8 +532,15 @@ mod loader {
 
         /// Override the name of the app used to build [`SdkConfig`].
         ///
-        /// This _optional_ name is used to identify the application in the user agent that
+        /// This _optional_ name is used to identify the application in the user agent header that
         /// gets sent along with requests.
+        ///
+        /// The app name is selected from an ordered list of sources:
+        /// 1. This override.
+        /// 2. The value of the `AWS_SDK_UA_APP_ID` environment variable.
+        /// 3. Profile files from the key `sdk_ua_app_id`
+        ///
+        /// If none of those sources are set the value is `None` and it is not added to the user agent header.
         ///
         /// # Examples
         /// ```no_run

--- a/tools/ci-build/changelogger/smithy-rs-maintainers.txt
+++ b/tools/ci-build/changelogger/smithy-rs-maintainers.txt
@@ -9,3 +9,4 @@ drganjoo
 rschmitt
 rhernandez35
 aajtodd
+landonxjames


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Docs indicating that the `AppName` can be loaded from an environment variable or profile key were buried in the default provider and would be hard to find for users.

## Description
<!--- Describe your changes in detail -->
This change adds documentation to the `app_name` method on `ConfigLoader` that makes the options for loading the `AppName` more explicit.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `cargo doc` to ensure the docs were generated correctly

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
