### PR TITLE
backport connection poisoning to hyper 1.x client

### DIFF
--- a/.changelog/1724090349.md
+++ b/.changelog/1724090349.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- client
+authors:
+- aajtodd
+references:
+- smithy-rs#1925
+breaking: false
+new_feature: false
+bug_fix: false
+---
+Backport connection poisoning to hyper 1.x support

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-experimental"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime 1.6.3",
@@ -412,7 +412,7 @@ dependencies = [
  "aws-smithy-types 1.2.2",
  "h2 0.4.5",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
  "once_cell",
@@ -1862,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1904,7 +1904,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-native-certs 0.7.0",
@@ -1916,16 +1916,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",

--- a/rust-runtime/aws-smithy-experimental/Cargo.toml
+++ b/rust-runtime/aws-smithy-experimental/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-experimental"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Experiments for the smithy-rs ecosystem"
 edition = "2021"
@@ -15,10 +15,11 @@ crypto-aws-lc-fips = ["rustls/fips"]
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"] }
 aws-smithy-runtime-api = { features = ["client", "http-1x"], path = "../aws-smithy-runtime-api" }
+aws-smithy-runtime = { features = ["client"], path = "../aws-smithy-runtime" }
 aws-smithy-async = { path = "../aws-smithy-async" }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 pin-project-lite = "0.2.13"
-hyper-util = "0.1.3"
+hyper-util = "0.1.7"
 http = "1"
 tokio = "1"
 hyper-rustls = { version = "0.27", features = ["http2", "http1", "native-tokio", "tls12"], default-features = false }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/smithy-lang/smithy-rs/issues/1925

## Description
Backports connection poisoning that hyper 0.14 HTTP client has to the hyper 1.x client. 

See also:
* upstream support: https://github.com/hyperium/hyper-util/pull/121

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
