### PR TITLE
don't apply stalled stream protection to CopyObject

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/StalledStreamProtectionConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/StalledStreamProtectionConfigCustomization.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.configReexport
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationSection
+import software.amazon.smithy.rust.codegen.client.smithy.traits.IncompatibleWithStalledStreamProtectionTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
@@ -34,7 +35,7 @@ class StalledStreamProtectionDecorator : ClientCodegenDecorator {
         operation: OperationShape,
         baseCustomizations: List<OperationCustomization>,
     ): List<OperationCustomization> {
-        return baseCustomizations + StalledStreamProtectionOperationCustomization(codegenContext)
+        return baseCustomizations + StalledStreamProtectionOperationCustomization(codegenContext, operation)
     }
 }
 
@@ -111,11 +112,17 @@ class StalledStreamProtectionConfigCustomization(codegenContext: ClientCodegenCo
 
 class StalledStreamProtectionOperationCustomization(
     codegenContext: ClientCodegenContext,
+    private val operationShape: OperationShape,
 ) : OperationCustomization() {
     private val rc = codegenContext.runtimeConfig
 
     override fun section(section: OperationSection): Writable =
         writable {
+            // Don't add the stalled stream protection interceptor if the operation is incompatible with it
+            if (operationShape.hasTrait(IncompatibleWithStalledStreamProtectionTrait.ID)) {
+                return@writable
+            }
+
             when (section) {
                 is OperationSection.AdditionalInterceptors -> {
                     val stalledStreamProtectionModule = RuntimeType.smithyRuntime(rc).resolve("client::stalled_stream_protection")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/traits/IncompatibleWithStalledStreamProtectionTrait.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/traits/IncompatibleWithStalledStreamProtectionTrait.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.traits
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.AnnotationTrait
+
+/**
+ * Indicates that an operation shape is incompatible with stalled stream protection.
+ */
+class IncompatibleWithStalledStreamProtectionTrait : AnnotationTrait(ID, Node.objectNode()) {
+    companion object {
+        val ID: ShapeId = ShapeId.from("software.amazon.smithy.rust.codegen.client.smithy.traits#incompatibleWithStalledStreamProtectionTrait")
+    }
+}


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Disables SSP for S3's CopyObject

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
