### PR TITLE
Fix Server README to remove stale warning on unstable good generation

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,7 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+[[smithy-rs]]
+message = "Fix server README"
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server"}
+author = "drganjoo"

--- a/codegen-server/README.md
+++ b/codegen-server/README.md
@@ -2,13 +2,11 @@
 
 Server-side Smithy code generator
 
-** This is a work in progress and generates serialization/de-serialization code that is probably unusable for the time being. **
-
-[Design documentation (WIP)](https://smithy-lang.github.io/smithy-rs/)
+[Design documentation](https://smithy-lang.github.io/smithy-rs/design/server/overview.html)
 
 ## Project Layout
 
-* `codegen-server`: Server-side code generation
-* `codegen-server-test`: Server-side Smithy test and validation generation
+* `codegen-server`: Server-side code generation.
+* `codegen-server-test`: Server-side Smithy test and validation generation.
   Common commands:
   * `./gradlew :codegen-server-test:test` Generate code and run tests against it


### PR DESCRIPTION
The Server README had a stale warning:

```
** This is a work in progress and generates serialization/de-serialization code that is probably unusable for the time being. ```