### PR TITLE
Fix execution order of `read_before_serialization` and `modify_before_serialization`

### DIFF
--- a/.changelog/1724255475.md
+++ b/.changelog/1724255475.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#3798
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix the execution order of [modify_before_serialization](https://docs.rs/aws-smithy-runtime-api/latest/aws_smithy_runtime_api/client/interceptors/trait.Intercept.html#method.modify_before_serialization) and [read_before_serialization](https://docs.rs/aws-smithy-runtime-api/latest/aws_smithy_runtime_api/client/interceptors/trait.Intercept.html#method.read_before_serialization) in the orchestrator. The `modify_before_serialization` method now executes before the `read_before_serialization` method. This adjustment may result in changes in behavior depending on how you customize interceptors.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -407,7 +407,7 @@ name = "aws-smithy-experimental"
 version = "0.1.3"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.6.3",
+ "aws-smithy-runtime 1.6.4",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.2",
  "h2 0.4.5",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -407,7 +407,7 @@ name = "aws-smithy-experimental"
 version = "0.1.3"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.6.4",
+ "aws-smithy-runtime 1.7.0",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.2",
  "h2 0.4.5",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.4"
+version = "1.7.0"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.6.4"
+version = "1.7.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.6.3"
+version = "1.6.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -217,8 +217,8 @@ async fn try_op(
 ) {
     // Before serialization
     run_interceptors!(halt_on_err: {
-        read_before_serialization(ctx, runtime_components, cfg);
         modify_before_serialization(ctx, runtime_components, cfg);
+        read_before_serialization(ctx, runtime_components, cfg);
     });
 
     // Serialization


### PR DESCRIPTION
## Motivation and Context
Fixes the execution order of [modify_before_serialization](https://docs.rs/aws-smithy-runtime-api/latest/aws_smithy_runtime_api/client/interceptors/trait.Intercept.html#method.modify_before_serialization) and [read_before_serialization](https://docs.rs/aws-smithy-runtime-api/latest/aws_smithy_runtime_api/client/interceptors/trait.Intercept.html#method.read_before_serialization) in the orchestrator.

## Description
The fix ensures that the execution order of these interceptor methods aligns with our orchestrator design. While customers may see a behavior change as a result, we don't treat this as a new `BehaviorVersion` since it is intended as a bug fix.

## Testing
Existing tests in CI

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
