### PR TITLE
Refactor determining server error type when deserializing an `@httpPayload`

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/http/ServerRequestBindingGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/http/ServerRequestBindingGenerator.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy.generators.http
 
-import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
@@ -20,12 +19,12 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.http.HttpBindi
 import software.amazon.smithy.rust.codegen.core.smithy.generators.http.HttpMessageType
 import software.amazon.smithy.rust.codegen.core.smithy.mapRustType
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBindingDescriptor
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
+import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocol
 import software.amazon.smithy.rust.codegen.server.smithy.targetCanReachConstrainedShape
 
 class ServerRequestBindingGenerator(
-    protocol: Protocol,
+    val protocol: ServerProtocol,
     codegenContext: ServerCodegenContext,
     operationShape: OperationShape,
     additionalHttpBindingCustomizations: List<HttpBindingCustomization> = listOf(),
@@ -50,12 +49,11 @@ class ServerRequestBindingGenerator(
 
     fun generateDeserializePayloadFn(
         binding: HttpBindingDescriptor,
-        errorSymbol: Symbol,
         structuredHandler: RustWriter.(String) -> Unit,
     ): RuntimeType =
         httpBindingGenerator.generateDeserializePayloadFn(
             binding,
-            errorSymbol,
+            protocol.deserializeHttpPayloadErrorType(binding).toSymbol(),
             structuredHandler,
             HttpMessageType.REQUEST,
         )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/http/ServerRequestBindingGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/http/ServerRequestBindingGenerator.kt
@@ -53,7 +53,7 @@ class ServerRequestBindingGenerator(
     ): RuntimeType =
         httpBindingGenerator.generateDeserializePayloadFn(
             binding,
-            protocol.deserializeHttpPayloadErrorType(binding).toSymbol(),
+            protocol.deserializePayloadErrorType(binding).toSymbol(),
             structuredHandler,
             HttpMessageType.REQUEST,
         )


### PR DESCRIPTION
Determining the error type when deserializing an `@httpPayload` is a
protocol-specific concern, and as such should not live in
`ServerHttpBoundProtocolGenerator`, which should remain
protocol-agnostic. This commits makes that determination part of the
`ServerProtocol` interface.

As a drive-by improvement, the companion object in
`ServerHttpBoundProtocolGenerator` has also been removed, since its
members have been unused for a long time.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
