### PR TITLE
Re-export `ByteStream`'s `Length` and `FsBuilder` in client crates

### DIFF
--- a/.changelog/1724096455.md
+++ b/.changelog/1724096455.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- aws-sdk-rust#820
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Re-export `ByteStream`'s `Length` and `FsBuilder`. By making these types available directly within a client crate, customers can use `ByteStream::read_from` without needing to import them separately from the `aws-smithy-types` crate.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
@@ -82,11 +82,15 @@ fun pubUseSmithyPrimitives(
                 pub use #{ByteStream};
                 pub use #{AggregatedBytes};
                 pub use #{Error} as ByteStreamError;
+                pub use #{FsBuilder};
+                pub use #{Length};
                 pub use #{SdkBody};
                 """,
                 "ByteStream" to RuntimeType.smithyTypes(rc).resolve("byte_stream::ByteStream"),
                 "AggregatedBytes" to RuntimeType.smithyTypes(rc).resolve("byte_stream::AggregatedBytes"),
                 "Error" to RuntimeType.smithyTypes(rc).resolve("byte_stream::error::Error"),
+                "FsBuilder" to RuntimeType.smithyTypes(rc).resolve("byte_stream::FsBuilder"),
+                "Length" to RuntimeType.smithyTypes(rc).resolve("byte_stream::Length"),
                 "SdkBody" to RuntimeType.smithyTypes(rc).resolve("body::SdkBody"),
             )
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
@@ -82,7 +82,9 @@ fun pubUseSmithyPrimitives(
                 pub use #{ByteStream};
                 pub use #{AggregatedBytes};
                 pub use #{Error} as ByteStreamError;
+                ##[cfg(feature = "rt-tokio")]
                 pub use #{FsBuilder};
+                ##[cfg(feature = "rt-tokio")]
                 pub use #{Length};
                 pub use #{SdkBody};
                 """,

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtraTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtraTest.kt
@@ -147,7 +147,12 @@ class SmithyTypesPubUseExtraTest {
     @Test
     fun `it re-exports ByteStream and AggregatedBytes when a model has streaming`() {
         val streamingTypes =
-            listOf("::aws_smithy_types::byte_stream::ByteStream", "::aws_smithy_types::byte_stream::AggregatedBytes")
+            listOf(
+                "::aws_smithy_types::byte_stream::ByteStream",
+                "::aws_smithy_types::byte_stream::AggregatedBytes",
+                "::aws_smithy_types::byte_stream::FsBuilder",
+                "::aws_smithy_types::byte_stream::Length",
+            )
         val streamingShape = "@streaming blob Streaming"
 
         this.assertDoesntHaveReexports(reexportsWithEmptyModel(), streamingTypes)


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/aws-sdk-rust/issues/820

## Description
This PR re-exports `ByteStream`'s `Length` and `FsBuilder`. By making these types available in a client crate, customers can use `ByteStream::read_from` without needing to import them separately from the `aws-smithy-types` crate.

## Testing
- Updated an existing re-export test to include `Length` and `FsBuilder` as well.
- Existing tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
