### PR TITLE
Pin `httparse` to =1.8 to avoid unit test failures in runtime crates

### DIFF
--- a/.cargo-deny-config.toml
+++ b/.cargo-deny-config.toml
@@ -18,6 +18,7 @@ allow = [
     "MIT",
     "MPL-2.0",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
 ]
 confidence-threshold = 1.0
 exceptions = [

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"
@@ -44,7 +44,7 @@ aws-credential-types = { path = "../aws-credential-types", features = ["test-uti
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client", "test-util"] }
 bytes = "1"
 hex-literal = "0.4.1"
-httparse = "1.8"
+httparse = "=1.8"
 libfuzzer-sys = "0.4.6"
 pretty_assertions = "1.3"
 proptest = "1.2"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.5.6"
+version = "1.5.7"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -34,6 +34,8 @@ h2 = { version = "0.3", default-features = false, optional = true }
 http = { version = "0.2.8" }
 http-body-0-4 = { package = "http-body", version = "0.4.4" }
 http-body-1 = { package = "http-body", version = "1" }
+# This avoids bringing `httparse` 1.9.0 and 1.9.1 through `hyper-0-14` that break unit tests of runtime crates
+httparse = "=1.8.0"
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, optional = true }
 hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
 once_cell = "1.18.0"


### PR DESCRIPTION
## Motivation and Context
To fix current CI and release pipeline failures coming from `aws-smithy-runtime` and `aws-sigv4` now depending on `httparse` version 1.9.0 or greater.

## Testing
Tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
