### PR TITLE
Add invocation ID to root level “invoke” operation span

### DIFF
--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"
@@ -20,6 +20,7 @@ aws-sigv4 = { path = "../aws-sigv4", features = ["http0-compat"] }
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
 aws-smithy-eventstream = { path = "../../../rust-runtime/aws-smithy-eventstream", optional = true }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
+aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", features = ["client"] }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-types = { path = "../aws-types" }

--- a/aws/rust-runtime/aws-runtime/external-types.toml
+++ b/aws/rust-runtime/aws-runtime/external-types.toml
@@ -1,7 +1,6 @@
 allowed_external_types = [
     "aws_sigv4::*",
     "aws_smithy_types::*",
-    "aws_smithy_runtime::*",
     "aws_smithy_runtime_api::*",
     "aws_types::*",
     "bytes::bytes::Bytes",

--- a/aws/rust-runtime/aws-runtime/external-types.toml
+++ b/aws/rust-runtime/aws-runtime/external-types.toml
@@ -1,6 +1,7 @@
 allowed_external_types = [
     "aws_sigv4::*",
     "aws_smithy_types::*",
+    "aws_smithy_runtime::*",
     "aws_smithy_runtime_api::*",
     "aws_types::*",
     "bytes::bytes::Bytes",

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -18,7 +18,7 @@ use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 #[cfg(feature = "test-util")]
-pub use test_util::PredefinedInvocationIdGenerator;
+pub use test_util::{NoInvocationIdGenerator, PredefinedInvocationIdGenerator};
 
 #[allow(clippy::declare_interior_mutable_const)] // we will never mutate this
 const AMZ_SDK_INVOCATION_ID: HeaderName = HeaderName::from_static("amz-sdk-invocation-id");
@@ -189,6 +189,23 @@ mod test_util {
                     .pop()
                     .expect("testers will provide enough invocation IDs"),
             ))
+        }
+    }
+
+    /// A "generator" that always returns `None`.
+    #[derive(Debug, Default)]
+    pub struct NoInvocationIdGenerator;
+
+    impl NoInvocationIdGenerator {
+        /// Create a new [`NoInvocationIdGenerator`].
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    impl InvocationIdGenerator for NoInvocationIdGenerator {
+        fn generate(&self) -> Result<Option<InvocationId>, BoxError> {
+            Ok(None)
         }
     }
 }

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -212,27 +212,25 @@ mod test_util {
 
 #[cfg(test)]
 mod tests {
-    use aws_smithy_runtime_api::client::interceptors::context::{
-        BeforeTransmitInterceptorContextMut, Input, InterceptorContext,
-    };
-    use aws_smithy_runtime_api::client::interceptors::Intercept;
-    use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
-    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
-    use aws_smithy_types::config_bag::ConfigBag;
-
-    use super::*;
-
-    fn expect_header<'a>(
-        context: &'a BeforeTransmitInterceptorContextMut<'_>,
-        header_name: &str,
-    ) -> &'a str {
-        context.request().headers().get(header_name).unwrap()
-    }
-
     #[cfg(feature = "test-util")]
     #[test]
     fn custom_id_generator() {
+        use super::*;
+        use aws_smithy_runtime_api::client::interceptors::context::{
+            BeforeTransmitInterceptorContextMut, Input, InterceptorContext,
+        };
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
+        use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+        use aws_smithy_types::config_bag::ConfigBag;
         use aws_smithy_types::config_bag::Layer;
+
+        fn expect_header<'a>(
+            context: &'a BeforeTransmitInterceptorContextMut<'_>,
+            header_name: &str,
+        ) -> &'a str {
+            context.request().headers().get(header_name).unwrap()
+        }
 
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
         let mut ctx = InterceptorContext::new(Input::doesnt_matter());

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -9,17 +9,24 @@ use std::sync::{Arc, Mutex};
 use fastrand::Rng;
 use http::{HeaderName, HeaderValue};
 
+use aws_smithy_runtime::client::invocation_id::{
+    GenerateInvocationId, InvocationId as GenericClientInvocationId,
+};
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 #[cfg(feature = "test-util")]
-pub use test_util::{NoInvocationIdGenerator, PredefinedInvocationIdGenerator};
+pub use test_util::PredefinedInvocationIdGenerator;
 
 #[allow(clippy::declare_interior_mutable_const)] // we will never mutate this
 const AMZ_SDK_INVOCATION_ID: HeaderName = HeaderName::from_static("amz-sdk-invocation-id");
 
+// We have a trait `aws_smithy_runtime::client::invocation_id::GenerateInvocationId` to
+// represent effectively the same concept, but this pub trait was defined first, making it
+// challenging to promote it to the `aws_smithy_runtime` crate. We keep this trait here to avoid
+// breaking existing users.
 /// A generator for returning new invocation IDs on demand.
 pub trait InvocationIdGenerator: Debug + Send + Sync {
     /// Call this function to receive a new [`InvocationId`] or an error explaining why one couldn't
@@ -44,16 +51,28 @@ impl InvocationIdGenerator for SharedInvocationIdGenerator {
     }
 }
 
+impl GenerateInvocationId for SharedInvocationIdGenerator {
+    fn generate(&self) -> Result<Option<GenericClientInvocationId>, BoxError> {
+        InvocationIdGenerator::generate(self)
+            .map(|id| id.map(|id| GenericClientInvocationId::new(id.0)))
+    }
+}
+
 impl Storable for SharedInvocationIdGenerator {
     type Storer = StoreReplace<Self>;
 }
 
 /// An invocation ID generator that uses random UUIDs for the invocation ID.
+#[deprecated(
+    since = "1.2.3",
+    note = "This struct was meant to be used internally. Do not use."
+)]
 #[derive(Debug, Default)]
 pub struct DefaultInvocationIdGenerator {
     rng: Mutex<Rng>,
 }
 
+#[allow(deprecated)]
 impl DefaultInvocationIdGenerator {
     /// Creates a new [`DefaultInvocationIdGenerator`].
     pub fn new() -> Self {
@@ -68,6 +87,7 @@ impl DefaultInvocationIdGenerator {
     }
 }
 
+#[allow(deprecated)]
 impl InvocationIdGenerator for DefaultInvocationIdGenerator {
     fn generate(&self) -> Result<Option<InvocationId>, BoxError> {
         let mut rng = self.rng.lock().unwrap();
@@ -82,9 +102,7 @@ impl InvocationIdGenerator for DefaultInvocationIdGenerator {
 /// This interceptor generates a UUID and attaches it to all request attempts made as part of this operation.
 #[non_exhaustive]
 #[derive(Debug, Default)]
-pub struct InvocationIdInterceptor {
-    default: DefaultInvocationIdGenerator,
-}
+pub struct InvocationIdInterceptor {}
 
 impl InvocationIdInterceptor {
     /// Creates a new `InvocationIdInterceptor`
@@ -98,23 +116,6 @@ impl Intercept for InvocationIdInterceptor {
         "InvocationIdInterceptor"
     }
 
-    fn modify_before_retry_loop(
-        &self,
-        _ctx: &mut BeforeTransmitInterceptorContextMut<'_>,
-        _runtime_components: &RuntimeComponents,
-        cfg: &mut ConfigBag,
-    ) -> Result<(), BoxError> {
-        let gen = cfg
-            .load::<SharedInvocationIdGenerator>()
-            .map(|gen| gen as &dyn InvocationIdGenerator)
-            .unwrap_or(&self.default);
-        if let Some(id) = gen.generate()? {
-            cfg.interceptor_state().store_put::<InvocationId>(id);
-        }
-
-        Ok(())
-    }
-
     fn modify_before_transmit(
         &self,
         ctx: &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -122,8 +123,11 @@ impl Intercept for InvocationIdInterceptor {
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         let headers = ctx.request_mut().headers_mut();
-        if let Some(id) = cfg.load::<InvocationId>() {
-            headers.append(AMZ_SDK_INVOCATION_ID, id.0.clone());
+        if let Some(id) = cfg.load::<GenericClientInvocationId>() {
+            headers.append(
+                AMZ_SDK_INVOCATION_ID,
+                HeaderValue::try_from(id.to_string())?,
+            );
         }
         Ok(())
     }
@@ -131,18 +135,12 @@ impl Intercept for InvocationIdInterceptor {
 
 /// InvocationId provides a consistent ID across retries
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvocationId(HeaderValue);
+pub struct InvocationId(String);
 
 impl InvocationId {
     /// Create an invocation ID with the given value.
-    ///
-    /// # Panics
-    /// This constructor will panic if the given invocation ID is not a valid HTTP header value.
     pub fn new(invocation_id: String) -> Self {
-        Self(
-            HeaderValue::try_from(invocation_id)
-                .expect("invocation ID must be a valid HTTP header value"),
-        )
+        Self(invocation_id)
     }
 }
 
@@ -159,7 +157,7 @@ mod test_util {
     impl InvocationId {
         /// Create a new invocation ID from a `&'static str`.
         pub fn new_from_str(uuid: &'static str) -> Self {
-            InvocationId(HeaderValue::from_static(uuid))
+            Self(uuid.to_owned())
         }
     }
 
@@ -193,23 +191,6 @@ mod test_util {
             ))
         }
     }
-
-    /// A "generator" that always returns `None`.
-    #[derive(Debug, Default)]
-    pub struct NoInvocationIdGenerator;
-
-    impl NoInvocationIdGenerator {
-        /// Create a new [`NoInvocationIdGenerator`].
-        pub fn new() -> Self {
-            Self
-        }
-    }
-
-    impl InvocationIdGenerator for NoInvocationIdGenerator {
-        fn generate(&self) -> Result<Option<InvocationId>, BoxError> {
-            Ok(None)
-        }
-    }
 }
 
 #[cfg(test)]
@@ -231,36 +212,11 @@ mod tests {
         context.request().headers().get(header_name).unwrap()
     }
 
-    #[test]
-    fn default_id_generator() {
-        let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
-        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
-        ctx.enter_serialization_phase();
-        ctx.set_request(HttpRequest::empty());
-        let _ = ctx.take_input();
-        ctx.enter_before_transmit_phase();
-
-        let mut cfg = ConfigBag::base();
-        let interceptor = InvocationIdInterceptor::new();
-        let mut ctx = Into::into(&mut ctx);
-        interceptor
-            .modify_before_retry_loop(&mut ctx, &rc, &mut cfg)
-            .unwrap();
-        interceptor
-            .modify_before_transmit(&mut ctx, &rc, &mut cfg)
-            .unwrap();
-
-        let expected = cfg.load::<InvocationId>().expect("invocation ID was set");
-        let header = expect_header(&ctx, "amz-sdk-invocation-id");
-        assert_eq!(expected.0, header, "the invocation ID in the config bag must match the invocation ID in the request header");
-        // UUID should include 32 chars and 4 dashes
-        assert_eq!(header.len(), 36);
-    }
-
     #[cfg(feature = "test-util")]
     #[test]
     fn custom_id_generator() {
         use aws_smithy_types::config_bag::Layer;
+
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
         let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.enter_serialization_phase();
@@ -270,18 +226,16 @@ mod tests {
 
         let mut cfg = ConfigBag::base();
         let mut layer = Layer::new("test");
-        layer.store_put(SharedInvocationIdGenerator::new(
-            PredefinedInvocationIdGenerator::new(vec![InvocationId::new(
-                "the-best-invocation-id".into(),
-            )]),
+        let gen = PredefinedInvocationIdGenerator::new(vec![InvocationId::new(
+            "the-best-invocation-id".into(),
+        )]);
+        layer.store_put(GenericClientInvocationId::new(
+            gen.generate().unwrap().unwrap().0,
         ));
         cfg.push_layer(layer);
 
         let interceptor = InvocationIdInterceptor::new();
         let mut ctx = Into::into(&mut ctx);
-        interceptor
-            .modify_before_retry_loop(&mut ctx, &rc, &mut cfg)
-            .unwrap();
         interceptor
             .modify_before_transmit(&mut ctx, &rc, &mut cfg)
             .unwrap();

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -165,6 +165,7 @@ impl Storable for InvocationId {
 
 #[cfg(feature = "test-util")]
 mod test_util {
+    use aws_smithy_runtime::client::invocation_id::GenerateInvocationId;
     use std::sync::{Arc, Mutex};
 
     use super::*;
@@ -207,6 +208,13 @@ mod test_util {
         }
     }
 
+    impl GenerateInvocationId for PredefinedInvocationIdGenerator {
+        fn generate(&self) -> Result<Option<GenericClientInvocationId>, BoxError> {
+            InvocationIdGenerator::generate(self)
+                .map(|id| id.map(|id| GenericClientInvocationId::new(id.0)))
+        }
+    }
+
     /// A "generator" that always returns `None`.
     #[derive(Debug, Default)]
     pub struct NoInvocationIdGenerator;
@@ -220,6 +228,12 @@ mod test_util {
 
     impl InvocationIdGenerator for NoInvocationIdGenerator {
         fn generate(&self) -> Result<Option<InvocationId>, BoxError> {
+            Ok(None)
+        }
+    }
+
+    impl GenerateInvocationId for NoInvocationIdGenerator {
+        fn generate(&self) -> Result<Option<GenericClientInvocationId>, BoxError> {
             Ok(None)
         }
     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecorator.kt
@@ -94,7 +94,7 @@ private class InvocationIdConfigCustomization(
                             // HACK: We're adding a shallow copy of the inner invocation generator before it gets wrapped in a new-type.
                             // This helps keep a getter `invocation_id_generator` working.
                             self.config.store_or_unset(gen.clone());
-                            self.config.store_or_unset(gen.map(|g| #{SharedGenericClientInvocationIdGenerator}::new(g)));
+                            self.config.store_or_unset(gen.map(#{SharedGenericClientInvocationIdGenerator}::new));
                             self
                         }
                         """,

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
@@ -51,10 +51,10 @@ class InvocationIdDecoratorTest {
                             assert_eq!("custom", request.headers().get("amz-sdk-invocation-id").unwrap());
                         }
 
-                        verify_request_header( $moduleName::Config::builder()
+                        verify_request_header($moduleName::Config::builder()
                             .invocation_id_generator(TestIdGen), |cfg| cfg.invocation_id_generator().is_some()).await;
 
-                        verify_request_header( $moduleName::Config::builder()
+                        verify_request_header($moduleName::Config::builder()
                             .invocation_id_generator_v2(TestIdGen), |cfg| cfg.invocation_id_generator_v2().is_some()).await;
                     }
                     """,
@@ -162,10 +162,10 @@ class InvocationIdDecoratorTest {
                             assert!(request.headers().get("amz-sdk-invocation-id").is_none());
                         }
 
-                        verify_request_header( $moduleName::Config::builder()
+                        verify_request_header($moduleName::Config::builder()
                             .invocation_id_generator(NoInvocationIdGenerator), |cfg| cfg.invocation_id_generator().is_some()).await;
 
-                        verify_request_header( $moduleName::Config::builder()
+                        verify_request_header($moduleName::Config::builder()
                             .invocation_id_generator_v2(NoInvocationIdGenerator), |cfg| cfg.invocation_id_generator_v2().is_some()).await;
                     }
                     """,

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
@@ -22,6 +22,7 @@ class InvocationIdDecoratorTest {
             rustCrate.integrationTest("custom_invocation_id") {
                 rustTemplate(
                     """
+                    ##[allow(deprecated)]
                     ##[#{tokio}::test]
                     async fn custom_invocation_id() {
                         ##[derive(::std::fmt::Debug)]
@@ -69,6 +70,7 @@ class InvocationIdDecoratorTest {
             rustCrate.integrationTest("default_invocation_id") {
                 rustTemplate(
                     """
+                    ##[allow(deprecated)]
                     ##[#{tokio}::test]
                     async fn default_invocation_id() {
                         let (http_client, rx) = #{capture_request}(None);
@@ -109,6 +111,7 @@ class InvocationIdDecoratorTest {
             rustCrate.integrationTest("no_invocation_id") {
                 rustTemplate(
                     """
+                    ##[allow(deprecated)]
                     ##[#{tokio}::test]
                     async fn no_invocation_id() {
                         /// A "generator" that always returns `None`.

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
@@ -60,4 +60,92 @@ class InvocationIdDecoratorTest {
             }
         }
     }
+
+    @Test
+    fun defaultInvocationIdGenerator() {
+        awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { context, rustCrate ->
+            val rc = context.runtimeConfig
+            val moduleName = context.moduleUseName()
+            rustCrate.integrationTest("default_invocation_id") {
+                rustTemplate(
+                    """
+                    ##[#{tokio}::test]
+                    async fn default_invocation_id() {
+                        let (http_client, rx) = #{capture_request}(None);
+                        // not calling `.invocation_id_generator` to trigger the default
+                        let config = $moduleName::Config::builder()
+                            .http_client(http_client)
+                            .build();
+                        assert!(config.invocation_id_generator().is_none());
+
+                        let client = $moduleName::Client::from_conf(config);
+
+                        let _ = dbg!(client.some_operation().send().await);
+                        let request = rx.expect_request();
+                        // UUID should include 32 chars and 4 dashes
+                        assert_eq!(36, request.headers().get("amz-sdk-invocation-id").unwrap().len());
+                    }
+                    """,
+                    *preludeScope,
+                    "tokio" to CargoDependency.Tokio.toType(),
+                    "InvocationIdGenerator" to
+                        AwsRuntimeType.awsRuntime(rc)
+                            .resolve("invocation_id::InvocationIdGenerator"),
+                    "InvocationId" to
+                        AwsRuntimeType.awsRuntime(rc)
+                            .resolve("invocation_id::InvocationId"),
+                    "BoxError" to RuntimeType.boxError(rc),
+                    "capture_request" to RuntimeType.captureRequest(rc),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun noInvocationIdGenerator() {
+        awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { context, rustCrate ->
+            val rc = context.runtimeConfig
+            val moduleName = context.moduleUseName()
+            rustCrate.integrationTest("no_invocation_id") {
+                rustTemplate(
+                    """
+                    ##[#{tokio}::test]
+                    async fn no_invocation_id() {
+                        /// A "generator" that always returns `None`.
+                        ##[derive(Debug, Default)]
+                        struct NoInvocationIdGenerator;
+                        impl #{InvocationIdGenerator} for NoInvocationIdGenerator {
+                            fn generate(&self) -> #{Result}<#{Option}<#{InvocationId}>, #{BoxError}> {
+                                #{Ok}(#{None})
+                            }
+                        }
+
+                        let (http_client, rx) = #{capture_request}(None);
+                        let config = $moduleName::Config::builder()
+                            .http_client(http_client)
+                            .invocation_id_generator(NoInvocationIdGenerator)
+                            .build();
+                        assert!(config.invocation_id_generator().is_some());
+
+                        let client = $moduleName::Client::from_conf(config);
+
+                        let _ = dbg!(client.some_operation().send().await);
+                        let request = rx.expect_request();
+                        assert!(request.headers().get("amz-sdk-invocation-id").is_none());
+                    }
+                    """,
+                    *preludeScope,
+                    "tokio" to CargoDependency.Tokio.toType(),
+                    "InvocationIdGenerator" to
+                        AwsRuntimeType.awsRuntime(rc)
+                            .resolve("invocation_id::InvocationIdGenerator"),
+                    "InvocationId" to
+                        AwsRuntimeType.awsRuntime(rc)
+                            .resolve("invocation_id::InvocationId"),
+                    "BoxError" to RuntimeType.boxError(rc),
+                    "capture_request" to RuntimeType.captureRequest(rc),
+                )
+            }
+        }
+    }
 }

--- a/aws/sdk/benchmarks/s3-express/Cargo.lock
+++ b/aws/sdk/benchmarks/s3-express/Cargo.lock
@@ -24,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -65,7 +64,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.1.10"
+version = "1.5.0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -94,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.1.8"
+version = "1.2.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -104,13 +103,14 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.1.9"
+version = "1.2.3"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
  "aws-smithy-http",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.7"
+version = "0.60.8"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.7"
+version = "0.60.8"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.3.0"
+version = "1.5.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -338,11 +338,12 @@ dependencies = [
  "rustls",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.4.0"
+version = "1.6.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -357,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.8"
+version = "1.1.10"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -381,14 +382,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.7"
+version = "0.60.8"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.1.9"
+version = "1.3.0"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/aws/sdk/integration-tests/s3/tests/request_information_headers.rs
+++ b/aws/sdk/integration-tests/s3/tests/request_information_headers.rs
@@ -84,7 +84,7 @@ async fn three_retries_and_then_success() {
                 .read_timeout(Duration::from_secs(10))
                 .build(),
         )
-        .invocation_id_generator(PredefinedInvocationIdGenerator::new(vec![
+        .invocation_id_generator_v2(PredefinedInvocationIdGenerator::new(vec![
             InvocationId::new_from_str("00000000-0000-4000-8000-000000000000"),
         ]))
         .interceptor(TimeInterceptor { time_source })

--- a/aws/sdk/sdk-external-types.toml
+++ b/aws/sdk/sdk-external-types.toml
@@ -3,6 +3,7 @@ allowed_external_types = [
     "aws_smithy_types::*",
     "aws_credential_types::*",
     "aws_types::*",
+    "aws_smithy_runtime::*",
     "aws_smithy_runtime_api::*",
     "aws_smithy_async::rt::sleep::*",
     "aws_smithy_async::time::*",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InvocationIdCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InvocationIdCustomization.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.customizations
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.smithyRuntime
+
+const val GENERATOR_DOCS: String =
+    "The invocation ID generator generates ID values for client operation invocation. " +
+        "By default, this will be a random UUID per client. Overriding it may be useful in tests that " +
+        "examine the HTTP request and need to be deterministic."
+
+class InvocationIdConfigCustomization(codegenContext: ClientCodegenContext) : ConfigCustomization() {
+    private val smithyRuntime = smithyRuntime(codegenContext.runtimeConfig)
+    private val codegenScope =
+        arrayOf(
+            *RuntimeType.preludeScope,
+            "GenerateInvocationId" to smithyRuntime.resolve("client::invocation_id::GenerateInvocationId"),
+            "SharedInvocationIdGenerator" to smithyRuntime.resolve("client::invocation_id::SharedInvocationIdGenerator"),
+        )
+
+    override fun section(section: ServiceConfig): Writable =
+        writable {
+            when (section) {
+                is ServiceConfig.BuilderImpl -> {
+                    docs("Overrides the default invocation ID generator.\n\n$GENERATOR_DOCS")
+                    rustTemplate(
+                        """
+                        pub fn invocation_id_generator_v2(mut self, gen: impl #{GenerateInvocationId} + 'static) -> Self {
+                            self.set_invocation_id_generator_v2(#{Some}(#{SharedInvocationIdGenerator}::new(gen)));
+                            self
+                        }
+                        """,
+                        *codegenScope,
+                    )
+
+                    docs("Overrides the default invocation ID generator.\n\n$GENERATOR_DOCS")
+                    rustTemplate(
+                        """
+                        pub fn set_invocation_id_generator_v2(&mut self, gen: #{Option}<#{SharedInvocationIdGenerator}>) -> &mut Self {
+                            self.config.store_or_unset(gen);
+                            self
+                        }
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                is ServiceConfig.ConfigImpl -> {
+                    docs("Returns the invocation ID generator if one was given in config.\n\n$GENERATOR_DOCS")
+                    rustTemplate(
+                        """
+                        pub fn invocation_id_generator_v2(&self) -> #{Option}<#{SharedInvocationIdGenerator}> {
+                            self.config.load::<#{SharedInvocationIdGenerator}>().cloned()
+                        }
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                is ServiceConfig.BuilderFromConfigBag -> {
+                    writable {
+                        rustTemplate(
+                            "${section.builder}.set_invocation_id_generator_v2(${section.configBag}.load::<#{SharedInvocationIdGenerator}>().cloned());",
+                            *codegenScope,
+                        )
+                    }
+                }
+
+                else -> {}
+            }
+        }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.customizations.Connecti
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpChecksumRequiredGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdentityCacheConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.InterceptorConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.customizations.InvocationIdConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.MetadataCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.RequestCompressionGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
@@ -65,7 +66,8 @@ class RequiredCustomizations : ClientCodegenDecorator {
             IdentityCacheConfigCustomization(codegenContext) +
             InterceptorConfigCustomization(codegenContext) +
             TimeSourceCustomization(codegenContext) +
-            RetryClassifierConfigCustomization(codegenContext)
+            RetryClassifierConfigCustomization(codegenContext) +
+            InvocationIdConfigCustomization(codegenContext)
 
     override fun libRsCustomizations(
         codegenContext: ClientCodegenContext,

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.4"
+version = "1.5.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -46,6 +46,7 @@ indexmap = { version = "2", optional = true, features = ["serde"] }
 tokio = { version = "1.25", features = [] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter", "fmt", "json"] }
+uuid = { version = "1" }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/rust-runtime/aws-smithy-runtime/src/client.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client.rs
@@ -18,6 +18,9 @@ pub mod endpoint;
 /// for more information about clients and connectors.
 pub mod http;
 
+/// Client operation invocation ID.
+pub mod invocation_id;
+
 /// Utility to simplify config building for config and config overrides.
 pub mod config_override;
 

--- a/rust-runtime/aws-smithy-runtime/src/client/invocation_id.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/invocation_id.rs
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use fastrand::Rng;
+use std::fmt::{Debug, Display, Formatter};
+use std::sync::{Arc, Mutex};
+
+/// A generator for returning new invocation IDs on demand.
+pub trait GenerateInvocationId: Debug + Send + Sync {
+    /// Call this method to obtain a new [`InvocationId`] or an error explaining why one couldn't
+    /// be provided.
+    fn generate(&self) -> Result<Option<InvocationId>, BoxError>;
+}
+
+/// Dynamic dispatch implementation of [`GenerateInvocationId`]
+#[derive(Clone, Debug)]
+pub struct SharedInvocationIdGenerator(Arc<dyn GenerateInvocationId>);
+
+impl SharedInvocationIdGenerator {
+    /// Creates a new [`SharedInvocationIdGenerator`].
+    pub fn new(gen: impl GenerateInvocationId + 'static) -> Self {
+        Self(Arc::new(gen))
+    }
+}
+
+impl GenerateInvocationId for SharedInvocationIdGenerator {
+    fn generate(&self) -> Result<Option<InvocationId>, BoxError> {
+        self.0.generate()
+    }
+}
+
+impl Storable for SharedInvocationIdGenerator {
+    type Storer = StoreReplace<Self>;
+}
+
+/// `InvocationId` represents a unique ID for each operation invocation per client (retries share the same invocation ID).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvocationId(String);
+
+impl InvocationId {
+    /// Create an invocation ID with the given value.
+    pub fn new(invocation_id: impl Into<String>) -> Self {
+        Self(invocation_id.into())
+    }
+}
+
+impl Display for InvocationId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Storable for InvocationId {
+    type Storer = StoreReplace<Self>;
+}
+
+/// An invocation ID generator that uses random UUIDs for the invocation ID.
+#[derive(Debug, Default)]
+pub(crate) struct DefaultInvocationIdGenerator {
+    rng: Mutex<Rng>,
+}
+
+impl DefaultInvocationIdGenerator {
+    /// Creates a new [`DefaultInvocationIdGenerator`].
+    #[allow(dead_code)]
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl GenerateInvocationId for DefaultInvocationIdGenerator {
+    fn generate(&self) -> Result<Option<InvocationId>, BoxError> {
+        let mut rng = self.rng.lock().unwrap();
+        let mut random_bytes = [0u8; 16];
+        rng.fill(&mut random_bytes);
+
+        let id = uuid::Builder::from_random_bytes(random_bytes).into_uuid();
+        Ok(Some(InvocationId::new(id.to_string())))
+    }
+}


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
