### PR TITLE
Define a function to return operation shapes that need a `ValidationException`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -15,10 +15,3 @@ message = "A feature, `aws-lambda`, has been added to generated SDKs to re-expor
 references = ["smithy-rs#3643"]
 meta = { "breaking" = false, "bug" = true, "tada" = false, "target" = "server" }
 author = "drganjoo"
-
-[[smithy-rs]]
-message = "Define a function to return operation shapes that need a `ValidationException`."
-references = ["smithy-rs#3722"]
-meta = { "breaking" = false, "bug" = false, "tada" = false, "target" = "server" }
-author = "drganjoo"
-

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -15,3 +15,9 @@ message = "A feature, `aws-lambda`, has been added to generated SDKs to re-expor
 references = ["smithy-rs#3643"]
 meta = { "breaking" = false, "bug" = true, "tada" = false, "target" = "server" }
 author = "drganjoo"
+
+[[smithy-rs]]
+message = "Define a function to return operation shapes that need a `ValidationException`."
+meta = { "breaking" = false, "bug" = false, "tada" = false, "target" = "server" }
+author = "drganjoo"
+

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -18,6 +18,7 @@ author = "drganjoo"
 
 [[smithy-rs]]
 message = "Define a function to return operation shapes that need a `ValidationException`."
+references = ["smithy-rs#3722"]
 meta = { "breaking" = false, "bug" = false, "tada" = false, "target" = "server" }
 author = "drganjoo"
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
@@ -179,7 +179,10 @@ data class ValidationResult(val shouldAbort: Boolean, val messages: List<LogMess
  * Returns the set of operation shapes that must have a supported validation exception shape
  * in their associated errors list.
  */
-fun operationShapesThatMustHaveValidationException(model: Model, service: ServiceShape): Set<OperationShape> {
+fun operationShapesThatMustHaveValidationException(
+    model: Model,
+    service: ServiceShape,
+): Set<OperationShape> {
     val walker = DirectedWalker(model)
     return walker.walkShapes(service)
         .filterIsInstance<OperationShape>()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
@@ -176,7 +176,7 @@ data class ValidationResult(val shouldAbort: Boolean, val messages: List<LogMess
     Throwable(message = messages.joinToString("\n") { it.message })
 
 /*
- * Returns a set of operation shapes that must have a supported validation exception shape
+ * Returns the set of operation shapes that must have a supported validation exception shape
  * in their associated errors list.
  */
 fun operationShapesThatMustHaveValidationException(model: Model, service: ServiceShape): Set<OperationShape> {


### PR DESCRIPTION
Refactor and define a separate function that returns a set of operation shapes that must have a supported validation exception shape in their associated errors list.

This helps identify which type of `ValidationException` has been added to the operation shape's errors list.

Closes: [3722](https://github.com/smithy-lang/smithy-rs/issues/3722)