### PR TITLE
Remove assumption about repo name by using git

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -87,12 +87,8 @@ object TestWorkspace {
     private val subprojects = mutableListOf<String>()
 
     private val cargoLock: File by lazy {
-        var curFile = File(this.javaClass.protectionDomain.codeSource.location.path)
-        while (!curFile.endsWith("smithy-rs")) {
-            curFile = curFile.parentFile
-        }
-
-        curFile.resolve("aws/sdk/Cargo.lock")
+        val projectDir = "git rev-parse --show-toplevel".runCommand().replace("\n", "")
+        File(projectDir).resolve("aws/sdk/Cargo.lock")
     }
 
     init {


### PR DESCRIPTION
to get the path of the top level of the repo

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixing issue with test workspaces that would break if the repo is not named `smithy-rs`

## Description
<!--- Describe your changes in detail -->
Moved to using `git rev-parse --show-toplevel` to get the project directory instead of climbing the file tree.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All of our CI tests this since it is part of generating test workspaces

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
