### PR TITLE
Bump `aws-smithy-http-server-python` version number

### DIFF
--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.62.1"
+version = "0.63.1"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
The Python server relies on types defined in `aws-smithy-http-server`, which has a new version published. A new version of the Python server should be released to ensure there is only one `aws-smithy-http-server` in the dependency closure of the generated crates.