### PR TITLE
Add invocation ID to root level “invoke” operation span

### DIFF
--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.4"
+version = "1.5.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -46,6 +46,7 @@ indexmap = { version = "2", optional = true, features = ["serde"] }
 tokio = { version = "1.25", features = [] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter", "fmt", "json"] }
+uuid = "1"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -46,7 +46,6 @@ indexmap = { version = "2", optional = true, features = ["serde"] }
 tokio = { version = "1.25", features = [] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter", "fmt", "json"] }
-uuid = "1"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -139,6 +139,11 @@ pub async fn invoke_with_stop_point(
     runtime_plugins: &RuntimePlugins,
     stop_point: StopPoint,
 ) -> Result<InterceptorContext, SdkError<Error, HttpResponse>> {
+    let mut random_bytes = [0u8; 16];
+    fastrand::Rng::default().fill(&mut random_bytes);
+    // This is for internal use only, serving to correlate logs to a single operation.
+    // It always emits a random UUID per client and is currently not configurable.
+    let id = uuid::Builder::from_random_bytes(random_bytes).into_uuid();
     async move {
         let mut cfg = ConfigBag::base();
         let cfg = &mut cfg;
@@ -168,7 +173,7 @@ pub async fn invoke_with_stop_point(
         .maybe_timeout(operation_timeout_config)
         .await
     }
-    .instrument(debug_span!("invoke", service = %service_name, operation = %operation_name))
+    .instrument(debug_span!("invoke", service = %service_name, operation = %operation_name, sdk_invocation_id = %id))
     .await
 }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -139,11 +139,6 @@ pub async fn invoke_with_stop_point(
     runtime_plugins: &RuntimePlugins,
     stop_point: StopPoint,
 ) -> Result<InterceptorContext, SdkError<Error, HttpResponse>> {
-    let mut random_bytes = [0u8; 16];
-    fastrand::Rng::default().fill(&mut random_bytes);
-    // This is for internal use only, serving to correlate logs to a single operation.
-    // It always emits a random UUID per client and is currently not configurable.
-    let id = uuid::Builder::from_random_bytes(random_bytes).into_uuid();
     async move {
         let mut cfg = ConfigBag::base();
         let cfg = &mut cfg;
@@ -173,7 +168,8 @@ pub async fn invoke_with_stop_point(
         .maybe_timeout(operation_timeout_config)
         .await
     }
-    .instrument(debug_span!("invoke", service = %service_name, operation = %operation_name, sdk_invocation_id = %id))
+    // Include a random, internal-only, seven-digit ID for the operation invocation so that it can be correlated in the logs.
+    .instrument(debug_span!("invoke", service = %service_name, operation = %operation_name, sdk_invocation_id = fastrand::u32(1_000_000..10_000_000)))
     .await
 }
 


### PR DESCRIPTION
## Motivation and Context
The `invoke` debug span now includes invocation IDs for operation invocations. It is a random unique ID per client and shared across retries for the same operation.
 
Example debug trace output with the changes in this PR:
```
2024-05-29T17:50:22.230526Z DEBUG invoke{service=s3 operation=ListObjectsV2 sdk_invocation_id=4652364}:try_op:try_attempt: aws_smithy_runtime_api::client::interceptors::context: entering 'before deserialization' phase
```

## Description
Note that this invocation ID is currently for internal use only to improve debuggability when looking at logs (usually with customers). Note also that the invocation ID is not related to [that used in amz-sdk-invocation-id](https://github.com/smithy-lang/smithy-rs/pull/2626) (we [attempted to make it related](https://github.com/smithy-lang/smithy-rs/pull/3661) but decided to go for this two-way door approach).

In sum, this PR is meant to be simple, and if we are to augment the functionality (e.g. make the ID configurable or make it related to that in `amz-sdk-invocation-id`), we can do so without breaking anything.

## Testing
Relies on the existing tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
