### PR TITLE
Publish "Detailed error explanations" design documentation page

### DIFF
--- a/design/src/SUMMARY.md
+++ b/design/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Client](./client/overview.md)
   - [What is the 'orchestrator' and why does it exist?](./client/orchestrator.md)
   - [Identity and Auth](./client/identity_and_auth.md)
+  - [Detailed error explanations](./client/detailed_error_explanations.md)
 
 - [Server](./server/overview.md)
   - [Middleware](./server/middleware.md)


### PR DESCRIPTION
The page was added back in #3734, but was not added to the index, so
https://smithy-lang.github.io/smithy-rs/design/client/detailed_error_explanations.html,
which is exposed here:

https://github.com/smithy-lang/smithy-rs/blob/10a92052b1ca4f6442b15f544dd2940f613bd008/rust-runtime/aws-smithy-runtime-api/src/client/connection.rs#L24-L27

currently points to a 404.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
