### PR TITLE
Support `stringArray` type in endpoints params

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "Support `stringArray` type in endpoints params"
+references = ["smithy-rs#3742"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+author = "landonxjames"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -114,6 +114,7 @@ fun Model.sdkConfigSetter(
         when (builtinType) {
             ParameterType.STRING -> writable { rust("|s|s.to_string()") }
             ParameterType.BOOLEAN -> null
+            // No builtins currently map to stringArray
             else -> PANIC("needs to handle unimplemented endpoint parameter builtin type: $builtinType")
         }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextConfigCustomization.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rust.codegen.client.smithy.endpoint
 
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.BooleanShape
+import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.ShapeType
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.rulesengine.traits.ClientContextParamDefinition
@@ -51,6 +52,7 @@ class ClientContextConfigCustomization(ctx: ClientCodegenContext) : ConfigCustom
                 when (shapeType) {
                     ShapeType.STRING -> StringShape.builder().id("smithy.api#String").build()
                     ShapeType.BOOLEAN -> BooleanShape.builder().id("smithy.api#Boolean").build()
+                    ShapeType.LIST -> ListShape.builder().id("smithy.api#List").build()
                     else -> TODO("unsupported type")
                 },
             )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
@@ -109,6 +109,7 @@ fun Parameter.symbol(): Symbol {
         when (this.type) {
             ParameterType.STRING -> RustType.String
             ParameterType.BOOLEAN -> RustType.Bool
+            ParameterType.STRING_ARRAY -> RustType.Vec(RustType.String)
             else -> TODO("unexpected type: ${this.type}")
         }
     // Parameter return types are always optional

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators
 
+import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.BooleanNode
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.StringNode
@@ -156,6 +157,11 @@ class EndpointParamsInterceptorGenerator(
             when (node) {
                 is StringNode -> rust("Some(${node.value.dq()}.to_string())")
                 is BooleanNode -> rust("Some(${node.value})")
+                is ArrayNode -> {
+                    val elms = node.elements.map { "\"$it\".to_string()" }.joinToString(",")
+                    rust("Some(vec![$elms])")
+                }
+
                 else -> PANIC("unsupported default value: $node")
             }
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -158,7 +158,8 @@ class EndpointParamsInterceptorGenerator(
                 is StringNode -> rust("Some(${node.value.dq()}.to_string())")
                 is BooleanNode -> rust("Some(${node.value})")
                 is ArrayNode -> {
-                    val elms = node.elements.map { "\"$it\".to_string()" }.joinToString(",")
+                    // Cast the elements to a StringNode so this will fail if non-string values are provided
+                    val elms = node.elements.map { "\"${(it as StringNode).value}\".to_string()" }.joinToString(",")
                     rust("Some(vec![$elms])")
                 }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -159,7 +159,7 @@ class EndpointParamsInterceptorGenerator(
                 is BooleanNode -> rust("Some(${node.value})")
                 is ArrayNode -> {
                     // Cast the elements to a StringNode so this will fail if non-string values are provided
-                    val elms = node.elements.map { "\"${(it as StringNode).value}\".to_string()" }.joinToString(",")
+                    val elms = node.elements.map { "${(it as StringNode).value.dq()}.to_string()" }.joinToString(",")
                     rust("Some(vec![$elms])")
                 }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/ClientCodegenIntegrationTest.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/ClientCodegenIntegrationTest.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.RustClientCodegenPlugin
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.codegenIntegrationTest
 import java.nio.file.Path
@@ -36,6 +37,13 @@ fun clientIntegrationTest(
                     rustCrate: RustCrate,
                 ) {
                     test(codegenContext, rustCrate)
+                }
+
+                override fun protocolTestGenerator(
+                    codegenContext: ClientCodegenContext,
+                    baseGenerator: ProtocolTestGenerator,
+                ): ProtocolTestGenerator {
+                    return super.protocolTestGenerator(codegenContext, baseGenerator)
                 }
             }
         RustClientCodegenPlugin().executeWithDecorator(ctx, codegenDecorator, *additionalDecorators.toTypedArray())

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/ClientCodegenIntegrationTest.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/ClientCodegenIntegrationTest.kt
@@ -12,7 +12,6 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.RustClientCodegenPlugin
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.codegenIntegrationTest
 import java.nio.file.Path
@@ -37,13 +36,6 @@ fun clientIntegrationTest(
                     rustCrate: RustCrate,
                 ) {
                     test(codegenContext, rustCrate)
-                }
-
-                override fun protocolTestGenerator(
-                    codegenContext: ClientCodegenContext,
-                    baseGenerator: ProtocolTestGenerator,
-                ): ProtocolTestGenerator {
-                    return super.protocolTestGenerator(codegenContext, baseGenerator)
                 }
             }
         RustClientCodegenPlugin().executeWithDecorator(ctx, codegenDecorator, *additionalDecorators.toTypedArray())

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -63,7 +63,8 @@ class EndpointsDecoratorTest {
                 "BuiltInWithDefault": { "required": true, "type": "String", "builtIn": "AWS::DefaultBuiltIn", "default": "some-default" },
                 "BoolBuiltInWithDefault": { "required": true, "type": "Boolean", "builtIn": "AWS::FooBar", "default": true },
                 "AStringParam": { "required": false, "type": "String" },
-                "ABoolParam": { "required": false, "type": "Boolean" }
+                "ABoolParam": { "required": false, "type": "Boolean" },
+                "AStringArrayParam": { "required": false, "type": "stringArray" }
             }
         })
         @clientContextParams(
@@ -107,7 +108,10 @@ class EndpointsDecoratorTest {
             operations: [TestOperation]
         }
 
-        @staticContextParams(Region: { value: "us-east-2" })
+        @staticContextParams(
+            Region: { value: "us-east-2" },
+            AStringArrayParam: {value: ["a", "b", "c"]}
+        )
         operation TestOperation {
             input: TestOperationInput
         }
@@ -184,6 +188,12 @@ class EndpointsDecoratorTest {
                                             .a_bool_param(false)
                                             .a_string_param("hello".to_string())
                                             .region("us-east-2".to_string())
+                                            .a_string_array_param(
+                                                vec!["a", "b", "c"]
+                                                    .iter()
+                                                    .map(|i| i.to_string())
+                                                    .collect::<Vec<String>>()
+                                            )
                                             .build()
                                             .unwrap()
                                     );
@@ -198,6 +208,7 @@ class EndpointsDecoratorTest {
 
                             let interceptor = TestInterceptor::default();
                             let config = Config::builder()
+                                .behavior_version_latest()
                                 .http_client(NeverClient::new())
                                 .interceptor(interceptor.clone())
                                 .timeout_config(

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -58,12 +58,12 @@ class EndpointsDecoratorTest {
                 }
             }],
             "parameters": {
-                "Bucket": { "required": false, "type": "String" },
-                "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
-                "BuiltInWithDefault": { "required": true, "type": "String", "builtIn": "AWS::DefaultBuiltIn", "default": "some-default" },
-                "BoolBuiltInWithDefault": { "required": true, "type": "Boolean", "builtIn": "AWS::FooBar", "default": true },
-                "AStringParam": { "required": false, "type": "String" },
-                "ABoolParam": { "required": false, "type": "Boolean" },
+                "Bucket": { "required": false, "type": "string" },
+                "Region": { "required": false, "type": "string", "builtIn": "AWS::Region" },
+                "BuiltInWithDefault": { "required": true, "type": "string", "builtIn": "AWS::DefaultBuiltIn", "default": "some-default" },
+                "BoolBuiltInWithDefault": { "required": true, "type": "boolean", "builtIn": "AWS::FooBar", "default": true },
+                "AStringParam": { "required": false, "type": "string" },
+                "ABoolParam": { "required": false, "type": "boolean" },
                 "AStringArrayParam": { "required": false, "type": "stringArray" }
             }
         })

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -191,8 +191,8 @@ class EndpointsDecoratorTest {
                                             .a_string_array_param(
                                                 vec!["a", "b", "c"]
                                                     .iter()
-                                                    .map(|i| i.to_string())
-                                                    .collect::<Vec<String>>()
+                                                    .map(ToString::to_string)
+                                                    .collect::<Vec<_>>()
                                             )
                                             .build()
                                             .unwrap()


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->
Updated our endpoint rule generation to support the new `stringArray` parameter type

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the existing `EndpointsDecoratorTest` with tests for `stringArray` 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
