### PR TITLE
Reverting some accidentally ressurected CHANGELOG entries

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,30 +11,6 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
-[[smithy-rs]]
-message = "Support `stringArray` type in endpoints params"
-references = ["smithy-rs#3742"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
-author = "landonxjames"
-
-[[smithy-rs]]
-message = "Add support for `operationContextParams` Endpoints trait"
-references = ["smithy-rs#3755"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
-author = "landonxjames"
-
-[[aws-sdk-rust]]
-message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in AWS SDK clients so that using these types does not require directly depending on `aws-smithy-runtime-api`."
-references = ["smithy-rs#3591"]
-meta = { "breaking" = false, "tada" = false, "bug" = false }
-author = "ysaito1001"
-
-[[smithy-rs]]
-message = "`aws_smithy_runtime_api::client::orchestrator::HttpRequest` and `aws_smithy_runtime_api::client::orchestrator::HttpResponse` are now re-exported in generated clients so that using these types does not require directly depending on `aws-smithy-runtime-api`."
-references = ["smithy-rs#3591"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
-author = "ysaito1001"
-
 [[aws-sdk-rust]]
 message = "Fix incorrect redaction of `@sensitive` types in maps and lists."
 references = ["smithy-rs#3765",  "smithy-rs#3757"]


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
