### PR TITLE
Fix behavior of datetime formatting

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "criterion",
  "minicbor",
 ]
@@ -337,7 +337,7 @@ name = "aws-smithy-checksums"
 version = "0.60.12"
 dependencies = [
  "aws-smithy-http 0.60.9",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "bytes-utils",
  "crc32c",
@@ -364,7 +364,7 @@ name = "aws-smithy-compression"
 version = "0.0.1"
 dependencies = [
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -384,7 +384,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.4"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -409,7 +409,7 @@ dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime 1.6.3",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "h2 0.4.5",
  "http 1.1.0",
  "hyper 1.3.1",
@@ -451,7 +451,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.4",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -480,7 +480,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "futures-util",
@@ -510,7 +510,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-http-server",
  "aws-smithy-json 0.60.7",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "futures",
@@ -550,7 +550,7 @@ version = "0.60.3"
 name = "aws-smithy-json"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "proptest",
  "serde_json",
 ]
@@ -570,7 +570,7 @@ version = "0.2.1"
 dependencies = [
  "aws-sdk-s3",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "tokio",
 ]
 
@@ -611,7 +611,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "urlencoding",
 ]
 
@@ -655,7 +655,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "fastrand",
  "futures-util",
@@ -703,7 +703,7 @@ name = "aws-smithy-runtime-api"
 version = "1.7.2"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -779,7 +779,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.8"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "chrono",
  "futures-core",
  "time",
@@ -791,7 +791,7 @@ version = "0.1.3"
 dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "bytes",
  "http 1.1.0",
  "tracing",
@@ -1980,7 +1980,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.1",
+ "aws-smithy-types 1.2.2",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "fastrand",

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.2.1"
+version = "1.2.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -332,7 +332,12 @@ impl Ord for DateTime {
 
 impl Display for DateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let date = self.fmt(Format::DateTime).map_err(|_| fmt::Error)?;
+        // Some dates are out of range to be serialized with `DateTime`.
+        // In these cases, fallback to using epoch seconds which always works
+        let date = match self.fmt(Format::DateTime) {
+            Ok(date) => date,
+            Err(_err) => format::epoch_seconds::format(self),
+        };
         write!(f, "{}", date)
     }
 }
@@ -627,6 +632,13 @@ mod test {
             SystemTime::from(off_date_time),
             SystemTime::try_from(date_time).unwrap()
         );
+    }
+
+    #[test]
+    fn formatting_of_early_dates() {
+        let date: DateTime =
+            DateTime::from_str("Mon, 16 Dec -019 23:48:18 GMT", Format::HttpDate).unwrap();
+        assert_eq!(format!("{}", date), "-62736509502");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation and Context
Fix formatting of date times before 0000 and after 9999


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
