### PR TITLE
Adjust error message when bodies don't match in `aws-smithy-protocol-test`

### DIFF
--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-protocol-test"
-version = "0.60.7"
+version = "0.60.8"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "A collection of library functions to validate HTTP requests against Smithy protocol tests."
 edition = "2021"

--- a/rust-runtime/aws-smithy-protocol-test/src/lib.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/lib.rs
@@ -84,7 +84,7 @@ pub enum ProtocolTestFailure {
     #[error("Header `{forbidden}` was forbidden but found: `{found}`")]
     ForbiddenHeader { forbidden: String, found: String },
     #[error(
-        "body did not match. left=actual, right=expected\n{comparison:?} \n == hint:\n{hint}."
+        "body did not match. left=expected, right=actual\n{comparison:?} \n == hint:\n{hint}."
     )]
     BodyDidNotMatch {
         // the comparison includes colorized escapes. PrettyString ensures that even during


### PR DESCRIPTION
The left parameter is the expected one, see
<https://github.com/smithy-lang/smithy-rs/blob/dc1ffb8a0d2cf9ba413d7c62097797863b12db07/rust-runtime/aws-smithy-protocol-test/src/lib.rs#L389-L394>.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
