### PR TITLE
Pin crc32c to a newer working version

### DIFF
--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.60.9"
+version = "0.60.10"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Zelda Hessler <zhessler@amazon.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
-crc32c = "=0.6.5"
+crc32c = "=0.6.8"
 crc32fast = "1.3"
 hex = "0.4.3"
 http = "0.2.8"


### PR DESCRIPTION
## Motivation and Context
https://github.com/smithy-lang/smithy-rs/issues/3672

## Description
Pin to a newer working version of `crc32c` (will still pin to a particular version to avoid a breaking change, until the lockfile protection is available)

## Testing
- Verified locally build of `aws-smithy-checksums` with the updated `crc32c`

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
