### PR TITLE
fix tracing-test 0.2.5 compat

### DIFF
--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -27,7 +27,7 @@ hyper-rustls = { version = "0.24", optional = true, features = ["rustls-native-c
 [dev-dependencies]
 http = "0.2.4"
 tempfile = "3"
-tracing-test = "0.2.5"
+tracing-test = "=0.2.5"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [build-dependencies]

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-types"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Cross-service types for the AWS SDK."
 edition = "2021"
@@ -27,7 +27,7 @@ hyper-rustls = { version = "0.24", optional = true, features = ["rustls-native-c
 [dev-dependencies]
 http = "0.2.4"
 tempfile = "3"
-tracing-test = "0.2.4"
+tracing-test = "0.2.5"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [build-dependencies]

--- a/aws/rust-runtime/aws-types/src/app_name.rs
+++ b/aws/rust-runtime/aws-types/src/app_name.rs
@@ -140,7 +140,7 @@ mod tests {
 
         // HACK: there's no way to reset tracing-test, so just
         // reach into its internals and clear it manually
-        tracing_test::internal::GLOBAL_BUF.lock().unwrap().clear();
+        tracing_test::internal::global_buf().lock().unwrap().clear();
 
         AppName::new("greaterthanfiftycharactersgreaterthanfiftycharacters").unwrap();
         assert!(!logs_contain(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -320,7 +320,7 @@ data class CargoDependency(
         val TracingTest: CargoDependency =
             CargoDependency(
                 "tracing-test",
-                CratesIo("0.2.4"),
+                CratesIo("0.2.5"),
                 DependencyScope.Dev,
                 features = setOf("no-env-filter"),
             )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -300,7 +300,7 @@ data class CargoDependency(
         val Tokio: CargoDependency =
             CargoDependency(
                 "tokio",
-                CratesIo("1.23.1"),
+                CratesIo("=1.37.0"),
                 DependencyScope.Dev,
                 features = setOf("macros", "test-util", "rt-multi-thread"),
             )

--- a/tools/ci-scripts/check-sdk-codegen-unit-tests
+++ b/tools/ci-scripts/check-sdk-codegen-unit-tests
@@ -6,5 +6,4 @@
 
 set -eux
 cd smithy-rs
-rm -rf ~/.cargo/registry/cache/
 ./gradlew aws:sdk-codegen:test

--- a/tools/ci-scripts/check-sdk-codegen-unit-tests
+++ b/tools/ci-scripts/check-sdk-codegen-unit-tests
@@ -6,4 +6,5 @@
 
 set -eux
 cd smithy-rs
+rm -rf ~/.cargo/registry/cache/
 ./gradlew aws:sdk-codegen:test


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

https://github.com/smithy-lang/smithy-rs/issues/3676

## Description

Internals one of our tests was leveraging has changed in latest release of `tracing-test`, updates version and test to be compatible. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
