### PR TITLE
bootstrap s3 transfer manager

### DIFF
--- a/aws/hll/.gitignore
+++ b/aws/hll/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/aws/hll/aws-s3-transfer-manager/Cargo.toml
+++ b/aws/hll/aws-s3-transfer-manager/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "aws-s3-transfer-manager"
+version = "0.1.0"
+edition = "2021"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Aaron Todd <todaaron@amazon.com>"]
+description = "S3 Transfer Manager"
+license = "Apache-2.0"
+repository = "https://github.com/smithy-lang/smithy-rs"
+publish = false
+
+
+[dependencies]
+aws-sdk-s3 = "1.22.0"
+aws-smithy-http = "0.60.7"
+tracing = "0.1"
+async-trait = "0.1.80"
+# FIXME - upgrade to hyper 1.x
+hyper = { version = "0.14.28", features = ["client"] }
+aws-smithy-types = "1.1.8"
+bytes = "1"
+thiserror = "1.0.58"
+aws-types = "1.2.0"
+tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
+aws-smithy-runtime-api = "1.4.0"
+async-channel = "2.2.1"
+
+[dev-dependencies]
+aws-config = { version = "1.2.0", features = ["behavior-version-latest"] }
+clap = { version = "4.5.4", default-features = false, features = ["derive", "std", "help"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/aws/hll/aws-s3-transfer-manager/Cargo.toml
+++ b/aws/hll/aws-s3-transfer-manager/Cargo.toml
@@ -8,24 +8,23 @@ license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
 publish = false
 
-
 [dependencies]
+async-channel = "2.2.1"
+async-trait = "0.1.80"
 aws-sdk-s3 = { version = "1.22.0", features = ["behavior-version-latest", "test-util"] }
 aws-smithy-http = "0.60.7"
-tracing = "0.1"
-async-trait = "0.1.80"
+aws-smithy-runtime-api = "1.4.0"
+aws-smithy-types = "1.1.8"
+aws-types = "1.2.0"
+bytes = "1"
 # FIXME - upgrade to hyper 1.x
 hyper = { version = "0.14.28", features = ["client"] }
-aws-smithy-types = "1.1.8"
-bytes = "1"
 thiserror = "1.0.58"
-aws-types = "1.2.0"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
-aws-smithy-runtime-api = "1.4.0"
-async-channel = "2.2.1"
+tracing = "0.1"
 
 [dev-dependencies]
 aws-config = { version = "1.2.0", features = ["behavior-version-latest"] }
+aws-smithy-mocks-experimental = "0.2.1"
 clap = { version = "4.5.4", default-features = false, features = ["derive", "std", "help"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-aws-smithy-mocks-experimental = "0.2.1"

--- a/aws/hll/aws-s3-transfer-manager/Cargo.toml
+++ b/aws/hll/aws-s3-transfer-manager/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 
 [dependencies]
-aws-sdk-s3 = "1.22.0"
+aws-sdk-s3 = { version = "1.22.0", features = ["behavior-version-latest", "test-util"] }
 aws-smithy-http = "0.60.7"
 tracing = "0.1"
 async-trait = "0.1.80"
@@ -28,3 +28,4 @@ async-channel = "2.2.1"
 aws-config = { version = "1.2.0", features = ["behavior-version-latest"] }
 clap = { version = "4.5.4", default-features = false, features = ["derive", "std", "help"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+aws-smithy-mocks-experimental = "0.2.1"

--- a/aws/hll/aws-s3-transfer-manager/external-types.toml
+++ b/aws/hll/aws-s3-transfer-manager/external-types.toml
@@ -1,0 +1,8 @@
+allowed_external_types = [
+    "aws_sdk_s3::operation::get_object::builders::GetObjectFluentBuilder",
+    "aws_sdk_s3::operation::get_object::_get_object_input::GetObjectInputBuilder",
+    "aws_sdk_s3::operation::get_object::GetObjectError",
+    "aws_sdk_s3::operation::head_object::HeadObjectError",
+    "aws_smithy_runtime_api::*",
+    "aws_smithy_types::*",
+]

--- a/aws/hll/aws-s3-transfer-manager/src/download.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download.rs
@@ -12,6 +12,9 @@ use aws_sdk_s3::operation::get_object::builders::{GetObjectFluentBuilder, GetObj
 
 use self::object_meta::ObjectMetadata;
 
+/// Request type for downloading a single object
+#[derive(Debug)]
+#[non_exhaustive]
 pub struct DownloadRequest {
     pub(crate) input: GetObjectInputBuilder,
 }
@@ -31,8 +34,17 @@ impl From<GetObjectInputBuilder> for DownloadRequest {
     }
 }
 
-// FIXME - expose common fields?
+/// Response type for a single download object request.
+#[derive(Debug)]
+#[non_exhaustive]
 pub struct DownloadResponse {
     /// Object metadata
     pub object_meta: ObjectMetadata,
+}
+
+impl DownloadResponse {
+    /// Object metadata
+    pub fn object_meta(&self) -> &ObjectMetadata {
+        &self.object_meta
+    }
 }

--- a/aws/hll/aws-s3-transfer-manager/src/download.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+mod discovery;
+mod handle;
+mod header;
+mod object_meta;
+
+use aws_sdk_s3::operation::get_object::builders::{GetObjectFluentBuilder, GetObjectInputBuilder};
+
+use self::object_meta::ObjectMetadata;
+
+pub struct DownloadRequest {
+    pub(crate) input: GetObjectInputBuilder,
+}
+
+// FIXME - should probably be TryFrom since checksums may conflict?
+impl From<GetObjectFluentBuilder> for DownloadRequest {
+    fn from(value: GetObjectFluentBuilder) -> Self {
+        Self {
+            input: value.as_input().clone(),
+        }
+    }
+}
+
+impl From<GetObjectInputBuilder> for DownloadRequest {
+    fn from(value: GetObjectInputBuilder) -> Self {
+        Self { input: value }
+    }
+}
+
+// FIXME - expose common fields?
+pub struct DownloadResponse {
+    /// Object metadata
+    pub object_meta: ObjectMetadata,
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/discovery.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/discovery.rs
@@ -1,0 +1,211 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::{mem, ops::RangeInclusive, str::FromStr};
+
+use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+use aws_smithy_types::{
+    body::SdkBody,
+    byte_stream::{AggregatedBytes, ByteStream},
+};
+use bytes::Buf;
+
+use crate::error;
+
+use super::{
+    handle::DownloadHandle,
+    header::{self, ByteRange},
+    object_meta::ObjectMetadata,
+    DownloadRequest,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+enum ObjectDiscoveryStrategy {
+    // Send a `HeadObject` request.
+    // The overall transfer is optionally constrained to the given range.
+    HeadObject(Option<ByteRange>),
+    // Send `GetObject` with `part_number` = 1
+    FirstPart,
+    // Send `GetObject` request using a ranged get.
+    // The overall transfer is optionally constrained to the given range.
+    RangedGet(Option<RangeInclusive<u64>>),
+}
+
+/// Discovered object metadata (optionally with first chunk of data)
+#[derive(Debug)]
+pub(super) struct ObjectDiscovery {
+    /// range of data remaining to be fetched
+    pub(super) remaining: RangeInclusive<u64>,
+
+    /// the discovered metadata
+    pub(super) meta: ObjectMetadata,
+
+    /// the first chunk of data if fetched during discovery
+    pub(super) initial_chunk: Option<AggregatedBytes>,
+}
+
+impl ObjectDiscoveryStrategy {
+    fn from_request(
+        request: &DownloadRequest,
+    ) -> Result<ObjectDiscoveryStrategy, error::TransferError> {
+        let strategy = match request.input.get_range() {
+            Some(h) => {
+                let byte_range = header::Range::from_str(h)?.0;
+                match byte_range {
+                    ByteRange::Inclusive(start, end) => {
+                        ObjectDiscoveryStrategy::RangedGet(Some(start..=end))
+                    }
+                    // TODO: explore when given a start range what it would like to just start
+                    // sending requests from [start, start+part_size]
+                    _ => ObjectDiscoveryStrategy::HeadObject(Some(byte_range)),
+                }
+            }
+            None => ObjectDiscoveryStrategy::RangedGet(None),
+        };
+
+        Ok(strategy)
+    }
+}
+
+pub(super) async fn discover_obj(
+    handle: &DownloadHandle,
+    request: &DownloadRequest,
+) -> Result<ObjectDiscovery, error::TransferError> {
+    let strategy = ObjectDiscoveryStrategy::from_request(request)?;
+    match strategy {
+        ObjectDiscoveryStrategy::HeadObject(byte_range) => {
+            discover_obj_with_head(handle, request, byte_range).await
+        }
+        ObjectDiscoveryStrategy::FirstPart => {
+            let r = request.input.clone().part_number(1);
+            discover_obj_with_get(handle, r, None).await
+        }
+        ObjectDiscoveryStrategy::RangedGet(range) => {
+            let byte_range = match range.as_ref() {
+                Some(r) => ByteRange::Inclusive(*r.start(), *r.start() + handle.target_part_size),
+                None => ByteRange::Inclusive(0, handle.target_part_size),
+            };
+            let r = request
+                .input
+                .clone()
+                .set_part_number(None)
+                .range(header::Range::bytes(byte_range));
+
+            discover_obj_with_get(handle, r, range).await
+        }
+    }
+}
+
+async fn discover_obj_with_head(
+    handle: &DownloadHandle,
+    request: &DownloadRequest,
+    byte_range: Option<ByteRange>,
+) -> Result<ObjectDiscovery, error::TransferError> {
+    let meta: ObjectMetadata = handle
+        .client
+        .head_object()
+        .set_bucket(request.input.get_bucket().clone())
+        .set_key(request.input.get_key().clone())
+        .send()
+        .await
+        .map_err(|e| error::DownloadError::DiscoverFailed(e.into()))?
+        .into();
+
+    let remaining = match byte_range {
+        Some(range) => match range {
+            ByteRange::Inclusive(start, end) => start..=end,
+            ByteRange::AllFrom(start) => start..=meta.total_size(),
+            ByteRange::Last(n) => (meta.total_size() - n + 1)..=meta.total_size(),
+        },
+        None => 0..=meta.total_size(),
+    };
+
+    Ok(ObjectDiscovery {
+        remaining,
+        meta,
+        initial_chunk: None,
+    })
+}
+
+async fn discover_obj_with_get(
+    handle: &DownloadHandle,
+    request: GetObjectInputBuilder,
+    range: Option<RangeInclusive<u64>>,
+) -> Result<ObjectDiscovery, error::TransferError> {
+    let resp = request.send_with(&handle.client).await;
+
+    if resp.is_err() {
+        // TODO - deal with empty file errors, see https://github.com/awslabs/aws-c-s3/blob/v0.5.7/source/s3_auto_ranged_get.c#L147-L153
+    }
+
+    let mut resp = resp.map_err(|e| error::DownloadError::DiscoverFailed(e.into()))?;
+
+    // take the body so we can convert the metadata
+    let empty_stream = ByteStream::new(SdkBody::empty());
+    let body = mem::replace(&mut resp.body, empty_stream);
+
+    let data = body
+        .collect()
+        .await
+        .map_err(|e| error::DownloadError::DiscoverFailed(e.into()))?;
+
+    let meta: ObjectMetadata = resp.into();
+
+    let remaining = match range {
+        Some(range) => (*range.start() + data.remaining() as u64 + 1)..=*range.end(),
+        None => (data.remaining() as u64 + 1)..=meta.total_size(),
+    };
+
+    Ok(ObjectDiscovery {
+        remaining,
+        meta,
+        initial_chunk: Some(data),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::download::discovery::discover_obj_with_head;
+    use crate::download::discovery::ObjectDiscoveryStrategy;
+    use crate::download::handle::DownloadHandle;
+    use crate::download::header::ByteRange;
+    use aws_sdk_s3::operation::get_object::GetObjectInput;
+
+    fn strategy_from_range(range: Option<&str>) -> ObjectDiscoveryStrategy {
+        let req = GetObjectInput::builder()
+            .set_range(range.map(|r| r.to_string()))
+            .into();
+        ObjectDiscoveryStrategy::from_request(&req).unwrap()
+    }
+
+    #[test]
+    fn test_stategy_from_req() {
+        assert_eq!(
+            ObjectDiscoveryStrategy::RangedGet(None),
+            strategy_from_range(None)
+        );
+
+        assert_eq!(
+            ObjectDiscoveryStrategy::RangedGet(Some(100..=200)),
+            strategy_from_range(Some("bytes=100-200"))
+        );
+        assert_eq!(
+            ObjectDiscoveryStrategy::HeadObject(Some(ByteRange::AllFrom(100))),
+            strategy_from_range(Some("bytes=100-"))
+        );
+        assert_eq!(
+            ObjectDiscoveryStrategy::HeadObject(Some(ByteRange::Last(500))),
+            strategy_from_range(Some("bytes=-500"))
+        );
+    }
+
+    // TODO
+    // #[tokio::test]
+    // async fn test_discover_obj_with_head() {
+    //     let handle = DownloadHandle {};
+    //     let request = GetObjectInput::builder().into();
+    //     let discovery = discover_obj_with_head(&handle, &request, None).await.unwrap();
+    // }
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/handle.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/handle.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// Shared handle used across a single download request
+#[derive(Debug, Clone)]
+pub(super) struct DownloadHandle {
+    pub(crate) client: aws_sdk_s3::Client,
+    pub(crate) target_part_size: u64,
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/header.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/header.rs
@@ -45,7 +45,7 @@ impl FromStr for Range {
         match (iter.next(), iter.next()) {
             (Some("bytes"), Some(range)) => {
                 if range.contains(',') {
-                    // TODO - error S3 doesn't support multiple byte ranges
+                    // TODO(aws-sdk-rust#1159) - error S3 doesn't support multiple byte ranges
                     Err(error::invalid_meta_request(format!(
                         "multiple byte ranges not supported for range header {}",
                         s

--- a/aws/hll/aws-s3-transfer-manager/src/download/header.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/header.rs
@@ -58,7 +58,7 @@ impl FromStr for Range {
                 }
             }
             _ => Err(error::invalid_meta_request(format!(
-                "unsupported byte range header format {}",
+                "unsupported byte range header format {}; see https://www.rfc-editor.org/rfc/rfc9110.html#name-range for valid formats",
                 s
             ))),
         }

--- a/aws/hll/aws-s3-transfer-manager/src/download/header.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/header.rs
@@ -58,8 +58,7 @@ impl FromStr for Range {
                 }
             }
             _ => Err(error::invalid_meta_request(format!(
-                "unsupported byte range header format {}; see https://www.rfc-editor.org/rfc/rfc9110.html#name-range for valid formats",
-                s
+                "unsupported byte range header format `{s}`; see https://www.rfc-editor.org/rfc/rfc9110.html#name-range for valid formats"
             ))),
         }
     }

--- a/aws/hll/aws-s3-transfer-manager/src/download/header.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/header.rs
@@ -1,0 +1,149 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use core::fmt;
+use std::str::FromStr;
+
+use crate::error;
+
+/// Representation of `Range` header.
+/// NOTE: S3 only supports a single bytes range this is a simplified representation
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Range(pub(crate) ByteRange);
+
+impl Range {
+    /// Create a range from the given byte range
+    pub(crate) fn bytes(rng: ByteRange) -> Self {
+        Self(rng)
+    }
+
+    /// Create a range from the inclusive start and end offsets
+    pub(crate) fn bytes_inclusive(start: u64, end: u64) -> Self {
+        Range::bytes(ByteRange::Inclusive(start, end))
+    }
+}
+
+impl fmt::Display for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "bytes={}", self.0)
+    }
+}
+
+impl From<Range> for String {
+    fn from(value: Range) -> Self {
+        format!("{}", value)
+    }
+}
+
+impl FromStr for Range {
+    type Err = error::TransferError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.splitn(2, '=');
+        match (iter.next(), iter.next()) {
+            (Some("bytes"), Some(range)) => {
+                if range.contains(',') {
+                    // TODO - error S3 doesn't support multiple byte ranges
+                    Err(error::invalid_meta_request(format!(
+                        "multiple byte ranges not supported for range header {}",
+                        s
+                    )))
+                } else {
+                    let spec = ByteRange::from_str(range).map_err(|_| {
+                        error::invalid_meta_request(format!("invalid range header {}", s))
+                    })?;
+                    Ok(Range(spec))
+                }
+            }
+            _ => Err(error::invalid_meta_request(format!(
+                "unsupported byte range header format {}",
+                s
+            ))),
+        }
+    }
+}
+
+/// Representation of a single [RFC-99110 byte range](https://www.rfc-editor.org/rfc/rfc9110.html#name-byte-ranges)
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ByteRange {
+    /// Get all bytes between x and y inclusive ("bytes=x-y")
+    Inclusive(u64, u64),
+
+    /// Get all bytes starting from x ("bytes=x-")
+    AllFrom(u64),
+
+    /// Get the last n bytes ("bltes=-n")
+    Last(u64),
+}
+
+impl fmt::Display for ByteRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ByteRange::Inclusive(start, end) => write!(f, "{}-{}", start, end),
+            ByteRange::AllFrom(from) => write!(f, "{}-", from),
+            ByteRange::Last(n) => write!(f, "-{}", n),
+        }
+    }
+}
+
+impl FromStr for ByteRange {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.splitn(2, '-');
+        match (iter.next(), iter.next()) {
+            (Some(""), Some(end)) => end.parse().map(ByteRange::Last).or(Err(())),
+            (Some(start), Some("")) => start.parse().map(ByteRange::AllFrom).or(Err(())),
+            (Some(start), Some(end)) => match (start.parse(), end.parse()) {
+                (Ok(start), Ok(end)) if start <= end => Ok(ByteRange::Inclusive(start, end)),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ByteRange, Range};
+    use crate::error::TransferError;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_byte_range_from_str() {
+        assert_eq!(
+            ByteRange::Last(500),
+            Range::from_str("bytes=-500").unwrap().0
+        );
+        assert_eq!(
+            ByteRange::AllFrom(200),
+            Range::from_str("bytes=200-").unwrap().0
+        );
+        assert_eq!(
+            ByteRange::Inclusive(200, 500),
+            Range::from_str("bytes=200-500").unwrap().0
+        );
+    }
+
+    fn assert_err_contains(r: Result<Range, TransferError>, msg: &str) {
+        let err = r.unwrap_err();
+        match err {
+            TransferError::InvalidMetaRequest(m) => {
+                assert!(m.contains(msg), "'{}' does not contain '{}'", m, msg);
+            }
+            _ => panic!("unexpected error type"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_byte_range_from_str() {
+        assert_err_contains(Range::from_str("bytes=-"), "invalid range header");
+        assert_err_contains(Range::from_str("bytes=500-200"), "invalid range header");
+        assert_err_contains(
+            Range::from_str("bytes=0-200,400-500"),
+            "multiple byte ranges not supported for range header",
+        );
+    }
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
@@ -1,0 +1,144 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_sdk_s3::operation::{get_object::GetObjectOutput, head_object::HeadObjectOutput};
+
+/// Object metadata other than the body that can be set from either `GetObject` or `HeadObject`
+#[derive(Debug, Clone)]
+pub struct ObjectMetadata {
+    pub delete_marker: Option<bool>,
+    pub accept_ranges: Option<String>,
+    pub expiration: Option<String>,
+    pub restore: Option<String>,
+    pub last_modified: Option<::aws_smithy_types::DateTime>,
+    pub content_length: Option<i64>,
+    pub e_tag: Option<String>,
+    pub checksum_crc32: Option<String>,
+    pub checksum_crc32_c: Option<String>,
+    pub checksum_sha1: Option<String>,
+    pub checksum_sha256: Option<String>,
+    pub missing_meta: Option<i32>,
+    pub version_id: Option<String>,
+    pub cache_control: Option<String>,
+    pub content_disposition: Option<String>,
+    pub content_encoding: Option<String>,
+    pub content_language: Option<String>,
+    pub content_range: Option<String>,
+    pub content_type: Option<String>,
+    pub expires: Option<::aws_smithy_types::DateTime>,
+    pub website_redirect_location: Option<String>,
+    pub server_side_encryption: Option<aws_sdk_s3::types::ServerSideEncryption>,
+    pub metadata: Option<::std::collections::HashMap<String, String>>,
+    pub sse_customer_algorithm: Option<String>,
+    pub sse_customer_key_md5: Option<String>,
+    pub ssekms_key_id: Option<String>,
+    pub bucket_key_enabled: Option<bool>,
+    pub storage_class: Option<aws_sdk_s3::types::StorageClass>,
+    pub request_charged: Option<aws_sdk_s3::types::RequestCharged>,
+    pub replication_status: Option<aws_sdk_s3::types::ReplicationStatus>,
+    pub parts_count: Option<i32>,
+    pub tag_count: Option<i32>,
+    pub object_lock_mode: Option<aws_sdk_s3::types::ObjectLockMode>,
+    pub object_lock_retain_until_date: Option<::aws_smithy_types::DateTime>,
+    pub object_lock_legal_hold_status: Option<aws_sdk_s3::types::ObjectLockLegalHoldStatus>,
+}
+
+impl ObjectMetadata {
+    /// The total object size
+    pub(crate) fn total_size(&self) -> u64 {
+        match (self.content_length, self.content_range.as_ref()) {
+            (_, Some(range)) => {
+                let total = range.split_once('/').map(|x| x.1).expect("content range total");
+                total.parse().expect("valid range total")
+            }
+            (Some(length), None) => length as u64,
+            (None, None) => panic!("total object size cannot be calculated without either content length or content range headers")
+        }
+    }
+}
+
+impl From<GetObjectOutput> for ObjectMetadata {
+    fn from(value: GetObjectOutput) -> Self {
+        Self {
+            delete_marker: value.delete_marker,
+            accept_ranges: value.accept_ranges,
+            expiration: value.expiration,
+            restore: value.restore,
+            last_modified: value.last_modified,
+            content_length: value.content_length,
+            e_tag: value.e_tag,
+            checksum_crc32: value.checksum_crc32,
+            checksum_crc32_c: value.checksum_crc32_c,
+            checksum_sha1: value.checksum_sha1,
+            checksum_sha256: value.checksum_sha256,
+            missing_meta: value.missing_meta,
+            version_id: value.version_id,
+            cache_control: value.cache_control,
+            content_disposition: value.content_disposition,
+            content_encoding: value.content_encoding,
+            content_language: value.content_language,
+            content_range: value.content_range,
+            content_type: value.content_type,
+            expires: value.expires,
+            website_redirect_location: value.website_redirect_location,
+            server_side_encryption: value.server_side_encryption,
+            metadata: value.metadata,
+            sse_customer_algorithm: value.sse_customer_algorithm,
+            sse_customer_key_md5: value.sse_customer_key_md5,
+            ssekms_key_id: value.ssekms_key_id,
+            bucket_key_enabled: value.bucket_key_enabled,
+            storage_class: value.storage_class,
+            request_charged: value.request_charged,
+            replication_status: value.replication_status,
+            parts_count: value.parts_count,
+            tag_count: value.tag_count,
+            object_lock_mode: value.object_lock_mode,
+            object_lock_retain_until_date: value.object_lock_retain_until_date,
+            object_lock_legal_hold_status: value.object_lock_legal_hold_status,
+        }
+    }
+}
+
+impl From<HeadObjectOutput> for ObjectMetadata {
+    fn from(value: HeadObjectOutput) -> Self {
+        Self {
+            delete_marker: value.delete_marker,
+            accept_ranges: value.accept_ranges,
+            expiration: value.expiration,
+            restore: value.restore,
+            last_modified: value.last_modified,
+            content_length: value.content_length,
+            e_tag: value.e_tag,
+            checksum_crc32: value.checksum_crc32,
+            checksum_crc32_c: value.checksum_crc32_c,
+            checksum_sha1: value.checksum_sha1,
+            checksum_sha256: value.checksum_sha256,
+            missing_meta: value.missing_meta,
+            version_id: value.version_id,
+            cache_control: value.cache_control,
+            content_disposition: value.content_disposition,
+            content_encoding: value.content_encoding,
+            content_language: value.content_language,
+            content_range: None,
+            content_type: value.content_type,
+            expires: value.expires,
+            website_redirect_location: value.website_redirect_location,
+            server_side_encryption: value.server_side_encryption,
+            metadata: value.metadata,
+            sse_customer_algorithm: value.sse_customer_algorithm,
+            sse_customer_key_md5: value.sse_customer_key_md5,
+            ssekms_key_id: value.ssekms_key_id,
+            bucket_key_enabled: value.bucket_key_enabled,
+            storage_class: value.storage_class,
+            request_charged: value.request_charged,
+            replication_status: value.replication_status,
+            parts_count: value.parts_count,
+            tag_count: None,
+            object_lock_mode: value.object_lock_mode,
+            object_lock_retain_until_date: value.object_lock_retain_until_date,
+            object_lock_legal_hold_status: value.object_lock_legal_hold_status,
+        }
+    }
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
@@ -5,6 +5,9 @@
 
 use aws_sdk_s3::operation::{get_object::GetObjectOutput, head_object::HeadObjectOutput};
 
+// TODO(design): how many of these fields should we expose?
+// TODO(docs): Document fields
+
 /// Object metadata other than the body that can be set from either `GetObject` or `HeadObject`
 #[derive(Debug, Clone)]
 pub struct ObjectMetadata {

--- a/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_s3::operation::{get_object::GetObjectOutput, head_object::HeadObjectOutput};
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
+use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 
-// TODO(design): how many of these fields should we expose?
-// TODO(docs): Document fields
+// TODO(aws-sdk-rust#1159,design): how many of these fields should we expose?
+// TODO(aws-sdk-rust#1159,docs): Document fields
 
 /// Object metadata other than the body that can be set from either `GetObject` or `HeadObject`
 #[derive(Debug, Clone)]

--- a/aws/hll/aws-s3-transfer-manager/src/error.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/error.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_types::byte_stream;
+use std::io;
+
+// TODO(design): revisit errors
+
+/// Failed transfer result
+#[derive(thiserror::Error, Debug)]
+pub enum TransferError {
+    /// The request was invalid
+    #[error("invalid meta request: {0}")]
+    InvalidMetaRequest(String),
+
+    #[error("download failed")]
+    DownloadFailed(#[from] DownloadError),
+}
+
+pub(crate) type GetObjectSdkError = ::aws_smithy_runtime_api::client::result::SdkError<
+    aws_sdk_s3::operation::get_object::GetObjectError,
+    ::aws_smithy_runtime_api::client::orchestrator::HttpResponse,
+>;
+pub(crate) type HeadObjectSdkError = ::aws_smithy_runtime_api::client::result::SdkError<
+    aws_sdk_s3::operation::head_object::HeadObjectError,
+    ::aws_smithy_runtime_api::client::orchestrator::HttpResponse,
+>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DownloadError {
+    #[error(transparent)]
+    DiscoverFailed(SdkOperationError),
+
+    #[error("download chunk failed")]
+    ChunkFailed { source: SdkOperationError },
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SdkOperationError {
+    #[error(transparent)]
+    HeadObject(#[from] HeadObjectSdkError),
+
+    #[error(transparent)]
+    GetObject(#[from] GetObjectSdkError),
+
+    #[error(transparent)]
+    ReadError(#[from] byte_stream::error::Error),
+
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+}
+
+// convenience to construct a TransferError from a chunk failure
+pub(crate) fn chunk_failed<E: Into<SdkOperationError>>(e: E) -> TransferError {
+    DownloadError::ChunkFailed { source: e.into() }.into()
+}
+
+pub(crate) fn invalid_meta_request(message: String) -> TransferError {
+    TransferError::InvalidMetaRequest(message)
+}

--- a/aws/hll/aws-s3-transfer-manager/src/error.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/error.rs
@@ -15,6 +15,7 @@ pub enum TransferError {
     #[error("invalid meta request: {0}")]
     InvalidMetaRequest(String),
 
+    /// A download failed
     #[error("download failed")]
     DownloadFailed(#[from] DownloadError),
 }
@@ -28,26 +29,34 @@ pub(crate) type HeadObjectSdkError = ::aws_smithy_runtime_api::client::result::S
     ::aws_smithy_runtime_api::client::orchestrator::HttpResponse,
 >;
 
+/// An error related to downloading an object
 #[derive(thiserror::Error, Debug)]
 pub enum DownloadError {
+    /// Discovery of object metadata failed
     #[error(transparent)]
     DiscoverFailed(SdkOperationError),
 
+    /// A failure occurred fetching a single chunk of the overall object data
     #[error("download chunk failed")]
     ChunkFailed { source: SdkOperationError },
 }
 
+/// An underlying S3 SDK error
 #[derive(thiserror::Error, Debug)]
 pub enum SdkOperationError {
+    /// An error occurred invoking [aws_sdk_s3::Client::head_object]
     #[error(transparent)]
     HeadObject(#[from] HeadObjectSdkError),
 
+    /// An error occurred invoking [aws_sdk_s3::Client::get_object]
     #[error(transparent)]
     GetObject(#[from] GetObjectSdkError),
 
+    /// An error occurred reading the underlying data
     #[error(transparent)]
     ReadError(#[from] byte_stream::error::Error),
 
+    /// An unknown IO error occurred carrying out the request
     #[error(transparent)]
     IoError(#[from] io::Error),
 }

--- a/aws/hll/aws-s3-transfer-manager/src/lib.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/lib.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Automatically managed default lints */
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+/* End of automatically managed default lints */
+
+//! AWS S3 Transfer Manager
+//!
+//! # Crate Features
+//!
+//! - `test-util`: Enables utilities for unit tests. DO NOT ENABLE IN PRODUCTION.
+
+#![warn(
+    // TODO - re-enable missing_docs,
+    rustdoc::missing_crate_level_docs,
+    unreachable_pub,
+    rust_2018_idioms
+)]
+
+pub(crate) const MEBI_BYTE: u64 = 1024 * 1024;
+pub(crate) const GIBI_BYTE: u64 = MEBI_BYTE * 1024;
+pub(crate) const MIN_PART_SIZE: u64 = 5 * MEBI_BYTE;
+
+pub mod download;
+pub mod error;

--- a/aws/hll/aws-s3-transfer-manager/src/lib.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/lib.rs
@@ -14,7 +14,8 @@
 //! - `test-util`: Enables utilities for unit tests. DO NOT ENABLE IN PRODUCTION.
 
 #![warn(
-    // TODO - re-enable missing_docs,
+    missing_debug_implementations,
+    missing_docs,
     rustdoc::missing_crate_level_docs,
     unreachable_pub,
     rust_2018_idioms

--- a/aws/hll/aws-s3-transfer-manager/src/lib.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/lib.rs
@@ -21,9 +21,9 @@
     rust_2018_idioms
 )]
 
-pub(crate) const MEBI_BYTE: u64 = 1024 * 1024;
-pub(crate) const GIBI_BYTE: u64 = MEBI_BYTE * 1024;
-pub(crate) const MIN_PART_SIZE: u64 = 5 * MEBI_BYTE;
+pub(crate) const MEBIBYTE: u64 = 1024 * 1024;
+pub(crate) const GIBIBYTE: u64 = MEBIBYTE * 1024;
+pub(crate) const MIN_PART_SIZE: u64 = 5 * MEBIBYTE;
 
 pub mod download;
 pub mod error;


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description

This PR bootstraps a new crate `aws-s3-transfer-manager` (feel free to bikeshed the crate name 🤷 ).

* Establishes a new crate and initial project setup
* Adds basic object discovery related functionality required for multi-part download/concurrent ranged gets.
* Adds initial error types (WIP and subject to change/feedback).


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
