### PR TITLE
CHANGELOG entry for PR:3378

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -36,8 +36,8 @@ message = """
 An operation handler can accept user-defined data types as long as they implement
 [FromParts<Protocol>](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html).
 The trait has an associated type [`Rejection`](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html#associatedtype.Rejection).
-Whatever data type is set for `Rejection` must now implement (at least) `std::fmt::Display`.
-Additionally, it is recommended to implement `std::error::Error` for that type.
+Whatever data type is set for `Rejection` must now implement (at least) [`std::fmt::Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html).
+Additionally, it is recommended to implement [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html) for that type.
 
 This requirement is necessary to help us write error log entries when the parameter that the operation handler expects fails to be
 constructed from the request parts.

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,20 @@ message = "Fix bug where stalled stream protection would panic with an underflow
 references = ["smithy-rs#3744"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "Velfi"
+
+[[smithy-rs]]
+message = """
+`FromParts<Protocol>::Rejection` must implement `std::fmt::Display`.
+
+An operation handler can accept user-defined data types as long as they implement
+[FromParts<Protocol>](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html).
+The trait has an associated type [`Rejection`](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html#associatedtype.Rejection).
+Whatever data type is set for `Rejection` must now implement (at least) `std::fmt::Display`.
+Additionally, it is recommended to implement `std::error::Error` for that type.
+
+This requirement is necessary to help us write error log entries when the parameter that the operation handler expects fails to be
+constructed from the request parts.
+"""
+references = ["smithy-rs#3746"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
+author = "drganjoo"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -33,14 +33,11 @@ author = "Velfi"
 message = """
 `FromParts<Protocol>::Rejection` must implement `std::fmt::Display`.
 
-An operation handler can accept user-defined data types as long as they implement
-[FromParts<Protocol>](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html).
-The trait has an associated type [`Rejection`](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html#associatedtype.Rejection).
-Whatever data type is set for `Rejection` must now implement (at least) [`std::fmt::Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html).
-Additionally, it is recommended to implement [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html) for that type.
+Handlers can accept user-defined types if they implement 
+[FromParts<Protocol>](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html) with a `Rejection` 
+type that implements `std::fmt::Display` (preferably `std::error::Error`) to enable error logging when parameter construction from request parts fails.
 
-This requirement is necessary to help us write error log entries when the parameter that the operation handler expects fails to be
-constructed from the request parts.
+See the [changelog discussion for futher details](https://github.com/smithy-lang/smithy-rs/discussions/3749).
 """
 references = ["smithy-rs#3746"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }


### PR DESCRIPTION
Adds an entry to CHANGELOG.next.toml for the [PR:3378](https://github.com/smithy-lang/smithy-rs/pull/3378) 