### PR TITLE
Add client-support for RPC v2 CBOR

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,11 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = """
+Add support for <a href="https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html">the Smithy RPC v2 CBOR protocol</a> both on the client and on the server.
+"""
+references = ["smithy-rs#2544", "smithy-rs#3767"]
+meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all" }
+author = ["david-perez", "jjant", "ysaito1001"]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,3 +22,9 @@ message = "Fix incorrect redaction of `@sensitive` types in maps and lists."
 references = ["smithy-rs#3765",  "smithy-rs#3757"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "landonxjames"
+
+[[smithy-rs]]
+message = "Fix client error correction to properly parse structure members that target a `Union` containing that structure recursively."
+references = ["smithy-rs#3767"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
+author = "ysaito1001"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -25,7 +25,7 @@ author = "landonxjames"
 
 [[smithy-rs]]
 message = """
-Add support for <a href="https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html">the Smithy RPC v2 CBOR protocol</a> both on the client and on the server.
+Add initial support for [the Smithy RPC v2 CBOR protocol](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html) both on the client and on the server. The remaining work, including event streams, is being tracked under [this umbrella issue](https://github.com/smithy-lang/smithy-rs/issues/3573).
 """
 references = ["smithy-rs#2544", "smithy-rs#3767"]
 meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all" }

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,11 +22,3 @@ message = "Fix incorrect redaction of `@sensitive` types in maps and lists."
 references = ["smithy-rs#3765",  "smithy-rs#3757"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "landonxjames"
-
-[[smithy-rs]]
-message = """
-Add initial support for [the Smithy RPC v2 CBOR protocol](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html) both on the client and on the server. The remaining work, including event streams, is being tracked under [this umbrella issue](https://github.com/smithy-lang/smithy-rs/issues/3573).
-"""
-references = ["smithy-rs#2544", "smithy-rs#3767"]
-meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all" }
-author = ["david-perez", "jjant", "ysaito1001"]

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -24,6 +24,7 @@ val workingDirUnderBuildDir = "smithyprojections/codegen-client-test/"
 dependencies {
     implementation(project(":codegen-client"))
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-protocol-tests:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
 }
@@ -72,6 +73,12 @@ val allCodegenTests = listOf(
     ClientTest("aws.protocoltests.restxml#RestXml", "rest_xml", addMessageToErrors = false),
     ClientTest("aws.protocoltests.query#AwsQuery", "aws_query", addMessageToErrors = false),
     ClientTest("aws.protocoltests.ec2#AwsEc2", "ec2_query", addMessageToErrors = false),
+    ClientTest("smithy.protocoltests.rpcv2Cbor#RpcV2Protocol", "rpcv2Cbor"),
+    ClientTest(
+        "smithy.protocoltests.rpcv2Cbor#RpcV2CborService",
+        "rpcv2Cbor_extras",
+        dependsOn = listOf("rpcv2Cbor-extras.smithy")
+    ),
     ClientTest(
         "aws.protocoltests.restxml.xmlns#RestXmlWithNamespace",
         "rest_xml_namespace",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ErrorCorrection.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ErrorCorrection.kt
@@ -87,7 +87,18 @@ private fun ClientCodegenContext.errorCorrectedDefault(member: MemberShape): Wri
 
             target is TimestampShape -> instantiator.instantiate(target, Node.from(0)).some()(this)
             target is BlobShape -> instantiator.instantiate(target, Node.from("")).some()(this)
-            target is UnionShape -> rust("Some(#T::Unknown)", targetSymbol)
+            target is UnionShape ->
+                rustTemplate(
+                    "Some(#{unknown})", *preludeScope,
+                    "unknown" to
+                        writable {
+                            if (memberSymbol.isRustBoxed()) {
+                                rust("Box::new(#T::Unknown)", targetSymbol)
+                            } else {
+                                rust("#T::Unknown", targetSymbol)
+                            }
+                        },
+                )
         }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -19,7 +19,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolPayloadGenerator
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.findStreamingMember
@@ -125,10 +124,8 @@ class RequestSerializerGenerator(
         )
     }
 
-    private fun needsContentLength(operationShape: OperationShape): Boolean {
-        return protocol.httpBindingResolver.requestBindings(operationShape)
-            .any { it.location == HttpLocation.DOCUMENT || it.location == HttpLocation.PAYLOAD }
-    }
+    private fun needsContentLength(operationShape: OperationShape): Boolean =
+        protocol.needsRequestContentLength(operationShape)
 
     private fun createHttpRequest(operationShape: OperationShape): Writable =
         writable {

--- a/codegen-core/common-test-models/rpcv2Cbor-extras.smithy
+++ b/codegen-core/common-test-models/rpcv2Cbor-extras.smithy
@@ -149,9 +149,9 @@ apply ErrorSerializationOperation @httpResponseTests([
         id: "OperationOutputSerializationQuestionablyIncludesTypeField",
         documentation: """
         Despite the operation output being a structure shape with the `@error` trait,
-        `__type` field should, in a strict interpretation of the spec, not be included, 
-        because we're not serializing a server error response. However, we do, because 
-        there shouldn't™️ be any harm in doing so, and it greatly simplifies the 
+        `__type` field should, in a strict interpretation of the spec, not be included,
+        because we're not serializing a server error response. However, we do, because
+        there shouldn't™️ be any harm in doing so, and it greatly simplifies the
         code generator. This test just pins this behavior in case we ever modify it.""",
         protocol: rpcv2Cbor,
         code: 200,
@@ -170,6 +170,12 @@ apply SimpleStructOperation @httpResponseTests([
         id: "SimpleStruct",
         protocol: rpcv2Cbor,
         code: 200, // Not used.
+        body: "v2RibG9iS2Jsb2JieSBibG9iZ2Jvb2xlYW70ZnN0cmluZ3hwVGhlcmUgYXJlIHRocmVlIHRoaW5ncyBhbGwgd2lzZSBtZW4gZmVhcjogdGhlIHNlYSBpbiBzdG9ybSwgYSBuaWdodCB3aXRoIG5vIG1vb24sIGFuZCB0aGUgYW5nZXIgb2YgYSBnZW50bGUgbWFuLmRieXRlGEVlc2hvcnQYRmdpbnRlZ2VyGEdkbG9uZxhIZWZsb2F0+j8wo9dmZG91Ymxl+z/mTQE6kqMFaXRpbWVzdGFtcMH7QdcKq2AAAABkZW51bWdESUFNT05EbHJlcXVpcmVkQmxvYktibG9iYnkgYmxvYm9yZXF1aXJlZEJvb2xlYW70bnJlcXVpcmVkU3RyaW5neHBUaGVyZSBhcmUgdGhyZWUgdGhpbmdzIGFsbCB3aXNlIG1lbiBmZWFyOiB0aGUgc2VhIGluIHN0b3JtLCBhIG5pZ2h0IHdpdGggbm8gbW9vbiwgYW5kIHRoZSBhbmdlciBvZiBhIGdlbnRsZSBtYW4ubHJlcXVpcmVkQnl0ZRhFbXJlcXVpcmVkU2hvcnQYRm9yZXF1aXJlZEludGVnZXIYR2xyZXF1aXJlZExvbmcYSG1yZXF1aXJlZEZsb2F0+j8wo9ducmVxdWlyZWREb3VibGX7P+ZNATqSowVxcmVxdWlyZWRUaW1lc3RhbXDB+0HXCqtgAAAAbHJlcXVpcmVkRW51bWdESUFNT05E/w==",
+        bodyMediaType: "application/cbor",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
+        },
         params: {
             blob: "blobby blob",
             boolean: false,
@@ -211,6 +217,12 @@ apply SimpleStructOperation @httpResponseTests([
         id: "SimpleStructWithOptionsSetToNone",
         protocol: rpcv2Cbor,
         code: 200, // Not used.
+        body: "v2xyZXF1aXJlZEJsb2JLYmxvYmJ5IGJsb2JvcmVxdWlyZWRCb29sZWFu9G5yZXF1aXJlZFN0cmluZ3hwVGhlcmUgYXJlIHRocmVlIHRoaW5ncyBhbGwgd2lzZSBtZW4gZmVhcjogdGhlIHNlYSBpbiBzdG9ybSwgYSBuaWdodCB3aXRoIG5vIG1vb24sIGFuZCB0aGUgYW5nZXIgb2YgYSBnZW50bGUgbWFuLmxyZXF1aXJlZEJ5dGUYRW1yZXF1aXJlZFNob3J0GEZvcmVxdWlyZWRJbnRlZ2VyGEdscmVxdWlyZWRMb25nGEhtcmVxdWlyZWRGbG9hdPo/MKPXbnJlcXVpcmVkRG91Ymxl+z/mTQE6kqMFcXJlcXVpcmVkVGltZXN0YW1wwftB1wqrYAAAAGxyZXF1aXJlZEVudW1nRElBTU9ORP8=",
+        bodyMediaType: "application/cbor",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
+        },
         params: {
             requiredBlob: "blobby blob",
             requiredBoolean: false,

--- a/codegen-core/common-test-models/rpcv2Cbor-extras.smithy
+++ b/codegen-core/common-test-models/rpcv2Cbor-extras.smithy
@@ -130,7 +130,8 @@ apply ErrorSerializationOperation @httpMalformedRequestTests([
                 "Content-Type": "application/cbor"
             }
             // An empty CBOR map. We're missing a lot of `@required` members!
-            body: "oA=="
+            body: "oA==",
+            bodyMediaType: "application/cbor"
         },
         response: {
             code: 400,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -147,6 +147,14 @@ class InlineDependency(
                 CargoDependency.smithyTypes(runtimeConfig),
             )
 
+        fun cborErrors(runtimeConfig: RuntimeConfig): InlineDependency =
+            forInlineableRustFile(
+                "cbor_errors",
+                CargoDependency.smithyCbor(runtimeConfig),
+                CargoDependency.smithyRuntimeApi(runtimeConfig),
+                CargoDependency.smithyTypes(runtimeConfig),
+            )
+
         fun ec2QueryErrors(runtimeConfig: RuntimeConfig): InlineDependency =
             forInlineableRustFile("ec2_query_errors", CargoDependency.smithyXml(runtimeConfig))
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -519,6 +519,8 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         )
 
         // inlinable types
+        fun cborErrors(runtimeConfig: RuntimeConfig) = forInlineDependency(InlineDependency.cborErrors(runtimeConfig))
+
         fun ec2QueryErrors(runtimeConfig: RuntimeConfig) =
             forInlineDependency(InlineDependency.ec2QueryErrors(runtimeConfig))
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/Protocol.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/Protocol.kt
@@ -78,6 +78,13 @@ interface Protocol {
      * there are no response headers or statuses available to further inform the error parsing.
      */
     fun parseEventStreamErrorMetadata(operationShape: OperationShape): RuntimeType
+
+    /**
+     * Determines whether the `Content-Length` header should be set in an HTTP request.
+     */
+    fun needsRequestContentLength(operationShape: OperationShape): Boolean =
+        httpBindingResolver.requestBindings(operationShape)
+            .any { it.location == HttpLocation.DOCUMENT || it.location == HttpLocation.PAYLOAD }
 }
 
 typealias ProtocolMap<T, C> = Map<ShapeId, ProtocolGeneratorFactory<T, C>>

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RpcV2Cbor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RpcV2Cbor.kt
@@ -144,10 +144,9 @@ open class RpcV2Cbor(val codegenContext: CodegenContext) : Protocol {
     override fun parseEventStreamErrorMetadata(operationShape: OperationShape): RuntimeType =
         TODO("rpcv2Cbor event streams have not yet been implemented")
 
-    // Unlike other protocols, RpcV2Cbor also needs to set the `Content-Length` header when the input is an empty structure, see
+    // Unlike other protocols, the `rpcv2Cbor` protocol requires that `Content-Length` is always set
+    // unless there is no input or if the operation is an event stream, see
     // https://github.com/smithy-lang/smithy/blob/6466fe77c65b8a17b219f0b0a60c767915205f95/smithy-protocol-tests/model/rpcv2Cbor/empty-input-output.smithy#L106
-    // Since we generate a synthetic empty input when the input of an operation is Unit / no input, this method can
-    // return true unconditionally.
     // TODO(https://github.com/smithy-lang/smithy-rs/issues/3772): Do not set `Content-Length` for event stream operations
-    override fun needsRequestContentLength(operationShape: OperationShape) = true
+    override fun needsRequestContentLength(operationShape: OperationShape) = operationShape.input.isPresent
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RpcV2Cbor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RpcV2Cbor.kt
@@ -144,9 +144,10 @@ open class RpcV2Cbor(val codegenContext: CodegenContext) : Protocol {
     override fun parseEventStreamErrorMetadata(operationShape: OperationShape): RuntimeType =
         TODO("rpcv2Cbor event streams have not yet been implemented")
 
-    override fun needsRequestContentLength(operationShape: OperationShape): Boolean =
-        // Unlike other protocols, RpcV2Cbor also needs to set the `Content-Length` header when the input is an empty structure, see
-        // https://github.com/smithy-lang/smithy/blob/6466fe77c65b8a17b219f0b0a60c767915205f95/smithy-protocol-tests/model/rpcv2Cbor/empty-input-output.smithy#L106
-        super.needsRequestContentLength(operationShape) ||
-            !operationShape.inputShape.hasMember()
+    // Unlike other protocols, RpcV2Cbor also needs to set the `Content-Length` header when the input is an empty structure, see
+    // https://github.com/smithy-lang/smithy/blob/6466fe77c65b8a17b219f0b0a60c767915205f95/smithy-protocol-tests/model/rpcv2Cbor/empty-input-output.smithy#L106
+    // Since we generate a synthetic empty input when the input of an operation is Unit / no input, this method can
+    // return true unconditionally.
+    // TODO(https://github.com/smithy-lang/smithy-rs/issues/3772): Do not set `Content-Legnth` for event stream operations
+    override fun needsRequestContentLength(operationShape: OperationShape) = true
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RpcV2Cbor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RpcV2Cbor.kt
@@ -148,6 +148,6 @@ open class RpcV2Cbor(val codegenContext: CodegenContext) : Protocol {
     // https://github.com/smithy-lang/smithy/blob/6466fe77c65b8a17b219f0b0a60c767915205f95/smithy-protocol-tests/model/rpcv2Cbor/empty-input-output.smithy#L106
     // Since we generate a synthetic empty input when the input of an operation is Unit / no input, this method can
     // return true unconditionally.
-    // TODO(https://github.com/smithy-lang/smithy-rs/issues/3772): Do not set `Content-Legnth` for event stream operations
+    // TODO(https://github.com/smithy-lang/smithy-rs/issues/3772): Do not set `Content-Length` for event stream operations
     override fun needsRequestContentLength(operationShape: OperationShape) = true
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
@@ -437,9 +437,6 @@ class CborParserGenerator(
                     #{StructurePairParserFn:W}
 
                     let decoder = &mut #{Decoder}::new(value);
-                    if decoder.position() == value.len() {
-                        return #{Ok}(builder);
-                    }
 
                     #{DecodeStructureMapLoop:W}
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
@@ -516,7 +516,7 @@ class CborParserGenerator(
                     if (this@CborParserGenerator.returnSymbolToParse(target).isUnconstrained) {
                         rust("decoder.string()")
                     } else {
-                        rust("decoder.string().map(|s| s.as_str().into())")
+                        rust("decoder.string().map(|s| #T::from(s.as_ref()))", symbolProvider.toSymbol(target))
                     }
                 }
                 false -> rust("decoder.string()")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
@@ -70,7 +70,9 @@ class CborParserGenerator(
     private val returnSymbolToParse: (Shape) -> ReturnSymbolToParse = { shape ->
         ReturnSymbolToParse(codegenContext.symbolProvider.toSymbol(shape), false)
     },
+    /** Lambda that controls what to do when seeing a NULL value while parsing an element for a non-sparse collection */
     private val handleNullForNonSparseCollection: (String) -> Writable,
+    /** Lambda that determines whether the input to a builder setter needs to be wrapped in `Some` */
     private val shouldWrapBuilderMemberSetterInputWithOption: (MemberShape) -> Boolean = { _ -> true },
     private val customizations: List<CborParserCustomization> = emptyList(),
 ) : StructuredDataParserGenerator {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
@@ -45,7 +45,6 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerat
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.renderUnknownVariant
 import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
-import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.isRustBoxed
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBindingResolver
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
@@ -74,6 +73,7 @@ class CborParserGenerator(
         ReturnSymbolToParse(codegenContext.symbolProvider.toSymbol(shape), false)
     },
     private val handleNullForNonSparseCollection: (String) -> Writable,
+    private val shouldWrapBuilderMemberSetterInputWithOption: (MemberShape) -> Boolean = { _ -> true },
     private val customizations: List<CborParserCustomization> = emptyList(),
 ) : StructuredDataParserGenerator {
     private val model = codegenContext.model
@@ -237,7 +237,7 @@ class CborParserGenerator(
                         val callBuilderSetMemberFieldWritable =
                             writable {
                                 withBlock("builder.${member.setterName()}(", ")") {
-                                    conditionalBlock("Some(", ")", codegenTarget != CodegenTarget.SERVER || symbolProvider.toSymbol(member).isOptional()) {
+                                    conditionalBlock("Some(", ")", shouldWrapBuilderMemberSetterInputWithOption(member)) {
                                         val symbol = symbolProvider.toSymbol(member)
                                         if (symbol.isRustBoxed()) {
                                             rustBlock("") {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.AwsJson
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.AwsJsonVersion
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBindingDescriptor
@@ -330,6 +331,9 @@ class ServerRpcV2CborProtocol(
                                 .resolve("decode::DeserializeError"),
                     )
                 }
+            },
+            shouldWrapBuilderMemberSetterInputWithOption = { member: MemberShape ->
+                codegenContext.symbolProvider.toSymbol(member).isOptional()
             },
             listOf(
                 ServerRequestBeforeBoxingDeserializedMemberConvertToMaybeConstrainedCborParserCustomization(

--- a/rust-runtime/aws-smithy-cbor/Cargo.toml
+++ b/rust-runtime/aws-smithy-cbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-cbor"
-version = "0.60.6"
+version = "0.60.7"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "David Pérez <d@vidp.dev>",

--- a/rust-runtime/aws-smithy-cbor/src/decode.rs
+++ b/rust-runtime/aws-smithy-cbor/src/decode.rs
@@ -297,6 +297,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::Decoder;
+    use aws_smithy_types::date_time::Format;
 
     #[test]
     fn test_definite_str_is_cow_borrowed() {
@@ -366,10 +367,13 @@ mod tests {
         ];
         let mut decoder = Decoder::new(&bytes);
         let timestamp = decoder.timestamp().expect("should decode timestamp");
-        // `timestamp` == 2000-01-02T20:34:56.123Z
         assert_eq!(
             timestamp,
-            aws_smithy_types::date_time::DateTime::from_secs_and_nanos(946845296, 123000000)
+            aws_smithy_types::date_time::DateTime::from_str(
+                "2000-01-02T20:34:56.123Z",
+                Format::DateTime
+            )
+            .unwrap()
         );
     }
 }

--- a/rust-runtime/aws-smithy-protocol-test/src/lib.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/lib.rs
@@ -23,6 +23,7 @@ use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_runtime_api::http::Headers;
 use http::{HeaderMap, Uri};
 use pretty_assertions::Comparison;
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt::{self, Debug};
 use thiserror::Error;
@@ -471,6 +472,17 @@ actual body in base64 (useful to update the protocol test):
         })
     } else {
         Ok(())
+    }
+}
+
+pub fn decode_body_data(body: &[u8], media_type: MediaType) -> Cow<'_, [u8]> {
+    match media_type {
+        MediaType::Cbor => Cow::Owned(
+            base64_simd::STANDARD
+                .decode_to_vec(body)
+                .expect("smithy protocol test `body` property is not properly base64 encoded"),
+        ),
+        _ => Cow::Borrowed(body),
     }
 }
 

--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -17,6 +17,7 @@ gated-tests = []
 default = ["gated-tests"]
 
 [dependencies]
+aws-smithy-cbor = { path = "../aws-smithy-cbor" }
 aws-smithy-compression = { path = "../aws-smithy-compression", features = ["http-body-0-4-x"] }
 aws-smithy-http = { path = "../aws-smithy-http", features = ["event-stream"] }
 aws-smithy-json = { path = "../aws-smithy-json" }

--- a/rust-runtime/inlineable/src/cbor_errors.rs
+++ b/rust-runtime/inlineable/src/cbor_errors.rs
@@ -8,6 +8,10 @@ use aws_smithy_cbor::Decoder;
 use aws_smithy_runtime_api::http::Headers;
 use aws_smithy_types::error::metadata::{Builder as ErrorMetadataBuilder, ErrorMetadata};
 
+// This function is a copy-paste from `json_errors::sanitize_error_code`, therefore the functional
+// tests can be viewed in the unit tests there.
+// Since this is in the `inlineable` crate, there aren't good modules for housing common utilities
+// unless we move this to a Smithy runtime crate.
 fn sanitize_error_code(error_code: &str) -> &str {
     // Trim a trailing URL from the error code, beginning with a `:`
     let error_code = match error_code.find(':') {

--- a/rust-runtime/inlineable/src/cbor_errors.rs
+++ b/rust-runtime/inlineable/src/cbor_errors.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_cbor::decode::DeserializeError;
+use aws_smithy_cbor::Decoder;
+use aws_smithy_runtime_api::http::Headers;
+use aws_smithy_types::error::metadata::{Builder as ErrorMetadataBuilder, ErrorMetadata};
+
+fn sanitize_error_code(error_code: &str) -> &str {
+    // Trim a trailing URL from the error code, beginning with a `:`
+    let error_code = match error_code.find(':') {
+        Some(idx) => &error_code[..idx],
+        None => error_code,
+    };
+
+    // Trim a prefixing namespace from the error code, beginning with a `#`
+    match error_code.find('#') {
+        Some(idx) => &error_code[idx + 1..],
+        None => error_code,
+    }
+}
+
+pub fn parse_error_metadata(
+    _response_status: u16,
+    _response_headers: &Headers,
+    response_body: &[u8],
+) -> Result<ErrorMetadataBuilder, DeserializeError> {
+    fn error_code(
+        mut builder: ErrorMetadataBuilder,
+        decoder: &mut Decoder,
+    ) -> Result<ErrorMetadataBuilder, DeserializeError> {
+        builder = match decoder.str()?.as_ref() {
+            "__type" => {
+                let code = decoder.str()?;
+                builder.code(sanitize_error_code(&code))
+            }
+            _ => {
+                decoder.skip()?;
+                builder
+            }
+        };
+        Ok(builder)
+    }
+
+    let decoder = &mut Decoder::new(response_body);
+    let mut builder = ErrorMetadata::builder();
+
+    match decoder.map()? {
+        None => loop {
+            match decoder.datatype()? {
+                ::aws_smithy_cbor::data::Type::Break => {
+                    decoder.skip()?;
+                    break;
+                }
+                _ => {
+                    builder = error_code(builder, decoder)?;
+                }
+            };
+        },
+        Some(n) => {
+            for _ in 0..n {
+                builder = error_code(builder, decoder)?;
+            }
+        }
+    };
+
+    Ok(builder)
+}

--- a/rust-runtime/inlineable/src/cbor_errors.rs
+++ b/rust-runtime/inlineable/src/cbor_errors.rs
@@ -13,7 +13,8 @@ use aws_smithy_types::error::metadata::{Builder as ErrorMetadataBuilder, ErrorMe
 // Since this is in the `inlineable` crate, there aren't good modules for housing common utilities
 // unless we move this to a Smithy runtime crate.
 fn sanitize_error_code(error_code: &str) -> &str {
-    // Trim a trailing URL from the error code, beginning with a `:`
+    // Trim a trailing URL from the error code, which is done by removing the longest suffix
+    // beginning with a `:`
     let error_code = match error_code.find(':') {
         Some(idx) => &error_code[..idx],
         None => error_code,

--- a/rust-runtime/inlineable/src/json_errors.rs
+++ b/rust-runtime/inlineable/src/json_errors.rs
@@ -16,7 +16,8 @@ pub fn is_error<B>(response: &http::Response<B>) -> bool {
 }
 
 fn sanitize_error_code(error_code: &str) -> &str {
-    // Trim a trailing URL from the error code, beginning with a `:`
+    // Trim a trailing URL from the error code, which is done by removing the longest suffix
+    // beginning with a `:`
     let error_code = match error_code.find(':') {
         Some(idx) => &error_code[..idx],
         None => error_code,

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -9,6 +9,8 @@
 #[allow(dead_code)]
 mod aws_query_compatible_errors;
 #[allow(unused)]
+mod cbor_errors;
+#[allow(unused)]
 mod client_http_checksum_required;
 #[allow(dead_code)]
 mod client_idempotency_token;

--- a/tools/ci-build/runtime-versioner/Cargo.lock
+++ b/tools/ci-build/runtime-versioner/Cargo.lock
@@ -1041,6 +1041,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1091,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "toml 0.5.11",
  "tracing",
@@ -1401,6 +1415,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/tools/ci-cdk/canary-runner/Cargo.lock
+++ b/tools/ci-cdk/canary-runner/Cargo.lock
@@ -2559,6 +2559,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2662,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "toml 0.5.11",
@@ -3081,6 +3095,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"


### PR DESCRIPTION
## Motivation and Context
Follow-up on https://github.com/smithy-lang/smithy-rs/pull/2544 to add client-side support for the protocol

## Description
The client implementation mainly focuses on a sub-section [Requests](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests) in the spec. To that end, this PR addresses `TODO` for the client to fill in the blanks and  includes additional adjustments/refactoring to pass client protocol tests. 

## Testing
- Existing tests in CI
- Upstream protocol test `rpcv2Cbor`
- Our handwritten protocol test `rpcv2Cbor-extras.smithy`

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
