### PR TITLE
Refactor the `as_validation_exception_field` function definition in `ServerBuilderConstraintViolations`.

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -15,10 +15,3 @@ message = "A feature, `aws-lambda`, has been added to generated SDKs to re-expor
 references = ["smithy-rs#3643"]
 meta = { "breaking" = false, "bug" = true, "tada" = false, "target" = "server" }
 author = "drganjoo"
-
-[[smithy-rs]]
-message = "Refactor the `as_validation_exception_field` function definition in `ServerBuilderConstraintViolations`."
-references = ["smithy-rs#3178"]
-meta = { "breaking" = false, "bug" = false, "tada" = false, "target" = "server" }
-author = "drganjoo"
-

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -15,3 +15,10 @@ message = "A feature, `aws-lambda`, has been added to generated SDKs to re-expor
 references = ["smithy-rs#3643"]
 meta = { "breaking" = false, "bug" = true, "tada" = false, "target" = "server" }
 author = "drganjoo"
+
+[[smithy-rs]]
+message = "Refactor the `as_validation_exception_field` function definition in `ServerBuilderConstraintViolations`."
+references = ["smithy-rs#3178"]
+meta = { "breaking" = false, "bug" = false, "tada" = false, "target" = "server" }
+author = "drganjoo"
+

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
@@ -237,22 +237,26 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
         }
     }
 
-    override fun builderConstraintViolationImplBlock(constraintViolations: Collection<ConstraintViolation>) =
+    override fun builderConstraintViolationFn(constraintViolations: Collection<ConstraintViolation>) =
         writable {
-            rustBlock("match self") {
-                constraintViolations.forEach {
-                    if (it.hasInner()) {
-                        rust("""ConstraintViolation::${it.name()}(inner) => inner.as_validation_exception_field(path + "/${it.forMember.memberName}"),""")
-                    } else {
-                        rust(
-                            """
+            rustBlockTemplate("pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField",
+                "String" to RuntimeType.String,
+            ) {
+                rustBlock("match self") {
+                    constraintViolations.forEach {
+                        if (it.hasInner()) {
+                            rust("""ConstraintViolation::${it.name()}(inner) => inner.as_validation_exception_field(path + "/${it.forMember.memberName}"),""")
+                        } else {
+                            rust(
+                                """
                             ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
                                 message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
                                 name: path + "/${it.forMember.memberName}",
                                 reason: crate::model::ValidationExceptionFieldReason::Other,
                             },
                             """,
-                        )
+                            )
+                        }
                     }
                 }
             }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
@@ -249,12 +249,12 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                         } else {
                             rust(
                                 """
-                            ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
-                                message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
-                                name: path + "/${it.forMember.memberName}",
-                                reason: crate::model::ValidationExceptionFieldReason::Other,
-                            },
-                            """,
+                                ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
+                                    message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
+                                    name: path + "/${it.forMember.memberName}",
+                                    reason: crate::model::ValidationExceptionFieldReason::Other,
+                                },
+                                """,
                             )
                         }
                     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
@@ -239,7 +239,8 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
 
     override fun builderConstraintViolationFn(constraintViolations: Collection<ConstraintViolation>) =
         writable {
-            rustBlockTemplate("pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField",
+            rustBlockTemplate(
+                "pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField",
                 "String" to RuntimeType.String,
             ) {
                 rustBlock("match self") {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
@@ -192,7 +192,8 @@ class SmithyValidationExceptionConversionGenerator(private val codegenContext: S
 
     override fun builderConstraintViolationFn(constraintViolations: Collection<ConstraintViolation>) =
         writable {
-            rustBlockTemplate("pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField",
+            rustBlockTemplate(
+                "pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField",
                 "String" to RuntimeType.String,
             ) {
                 rustBlock("match self") {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
@@ -202,11 +202,11 @@ class SmithyValidationExceptionConversionGenerator(private val codegenContext: S
                         } else {
                             rust(
                                 """
-                            ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
-                                message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
-                                path: path + "/${it.forMember.memberName}",
-                            },
-                            """,
+                                ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
+                                    message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
+                                    path: path + "/${it.forMember.memberName}",
+                                },
+                                """,
                             )
                         }
                     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderConstraintViolations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderConstraintViolations.kt
@@ -171,12 +171,10 @@ class ServerBuilderConstraintViolations(
         writer.rustTemplate(
             """
             impl ConstraintViolation {
-                pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField {
-                    #{ValidationExceptionFieldWritable:W}
-                }
+                #{ValidationExceptionFnWritable:W}
             }
             """,
-            "ValidationExceptionFieldWritable" to validationExceptionConversionGenerator.builderConstraintViolationImplBlock((all)),
+            "ValidationExceptionFnWritable" to validationExceptionConversionGenerator.builderConstraintViolationFn((all)),
             "String" to RuntimeType.String,
         )
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ValidationExceptionConversionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ValidationExceptionConversionGenerator.kt
@@ -47,7 +47,7 @@ interface ValidationExceptionConversionGenerator {
         model: Model,
     ): Writable
 
-    fun builderConstraintViolationImplBlock(constraintViolations: Collection<ConstraintViolation>): Writable
+    fun builderConstraintViolationFn(constraintViolations: Collection<ConstraintViolation>): Writable
 
     fun collectionShapeConstraintViolationImplBlock(
         collectionConstraintsInfo: Collection<CollectionTraitInfo>,


### PR DESCRIPTION
This PR refactors the code to limit the visibility of `crate::model::ValidationExceptionField` to only those decorators and associated classes that are invoked when `smithy.framework#ValidationException` is being used.

More information is in [this issue](https://github.com/smithy-lang/smithy-rs/issues/3718).

Closes: [3178](https://github.com/smithy-lang/smithy-rs/issues/3718)