### PR TITLE
Fix `Length::UpTo` usage in `FsBuilder` so it does not exceed available file length

### DIFF
--- a/.changelog/1724182177.md
+++ b/.changelog/1724182177.md
@@ -1,0 +1,14 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- ysaito1001
+references:
+- aws-sdk-rust#821
+- smithy-rs#3797
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix the [Length::UpTo](https://docs.rs/aws-smithy-types/1.2.2/aws_smithy_types/byte_stream/enum.Length.html) usage in [FsBuilder](https://docs.rs/aws-smithy-types/1.2.2/aws_smithy_types/byte_stream/struct.FsBuilder.html), ensuring that the specified length does not exceed the remaining file length.

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.2.2"
+version = "1.2.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/aws-sdk-rust/issues/821

## Description
This PR addresses an issue with the [Length::UpTo](https://docs.rs/aws-smithy-types/1.2.2/aws_smithy_types/byte_stream/enum.Length.html) usage in `FsBuilder`. Previously, if a value specified for `UpTo` exceeded the remaining file length, `FsBuilder` would incorrectly accept the value. This discrepancy led to failures in subsequent request dispatches, as the actual body size did not match the advertised `Content-Length`, as explained [here](https://github.com/awslabs/aws-sdk-rust/issues/821#issuecomment-1937354372) (thank you @pablosichert for a self-contained reproducer and problem analysis!). 

## Testing
- Added a unit test for `FsBuilder` verifying the `Length::UpTo` usage
- Ran successfully a customer provided [reproducer](https://github.com/awslabs/aws-sdk-rust/issues/821#issuecomment-1937354372) with the code changes in this PR (with an added a call to `complete_multipart_upload` at the end, it also succeeded in uploading the object):
```
upload_id: cTDSngbubD25cOoFCNgjpG55o0hAMQNjO16dNFyNTKjg9PEtkcrKG5rTGzBns7CXoO8T.Qm9GpNj6jgwJTKcXDpsca95wSMWMDfPF0DBhmbk3OAGHuuGM1E70spk2suW
File created
part_number: 1, e_tag: "5648ddf58c7c90a788d7f16717a61b08"
part_number: 2, e_tag: "a6bdad6d65d18d842ef1d57ca4673bc3"
part_number: 3, e_tag: "f518f6b19b255ec49b61d511288554fc"
part_number: 4, e_tag: "1496524801eb1d0a7cfbe608eb037d9c"
part_number: 5, e_tag: "21340de04927ce1bed58ad0375c03e01"
```

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
