### PR TITLE
Fix `dubious ownership` error in runtime-versioner unit tests

### DIFF
--- a/tools/ci-build/runtime-versioner/Cargo.lock
+++ b/tools/ci-build/runtime-versioner/Cargo.lock
@@ -798,6 +798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1165,7 @@ dependencies = [
  "camino",
  "tempfile",
  "test_bin",
+ "whoami",
 ]
 
 [[package]]
@@ -1437,6 +1447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1526,17 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/tools/ci-build/runtime-versioner/test-common/Cargo.toml
+++ b/tools/ci-build/runtime-versioner/test-common/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 camino = "1.1.6"
 tempfile = "3.8.1"
 test_bin = "0.4.0"
+whoami = "1.5.1"

--- a/tools/ci-build/runtime-versioner/test-common/src/lib.rs
+++ b/tools/ci-build/runtime-versioner/test-common/src/lib.rs
@@ -37,6 +37,18 @@ impl TestBase {
                 .success(),
             "untarring the test_base into the temp directory failed"
         );
+        // ensure unpacked file has the current user assigned to the owner,
+        // otherwise we could get the `fatal: detected dubious ownership in repository` error
+        let test_repo = Utf8PathBuf::try_from(tmp.path().join("test_base.git")).unwrap();
+        assert!(
+            Command::new("chown")
+                .args(&[&format!("{}", whoami::username()), test_repo.as_str(),])
+                .current_dir(tmp.path())
+                .status()
+                .unwrap()
+                .success(),
+            "setting the owner of `test_base.git` to the current user failed"
+        );
         assert!(
             Command::new("git")
                 .args(["clone", "test_base.git"])


### PR DESCRIPTION
## Motivation and Context
In a Docker container we use in our release pipeline, we've got the following error in `runtime-versioner` unit tests
```
     Running tests/test_audit.rs (src/smithy-rs/tools/target/debug/deps/test_audit-9e2b5cd76b506229)

running 6 tests
Cloning into 'test_base'...
Cloning into 'test_base'...
Cloning into 'test_base'...
Cloning into 'test_base'...
Cloning into 'test_base'...
Cloning into 'test_base'...
fatal: detected dubious ownership in repository at '/tmp/.tmpjwZMOW/test_base.git'
To add an exception for this directory, call:

    git config --global --add safe.directory /tmp/.tmpjwZMOW/test_base.git
fatal: detected dubious ownership in repository at '/tmp/.tmp9Aw4By/test_base.git'
```

`runtime-versioner` unit tests [unpacks a tar file for a fake git repo](https://github.com/smithy-lang/smithy-rs/blob/cd0f0bac513a1f74e1d0fa232d753c0ac37d8348/tools/ci-build/runtime-versioner/test-common/src/lib.rs#L31-L39), but for some reason, the resulting file had a strange owner:group assigned to it
```
drwxr-xr-x 6  504 games  4096 Dec 20 00:46 test_base.git
``` 
The tests have been passing but they started breaking yesterday for some reason. To side step this issue, this PR will ensure the resulting file has the correct current user.

## Testing
Verified running unit tests in a container with the fix and confirmed it passed.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
