### PR TITLE
Clean up dependency usage for `aws-types` crate

### DIFF
--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Cross-service types for the AWS SDK."
 edition = "2021"
@@ -18,7 +18,6 @@ aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", optional = true }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
 tracing = "0.1"
-http = "0.2.6"
 # cargo does not support optional test dependencies, so to completely disable rustls
 # we need to add the webpki-roots feature here.
 # https://github.com/rust-lang/cargo/issues/1596
@@ -29,6 +28,7 @@ http = "0.2.4"
 tempfile = "3"
 tracing-test = "=0.2.5"
 tokio = { version = "1", features = ["rt", "macros"] }
+aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["http-02x"] }
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/aws/rust-runtime/aws-types/src/request_id.rs
+++ b/aws/rust-runtime/aws-types/src/request_id.rs
@@ -72,9 +72,12 @@ pub fn apply_request_id(builder: ErrorMetadataBuilder, headers: &Headers) -> Err
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::request_id::{apply_request_id, RequestId, AWS_REQUEST_ID};
     use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+    use aws_smithy_runtime_api::client::result::SdkError;
+    use aws_smithy_runtime_api::http::Headers;
     use aws_smithy_types::body::SdkBody;
+    use aws_smithy_types::error::ErrorMetadata;
     use http::{HeaderValue, Response};
 
     #[test]


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
