### PR TITLE
s3-tm naive multipart download

### DIFF
--- a/aws/hll/aws-s3-transfer-manager/Cargo.toml
+++ b/aws/hll/aws-s3-transfer-manager/Cargo.toml
@@ -9,22 +9,22 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 publish = false
 
 [dependencies]
-async-channel = "2.2.1"
+async-channel = "2.3.1"
 async-trait = "0.1.80"
-aws-sdk-s3 = { version = "1.22.0", features = ["behavior-version-latest", "test-util"] }
-aws-smithy-http = "0.60.7"
-aws-smithy-runtime-api = "1.4.0"
-aws-smithy-types = "1.1.8"
-aws-types = "1.2.0"
+aws-sdk-s3 = { version = "1.36.0", features = ["behavior-version-latest", "test-util"] }
+aws-smithy-http = "0.60.8"
+aws-smithy-runtime-api = "1.7.0"
+aws-smithy-types = "1.2.0"
+aws-types = "1.3.1"
 bytes = "1"
 # FIXME - upgrade to hyper 1.x
-hyper = { version = "0.14.28", features = ["client"] }
-thiserror = "1.0.58"
-tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
+hyper = { version = "0.14.29", features = ["client"] }
+thiserror = "1.0.61"
+tokio = { version = "1.38.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
 tracing = "0.1"
 
 [dev-dependencies]
-aws-config = { version = "1.2.0", features = ["behavior-version-latest"] }
+aws-config = { version = "1.5.1", features = ["behavior-version-latest"] }
 aws-smithy-mocks-experimental = "0.2.1"
-clap = { version = "4.5.4", default-features = false, features = ["derive", "std", "help"] }
+clap = { version = "4.5.7", default-features = false, features = ["derive", "std", "help"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/aws/hll/aws-s3-transfer-manager/README.md
+++ b/aws/hll/aws-s3-transfer-manager/README.md
@@ -1,0 +1,36 @@
+# AWS S3 Transfer Manager
+
+A high performance Amazon S3 client.
+
+
+## Development
+
+**Run all tests**
+
+```sh
+cargo test --all-features
+```
+
+**Run individual test**
+
+```sh
+cargo test --lib download::worker::tests::test_distribute_work
+```
+
+### Examples
+
+**Copy**
+
+See all options:
+```sh
+cargo run --example cp -- -h
+```
+
+**Download a file from S3**
+
+```sh
+AWS_PROFILE=<profile-name> RUST_LOG=trace cargo run --example cp s3://<my-bucket>/<my-key> /local/path/<filename>
+```
+
+NOTE: To run in release mode add `--release/-r` to the command, see `cargo run -h`.
+NOTE: `trace` may be too verbose, you can see just this library's logs with `RUST_LOG=aws_s3_transfer_manager=trace`

--- a/aws/hll/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws/hll/aws-s3-transfer-manager/examples/cp.rs
@@ -30,9 +30,14 @@ pub struct Args {
     /// Destination to copy to <S3Uri | Local>
     #[arg(required = true)]
     dest: TransferUri,
+
     /// Number of concurrent uploads/downloads to perform.
     #[arg(long, default_value_t = 8)]
     concurrency: usize,
+
+    /// Part size to use
+    #[arg(long, default_value_t = 8388608)]
+    part_size: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -114,6 +119,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let tm = Downloader::builder()
         .sdk_config(config)
         .concurrency(args.concurrency)
+        .target_part_size(args.part_size)
         .build();
 
     let (bucket, key) = args.source.expect_s3().parts();

--- a/aws/hll/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws/hll/aws-s3-transfer-manager/examples/cp.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use std::error::Error;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::{mem, time};
+
+use aws_s3_transfer_manager::download::Downloader;
+
+use aws_s3_transfer_manager::download::body::Body;
+use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+use clap::{CommandFactory, Parser};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+type BoxError = Box<dyn Error + Send + Sync>;
+
+const ONE_GIGABYTE: u64 = 1024 * 1024 * 1024;
+
+#[derive(Debug, Clone, clap::Parser)]
+#[command(name = "cp")]
+#[command(about = "Copies a local file or S3 object to another location locally or in S3.")]
+pub struct Args {
+    /// Source to copy from <S3Uri | Local>
+    #[arg(required = true)]
+    source: TransferUri,
+
+    /// Destination to copy to <S3Uri | Local>
+    #[arg(required = true)]
+    dest: TransferUri,
+    /// Number of concurrent uploads/downloads to perform.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+}
+
+#[derive(Clone, Debug)]
+enum TransferUri {
+    /// Local filesystem source/destination
+    Local(PathBuf),
+
+    /// S3 source/destination
+    S3(S3Uri),
+}
+
+impl TransferUri {
+    fn expect_s3(&self) -> &S3Uri {
+        match self {
+            TransferUri::S3(s3_uri) => s3_uri,
+            _ => panic!("expected S3Uri"),
+        }
+    }
+
+    fn expect_local(&self) -> &PathBuf {
+        match self {
+            TransferUri::Local(path) => path,
+            _ => panic!("expected Local"),
+        }
+    }
+}
+
+impl FromStr for TransferUri {
+    type Err = BoxError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uri = if s.starts_with("s3://") {
+            TransferUri::S3(S3Uri(s.to_owned()))
+        } else {
+            let path = PathBuf::from_str(s).unwrap();
+            TransferUri::Local(path)
+        };
+        Ok(uri)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct S3Uri(String);
+
+impl S3Uri {
+    /// Split the URI into it's component parts '(bucket, key)'
+    fn parts(&self) -> (&str, &str) {
+        self.0
+            .strip_prefix("s3://")
+            .expect("valid s3 uri prefix")
+            .split_once('/')
+            .expect("invalid s3 uri, missing '/' between bucket and key")
+    }
+}
+
+fn invalid_arg(message: &str) -> ! {
+    Args::command()
+        .error(clap::error::ErrorKind::InvalidValue, message)
+        .exit()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+    println!("{:#?}", args);
+
+    match (&args.source, &args.dest) {
+        (TransferUri::Local(_), TransferUri::S3(_)) => todo!("upload not implemented yet"),
+        (TransferUri::Local(_), TransferUri::Local(_)) => {
+            invalid_arg("local to local transfer not supported")
+        }
+        (TransferUri::S3(_), TransferUri::Local(_)) => (),
+        (TransferUri::S3(_), TransferUri::S3(_)) => invalid_arg("s3 to s3 transfer not supported"),
+    }
+
+    let config = aws_config::from_env().load().await;
+
+    let tm = Downloader::builder()
+        .sdk_config(config)
+        .concurrency(args.concurrency)
+        .build();
+
+    let (bucket, key) = args.source.expect_s3().parts();
+    let input = GetObjectInputBuilder::default().bucket(bucket).key(key);
+
+    let mut dest = fs::File::create(args.dest.expect_local()).await?;
+    println!("dest file opened, starting download");
+
+    let start = time::Instant::now();
+
+    // TODO(aws-sdk-rust#1159) - rewrite this less naively,
+    //      likely abstract this into performant utils for single file download. Higher level
+    //      TM will handle it's own thread pool for filesystem work
+    let mut handle = tm.download(input.into()).await?;
+    let mut body = mem::replace(&mut handle.body, Body::empty());
+
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.unwrap();
+        for segment in chunk.into_segments() {
+            dest.write_all(segment.as_ref()).await?;
+        }
+    }
+
+    let elapsed_secs = start.elapsed().as_secs_f64();
+
+    let obj_size = handle.object_meta.total_size();
+    let obj_size_gigabytes = obj_size as f64 / ONE_GIGABYTE as f64;
+    let obj_size_gigabits = obj_size_gigabytes * 8.0;
+
+    println!(
+        "downloaded {} bytes ({} GiB) in {} seconds; GiB/s: {}; Gbps: {}",
+        obj_size,
+        obj_size_gigabytes,
+        elapsed_secs,
+        obj_size_gigabytes / elapsed_secs,
+        obj_size_gigabits / elapsed_secs
+    );
+
+    Ok(())
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download.rs
@@ -3,14 +3,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+mod body;
+mod context;
 mod discovery;
 mod handle;
 mod header;
 mod object_meta;
+mod worker;
 
+use crate::download::body::Body;
+use crate::download::discovery::discover_obj;
+use crate::download::handle::DownloadHandle;
+use crate::download::worker::{chunk_downloader, distribute_work};
+use crate::error::TransferError;
+use crate::{MEBIBYTE, MIN_PART_SIZE};
 use aws_sdk_s3::operation::get_object::builders::{GetObjectFluentBuilder, GetObjectInputBuilder};
+use aws_types::SdkConfig;
+use context::DownloadContext;
+use std::cmp;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tracing::Instrument;
 
-use self::object_meta::ObjectMetadata;
+// TODO(aws-sdk-rust#1159) - need to set User-Agent header value for SEP, e.g. `ft/hll#s3-transfer`
 
 /// Request type for downloading a single object
 #[derive(Debug)]
@@ -34,17 +49,154 @@ impl From<GetObjectInputBuilder> for DownloadRequest {
     }
 }
 
-/// Response type for a single download object request.
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct DownloadResponse {
-    /// Object metadata
-    pub object_meta: ObjectMetadata,
+/// Fluent style builder for [Downloader]
+#[derive(Debug, Clone)]
+pub struct Builder {
+    target_part_size_bytes: u64,
+    checksum_validation_enabled: bool,
+    // TODO(design): should we instead consider an enum here allows for not only explicit but also
+    // an "Auto" mode that allows us to control the concurrency actually used based on overall transfer and part size?
+    concurrency: usize,
+    sdk_config: Option<SdkConfig>,
 }
 
-impl DownloadResponse {
-    /// Object metadata
-    pub fn object_meta(&self) -> &ObjectMetadata {
-        &self.object_meta
+impl Builder {
+    fn new() -> Self {
+        Self {
+            target_part_size_bytes: 8 * MEBIBYTE,
+            checksum_validation_enabled: true,
+            concurrency: 8,
+            sdk_config: None,
+        }
+    }
+
+    /// Size of parts the object will be downloaded in, in bytes.
+    /// The minimum part size is 5 MiB and any value given less than that will be rounded up.
+    /// Defaults is 8 MiB.
+    pub fn target_part_size(mut self, size_bytes: u64) -> Self {
+        self.target_part_size_bytes = cmp::min(size_bytes, MIN_PART_SIZE);
+        self
+    }
+
+    /// Set whether checksum validation is enabled.
+    /// Default is true.
+    pub fn enable_checksum_validation(mut self, enabled: bool) -> Self {
+        self.checksum_validation_enabled = enabled;
+        self
+    }
+
+    /// Set the configuration used by the S3 client
+    pub fn sdk_config(mut self, config: SdkConfig) -> Self {
+        self.sdk_config = Some(config);
+        self
+    }
+
+    /// Set the concurrency level this component is allowed to use. This sets the maximum
+    /// number of concurrent in-flight requests.
+    /// Default is 8.
+    pub fn concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
+    pub fn build(self) -> Downloader {
+        self.into()
+    }
+}
+
+impl From<Builder> for Downloader {
+    fn from(value: Builder) -> Self {
+        let sdk_config = value
+            .sdk_config
+            .unwrap_or_else(|| SdkConfig::builder().build());
+        let client = aws_sdk_s3::Client::new(&sdk_config);
+        Self {
+            target_part_size_bytes: value.target_part_size_bytes,
+            checksum_validation_enabled: value.checksum_validation_enabled,
+            concurrency: value.concurrency,
+            client,
+        }
+    }
+}
+
+/// Download an object in the most efficient way possible by splitting the request into
+/// concurrent requests (e.g. using ranged GET or part number).
+#[derive(Debug, Clone)]
+pub struct Downloader {
+    target_part_size_bytes: u64,
+    checksum_validation_enabled: bool,
+    concurrency: usize,
+    client: aws_sdk_s3::client::Client,
+}
+
+impl Downloader {
+    /// Download a single object from S3.
+    ///
+    /// A single logical request may be split into many concurrent ranged `GetObject` requests
+    /// to improve throughput.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::error::Error;
+    /// use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+    /// use aws_s3_transfer_manager::download::{Downloader, DownloadRequest};
+    ///
+    /// async fn get_object(client: Downloader) -> Result<(), Box<dyn Error>> {
+    ///     let request = GetObjectInputBuilder::default()
+    ///         .bucket("my-bucket")
+    ///         .key("my-key")
+    ///         .into();
+    ///
+    ///     let handle = client.download(request).await?;
+    ///     // process data off handle...
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn download(&self, req: DownloadRequest) -> Result<DownloadHandle, TransferError> {
+        // if there is a part number then just send the default request
+        if req.input.get_part_number().is_some() {
+            todo!("single part download not implemented")
+        }
+
+        let ctx = DownloadContext {
+            client: self.client.clone(),
+            target_part_size: self.target_part_size_bytes,
+        };
+
+        // make initial discovery about the object size, metadata, possibly first chunk
+        let discovery = discover_obj(&ctx, &req).await?;
+
+        let (comp_tx, comp_rx) = mpsc::channel(self.concurrency);
+
+        // spawn all work into the same JoinSet such that when the set is dropped all tasks are cancelled.
+        let mut tasks = JoinSet::new();
+
+        if !discovery.remaining.is_empty() {
+            // start assigning work
+            let (work_tx, work_rx) = async_channel::bounded(self.concurrency);
+            let input = req.input.clone();
+            let part_size = self.target_part_size_bytes;
+            let rem = discovery.remaining.clone();
+
+            tasks.spawn(distribute_work(rem, input, part_size, work_tx));
+
+            for i in 0..self.concurrency {
+                let worker = chunk_downloader(ctx.clone(), work_rx.clone(), comp_tx.clone())
+                    .instrument(tracing::debug_span!("chunk-downloader", worker = i));
+                tasks.spawn(worker);
+            }
+        }
+
+        // drop our reference to completion sender such that when all workers drop theirs it's closed
+        drop(comp_tx);
+
+        let handle = DownloadHandle {
+            object_meta: discovery.meta,
+            body: Body::new(comp_rx),
+            tasks,
+        };
+
+        Ok(handle)
     }
 }

--- a/aws/hll/aws-s3-transfer-manager/src/download/body.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/body.rs
@@ -1,0 +1,199 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use crate::download::worker::ChunkResponse;
+use crate::error::TransferError;
+use aws_smithy_types::byte_stream::AggregatedBytes;
+use std::cmp;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use tokio::sync::mpsc;
+
+/// Stream of binary data representing an object's contents.
+///
+/// Wraps potentially multiple streams of binary data into a single coherent stream.
+/// The data on this stream is sequenced into the correct order.
+#[derive(Debug)]
+pub struct Body {
+    inner: UnorderedBody,
+    sequencer: Sequencer,
+}
+
+type BodyChannel = mpsc::Receiver<Result<ChunkResponse, TransferError>>;
+
+impl Body {
+    /// Create a new empty Body
+    pub fn empty() -> Self {
+        Self::new_from_channel(None)
+    }
+
+    pub(crate) fn new(chunks: BodyChannel) -> Self {
+        Self::new_from_channel(Some(chunks))
+    }
+
+    fn new_from_channel(chunks: Option<BodyChannel>) -> Self {
+        Self {
+            inner: UnorderedBody::new(chunks),
+            sequencer: Sequencer::new(),
+        }
+    }
+
+    /// Convert this body into an unordered stream of chunks.
+    pub(crate) fn unordered(self) -> UnorderedBody {
+        self.inner
+    }
+
+    /// Pull the next chunk of data off the stream.
+    ///
+    /// Returns [None] when there is no more data.
+    /// Chunks returned from a [Body] are guaranteed to be sequenced
+    /// in the right order.
+    pub async fn next(&mut self) -> Option<Result<AggregatedBytes, TransferError>> {
+        // TODO(aws-sdk-rust#1159, design) - do we want ChunkResponse (or similar) rather than AggregatedBytes? Would
+        //  make additional retries of an individual chunk/part more feasible (though theoretically already exhausted retries)
+        loop {
+            if self.sequencer.is_ordered() {
+                break;
+            }
+
+            let chunk = self.inner.next().await;
+            if chunk.is_none() {
+                break;
+            }
+
+            match chunk? {
+                Ok(chunk) => self.sequencer.push(chunk),
+                Err(err) => return Some(Err(err)),
+            }
+        }
+
+        let chunk = self
+            .sequencer
+            .pop()
+            .map(|r| Ok(r.data.expect("chunk data")));
+
+        if chunk.is_some() {
+            // if we actually pulled data out, advance the next sequence we expect
+            self.sequencer.advance();
+        }
+
+        chunk
+    }
+}
+
+#[derive(Debug)]
+struct Sequencer {
+    /// next expected sequence
+    next_seq: u64,
+    chunks: BinaryHeap<cmp::Reverse<SequencedChunk>>,
+}
+
+impl Sequencer {
+    fn new() -> Self {
+        Self {
+            chunks: BinaryHeap::with_capacity(8),
+            next_seq: 0,
+        }
+    }
+
+    fn push(&mut self, chunk: ChunkResponse) {
+        self.chunks.push(cmp::Reverse(SequencedChunk(chunk)))
+    }
+
+    fn pop(&mut self) -> Option<ChunkResponse> {
+        self.chunks.pop().map(|c| c.0 .0)
+    }
+
+    fn is_ordered(&self) -> bool {
+        let next = self.peek();
+        if next.is_none() {
+            return false;
+        }
+
+        next.unwrap().seq == self.next_seq
+    }
+
+    fn peek(&self) -> Option<&ChunkResponse> {
+        self.chunks.peek().map(|c| &c.0 .0)
+    }
+
+    fn advance(&mut self) {
+        self.next_seq += 1
+    }
+}
+
+#[derive(Debug)]
+struct SequencedChunk(ChunkResponse);
+
+impl Ord for SequencedChunk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.seq.cmp(&other.0.seq)
+    }
+}
+
+impl PartialOrd for SequencedChunk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for SequencedChunk {}
+impl PartialEq for SequencedChunk {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.seq == other.0.seq
+    }
+}
+
+/// A body that returns chunks in whatever order they are received.
+#[derive(Debug)]
+pub(crate) struct UnorderedBody {
+    chunks: Option<mpsc::Receiver<Result<ChunkResponse, TransferError>>>,
+}
+
+impl UnorderedBody {
+    fn new(chunks: Option<BodyChannel>) -> Self {
+        Self { chunks }
+    }
+
+    /// Pull the next chunk of data off the stream.
+    ///
+    /// Returns [None] when there is no more data.
+    /// Chunks returned from an [UnorderedBody] are not guaranteed to be sequenced
+    /// in the right order. Consumers are expected to sequence the data themselves
+    /// using the chunk sequence number (starting from zero).
+    pub(crate) async fn next(&mut self) -> Option<Result<ChunkResponse, TransferError>> {
+        match self.chunks.as_mut() {
+            None => None,
+            Some(ch) => ch.recv().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::download::worker::ChunkResponse;
+    use aws_smithy_types::byte_stream::AggregatedBytes;
+
+    use super::Sequencer;
+
+    fn chunk_resp(seq: u64, data: Option<AggregatedBytes>) -> ChunkResponse {
+        ChunkResponse {
+            seq,
+            data,
+            object_meta: None,
+        }
+    }
+
+    #[test]
+    fn test_sequencer() {
+        let mut sequencer = Sequencer::new();
+        sequencer.push(chunk_resp(1, None));
+        sequencer.push(chunk_resp(2, None));
+        assert_eq!(sequencer.peek().unwrap().seq, 1);
+        sequencer.push(chunk_resp(0, None));
+        assert_eq!(sequencer.pop().unwrap().seq, 0);
+    }
+
+    // TODO(aws-sdk-rust#1159) - add body tests
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/context.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/context.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// Shared context used across a single download request
+#[derive(Debug, Clone)]
+pub(crate) struct DownloadContext {
+    pub(crate) client: aws_sdk_s3::Client,
+    pub(crate) target_part_size: u64,
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/handle.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/handle.rs
@@ -2,10 +2,32 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+use crate::download::body::Body;
+use crate::download::object_meta::ObjectMetadata;
+use tokio::task;
 
-/// Shared handle used across a single download request
-#[derive(Debug, Clone)]
-pub(super) struct DownloadHandle {
-    pub(crate) client: aws_sdk_s3::Client,
-    pub(crate) target_part_size: u64,
+/// Response type for a single download object request.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct DownloadHandle {
+    /// Object metadata
+    pub object_meta: ObjectMetadata,
+
+    /// The object content
+    pub body: Body,
+
+    /// All child tasks spawned for this download
+    pub(crate) tasks: task::JoinSet<()>,
+}
+
+impl DownloadHandle {
+    /// Object metadata
+    pub fn object_meta(&self) -> &ObjectMetadata {
+        &self.object_meta
+    }
+
+    /// Object content
+    pub fn body(&self) -> &Body {
+        &self.body
+    }
 }

--- a/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/object_meta.rs
@@ -51,7 +51,7 @@ pub struct ObjectMetadata {
 
 impl ObjectMetadata {
     /// The total object size
-    pub(crate) fn total_size(&self) -> u64 {
+    pub fn total_size(&self) -> u64 {
         match (self.content_length, self.content_range.as_ref()) {
             (_, Some(range)) => {
                 let total = range.split_once('/').map(|x| x.1).expect("content range total");

--- a/aws/hll/aws-s3-transfer-manager/src/download/worker.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/worker.rs
@@ -96,12 +96,13 @@ pub(super) async fn distribute_work(
     remaining: RangeInclusive<u64>,
     input: GetObjectInputBuilder,
     part_size: u64,
+    start_seq: u64,
     tx: async_channel::Sender<ChunkRequest>,
 ) {
     let end = *remaining.end();
     let mut pos = *remaining.start();
     let mut remaining = end - pos + 1;
-    let mut seq = 0;
+    let mut seq = start_seq;
 
     while remaining > 0 {
         let start = pos;
@@ -151,7 +152,7 @@ mod tests {
         let input = GetObjectInputBuilder::default();
         let (tx, rx) = async_channel::unbounded();
 
-        tokio::spawn(distribute_work(rem, input, part_size, tx));
+        tokio::spawn(distribute_work(rem, input, part_size, 0, tx));
 
         let mut chunks = Vec::new();
         while let Ok(chunk) = rx.recv().await {

--- a/aws/hll/aws-s3-transfer-manager/src/download/worker.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/worker.rs
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use crate::download::context::DownloadContext;
+use crate::download::header;
+use crate::download::object_meta::ObjectMetadata;
+use crate::error;
+use crate::error::TransferError;
+use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::byte_stream::{AggregatedBytes, ByteStream};
+use std::ops::RangeInclusive;
+use std::{cmp, mem};
+use tokio::sync::mpsc;
+use tracing::Instrument;
+
+// FIXME - should probably be enum ChunkRequest { Range(..), Part(..) } or have an inner field like such
+#[derive(Debug, Clone)]
+pub(super) struct ChunkRequest {
+    // byte range to download
+    pub(super) range: RangeInclusive<u64>,
+    pub(super) input: GetObjectInputBuilder,
+    // sequence number
+    pub(super) seq: u64,
+}
+
+impl ChunkRequest {
+    /// Size of this chunk request in bytes
+    pub(super) fn size(&self) -> u64 {
+        self.range.end() - self.range.start() + 1
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChunkResponse {
+    // the seq number
+    pub(crate) seq: u64,
+    // chunk data
+    pub(crate) data: Option<AggregatedBytes>,
+    // object metadata
+    pub(crate) object_meta: Option<ObjectMetadata>,
+}
+
+/// Worker function that processes requests from the [requests] channel and
+/// sends the result back on the [completed] channel.
+pub(super) async fn chunk_downloader(
+    ctx: DownloadContext,
+    requests: async_channel::Receiver<ChunkRequest>,
+    completed: mpsc::Sender<Result<ChunkResponse, TransferError>>,
+) {
+    while let Ok(request) = requests.recv().await {
+        let seq = request.seq;
+        tracing::trace!("worker recv'd request for chunk seq {seq}");
+
+        let result = download_chunk(&ctx, request)
+            .instrument(tracing::debug_span!("download-chunk", seq = seq))
+            .await;
+
+        if let Err(err) = completed.send(result).await {
+            tracing::debug!(error = ?err, "chunk worker send failed");
+            return;
+        }
+    }
+
+    tracing::trace!("req channel closed, worker finished");
+}
+
+/// Download an individual chunk of data (range / part)
+async fn download_chunk(
+    ctx: &DownloadContext,
+    request: ChunkRequest,
+) -> Result<ChunkResponse, TransferError> {
+    let mut resp = request
+        .input
+        .send_with(&ctx.client)
+        .await
+        .map_err(error::chunk_failed)?;
+
+    let body = mem::replace(&mut resp.body, ByteStream::new(SdkBody::taken()));
+
+    let bytes = body
+        .collect()
+        .instrument(tracing::debug_span!("collect-body", seq = request.seq))
+        .await
+        .map_err(error::chunk_failed)?;
+
+    Ok(ChunkResponse {
+        seq: request.seq,
+        data: Some(bytes),
+        object_meta: Some(ObjectMetadata::from(resp)),
+    })
+}
+
+pub(super) async fn distribute_work(
+    remaining: RangeInclusive<u64>,
+    input: GetObjectInputBuilder,
+    part_size: u64,
+    tx: async_channel::Sender<ChunkRequest>,
+) {
+    let end = *remaining.end();
+    let mut pos = *remaining.start();
+    let mut remaining = end - pos + 1;
+    let mut seq = 0;
+
+    while remaining > 0 {
+        let start = pos;
+        let end_inclusive = cmp::min(pos + part_size - 1, end);
+
+        let chunk_req = next_chunk(start, end_inclusive, seq, input.clone());
+        tracing::trace!(
+            "distributing chunk(size={}): {:?}",
+            chunk_req.size(),
+            chunk_req
+        );
+        let chunk_size = chunk_req.size();
+        tx.send(chunk_req).await.expect("channel open");
+
+        seq += 1;
+        remaining -= chunk_size;
+        tracing::trace!("remaining = {}", remaining);
+        pos += chunk_size;
+    }
+
+    tracing::trace!("work fully distributed");
+    tx.close();
+}
+
+fn next_chunk(
+    start: u64,
+    end_inclusive: u64,
+    seq: u64,
+    input: GetObjectInputBuilder,
+) -> ChunkRequest {
+    let range = start..=end_inclusive;
+    let input = input.range(header::Range::bytes_inclusive(start, end_inclusive));
+    ChunkRequest { seq, range, input }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::download::header;
+    use crate::download::worker::distribute_work;
+    use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+    use std::ops::RangeInclusive;
+
+    #[tokio::test]
+    async fn test_distribute_work() {
+        let rem = 0..=90u64;
+        let part_size = 20;
+        let input = GetObjectInputBuilder::default();
+        let (tx, rx) = async_channel::unbounded();
+
+        tokio::spawn(distribute_work(rem, input, part_size, tx));
+
+        let mut chunks = Vec::new();
+        while let Ok(chunk) = rx.recv().await {
+            chunks.push(chunk);
+        }
+
+        let expected_ranges = vec![0..=19u64, 20..=39u64, 40..=59u64, 60..=79u64, 80..=90u64];
+
+        let actual_ranges: Vec<RangeInclusive<u64>> =
+            chunks.iter().map(|c| c.range.clone()).collect();
+
+        assert_eq!(expected_ranges, actual_ranges);
+        assert!(rx.is_closed());
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(i as u64, chunk.seq);
+            let expected_range_header =
+                header::Range::bytes_inclusive(*chunk.range.start(), *chunk.range.end())
+                    .to_string();
+
+            assert_eq!(
+                expected_range_header,
+                chunk.input.get_range().clone().expect("range header set")
+            );
+        }
+    }
+}

--- a/aws/hll/aws-s3-transfer-manager/src/download/worker.rs
+++ b/aws/hll/aws-s3-transfer-manager/src/download/worker.rs
@@ -34,6 +34,7 @@ impl ChunkRequest {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ChunkResponse {
+    // TODO(aws-sdk-rust#1159, design) - consider PartialOrd for ChunkResponse and hiding `seq` as internal only detail
     // the seq number
     pub(crate) seq: u64,
     // chunk data
@@ -44,7 +45,7 @@ pub(crate) struct ChunkResponse {
 
 /// Worker function that processes requests from the [requests] channel and
 /// sends the result back on the [completed] channel.
-pub(super) async fn chunk_downloader(
+pub(super) async fn download_chunks(
     ctx: DownloadContext,
     requests: async_channel::Receiver<ChunkRequest>,
     completed: mpsc::Sender<Result<ChunkResponse, TransferError>>,


### PR DESCRIPTION
## Description

Adds a "naive" implementation of a multipart download as well as an example to exercise and play with the API. I haven't had much time to play around with it but the initial performance seems off (slow) and requires further investigation.

The basic idea in this initial implementation:
* do initial object discovery (possibly fetching first chunk of data with it)
* spin up a worker to distribute work, this worker simply takes the remaining total range of the object and chunks it by the part size and puts each chunk range to fetch onto a bounded worker channel. 
* spin up N workers that read off the "work to do" channel. They pull requests off the channel for a single range, fetch it, and place the result onto completion channel
* consumer reads from a new `Body` type that handles sequencing the chunks

I fully expect the `Body` type to change. Using `AggregatedBytes` seems limiting and we don't have much control over it. It's a very thin wrapper on `SegmentedBuf` from `bytes-util`. 

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
