### PR TITLE
Bumping MSRV to 1.76.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ on:
         required: false
 
 env:
-  rust_version: 1.75.0
+  rust_version: 1.76.0
   rust_toolchain_components: clippy,rustfmt
   ENCRYPTED_DOCKER_PASSWORD: ${{ secrets.ENCRYPTED_DOCKER_PASSWORD }}
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.75.0
+  rust_version: 1.76.0
 
 name: Claim unpublished crate names on crates.io
 run-name: ${{ github.workflow }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ on:
 name: Update GitHub Pages
 
 env:
-  rust_version: 1.75.0
+  rust_version: 1.76.0
 
 # Allow only one doc pages build to run at a time for the entire smithy-rs repo
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.75.0
+  rust_version: 1.76.0
 
 name: Release smithy-rs
 on:

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.75.0
+        toolchain: 1.76.0
     - name: Delete old SDK
       run: |
     - name: Generate a fresh SDK

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -53,3 +53,15 @@ message = "Updating the documentation for the `app_name` method on `ConfigLoader
 references = ["smithy-rs#3645"]
 meta = { "breaking" = false, "bug" = false, "tada" = false }
 author = "landonxjames"
+
+[[aws-sdk-rust]]
+message = "Update MSRV to `1.76.0`"
+references = ["smithy-rs#3653"]
+meta = { "breaking" = true, "tada" = true, "bug" = false }
+author = "landonxjames"
+
+[[smithy-rs]]
+message = "Update MSRV to `1.76.0`"
+references = ["smithy-rs#3653"]
+meta = { "breaking" = true, "tada" = true, "bug" = false, "target" = "all" }
+author = "landonxjames"

--- a/aws/rust-runtime/aws-config/src/environment/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/environment/credentials.rs
@@ -39,7 +39,7 @@ impl EnvironmentVariableCredentialsProvider {
                 .get("AWS_SESSION_TOKEN")
                 .ok()
                 .and_then(|token| match token.trim() {
-                    s if s.is_empty() => None,
+                    "" => None,
                     s => Some(s.to_string()),
                 });
         Ok(Credentials::new(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -118,7 +118,7 @@ object TestWorkspace {
                 // help rust select the right version when we run cargo test
                 // TODO(https://github.com/smithy-lang/smithy-rs/issues/2048): load this from the msrv property using a
                 //  method as we do for runtime crate versions
-                "[toolchain]\nchannel = \"1.75.0\"\n",
+                "[toolchain]\nchannel = \"1.76.0\"\n",
             )
             // ensure there at least an empty lib.rs file to avoid broken crates
             newProject.resolve("src").mkdirs()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.75.0
+rust.msrv=1.76.0
 
 # To enable debug, swap out the two lines below.
 # When changing this value, be sure to run `./gradlew --stop` to kill the Gradle daemon.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -6,7 +6,7 @@
 # This is the base Docker build image used by CI
 
 ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2023
-ARG rust_stable_version=1.75.0
+ARG rust_stable_version=1.76.0
 ARG rust_nightly_version=nightly-2024-02-07
 
 FROM ${base_image} AS bare_base_image


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Bumping MSRV to hopefully get around a canary dependency build issue

## Description
<!--- Describe your changes in detail -->
Bump MSRV to `1.76.0` throughout the codebase

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Will rerun canary against this commit to check the fix

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
