### PR TITLE
Reducing verbosity of various logs

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "Reduce verbosity of various debug logs"
+references = ["smithy-rs#3664"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+author = "landonxjames"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/imds/region.rs
+++ b/aws/rust-runtime/aws-config/src/imds/region.rs
@@ -14,15 +14,24 @@ use crate::provider_config::ProviderConfig;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal::Env;
 use aws_types::region::Region;
+use std::fmt::Debug;
 use tracing::Instrument;
 
 /// IMDSv2 Region Provider
 ///
 /// This provider is included in the default region chain, so it does not need to be used manually.
-#[derive(Debug)]
 pub struct ImdsRegionProvider {
     client: Client,
     env: Env,
+}
+
+impl Debug for ImdsRegionProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImdsRegionProvider")
+            .field("client", &"IMDS client truncated for readability")
+            .field("env", &self.env)
+            .finish()
+    }
 }
 
 const REGION_PATH: &str = "/latest/meta-data/placement/region";

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -9,6 +9,7 @@ use aws_credential_types::{
 };
 use aws_smithy_types::error::display::DisplayErrorContext;
 use std::borrow::Cow;
+use std::fmt::Debug;
 use tracing::Instrument;
 
 /// Credentials provider that checks a series of inner providers
@@ -31,9 +32,23 @@ use tracing::Instrument;
 ///     .or_else("Profile", ProfileFileCredentialsProvider::builder().build());
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct CredentialsProviderChain {
     providers: Vec<(Cow<'static, str>, Box<dyn ProvideCredentials>)>,
+}
+
+impl Debug for CredentialsProviderChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialsProviderChain")
+            .field(
+                "providers",
+                &self
+                    .providers
+                    .iter()
+                    .map(|provider| &provider.0)
+                    .collect::<Vec<&Cow<'static, str>>>(),
+            )
+            .finish()
+    }
 }
 
 impl CredentialsProviderChain {

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -483,7 +483,6 @@ impl RuntimeComponents {
             };
         }
 
-        tracing::trace!(runtime_components=?self, "validating final config");
         for validator in self.config_validators() {
             validator.validate_final_config(self, cfg)?;
         }
@@ -875,7 +874,6 @@ impl RuntimeComponentsBuilder {
             };
         }
 
-        tracing::trace!(runtime_components=?self, "validating base client config");
         for validator in self.config_validators() {
             validator.validate_base_client_config(self, cfg)?;
         }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -483,7 +483,7 @@ impl RuntimeComponents {
             };
         }
 
-        tracing::trace!(runtime_components=?self, cfg=?cfg, "validating final config");
+        tracing::trace!(runtime_components=?self, "validating final config");
         for validator in self.config_validators() {
             validator.validate_final_config(self, cfg)?;
         }
@@ -875,7 +875,7 @@ impl RuntimeComponentsBuilder {
             };
         }
 
-        tracing::trace!(runtime_components=?self, cfg=?cfg, "validating base client config");
+        tracing::trace!(runtime_components=?self, "validating base client config");
         for validator in self.config_validators() {
             validator.validate_base_client_config(self, cfg)?;
         }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Our logs had several entries that were extremely verbose and made them harder to sort through. This change aims to reduce the verbosity of those logs to something more manageable.

## Description
<!--- Describe your changes in detail -->
- Removed the logging of the full IMDS Client struct, replaced with a message that it was truncated
- Removed logging the full `Configbag` in a couple places in `RuntimeComponentsBuilder`
- Removed logging of full `ProvideCredentials` objects in the CredentialsProviderChain` and replaced with just their names

There are some verbose logs I did not remove because I was not sure of their usefulness. Most notably the `PartitionResolver` struct logs several hundred lines of region information each time it appears. Happy to truncate that as well if those logs aren't too helpful.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested locally by running the SDK [logging example](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/logging.html) code with `RUST_LOG=trace` prepended to the `cargo run` command. For comparison, when saved as a .txt file, the old logs take up `2.8MB` and the new logs take `273KB` for the same operation. 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
