### PR TITLE
Restore `ENABLE_SMOKETESTS` for running smoketests

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-services
+++ b/tools/ci-scripts/check-aws-sdk-services
@@ -4,12 +4,23 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+C_YELLOW='\033[1;33m'
+C_RESET='\033[0m'
+
 set -eux
 cd aws-sdk
 
-# Invoking `cargo test` at the root directory implicitly checks for the validity
-# of the top-level `Cargo.toml`
-cargo test --all-features
+ENABLE_SMOKETESTS="${ENABLE_SMOKETESTS:-false}"
+
+# Check if the $ENABLE_SMOKETESTS environment variable is set
+if [ "$ENABLE_SMOKETESTS" = "true" ]; then
+    # Invoking `cargo test` at the root directory implicitly checks for the validity
+    # of the top-level `Cargo.toml`
+    echo "${C_YELLOW}## Running smoketests...${C_RESET}"
+    RUSTFLAGS="--cfg smoketests" cargo test --all-features
+else
+    cargo test --all-features
+fi
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then


### PR DESCRIPTION
## Motivation and Context
This PR restores [an environment variable](https://github.com/smithy-lang/smithy-rs/pull/3758/files/62ff67ed89b1d920540b03a252a69bf50a1d1081#diff-903f493806a39cd49c26728eee0410545eb911162b1d889dd7154eae81b7c7c7) we attempted to add in https://github.com/smithy-lang/smithy-rs/pull/3758.

## Description
We removed that environment variable since we ran into an error `ENABLE_SMOKETESTS: unbound variable` in our release pipeline. This PR will have a default value `false` when `ENABLE_SMOKETESTS` is not present.

We expect the value to be `false` in smithy-rs CI and `true` in our release pipeline (can set it to `true` in our release pipeline asynchronously).

## Testing
- Existing tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
