### PR TITLE
Renaming gradle task `:aws:sdk:test` to `sdkTest` avoid task name collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Project Layout
 * `aws`: AWS specific codegen & Rust code (signing, endpoints, customizations, etc.)
   Common commands:
   * `./gradlew :aws:sdk:assemble`: Generate (but do not test / compile etc.) a fresh SDK into `sdk/build/aws-sdk`
-  * `./gradlew :aws:sdk:test`: Generate & run all tests for a fresh SDK
+  * `./gradlew :aws:sdk:sdkTest`: Generate & run all tests for a fresh SDK. (Note that these tests require Go to be
+  installed for FIP support to compile properly)
   * `./gradlew :aws:sdk:{cargoCheck, cargoTest, cargoDocs, cargoClippy}`: Generate & run specified cargo command.
 * `codegen-core`: Common code generation logic useful for clients and servers
 * `codegen-client`: Whitelabel Smithy client code generation
@@ -123,7 +124,7 @@ to generate more or less AWS service clients.
 # Generate an SDK, but do not attempt to compile / run tests. Useful for inspecting generated code
 ./gradlew :aws:sdk:assemble
 # Run all the tests
-./gradlew :aws:sdk:test
+./gradlew :aws:sdk:sdkTest
 # Validate that the generated code compiles
 ./gradlew :aws:sdk:cargoCheck
 # Validate that the generated code passes Clippy

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -445,8 +445,12 @@ tasks["assemble"].apply {
 project.registerCargoCommandsTasks(outputDir.asFile, defaultRustDocFlags)
 project.registerGenerateCargoConfigTomlTask(outputDir.asFile)
 
-tasks["test"].dependsOn("assemble")
-tasks["test"].finalizedBy(Cargo.CLIPPY.toString, Cargo.TEST.toString, Cargo.DOCS.toString)
+//The task name "test" is already registered by one of our plugins
+tasks.register("sdkTest") {
+    description = "Run Cargo clippy/test/docs against the generated SDK."
+    dependsOn("assemble")
+    finalizedBy(Cargo.CLIPPY.toString, Cargo.TEST.toString, Cargo.DOCS.toString)
+}
 
 tasks.register<Delete>("deleteSdk") {
     delete(


### PR DESCRIPTION
It is now called :aws:sdk:sdkTest and the README has been updated to align with this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The gradle task `:aws:sdk:test` mentioned in our `README` has been broken for sometime. This seems to be because one of the plugins we are using (I was unable to determine exactly which one) is registering a task named `test` and it was conflicting with ours. 

## Description
<!--- Describe your changes in detail -->
I changed the name of the broken task to `:aws:sdk:sdkTest`, explicitly registered it, and added the appropriate dependencies and steps for the task. I also updated the `README` to reflect this new name and added a note to indicate that these tests require Go to be installed (because they tests some FIPS functionality). 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I was able to successfully run `./gradlew :aws:sdk:sdkTest` on my local machine (after installing Go which I was initially missing).

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
No changes to any published code in this PR
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
