### PR TITLE
Destroy history of github-pages branch

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,7 +34,7 @@ jobs:
         git config --local user.name "AWS SDK Rust Bot"
         git config --local user.email "aws-sdk-rust-primary@amazon.com"
         git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
-        git fetch origin github-pages
+        REV=$(git rev-parse --short HEAD)
 
         pushd design &>/dev/null
         cargo install mdbook
@@ -42,9 +42,10 @@ jobs:
         mdbook build --dest-dir ../../output
         popd &>/dev/null
 
-        git checkout origin/github-pages -b github-pages
-        rm -rf design
+        git checkout --orphan github-pages
+        git rm --cached -r .
+        git clean -ffdx
         mv ../output design
         git add design
-        git commit -m "Update design docs"
-        git push origin github-pages
+        git commit -m "Design docs @ ${{ github.repository }}@${REV}"
+        git push origin github-pages --force


### PR DESCRIPTION
## Motivation and Context

Keeping the history of `github-pages` is not useful, and it hogs the output of `git log --graph --all` and other such views of the repository history. In the event that someone would need to look at old contents of the website, it can be regenerated using `mdbook` from any commit on `main`.

<img src="https://github.com/user-attachments/assets/f37630fa-92ef-4e49-a9e5-a1357a785e46" width="550">

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._