### PR TITLE
Update `CODEOWNERS` for the changelog directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,9 +16,9 @@
 /rust-runtime/aws-smithy-http-server-typescript/    @smithy-lang/smithy-rs-server
 
 # Shared ownership
+/.changelog/                                        @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server
 /.github/                                           @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server
 /CHANGELOG.md                                       @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server
-/CHANGELOG.next.toml                                @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server
 /README.md                                          @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server
 /build.gradle.kts                                   @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server
 /buildSrc/                                          @smithy-lang/aws-sdk-rust @smithy-lang/smithy-rs-server


### PR DESCRIPTION
## Motivation and Context
Removes `CHANGELOG.next.toml` from `CODEOWNERS` since it no longer exists. The file now lists the `.changelog` directory instead under `Shared ownership`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
