### PR TITLE
Add missing imports for `kotlin.streams.toList`

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CoreRustSettings.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CoreRustSettings.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.Optional
 import java.util.logging.Logger
+import kotlin.streams.toList
 
 private const val SERVICE = "service"
 private const val MODULE_NAME = "module"

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/OperationNormalizer.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/OperationNormalizer.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.rust.codegen.core.util.orNull
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 import software.amazon.smithy.rust.codegen.core.util.rename
 import java.util.Optional
+import kotlin.streams.toList
 
 /**
  * Generate synthetic Input and Output structures for operations.


### PR DESCRIPTION
Kotlin `toList` is required for the `stream.toList` extension functions that are used in this file.

The [PR](https://github.com/smithy-lang/smithy-rs/pull/2544/files#diff-4444943dae2fce81f218aa052d99a5db6a584f25207d742575ff042c69f7f60a) accidentally removed the import statement from `OperationNormalizer.kt`.