### PR TITLE
Re-export `HttpRequest` and `HttpResponse` in client crates

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -24,7 +24,7 @@ meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
 author = "landonxjames"
 
 [[aws-sdk-rust]]
-message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported AWS SDK clients so that using these types doen not require directly depending on `aws-smithy-runtime-api`."
+message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in AWS SDK clients so that using these types doen not require directly depending on `aws-smithy-runtime-api`."
 references = ["smithy-rs#3591"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ysaito1001"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,3 +22,15 @@ message = "Add support for `operationContextParams` Endpoints trait"
 references = ["smithy-rs#3755"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
 author = "landonxjames"
+
+[[aws-sdk-rust]]
+message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported AWS SDK clients so that using these types doen not require directly depending on `aws-smithy-runtime-api`."
+references = ["smithy-rs#3591"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "ysaito1001"
+
+[[smithy-rs]]
+message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in generated clients so that using these types doen not require directly depending on `aws-smithy-runtime-api`."
+references = ["smithy-rs#3591"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+author = "ysaito1001"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -24,13 +24,13 @@ meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
 author = "landonxjames"
 
 [[aws-sdk-rust]]
-message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in AWS SDK clients so that using these types doen not require directly depending on `aws-smithy-runtime-api`."
+message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in AWS SDK clients so that using these types does not require directly depending on `aws-smithy-runtime-api`."
 references = ["smithy-rs#3591"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ysaito1001"
 
 [[smithy-rs]]
-message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in generated clients so that using these types doen not require directly depending on `aws-smithy-runtime-api`."
+message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in generated clients so that using these types does not require directly depending on `aws-smithy-runtime-api`."
 references = ["smithy-rs#3591"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "ysaito1001"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -68,14 +68,17 @@ object ClientRustModule {
         /** crate::config::endpoint */
         val endpoint = RustModule.public("endpoint", parent = self)
 
+        /** crate::config::http */
+        val http = RustModule.public("http", parent = self)
+
+        /** crate::config::interceptors */
+        val interceptors = RustModule.public("interceptors", parent = self)
+
         /** crate::config::retry */
         val retry = RustModule.public("retry", parent = self)
 
         /** crate::config::timeout */
         val timeout = RustModule.public("timeout", parent = self)
-
-        /** crate::config::interceptors */
-        val interceptors = RustModule.public("interceptors", parent = self)
     }
 
     val Error = RustModule.public("error")
@@ -122,6 +125,7 @@ class ClientModuleDocProvider(
             ClientRustModule.Config.endpoint -> strDoc("Types needed to configure endpoint resolution.")
             ClientRustModule.Config.retry -> strDoc("Retry configuration.")
             ClientRustModule.Config.timeout -> strDoc("Timeout configuration.")
+            ClientRustModule.Config.http -> strDoc("HTTP request and response types.")
             ClientRustModule.Config.interceptors -> strDoc("Types needed to implement [`Intercept`](crate::config::Intercept).")
             ClientRustModule.Error -> strDoc("Common errors and error handling utilities.")
             ClientRustModule.Operation -> strDoc("All operations that this crate can perform.")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
@@ -56,6 +56,16 @@ class ClientRuntimeTypesReExportGenerator(
                 "ShouldAttempt" to smithyRuntimeApi.resolve("client::retries::ShouldAttempt"),
             )
         }
+        rustCrate.withModule(ClientRustModule.Config.http) {
+            rustTemplate(
+                """
+                pub use #{HttpRequest};
+                pub use #{HttpResponse};
+                """,
+                "HttpRequest" to smithyRuntimeApi.resolve("client::orchestrator::HttpRequest"),
+                "HttpResponse" to smithyRuntimeApi.resolve("client::orchestrator::HttpResponse"),
+            )
+        }
         rustCrate.withModule(ClientRustModule.Config.interceptors) {
             rustTemplate(
                 """

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGeneratorTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+
+class ClientRuntimeTypesReExportGeneratorTest {
+    private val model =
+        """
+        namespace test
+        use aws.protocols#awsJson1_0
+
+        @awsJson1_0
+        service HelloService {
+            operations: [],
+            version: "1"
+        }
+        """.asSmithyModel()
+
+    @Test
+    fun `it should reexport client runtime types`() {
+        clientIntegrationTest(model) { _, crate ->
+            crate.unitTest {
+                rust(
+                    """
+                    ##[allow(unused_imports)]
+                    {
+                        use crate::config::ConfigBag;
+                        use crate::config::RuntimeComponents;
+                        use crate::config::IdentityCache;
+
+                        use crate::config::endpoint::SharedEndpointResolver;
+                        use crate::config::endpoint::EndpointFuture;
+                        use crate::config::endpoint::Endpoint;
+
+                        use crate::config::retry::ClassifyRetry;
+                        use crate::config::retry::RetryAction;
+                        use crate::config::retry::ShouldAttempt;
+
+                        use crate::config::http::HttpRequest;
+                        use crate::config::http::HttpResponse;
+
+                        use crate::config::interceptors::AfterDeserializationInterceptorContextRef;
+                        use crate::config::interceptors::BeforeDeserializationInterceptorContextMut;
+                        use crate::config::interceptors::BeforeDeserializationInterceptorContextRef;
+                        use crate::config::interceptors::BeforeSerializationInterceptorContextMut;
+                        use crate::config::interceptors::BeforeSerializationInterceptorContextRef;
+                        use crate::config::interceptors::BeforeTransmitInterceptorContextMut;
+                        use crate::config::interceptors::BeforeTransmitInterceptorContextRef;
+                        use crate::config::interceptors::FinalizerInterceptorContextMut;
+                        use crate::config::interceptors::FinalizerInterceptorContextRef;
+                        use crate::config::interceptors::InterceptorContext;
+
+                        use crate::error::BoxError;
+                    }
+                    """,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
https://github.com/smithy-lang/smithy-rs/issues/3591

## Description
In early days of smithy-rs, we used to re-export [Request](https://docs.rs/aws-sdk-s3/0.25.0/aws_sdk_s3/client/customize/struct.Request.html) and [Response](https://docs.rs/aws-sdk-s3/0.25.0/aws_sdk_s3/client/customize/struct.Request.html) types. When we overhauled the underlying smithy runtime from middleware to orchestrator, we did not re-export the corresponding types [HttpRequest](https://docs.rs/aws-smithy-runtime-api/latest/aws_smithy_runtime_api/client/orchestrator/type.HttpRequest.html) and [HttpResponse](https://docs.rs/aws-smithy-runtime-api/latest/aws_smithy_runtime_api/client/orchestrator/type.HttpResponse.html) to client crates.

This PR will re-export them in `crate::config::http`.

## Testing
Added a new test file for `ClientRuntimeTypesReExportGenerator.kt` that verifies re-exports.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
