### PR TITLE
Add support for changelog entry markdown files

### DIFF
--- a/tools/ci-build/changelogger/Cargo.lock
+++ b/tools/ci-build/changelogger/Cargo.lock
@@ -998,6 +998,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1033,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "toml 0.5.11",
  "tracing",
@@ -1328,6 +1342,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/tools/ci-build/sdk-lints/Cargo.lock
+++ b/tools/ci-build/sdk-lints/Cargo.lock
@@ -931,6 +931,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +966,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "toml 0.5.11",
  "tracing",
@@ -1240,6 +1254,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/tools/ci-build/sdk-lints/src/changelog.rs
+++ b/tools/ci-build/sdk-lints/src/changelog.rs
@@ -6,7 +6,7 @@
 use crate::lint::LintError;
 use crate::{repo_root, Check, Lint};
 use anyhow::Result;
-use smithy_rs_tool_common::changelog::{Changelog, ValidationSet};
+use smithy_rs_tool_common::changelog::{ChangelogLoader, ValidationSet};
 use std::path::{Path, PathBuf};
 
 pub(crate) struct ChangelogNext;
@@ -30,9 +30,14 @@ impl Check for ChangelogNext {
     }
 }
 
+// TODO(file-per-change-changelog): Use `.load_from_dir` to read from the `.changelog` directory
+//  and run the validation only when the directory has at least one changelog entry file, otherwise
+//  a default constructed `ChangeLog` won't pass the validation.
 /// Validate that `CHANGELOG.next.toml` follows best practices
 fn check_changelog_next(path: impl AsRef<Path>) -> std::result::Result<(), Vec<LintError>> {
-    let parsed = Changelog::load_from_file(path).map_err(|e| vec![LintError::via_display(e)])?;
+    let parsed = ChangelogLoader::default()
+        .load_from_file(path)
+        .map_err(|e| vec![LintError::via_display(e)])?;
     parsed
         .validate(ValidationSet::Development)
         .map_err(|errs| {

--- a/tools/ci-build/smithy-rs-tool-common/Cargo.toml
+++ b/tools/ci-build/smithy-rs-tool-common/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.11.10", features = ["blocking"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 thiserror = "1.0.56"
 tokio = { version = "1.20.1", features = ["rt", "macros"], optional = true }
 toml = { version = "0.5.8", features = ["preserve_order"] }

--- a/tools/ci-build/smithy-rs-tool-common/src/changelog/parser.rs
+++ b/tools/ci-build/smithy-rs-tool-common/src/changelog/parser.rs
@@ -1,0 +1,340 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::changelog::{Authors, Changelog, HandAuthoredEntry, Meta, Reference, SdkAffected};
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fmt::Debug;
+
+pub(crate) trait ParseIntoChangelog: Debug {
+    fn parse(&self, value: &str) -> Result<Changelog>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct Toml;
+impl ParseIntoChangelog for Toml {
+    fn parse(&self, value: &str) -> Result<Changelog> {
+        let mut changelog: Changelog =
+            toml::from_str(value).context("Invalid TOML changelog format")?;
+        // all smithry-rs entries should have meta.target set to the default value instead of None
+        // TODO(file-per-change-changelog): Remove the following fix-up once we have switched over
+        //  to the new markdown format since it won't be needed.
+        for entry in &mut changelog.smithy_rs {
+            if entry.meta.target.is_none() {
+                entry.meta.target = Some(SdkAffected::default());
+            }
+        }
+        Ok(changelog)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Json;
+impl ParseIntoChangelog for Json {
+    fn parse(&self, value: &str) -> Result<Changelog> {
+        // Remove comments from the top
+        let value = value
+            .split('\n')
+            .filter(|line| !line.trim().starts_with('#'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        serde_json::from_str(&value).context("Invalid JSON changelog format")
+    }
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Hash, Serialize, PartialEq, Eq)]
+enum Target {
+    #[serde(rename = "client")]
+    Client,
+    #[serde(rename = "server")]
+    Server,
+    #[serde(rename = "aws-sdk-rust")]
+    AwsSdk,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct FrontMatter {
+    applies_to: HashSet<Target>,
+    authors: Authors,
+    references: Vec<Reference>,
+    breaking: bool,
+    new_feature: bool,
+    bug_fix: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Markdown {
+    front_matter: FrontMatter,
+    message: String,
+}
+
+impl From<Markdown> for Changelog {
+    fn from(value: Markdown) -> Self {
+        let front_matter = value.front_matter;
+        let entry = HandAuthoredEntry {
+            message: value.message.trim_start().to_owned(),
+            meta: Meta {
+                bug: front_matter.bug_fix,
+                breaking: front_matter.breaking,
+                tada: front_matter.new_feature,
+                target: None,
+            },
+            authors: front_matter.authors,
+            references: front_matter.references,
+            since_commit: None,
+            age: None,
+        };
+
+        let mut changelog = Changelog::new();
+
+        // Bin `entry` into the appropriate `Vec` based on the `applies_to` field in `front_matter`
+        if front_matter.applies_to.contains(&Target::AwsSdk) {
+            changelog.aws_sdk_rust.push(entry.clone())
+        }
+        if front_matter.applies_to.contains(&Target::Client)
+            && front_matter.applies_to.contains(&Target::Server)
+        {
+            let mut entry = entry.clone();
+            entry.meta.target = Some(SdkAffected::All);
+            changelog.smithy_rs.push(entry);
+        } else if front_matter.applies_to.contains(&Target::Client) {
+            let mut entry = entry.clone();
+            entry.meta.target = Some(SdkAffected::Client);
+            changelog.smithy_rs.push(entry);
+        } else if front_matter.applies_to.contains(&Target::Server) {
+            let mut entry = entry.clone();
+            entry.meta.target = Some(SdkAffected::Server);
+            changelog.smithy_rs.push(entry);
+        }
+
+        changelog
+    }
+}
+
+impl ParseIntoChangelog for Markdown {
+    fn parse(&self, value: &str) -> Result<Changelog> {
+        let mut parts = value.splitn(3, "---");
+        let _ = parts.next(); // Skip first empty element
+        let front_matter_str = parts
+            .next()
+            .context("front matter should follow the opening `---`")?;
+        let message = parts
+            .next()
+            .context("message should be included in changelog entry")?;
+
+        let markdown = Markdown {
+            front_matter: serde_yaml::from_str(front_matter_str)?,
+            message: message.to_owned(),
+        };
+
+        Ok(markdown.into())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ParserChain {
+    parsers: Vec<(&'static str, Box<dyn ParseIntoChangelog>)>,
+}
+
+impl Default for ParserChain {
+    fn default() -> Self {
+        Self {
+            parsers: vec![
+                ("markdown", Box::<Markdown>::default()),
+                ("toml", Box::<Toml>::default()),
+                ("json", Box::<Json>::default()),
+            ],
+        }
+    }
+}
+
+impl ParseIntoChangelog for ParserChain {
+    fn parse(&self, value: &str) -> Result<Changelog> {
+        for (name, parser) in &self.parsers {
+            match parser.parse(value) {
+                Ok(parsed) => {
+                    return Ok(parsed);
+                }
+                Err(err) => {
+                    tracing::debug!(parser = %name, err = %err, "failed to parse the input string");
+                }
+            }
+        }
+        bail!("no parsers in chain parsed ${value} into `Changelog`")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_json() {
+        let json = r#"
+            # Example changelog entries
+            # [[aws-sdk-rust]]
+            # message = "Fix typos in module documentation for generated crates"
+            # references = ["smithy-rs#920"]
+            # meta = { "breaking" = false, "tada" = false, "bug" = false }
+            # author = "rcoh"
+            #
+            # [[smithy-rs]]
+            # message = "Fix typos in module documentation for generated crates"
+            # references = ["smithy-rs#920"]
+            # meta = { "breaking" = false, "tada" = false, "bug" = false }
+            # author = "rcoh"
+            {
+                "smithy-rs": [],
+                "aws-sdk-rust": [
+                    {
+                        "message": "Some change",
+                        "meta": { "bug": true, "breaking": false, "tada": false },
+                        "author": "test-dev",
+                        "references": [
+                            "aws-sdk-rust#123",
+                            "smithy-rs#456"
+                        ]
+                    }
+                ],
+                "aws-sdk-model": [
+                    {
+                        "module": "aws-sdk-ec2",
+                        "version": "0.12.0",
+                        "kind": "Feature",
+                        "message": "Some API change"
+                    }
+                ]
+            }
+        "#;
+        let changelog = Json::default().parse(json).unwrap();
+        assert!(changelog.smithy_rs.is_empty());
+        assert_eq!(1, changelog.aws_sdk_rust.len());
+        assert_eq!("Some change", changelog.aws_sdk_rust[0].message);
+        assert_eq!(1, changelog.sdk_models.len());
+        assert_eq!("Some API change", changelog.sdk_models[0].message);
+    }
+
+    #[test]
+    fn parse_toml() {
+        // TODO(file-per-change-changelog): We keep the following test string while transitioning
+        //  to the new markdown format. Once we have switched to the new format, only use
+        //  `[[aws-sdk-model]]` in the test string because after the cutover, `[[aws-sdk-rust]]` or
+        //  `[[smithy-rs]]` are not a recommended way of writing changelogs.
+        let toml = r#"
+            [[aws-sdk-rust]]
+            message = "Fix typos in module documentation for generated crates"
+            references = ["smithy-rs#920"]
+            meta = { "breaking" = false, "tada" = false, "bug" = false }
+            author = "rcoh"
+            [[smithy-rs]]
+            message = "Fix typos in module documentation for generated crates"
+            references = ["smithy-rs#920"]
+            meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+            author = "rcoh"
+            [[smithy-rs]]
+            message = "Fix typos in module documentation for generated crates"
+            references = ["smithy-rs#920"]
+            meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server" }
+            author = "rcoh"
+            [[smithy-rs]]
+            message = "Fix typos in module documentation for generated crates"
+            references = ["smithy-rs#920"]
+            meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
+            author = "rcoh"
+            [[smithy-rs]]
+            message = "Fix typos in module documentation for generated crates"
+            references = ["smithy-rs#920"]
+            meta = { "breaking" = false, "tada" = false, "bug" = false }
+            author = "rcoh"
+        "#;
+        let changelog = Toml::default().parse(toml).unwrap();
+        assert_eq!(4, changelog.smithy_rs.len());
+        assert_eq!(
+            Some(SdkAffected::Client),
+            changelog.smithy_rs[0].meta.target,
+        );
+        assert_eq!(
+            Some(SdkAffected::Server),
+            changelog.smithy_rs[1].meta.target,
+        );
+        assert_eq!(Some(SdkAffected::All), changelog.smithy_rs[2].meta.target);
+        assert_eq!(Some(SdkAffected::All), changelog.smithy_rs[3].meta.target);
+    }
+
+    #[test]
+    fn parse_markdown() {
+        {
+            let markdown = r#"---
+applies_to: ["client", "server", "aws-sdk-rust"]
+authors: ["landonxjames","todaaron"]
+references: ["smithy-rs#123"]
+breaking: false
+new_feature: false
+bug_fix: false
+---
+# Markdown Content
+This is some **Markdown** content.
+"#;
+            let changelog = Markdown::default().parse(markdown).unwrap();
+            assert_eq!(1, changelog.smithy_rs.len());
+            assert_eq!(Some(SdkAffected::All), changelog.smithy_rs[0].meta.target);
+            assert_eq!(
+                "# Markdown Content\nThis is some **Markdown** content.\n",
+                &changelog.smithy_rs[0].message
+            );
+            // Should duplicate this entry into the SDK changelog by virtue of `aws-sdk-rust`
+            assert_eq!(1, changelog.aws_sdk_rust.len());
+        }
+        {
+            let markdown = r#"---
+applies_to: ["client"]
+authors: ["velfi"]
+references: ["smithy-rs#456", "aws-sdk-rust#1234"]
+breaking: false
+new_feature: false
+bug_fix: false
+---
+# Markdown Content
+This is some **Markdown** content.
+"#;
+            let changelog = Markdown::default().parse(markdown).unwrap();
+            assert_eq!(1, changelog.smithy_rs.len());
+            assert_eq!(
+                Some(SdkAffected::Client),
+                changelog.smithy_rs[0].meta.target
+            );
+            assert_eq!(
+                "# Markdown Content\nThis is some **Markdown** content.\n",
+                &changelog.smithy_rs[0].message
+            );
+            assert!(changelog.aws_sdk_rust.is_empty());
+        }
+        {
+            let markdown = r#"---
+applies_to: ["server"]
+authors: ["david-perez", "drganjoo"]
+references: ["smithy-rs#789"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+# Markdown Content
+This is some **Markdown** content.
+"#;
+            let changelog = Markdown::default().parse(markdown).unwrap();
+            assert_eq!(1, changelog.smithy_rs.len());
+            assert_eq!(
+                Some(SdkAffected::Server),
+                changelog.smithy_rs[0].meta.target
+            );
+            assert_eq!(
+                "# Markdown Content\nThis is some **Markdown** content.\n",
+                &changelog.smithy_rs[0].message
+            );
+            assert!(changelog.aws_sdk_rust.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
[RFC: File-per-change changelog](https://smithy-lang.github.io/smithy-rs/design/rfcs/rfc0042_file_per_change_changelog.html#rfc-file-per-change-changelog)

## Description
This PR is the first of the two implementing the proposal outlined in the RFC, and it focuses on the initial 4 bullets in the [Changes checklist](https://smithy-lang.github.io/smithy-rs/design/rfcs/rfc0042_file_per_change_changelog.html#changes-checklist). Crucially, this update does not modify the workflow for developers regarding changelog entries (editing `CHANGELOG.next.toml` remains necessary) or impact the `smithy-rs` CI process and our release pipeline.

The PR introduces support for deserializing the following Markdown front matter in the YAML format described in the RFC, e.g.
```
---
# Adding `aws-sdk-rust` here duplicates this entry into the SDK changelog.
applies_to: ["client", "server", "aws-sdk-rust"]
authors: ["author1", "author2"]
references: ["smithy-rs#1234", "aws-sdk-rust#1234"]
# The previous `meta` section is broken up into its constituents:
breaking: false
# This replaces "tada":
new_feature: false
bug_fix: false
---

Some message for the change.
```
These changelog entry Markdown files will be saved in the `smithy-rs/.changelog` directory:
```
┌───────────┐                  
│ smithy-rs │                  
└─────┬─────┘                  
      │                        
      │    ┌───────────┐       
      ├────┤.changelog │       
           └─────┬─────┘       
                 │             
                 ├─────test1.md  
                 │ 
                 └─────test2.md 
```
For a concrete example, see a test `end_to_end_changelog_entry_markdown_files` that directly converts from  `end_to_end_changelog` and uses Markdown files (the expected test results remain the same).

The next PR is expected to
- add new subcommands to `changelogger` to a) create a Markdown file and b) preview changelog entries pending to be released
- port existing `CHANGELOG.next.toml` at that time to individual Markdown files
- update `sdk-lints` to disallow the existence of `CHANGELOG.next.toml`
- pass a directory path for `smithy-rs/.changelog` to `--source` (one for [split](https://github.com/smithy-lang/smithy-rs/blob/dc970b37386b155eced5d41262ce0a7fc4a34a91/tools/ci-scripts/generate-smithy-rs-release#L22) and one for [render](https://github.com/smithy-lang/smithy-rs/blob/dc970b37386b155eced5d41262ce0a7fc4a34a91/tools/ci-scripts/generate-smithy-rs-release#L22)) and to [--source-to-truncate](https://github.com/smithy-lang/smithy-rs/blob/dc970b37386b155eced5d41262ce0a7fc4a34a91/tools/ci-scripts/generate-smithy-rs-release#L23C1-L23C47)

(the 4th bullet effectively does the cutover to the new changelog mode)

## Testing
- Added `parse_markdown` and `end_to_end_changelog_entry_markdown_files` for testing new changelog format (the rest of the tests showing up in the diff are moved from different places)
- Confirmed via [a release dry-run](https://github.com/smithy-lang/smithy-rs/actions/runs/9947165056) that this PR does not break the existing `smithy-rs` release process
- Confirmed that this PR does not break the use of `changelogger` in our internal release process 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
