### PR TITLE
Fix broken link on example's smithy model

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ installation of Rust, including `cargo`, to compile the generated code.
 ## Building
 
 Since these examples require both the server and client SDK to be code-generated
-from their [model](/codegen-server-test/model/pokemon.smithy), a Makefile is
+from their [model](/codegen-core/common-test-models/pokemon.smithy), a Makefile is
 provided to build and run the service. Just run `make` to prepare the first
 build.
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's a broken link on the Readme of the example:  https://github.com/smithy-lang/smithy-rs/blob/main/examples/README.md?plain=1#L34

## Description
Fix the link to point to the common-test models instead: https://github.com/smithy-lang/smithy-rs/blob/main/codegen-core/common-test-models/pokemon.smithy

## Testing
Readme update, no testing

## Checklist
None
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
