### PR TITLE
Remove unused hyper dependency in aws-config

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -64,7 +64,6 @@ dependencies = [
  "futures-util",
  "hex",
  "http 0.2.12",
- "hyper",
  "hyper-rustls",
  "ring",
  "serde",
@@ -80,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.1.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -90,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.1"
+version = "1.1.5"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -102,7 +101,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http-body 0.4.6",
+ "http-body",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -172,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.3"
+version = "1.1.5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -193,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.1.5"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -202,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.9"
+version = "0.60.5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -210,7 +209,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http-body 0.4.6",
+ "http-body",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -220,14 +219,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.60.5"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.60.7"
+version = "0.60.5"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -241,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.7"
+version = "0.60.5"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -249,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.1"
+version = "1.1.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -260,12 +259,9 @@ dependencies = [
  "fastrand",
  "h2",
  "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.0",
- "httparse",
+ "http-body",
  "hyper",
  "hyper-rustls",
- "indexmap",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -279,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.1"
+version = "1.1.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -294,16 +290,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.1.5"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
+ "futures-core",
  "http 0.2.12",
- "http 1.1.0",
- "http-body 0.4.6",
- "http-body 1.0.0",
- "http-body-util",
+ "http-body",
  "itoa",
  "num-integer",
  "pin-project-lite",
@@ -315,19 +309,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.8"
+version = "0.60.5"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.1.5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
@@ -669,29 +664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-dependencies = [
- "bytes",
- "http 1.1.0",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
-dependencies = [
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +687,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body 0.4.6",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -882,7 +854,6 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -1363,7 +1334,6 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
- "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.4"
+version = "1.5.5"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",
@@ -36,7 +36,6 @@ aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 bytes = "1.1.0"
 http = "0.2.4"
-hyper = { version = "0.14.26", default-features = false }
 time = { version = "0.3.4", features = ["parsing"] }
 tokio = { version = "1.13.1", features = ["sync"] }
 tracing = { version = "0.1" }

--- a/tools/ci-build/runtime-versioner/Cargo.lock
+++ b/tools/ci-build/runtime-versioner/Cargo.lock
@@ -1041,6 +1041,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1091,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "toml 0.5.11",
  "tracing",
@@ -1401,6 +1415,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"


### PR DESCRIPTION
This allows end-users to keep hyper 0.x out of their tree

## Motivation and Context
This dependency appears unused and means that I have a 0.14 import in my tree

## Description
Removes the dependency

## Testing
Builds locally, if CI passes I think its fair to say this is a no-op. I can't find any usages of this lib.

## Checklist
I'm not sure this change warrants a changelog as there is no user facing change

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
