### PR TITLE
Unpin pinned dependencies

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -81,7 +81,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.10"
+version = "0.60.11"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1836,7 +1836,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1998,7 +1998,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2078,7 +2078,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2129,7 +2129,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2189,7 +2189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2301,7 +2301,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -2323,7 +2323,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2549,7 +2549,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.2"
+version = "1.5.4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1217,7 +1217,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1294,9 +1294,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -1311,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1337,7 +1337,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1422,7 +1422,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1473,7 +1473,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.3"
+version = "1.5.4"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"
@@ -44,7 +44,7 @@ aws-credential-types = { path = "../aws-credential-types", features = ["test-uti
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client", "test-util"] }
 bytes = "1"
 hex-literal = "0.4.1"
-httparse = "=1.8"
+httparse = "1.8"
 libfuzzer-sys = "0.4.6"
 pretty_assertions = "1.3"
 proptest = "1.2"
@@ -65,7 +65,7 @@ harness = false
 [[bench]]
 name = "sigv4a"
 harness = false
-required-features = [ "sigv4a" ]
+required-features = ["sigv4a"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Cross-service types for the AWS SDK."
 edition = "2021"
@@ -26,7 +26,7 @@ hyper-rustls = { version = "0.24", optional = true, features = ["rustls-native-c
 [dev-dependencies]
 http = "0.2.4"
 tempfile = "3"
-tracing-test = "=0.2.5"
+tracing-test = "0.2.5"
 tokio = { version = "1", features = ["rt", "macros"] }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["http-02x"] }
 

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -329,7 +329,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime 1.3.0",
@@ -342,7 +342,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
@@ -456,7 +456,7 @@ dependencies = [
  "aws-smithy-protocol-test 0.60.7",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "bytes-utils",
  "fastrand 2.0.2",
@@ -488,7 +488,7 @@ dependencies = [
  "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-types 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -505,7 +505,7 @@ version = "1.1.8"
 
 [[package]]
 name = "aws-sdk-accessanalyzer"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -516,7 +516,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-account"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -539,7 +539,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-acm"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -561,7 +561,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -572,6 +572,28 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-acmpca"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-amp"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -583,29 +605,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-amp"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amplify"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -628,7 +628,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amplifybackend"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -650,7 +650,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amplifyuibuilder"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -672,7 +672,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -684,72 +684,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apigateway"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-apigatewaymanagement"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-apigatewayv2"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-appconfig"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -761,7 +695,73 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-apigatewaymanagement"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-apigatewayv2"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-appconfig"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appconfigdata"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -783,7 +783,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appfabric"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -805,7 +805,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appflow"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -828,7 +828,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appintegrations"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -851,7 +851,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationautoscaling"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -874,7 +874,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -885,28 +885,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationcostprofiler"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-applicationdiscovery"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -918,7 +896,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-applicationdiscovery"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationinsights"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -941,7 +941,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationsignals"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -963,7 +963,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appmesh"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -985,7 +985,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -997,6 +997,28 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apprunner"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-appstream"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -1008,29 +1030,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-appstream"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appsync"
-version = "1.36.0"
+version = "1.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1052,7 +1052,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apptest"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1074,7 +1074,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-arczonalshift"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1097,7 +1097,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-artifact"
-version = "1.19.0"
+version = "1.21.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1119,7 +1119,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-athena"
-version = "1.33.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1141,7 +1141,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-auditmanager"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1164,7 +1164,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-autoscaling"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1188,7 +1188,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1198,28 +1198,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-autoscalingplans"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-b2bi"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -1231,7 +1209,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-b2bi"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-backup"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1254,7 +1254,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-backupgateway"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1277,7 +1277,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-batch"
-version = "1.38.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1299,7 +1299,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bcmdataexports"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1322,7 +1322,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrock"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1344,7 +1344,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockagent"
-version = "1.36.0"
+version = "1.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1367,7 +1367,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockagentruntime"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1391,7 +1391,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1414,7 +1414,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-billingconductor"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1436,7 +1436,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-braket"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1459,7 +1459,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-budgets"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1482,7 +1482,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chatbot"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1504,7 +1504,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chime"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1526,7 +1526,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkidentity"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1549,7 +1549,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkmediapipelines"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1572,7 +1572,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1584,209 +1584,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkmeetings"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-chimesdkmessaging"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-chimesdkvoice"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cleanrooms"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cleanroomsml"
-version = "1.30.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cloud9"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cloudcontrol"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-clouddirectory"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cloudformation"
-version = "1.37.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cloudfront"
 version = "1.34.0"
 dependencies = [
  "aws-config",
@@ -1798,8 +1595,9 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1808,8 +1606,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudfrontkeyvaluestore"
-version = "1.32.0"
+name = "aws-sdk-chimesdkmessaging"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1820,19 +1618,19 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
+ "fastrand 2.0.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]
-name = "aws-sdk-cloudhsm"
-version = "1.32.0"
+name = "aws-sdk-chimesdkvoice"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1843,7 +1641,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1853,8 +1651,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudhsmv2"
-version = "1.32.0"
+name = "aws-sdk-cleanrooms"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1865,7 +1663,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1875,8 +1673,97 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudsearch"
-version = "1.32.0"
+name = "aws-sdk-cleanroomsml"
+version = "1.31.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloud9"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudcontrol"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-clouddirectory"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudformation"
+version = "1.38.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1889,7 +1776,8 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "fastrand 2.0.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1898,29 +1786,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudsearchdomain"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cloudtrail"
+name = "aws-sdk-cloudfront"
 version = "1.35.0"
 dependencies = [
  "aws-config",
@@ -1932,8 +1798,8 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
+ "aws-smithy-xml 0.60.8",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1942,8 +1808,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudtraildata"
-version = "1.32.0"
+name = "aws-sdk-cloudfrontkeyvaluestore"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1954,7 +1820,141 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-cloudhsm"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudhsmv2"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudsearch"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-query",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-smithy-xml 0.60.8",
+ "aws-types 1.3.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudsearchdomain"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudtrail"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudtraildata"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "1.36.0"
+version = "1.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -1979,7 +1979,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "flate2",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchevents"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2002,7 +2002,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2024,7 +2024,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codeartifact"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2047,7 +2047,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codebuild"
-version = "1.41.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2069,7 +2069,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codecatalyst"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2092,7 +2092,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codecommit"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2118,7 +2118,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codeconnections"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2141,7 +2141,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2152,6 +2152,28 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codedeploy"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-codeguruprofiler"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -2163,29 +2185,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-codeguruprofiler"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codegurureviewer"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2208,7 +2208,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codegurusecurity"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -2231,7 +2231,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2243,609 +2243,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codepipeline"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-codestar"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-codestarconnections"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-codestarnotifications"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cognitoidentity"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cognitoidentityprovider"
-version = "1.37.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-cognitosync"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-comprehend"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-comprehendmedical"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-computeoptimizer"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-config"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-connect"
-version = "1.46.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-connectcampaigns"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-connectcases"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-connectcontactlens"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-connectparticipant"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-controlcatalog"
-version = "1.13.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-controltower"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-costandusagereport"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-costexplorer"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-costoptimizationhub"
-version = "1.31.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-customerprofiles"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-databasemigration"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-databrew"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-dataexchange"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-datapipeline"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-datasync"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-datazone"
 version = "1.36.0"
 dependencies = [
  "aws-config",
@@ -2857,7 +2254,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2868,141 +2265,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-dax"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-deadline"
-version = "1.14.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-detective"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-devicefarm"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-devopsguru"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-directconnect"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-directory"
+name = "aws-sdk-codestar"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -3014,7 +2277,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3024,7 +2287,409 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-dlm"
+name = "aws-sdk-codestarconnections"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-codestarnotifications"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cognitoidentity"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cognitoidentityprovider"
+version = "1.38.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cognitosync"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-comprehend"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-comprehendmedical"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-computeoptimizer"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-config"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-connect"
+version = "1.47.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-connectcampaigns"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-connectcases"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-connectcontactlens"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-connectparticipant"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-controlcatalog"
+version = "1.14.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-controltower"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-costandusagereport"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-costexplorer"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-costoptimizationhub"
 version = "1.32.0"
 dependencies = [
  "aws-config",
@@ -3036,7 +2701,342 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-customerprofiles"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-databasemigration"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-databrew"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-dataexchange"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-datapipeline"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-datasync"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-datazone"
+version = "1.37.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-dax"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-deadline"
+version = "1.15.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-detective"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-devicefarm"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-devopsguru"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-directconnect"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-directory"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-dlm"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-docdb"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3060,7 +3060,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-docdbelastic"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3081,7 +3081,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-drs"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3104,7 +3104,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "approx",
  "aws-config",
@@ -3128,7 +3128,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "criterion",
  "fastrand 2.0.2",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodbstreams"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3155,7 +3155,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ebs"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3178,7 +3178,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3205,7 +3205,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "fastrand 2.0.2",
  "futures-util",
  "http 0.2.12",
@@ -3219,72 +3219,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2instanceconnect"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ecr"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ecrpublic"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ecs"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -3296,7 +3230,73 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ecr"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ecrpublic"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ecs"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-efs"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3319,7 +3319,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-eks"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3342,7 +3342,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-eksauth"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3365,7 +3365,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticache"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3389,7 +3389,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticbeanstalk"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3412,7 +3412,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticinference"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3433,7 +3433,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticloadbalancing"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3457,7 +3457,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticloadbalancingv2"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3480,7 +3480,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3490,72 +3490,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticsearch"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-elastictranscoder"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-emr"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-emrcontainers"
 version = "1.35.0"
 dependencies = [
  "aws-config",
@@ -3567,7 +3501,73 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-elastictranscoder"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-emr"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-emrcontainers"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-emrserverless"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3590,7 +3590,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3602,72 +3602,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-entityresolution"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-eventbridge"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-evidently"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-finspace"
 version = "1.35.0"
 dependencies = [
  "aws-config",
@@ -3679,7 +3613,73 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-eventbridge"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-evidently"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-finspace"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3691,207 +3691,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-finspacedata"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-firehose"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-fis"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-fms"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-forecast"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-forecastquery"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-frauddetector"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-freetier"
-version = "1.30.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-fsx"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-gamelift"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -3903,7 +3702,208 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-firehose"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-fis"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-fms"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-forecast"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-forecastquery"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-frauddetector"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-freetier"
+version = "1.31.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-fsx"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-gamelift"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-glacier"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3927,7 +3927,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "futures-util",
  "hex",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-globalaccelerator"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3955,7 +3955,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-glue"
-version = "1.42.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -3978,7 +3978,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-grafana"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4000,7 +4000,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4012,28 +4012,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-greengrass"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-greengrassv2"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -4045,7 +4023,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-greengrassv2"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-groundstation"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4068,7 +4068,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-guardduty"
-version = "1.37.0"
+version = "1.38.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4090,7 +4090,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4102,28 +4102,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-health"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-healthlake"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -4135,7 +4113,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-healthlake"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iam"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4161,7 +4161,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "futures-util",
  "http 0.2.12",
  "once_cell",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-identitystore"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4185,7 +4185,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4196,319 +4196,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-imagebuilder"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-inspector"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-inspector2"
-version = "1.36.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-inspectorscan"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-internetmonitor"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iot"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iot1clickdevices"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iot1clickprojects"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iotanalytics"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iotdataplane"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iotdeviceadvisor"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iotevents"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ioteventsdata"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iotfleethub"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-iotfleetwise"
 version = "1.34.0"
 dependencies = [
  "aws-config",
@@ -4520,7 +4207,320 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-inspector"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-inspector2"
+version = "1.37.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-inspectorscan"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-internetmonitor"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iot"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iot1clickdevices"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iot1clickprojects"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iotanalytics"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iotdataplane"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iotdeviceadvisor"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iotevents"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ioteventsdata"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iotfleethub"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-iotfleetwise"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotjobsdataplane"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4542,7 +4542,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotsecuretunneling"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4564,7 +4564,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4575,7 +4575,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotsitewise"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4586,7 +4586,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotthingsgraph"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4609,7 +4609,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iottwinmaker"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4631,7 +4631,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotwireless"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4653,7 +4653,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ivs"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4676,7 +4676,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4687,28 +4687,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ivschat"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ivsrealtime"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -4720,7 +4698,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ivsrealtime"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kafka"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4743,7 +4743,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kafkaconnect"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4765,7 +4765,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kendra"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4787,7 +4787,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kendraranking"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4810,7 +4810,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-keyspaces"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4833,7 +4833,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4855,7 +4855,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisanalytics"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4877,7 +4877,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisanalyticsv2"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4899,7 +4899,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4910,7 +4910,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideo"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4921,7 +4921,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideoarchivedmedia"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4943,7 +4943,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideomedia"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4965,7 +4965,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideosignaling"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -4987,7 +4987,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideowebrtcstorage"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5009,7 +5009,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5032,7 +5032,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lakeformation"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5057,7 +5057,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5081,7 +5081,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -5095,50 +5095,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-launchwizard"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-lexmodelbuilding"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-lexmodelsv2"
 version = "1.34.0"
 dependencies = [
  "aws-config",
@@ -5150,7 +5106,51 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-lexmodelbuilding"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-lexmodelsv2"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lexruntime"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5173,7 +5173,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5184,7 +5184,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lexruntimev2"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5197,7 +5197,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "hyper 0.14.29",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-licensemanager"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5220,7 +5220,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-licensemanagerlinuxsubscriptions"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5242,7 +5242,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-licensemanagerusersubscriptions"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5264,7 +5264,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5275,410 +5275,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lightsail"
-version = "1.36.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-location"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-lookoutequipment"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-lookoutmetrics"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-lookoutvision"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-m2"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-machinelearning"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-macie2"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mailmanager"
-version = "1.7.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-managedblockchain"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-managedblockchainquery"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-marketplaceagreement"
-version = "1.29.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-marketplacecatalog"
-version = "1.36.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-marketplacecommerceanalytics"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-marketplacedeployment"
-version = "1.29.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-marketplaceentitlement"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-marketplacemetering"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediaconnect"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediaconvert"
 version = "1.37.0"
 dependencies = [
  "aws-config",
@@ -5690,9 +5286,8 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
- "fastrand 2.0.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -5701,8 +5296,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-medialive"
-version = "1.38.0"
+name = "aws-sdk-location"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -5713,30 +5308,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediapackage"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5746,366 +5318,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-mediapackagev2"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediapackagevod"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediastore"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediastoredata"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mediatailor"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-medicalimaging"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-memorydb"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mgn"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-migrationhub"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-migrationhubconfig"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-migrationhuborchestrator"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-migrationhubrefactorspaces"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-migrationhubstrategy"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mobile"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mq"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mturk"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mwaa"
+name = "aws-sdk-lookoutequipment"
 version = "1.35.0"
 dependencies = [
  "aws-config",
@@ -6117,7 +5330,794 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-lookoutmetrics"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-lookoutvision"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-m2"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-machinelearning"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-macie2"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mailmanager"
+version = "1.8.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-managedblockchain"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-managedblockchainquery"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-marketplaceagreement"
+version = "1.30.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-marketplacecatalog"
+version = "1.37.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-marketplacecommerceanalytics"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-marketplacedeployment"
+version = "1.30.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-marketplaceentitlement"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-marketplacemetering"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediaconnect"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediaconvert"
+version = "1.38.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-medialive"
+version = "1.39.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediapackage"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediapackagev2"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediapackagevod"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediastore"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediastoredata"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-sigv4 1.2.2",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mediatailor"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-medicalimaging"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-memorydb"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mgn"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-migrationhub"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-migrationhubconfig"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-migrationhuborchestrator"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-migrationhubrefactorspaces"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-migrationhubstrategy"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mobile"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mq"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mturk"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-mwaa"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-neptune"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6141,7 +6141,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -6151,72 +6151,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-neptunedata"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-neptunegraph"
-version = "1.29.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-networkfirewall"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-networkmanager"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -6228,7 +6162,73 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-neptunegraph"
+version = "1.30.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-networkfirewall"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-networkmanager"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-networkmonitor"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6251,7 +6251,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-nimble"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6274,7 +6274,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-oam"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6297,7 +6297,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6308,7 +6308,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-omics"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6320,7 +6320,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6332,7 +6332,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opensearch"
-version = "1.37.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6343,7 +6343,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opensearchserverless"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6365,7 +6365,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6377,160 +6377,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opsworks"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-opsworkscm"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-organizations"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-osis"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-outposts"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-panorama"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-paymentcryptography"
-version = "1.34.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-paymentcryptographydata"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -6542,7 +6388,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6552,8 +6398,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-pcaconnectorad"
-version = "1.32.0"
+name = "aws-sdk-opsworkscm"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6564,7 +6410,161 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-organizations"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-osis"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-outposts"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-panorama"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-paymentcryptography"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-paymentcryptographydata"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-pcaconnectorad"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6576,7 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pcaconnectorscep"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6587,7 +6587,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6599,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-personalize"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6610,7 +6610,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6621,50 +6621,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-personalizeevents"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-personalizeruntime"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-pi"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -6676,7 +6632,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6686,7 +6642,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-pinpoint"
+name = "aws-sdk-personalizeruntime"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-pi"
 version = "1.34.0"
 dependencies = [
  "aws-config",
@@ -6698,7 +6676,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-pinpoint"
+version = "1.35.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6709,50 +6709,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pinpointemail"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-pinpointsmsvoice"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-pinpointsmsvoicev2"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -6764,7 +6720,51 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-pinpointsmsvoice"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-pinpointsmsvoicev2"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pipes"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6787,7 +6787,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-polly"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6811,7 +6811,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -6827,7 +6827,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pricing"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6838,7 +6838,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-privatenetworks"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6860,7 +6860,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6871,7 +6871,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-proton"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6882,7 +6882,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qbusiness"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6907,7 +6907,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6920,7 +6920,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qconnect"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6931,7 +6931,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qldb"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6954,7 +6954,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6965,7 +6965,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qldbsession"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -6977,7 +6977,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -6991,7 +6991,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-quicksight"
-version = "1.39.0"
+version = "1.40.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7002,7 +7002,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7013,7 +7013,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ram"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7024,7 +7024,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7035,7 +7035,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rbin"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7046,7 +7046,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7057,7 +7057,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rds"
-version = "1.42.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7070,7 +7070,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rdsdata"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7091,7 +7091,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-redshift"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7115,7 +7115,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -7125,7 +7125,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-redshiftdata"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7136,7 +7136,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-redshiftserverless"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7159,7 +7159,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7170,7 +7170,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rekognition"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7181,7 +7181,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7193,7 +7193,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-repostspace"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7204,7 +7204,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7215,7 +7215,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-resiliencehub"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7226,7 +7226,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7238,141 +7238,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-resourceexplorer2"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-resourcegroups"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-resourcegroupstagging"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-robomaker"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-rolesanywhere"
-version = "1.35.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-route53"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
- "http 0.2.12",
- "once_cell",
- "pretty_assertions",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-route53domains"
 version = "1.34.0"
 dependencies = [
  "aws-config",
@@ -7384,29 +7249,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-route53profiles"
-version = "1.11.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7417,8 +7260,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-route53recoverycluster"
-version = "1.32.0"
+name = "aws-sdk-resourcegroups"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7429,7 +7272,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7439,8 +7282,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-route53recoverycontrolconfig"
-version = "1.32.0"
+name = "aws-sdk-resourcegroupstagging"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7451,7 +7294,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-robomaker"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7462,8 +7327,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-route53recoveryreadiness"
-version = "1.32.0"
+name = "aws-sdk-rolesanywhere"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7474,7 +7339,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7484,7 +7349,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-route53resolver"
+name = "aws-sdk-route53"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-smithy-xml 0.60.8",
+ "aws-types 1.3.2",
+ "http 0.2.12",
+ "once_cell",
+ "pretty_assertions",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-route53domains"
 version = "1.35.0"
 dependencies = [
  "aws-config",
@@ -7496,7 +7384,119 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-route53profiles"
+version = "1.12.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-route53recoverycluster"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-route53recoverycontrolconfig"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-route53recoveryreadiness"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-route53resolver"
+version = "1.36.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7508,7 +7508,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rum"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7519,7 +7519,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7531,6 +7531,41 @@ dependencies = [
 [[package]]
 name = "aws-sdk-s3"
 version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955365fd032cc94608c7e0f4aea36a9825399d6a1bf7b96f56cf157414b04c40"
+dependencies = [
+ "ahash",
+ "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-runtime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-sigv4 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-checksums 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-types 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fastrand 2.0.2",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.38.0"
 dependencies = [
  "ahash",
  "async-std",
@@ -7549,7 +7584,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "bytes-utils",
  "fastrand 2.0.2",
@@ -7579,43 +7614,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-s3"
-version = "1.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955365fd032cc94608c7e0f4aea36a9825399d6a1bf7b96f56cf157414b04c40"
-dependencies = [
- "ahash",
- "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-runtime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-sigv4 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-checksums 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "fastrand 2.0.2",
- "hex",
- "hmac",
- "http 0.2.12",
- "http-body 0.4.6",
- "lru",
- "once_cell",
- "percent-encoding",
- "regex-lite",
- "sha2",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "aws-sdk-s3control"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7628,7 +7628,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "fastrand 2.0.2",
  "futures-util",
  "http 0.2.12",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3outposts"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7655,7 +7655,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7666,7 +7666,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemaker"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7677,7 +7677,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7689,50 +7689,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakera2iruntime"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sagemakeredge"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sagemakerfeaturestoreruntime"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -7744,7 +7700,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7754,8 +7710,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-sagemakergeospatial"
-version = "1.32.0"
+name = "aws-sdk-sagemakeredge"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7766,7 +7722,51 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sagemakerfeaturestoreruntime"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sagemakergeospatial"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7778,7 +7778,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakermetrics"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7789,7 +7789,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7800,7 +7800,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakerruntime"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7812,7 +7812,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-savingsplans"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7834,7 +7834,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7846,7 +7846,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-scheduler"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7857,7 +7857,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-schemas"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7880,7 +7880,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7892,7 +7892,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.36.0"
+version = "1.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7903,7 +7903,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-securityhub"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7926,7 +7926,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-securitylake"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -7948,7 +7948,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7959,28 +7959,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-serverlessapplicationrepository"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-servicecatalog"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -7992,7 +7970,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-servicecatalog"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicecatalogappregistry"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8015,7 +8015,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8027,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicediscovery"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8038,7 +8038,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8050,7 +8050,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicequotas"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8061,7 +8061,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8072,7 +8072,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ses"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8085,7 +8085,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -8095,7 +8095,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sesv2"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8106,7 +8106,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8117,7 +8117,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sfn"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8128,7 +8128,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8140,7 +8140,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-shield"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8151,7 +8151,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-signer"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8173,7 +8173,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-simspaceweaver"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8196,7 +8196,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8208,7 +8208,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sms"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8219,7 +8219,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8230,7 +8230,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-snowball"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8241,7 +8241,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8252,7 +8252,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-snowdevicemanagement"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8263,7 +8263,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8275,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sns"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8288,7 +8288,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -8298,7 +8298,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8309,7 +8309,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8320,7 +8320,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8331,7 +8331,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8343,7 +8343,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssmcontacts"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8354,7 +8354,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8366,7 +8366,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssmincidents"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8377,7 +8377,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8389,6 +8389,49 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssmsap"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.33.0"
+dependencies = [
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssoadmin"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -8400,50 +8443,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.32.0"
-dependencies = [
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssoadmin"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime 1.3.0",
@@ -8465,7 +8465,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-storagegateway"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8487,7 +8487,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime 1.3.0",
@@ -8511,7 +8511,7 @@ dependencies = [
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "futures-util",
  "http 0.2.12",
  "once_cell",
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-supplychain"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8535,7 +8535,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8547,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-support"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8558,7 +8558,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8569,28 +8569,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-supportapp"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-swf"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -8602,7 +8580,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-swf"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-synthetics"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8624,7 +8624,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-taxsettings"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8646,7 +8646,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8657,7 +8657,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-textract"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8668,7 +8668,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8680,7 +8680,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-timestreaminfluxdb"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8691,7 +8691,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-timestreamquery"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8714,7 +8714,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
@@ -8729,51 +8729,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-timestreamwrite"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "fastrand 2.0.2",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-tnb"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-transcribe"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -8785,7 +8740,52 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-tnb"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-transcribe"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8796,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-transcribestreaming"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "async-stream",
  "aws-config",
@@ -8811,7 +8811,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-transfer"
-version = "1.36.0"
+version = "1.37.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8839,7 +8839,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8850,7 +8850,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-translate"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8861,7 +8861,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8873,7 +8873,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-trustedadvisor"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8884,7 +8884,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8895,7 +8895,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-verifiedpermissions"
-version = "1.38.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8906,7 +8906,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-voiceid"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8929,7 +8929,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-vpclattice"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8952,7 +8952,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-waf"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -8975,7 +8975,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8986,50 +8986,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-wafregional"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-wafv2"
-version = "1.36.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-wellarchitected"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -9041,7 +8997,51 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-wafv2"
+version = "1.37.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-wellarchitected"
+version = "1.34.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9053,7 +9053,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-wisdom"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9064,7 +9064,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9076,7 +9076,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workdocs"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9087,7 +9087,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-worklink"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9109,7 +9109,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workmail"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9131,7 +9131,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9143,28 +9143,6 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workmailmessageflow"
-version = "1.32.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-workspaces"
 version = "1.33.0"
 dependencies = [
  "aws-config",
@@ -9176,7 +9154,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9186,8 +9164,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-workspacesthinclient"
-version = "1.32.0"
+name = "aws-sdk-workspaces"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9198,7 +9176,29 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-workspacesthinclient"
+version = "1.33.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.0",
+ "aws-runtime 1.3.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.8",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-types 1.2.0",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workspacesweb"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9221,7 +9221,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9233,7 +9233,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-xray"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aws-config",
  "aws-credential-types 1.2.0",
@@ -9244,7 +9244,7 @@ dependencies = [
  "aws-smithy-runtime 1.6.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
- "aws-types 1.3.1",
+ "aws-types 1.3.2",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9531,7 +9531,7 @@ dependencies = [
 name = "aws-smithy-mocks-experimental"
 version = "0.2.1"
 dependencies = [
- "aws-sdk-s3 1.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-sdk-s3 1.37.0",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "tokio",
@@ -9780,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-smithy-async 1.2.1",
@@ -9798,15 +9798,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f734808d43702a67e57d478a12e227d4d038d0b90c9005a78c87890d3805922"
+checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
 dependencies = [
  "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
@@ -12043,9 +12042,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -218,20 +218,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.37.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955365fd032cc94608c7e0f4aea36a9825399d6a1bf7b96f56cf157414b04c40"
+checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
 dependencies = [
  "ahash",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-checksums 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-checksums 0.60.10",
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.5.5",
  "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -305,6 +305,27 @@ dependencies = [
 [[package]]
 name = "aws-smithy-checksums"
 version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
+dependencies = [
+ "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.11"
 dependencies = [
  "aws-smithy-http 0.60.8",
  "aws-smithy-types 1.2.0",
@@ -323,27 +344,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-test",
-]
-
-[[package]]
-name = "aws-smithy-checksums"
-version = "0.60.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
-dependencies = [
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "crc32c",
- "crc32fast",
- "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
- "pin-project-lite",
- "sha1",
- "sha2",
- "tracing",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ name = "aws-smithy-experimental"
 version = "0.1.2"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.6.0",
+ "aws-smithy-runtime 1.6.1",
  "aws-smithy-runtime-api 1.7.0",
  "aws-smithy-types 1.2.0",
  "h2 0.4.5",
@@ -604,7 +604,38 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.0"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d3965f6417a92a6d1009c5958a67042f57e46342afb37ca58f9ad26744ec73"
+dependencies = [
+ "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-protocol-test 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fastrand",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.0",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
+ "indexmap 2.2.6",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.6.1"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",
@@ -635,38 +666,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db83b08939838d18e33b5dbaf1a0f048f28c10bd28071ab7ce6f245451855414"
-dependencies = [
- "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-protocol-test 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "fastrand",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.0",
- "httparse",
- "hyper 0.14.29",
- "hyper-rustls 0.24.2",
- "indexmap 2.2.6",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls 0.21.12",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -807,15 +806,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f734808d43702a67e57d478a12e227d4d038d0b90c9005a78c87890d3805922"
+checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
@@ -916,7 +914,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.67",
  "which",
 ]
 
@@ -1311,7 +1309,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1521,7 +1519,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1775,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2374,7 +2372,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2456,7 +2454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2485,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -3051,7 +3049,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3210,9 +3208,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -3227,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3286,7 +3284,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3396,7 +3394,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3549,7 +3547,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3622,7 +3620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3791,7 +3789,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -3813,7 +3811,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4063,7 +4061,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4083,5 +4081,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.60.10"
+version = "0.60.11"
 authors = [
-  "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
-  "Zelda Hessler <zhessler@amazon.com>",
+    "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
+    "Zelda Hessler <zhessler@amazon.com>",
 ]
 description = "Checksum calculation and verification callbacks"
 edition = "2021"
@@ -16,7 +16,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
-crc32c = "=0.6.8"
+crc32c = "0.6.8"
 crc32fast = "1.3"
 hex = "0.4.3"
 http = "0.2.8"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -35,7 +35,7 @@ http = { version = "0.2.8" }
 http-body-0-4 = { package = "http-body", version = "0.4.4" }
 http-body-1 = { package = "http-body", version = "1" }
 # This avoids bringing `httparse` 1.9.0 and 1.9.1 through `hyper-0-14` that break unit tests of runtime crates
-httparse = "=1.8.0"
+httparse = "1.8.0"
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, optional = true }
 hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
 once_cell = "1.18.0"


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Due to numerous dependency issues over the past few weeks several of our dependencies were pinned to specific minor versions. Now that we have lockfiles for all of our workspaces those pinned versions can be undone.

## Description
<!--- Describe your changes in detail -->
I unpinned those dependencies and generated new lockfiles after that change. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the gradle `assemble` and `sdkTest` tasks locally and they both passed. I ran a full set of preview/release e2e tests against this change in my local stack and those all passed. And since we copy the Cargo.lock into the test workspaces the CI run for this PR will also test the changes.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
No functional changes, only dependency changes.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
