### PR TITLE
Upgrade MSRV to 1.78.0

### DIFF
--- a/.changelog/1724459075.md
+++ b/.changelog/1724459075.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#3800
+breaking: true
+new_feature: false
+bug_fix: false
+---
+Upgrade MSRV to Rust 1.78.0.

--- a/.changelog/1724459075.md
+++ b/.changelog/1724459075.md
@@ -1,6 +1,7 @@
 ---
 applies_to:
 - client
+- server
 - aws-sdk-rust
 authors:
 - ysaito1001

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ on:
         required: false
 
 env:
-  rust_version: 1.76.0
+  rust_version: 1.78.0
   rust_toolchain_components: clippy,rustfmt
   ENCRYPTED_DOCKER_PASSWORD: ${{ secrets.ENCRYPTED_DOCKER_PASSWORD }}
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.76.0
+  rust_version: 1.78.0
 
 name: Claim unpublished crate names on crates.io
 run-name: ${{ github.workflow }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ on:
 name: Update GitHub Pages
 
 env:
-  rust_version: 1.76.0
+  rust_version: 1.78.0
 
 # Allow only one doc pages build to run at a time for the entire smithy-rs repo
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.76.0
+  rust_version: 1.78.0
 
 name: Release smithy-rs
 on:

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.76.0
+        toolchain: 1.78.0
     - name: Delete old SDK
       run: |
     - name: Generate a fresh SDK

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "aws-smithy-async",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.9"
+version = "0.60.10"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "arbitrary",
  "aws-credential-types",
@@ -158,6 +158,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-protocol-test",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
@@ -174,6 +175,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "proptest",
+ "regex-lite",
  "serde",
  "serde_json",
  "tokio",
@@ -301,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.3"
+version = "1.7.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -341,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Types for AWS SDK credentials."
 edition = "2021"

--- a/aws/rust-runtime/aws-credential-types/src/credential_fn.rs
+++ b/aws/rust-runtime/aws-credential-types/src/credential_fn.rs
@@ -73,42 +73,13 @@ where
 #[cfg(test)]
 mod test {
     use crate::credential_fn::provide_credentials_fn;
-    use crate::{
-        provider::{future, ProvideCredentials},
-        Credentials,
-    };
-    use async_trait::async_trait;
-    use std::fmt::{Debug, Formatter};
+    use crate::{provider::ProvideCredentials, Credentials};
 
     fn assert_send_sync<T: Send + Sync>() {}
 
     #[test]
     fn creds_are_send_sync() {
         assert_send_sync::<Credentials>()
-    }
-
-    #[async_trait]
-    trait AnotherTrait: Send + Sync {
-        async fn creds(&self) -> Credentials;
-    }
-
-    struct AnotherTraitWrapper<T> {
-        inner: T,
-    }
-
-    impl<T> Debug for AnotherTraitWrapper<T> {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "wrapper")
-        }
-    }
-
-    impl<T: AnotherTrait> ProvideCredentials for AnotherTraitWrapper<T> {
-        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
-        where
-            Self: 'a,
-        {
-            future::ProvideCredentials::new(async move { Ok(self.inner.creds().await) })
-        }
     }
 
     // Test that the closure passed to `provide_credentials_fn` is allowed to borrow things

--- a/aws/rust-runtime/aws-credential-types/src/token_fn.rs
+++ b/aws/rust-runtime/aws-credential-types/src/token_fn.rs
@@ -73,38 +73,12 @@ where
 mod test {
     use super::*;
     use crate::Token;
-    use async_trait::async_trait;
-    use std::fmt::{Debug, Formatter};
 
     fn assert_send_sync<T: Send + Sync>() {}
 
     #[test]
     fn creds_are_send_sync() {
         assert_send_sync::<Token>()
-    }
-
-    #[async_trait]
-    trait AnotherTrait: Send + Sync {
-        async fn token(&self) -> Token;
-    }
-
-    struct AnotherTraitWrapper<T> {
-        inner: T,
-    }
-
-    impl<T> Debug for AnotherTraitWrapper<T> {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "wrapper")
-        }
-    }
-
-    impl<T: AnotherTrait> ProvideToken for AnotherTraitWrapper<T> {
-        fn provide_token<'a>(&'a self) -> future::ProvideToken<'a>
-        where
-            Self: 'a,
-        {
-            future::ProvideToken::new(async move { Ok(self.inner.token().await) })
-        }
     }
 
     // Test that the closure passed to `provide_token_fn` is allowed to borrow things

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -57,6 +57,7 @@ pub mod endpoint_discovery;
 mod serialization_settings;
 
 /// Parse the Expires and ExpiresString fields correctly
+#[allow(dead_code)]
 pub mod s3_expires_interceptor;
 
 // just so docs work

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/env_config/property.rs
+++ b/aws/rust-runtime/aws-runtime/src/env_config/property.rs
@@ -166,7 +166,7 @@ impl Properties {
             .entry(properties_key.clone())
             .and_modify(|v| {
                 tracing::trace!("overwriting {properties_key}: was {v}, now {value}");
-                *v = value.clone();
+                v.clone_from(&value);
             })
             .or_insert(value);
     }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CodegenDelegator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CodegenDelegator.kt
@@ -46,7 +46,11 @@ interface ModuleDocProvider {
             }
             try {
                 when {
-                    module.documentationOverride != null -> writer.docs(module.documentationOverride)
+                    module.documentationOverride != null -> {
+                        if (module.documentationOverride.isNotEmpty()) {
+                            writer.docs(module.documentationOverride)
+                        }
+                    }
                     else -> provider?.docsWriter(module)?.also { writeTo -> writeTo(writer) }
                 }
             } catch (e: NotImplementedError) {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -125,7 +125,7 @@ object TestWorkspace {
                 // help rust select the right version when we run cargo test
                 // TODO(https://github.com/smithy-lang/smithy-rs/issues/2048): load this from the msrv property using a
                 //  method as we do for runtime crate versions
-                "[toolchain]\nchannel = \"1.76.0\"\n",
+                "[toolchain]\nchannel = \"1.78.0\"\n",
             )
             // ensure there at least an empty lib.rs file to avoid broken crates
             newProject.resolve("src").mkdirs()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.76.0
+rust.msrv=1.78.0
 
 # To enable debug, swap out the two lines below.
 # When changing this value, be sure to run `./gradlew --stop` to kill the Gradle daemon.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "criterion",
  "minicbor",
 ]
@@ -337,7 +337,7 @@ name = "aws-smithy-checksums"
 version = "0.60.12"
 dependencies = [
  "aws-smithy-http 0.60.9",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "crc32c",
@@ -364,7 +364,7 @@ name = "aws-smithy-compression"
 version = "0.0.1"
 dependencies = [
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -384,7 +384,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.4"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -409,7 +409,7 @@ dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime 1.7.0",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "h2 0.4.5",
  "http 1.1.0",
  "hyper 1.4.1",
@@ -451,7 +451,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.4",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -480,7 +480,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "futures-util",
@@ -510,7 +510,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-http-server",
  "aws-smithy-json 0.60.7",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "futures",
@@ -550,7 +550,7 @@ version = "0.60.3"
 name = "aws-smithy-json"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "proptest",
  "serde_json",
 ]
@@ -570,7 +570,7 @@ version = "0.2.1"
 dependencies = [
  "aws-sdk-s3",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "tokio",
 ]
 
@@ -611,7 +611,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "urlencoding",
 ]
 
@@ -655,7 +655,7 @@ dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "fastrand",
  "futures-util",
@@ -703,7 +703,7 @@ name = "aws-smithy-runtime-api"
 version = "1.7.2"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -779,7 +779,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.8"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "chrono",
  "futures-core",
  "time",
@@ -791,7 +791,7 @@ version = "0.1.3"
 dependencies = [
  "aws-smithy-http 0.60.9",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "http 1.1.0",
  "tracing",
@@ -1981,7 +1981,7 @@ dependencies = [
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime 1.7.0",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.3",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "fastrand",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 name = "aws-smithy-checksums"
 version = "0.60.12"
 dependencies = [
- "aws-smithy-http 0.60.9",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
@@ -407,7 +407,7 @@ name = "aws-smithy-experimental"
 version = "0.1.4"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.7.0",
+ "aws-smithy-runtime 1.7.1",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "h2 0.4.5",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.9"
+version = "0.60.10"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.4",
@@ -474,10 +474,10 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.63.2"
+version = "0.63.3"
 dependencies = [
  "aws-smithy-cbor",
- "aws-smithy-http 0.60.9",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
@@ -507,7 +507,7 @@ dependencies = [
 name = "aws-smithy-http-server-python"
 version = "0.63.1"
 dependencies = [
- "aws-smithy-http 0.60.9",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-http-server",
  "aws-smithy-json 0.60.7",
  "aws-smithy-types 1.2.4",
@@ -648,11 +648,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.9",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
@@ -789,7 +789,7 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
- "aws-smithy-http 0.60.9",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "bytes",
@@ -1977,9 +1977,9 @@ version = "0.1.0"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-compression",
- "aws-smithy-http 0.60.9",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.7.0",
+ "aws-smithy-runtime 1.7.1",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.63.2"
+version = "0.63.3"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/src/routing/tiny_map.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/tiny_map.rs
@@ -101,10 +101,10 @@ where
     ///
     /// The key may be borrowed form of map's key type, but [`Hash`] and [`Eq`] on the borrowed
     /// form _must_ match those for the key type.
-    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match &self.inner {
             TinyMapInner::Vec(vec) => vec

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.60.9"
+version = "0.60.10"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
@@ -208,15 +208,6 @@ mod tests {
     use futures_util::stream::StreamExt;
     use std::error::Error as StdError;
 
-    #[derive(Debug)]
-    struct FakeError;
-    impl std::fmt::Display for FakeError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "FakeError")
-        }
-    }
-    impl StdError for FakeError {}
-
     #[derive(Debug, Eq, PartialEq)]
     struct TestMessage(String);
 

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.7.0"
+version = "1.7.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
@@ -351,6 +351,7 @@ impl<I, O, E> OperationBuilder<I, O, E> {
     }
 
     /// Configures the a deserializer implementation for the builder.
+    #[allow(clippy::implied_bounds_in_impls)] // for `Send` and `Sync`
     pub fn deserializer_impl<O2, E2>(
         mut self,
         deserializer: impl DeserializeResponse + Send + Sync + 'static,

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -327,6 +327,7 @@ fn get_seconds_since_unix_epoch(runtime_components: &RuntimeComponents) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)] // will be unused with `--no-default-features --features client`
     use std::fmt;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -461,6 +462,7 @@ mod tests {
         assert_eq!(ShouldAttempt::YesAfterDelay(MAX_BACKOFF), actual);
     }
 
+    #[allow(dead_code)] // will be unused with `--no-default-features --features client`
     #[derive(Debug)]
     struct PresetReasonRetryClassifier {
         retry_actions: Mutex<Vec<RetryAction>>,

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -345,7 +345,7 @@ mod tests {
         RuntimeComponents, RuntimeComponentsBuilder,
     };
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
-    use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind, RetryConfig};
+    use aws_smithy_types::retry::{ErrorKind, RetryConfig};
 
     use super::{calculate_exponential_backoff, StandardRetryStrategy};
     #[cfg(feature = "test-util")]
@@ -459,26 +459,6 @@ mod tests {
             .should_attempt_retry(&ctx, &rc, &cfg)
             .expect("method is infallible for this use");
         assert_eq!(ShouldAttempt::YesAfterDelay(MAX_BACKOFF), actual);
-    }
-
-    #[derive(Debug)]
-    struct ServerError;
-    impl fmt::Display for ServerError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "OperationError")
-        }
-    }
-
-    impl std::error::Error for ServerError {}
-
-    impl ProvideErrorKind for ServerError {
-        fn retryable_error_kind(&self) -> Option<ErrorKind> {
-            Some(ErrorKind::ServerError)
-        }
-
-        fn code(&self) -> Option<&str> {
-            None
-        }
     }
 
     #[derive(Debug)]

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.2.3"
+version = "1.2.4"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/body.rs
+++ b/rust-runtime/aws-smithy-types/src/body.rs
@@ -62,7 +62,8 @@ enum BoxBody {
         feature = "http-body-1-x",
         feature = "rt-tokio"
     ))]
-    HttpBody04(http_body_0_4::combinators::BoxBody<Bytes, Error>),
+    // will be dead code with `--no-default-features --features rt-tokio`
+    HttpBody04(#[allow(dead_code)] http_body_0_4::combinators::BoxBody<Bytes, Error>),
 }
 
 pin_project! {

--- a/rust-runtime/aws-smithy-types/src/config_bag.rs
+++ b/rust-runtime/aws-smithy-types/src/config_bag.rs
@@ -583,9 +583,9 @@ impl ConfigBag {
     }
 
     /// Return a mutable reference to `T` if it is stored in the top layer of the bag
-    pub fn get_mut<T: Send + Sync + Debug + Clone + 'static>(&mut self) -> Option<&mut T>
+    pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: Storable<Storer = StoreReplace<T>>,
+        T: Storable<Storer = StoreReplace<T>> + Send + Sync + Debug + Clone + 'static,
     {
         // this code looks weird to satisfy the borrow checker—we can't keep the result of `get_mut`
         // alive (even in a returned branch) and then call `store_put`. So: drop the borrow immediately
@@ -617,11 +617,9 @@ impl ConfigBag {
     ///
     /// - If `T` is in a deeper layer of the bag, that value will be cloned and inserted into the top layer
     /// - If `T` is not present in the bag, the [`Default`] implementation will be used.
-    pub fn get_mut_or_default<T: Send + Sync + Debug + Clone + Default + 'static>(
-        &mut self,
-    ) -> &mut T
+    pub fn get_mut_or_default<T>(&mut self) -> &mut T
     where
-        T: Storable<Storer = StoreReplace<T>>,
+        T: Storable<Storer = StoreReplace<T>> + Send + Sync + Debug + Clone + Default + 'static,
     {
         self.get_mut_or_else(|| T::default())
     }
@@ -630,12 +628,9 @@ impl ConfigBag {
     ///
     /// - If `T` is in a deeper layer of the bag, that value will be cloned and inserted into the top layer
     /// - If `T` is not present in the bag, `default` will be used to construct a new value
-    pub fn get_mut_or_else<T: Send + Sync + Debug + Clone + 'static>(
-        &mut self,
-        default: impl Fn() -> T,
-    ) -> &mut T
+    pub fn get_mut_or_else<T>(&mut self, default: impl Fn() -> T) -> &mut T
     where
-        T: Storable<Storer = StoreReplace<T>>,
+        T: Storable<Storer = StoreReplace<T>> + Send + Sync + Debug + Clone + 'static,
     {
         // this code looks weird to satisfy the borrow checker—we can't keep the result of `get_mut`
         // alive (even in a returned branch) and then call `store_put`. So: drop the borrow immediately

--- a/rust-runtime/aws-smithy-types/src/type_erasure.rs
+++ b/rust-runtime/aws-smithy-types/src/type_erasure.rs
@@ -232,11 +232,6 @@ mod tests {
     use super::{TypeErasedBox, TypeErasedError};
     use std::fmt;
 
-    #[derive(Debug)]
-    struct Foo(#[allow(dead_code)] &'static str);
-    #[derive(Debug)]
-    struct Bar(#[allow(dead_code)] isize);
-
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct TestErr {
         inner: &'static str,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.78.0"

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -131,7 +131,7 @@ ARG rust_nightly_version
 RUN cargo +${rust_nightly_version} install cargo-component --locked --version ${cargo_component_version}
 
 FROM install_rust AS cargo_semver_checks
-ARG cargo_semver_checks_version=0.24.1
+ARG cargo_semver_checks_version=0.27.0
 RUN cargo install cargo-semver-checks --locked --version ${cargo_semver_checks_version}
 
 FROM install_rust AS cargo_mdbook

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -6,7 +6,7 @@
 # This is the base Docker build image used by CI
 
 ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2023
-ARG rust_stable_version=1.76.0
+ARG rust_stable_version=1.78.0
 ARG rust_nightly_version=nightly-2024-02-07
 
 FROM ${base_image} AS bare_base_image


### PR DESCRIPTION
## Motivation and Context
Upgrades MSRV to 1.78.0 since the [latest Rust](https://www.rust-lang.org/) at the time of writing is 1.80.1 (we try keeping [two releases behind](https://github.com/awslabs/aws-sdk-rust?tab=readme-ov-file#supported-rust-versions-msrv)).

## Description
In Rust 1.78.0, `clippy` enforces stricter checks in two areas:
- `dead_code`
It seems to be able to uncover more unused code patterns, especially when different combinations of cargo features are enabled
- `empty_docs`
Prior to 1.78.0, the codegen used to render the following empty docs `///`, regardless whether the codegen is for the server or for the client. This is now flagged as `empty_docs` by `clippy`:
```
///
pub(crate) mod XXX {
    ...
}
```

Other than bumping MSRV to 1.78.0, the remaining code changes address issues related to the fixes mentioned above.

**EDIT:**
`cargo-semver-checks` required an upgrade due to incompatibility issues following the MSRV upgrade ([example error](https://github.com/smithy-lang/smithy-rs/actions/runs/10534205294/job/29261105195#step:4:2068)). Specifically, after updating the MSRV to 1.78.0, the rustdoc version was upgraded to v28. However, the version of `cargo-semver-checks` we were using (0.24.1) only supported rustdoc [up to v27](https://github.com/obi1kenobi/cargo-semver-checks/blob/4bce03d4a6a32cf651b9eccddb40e3418dc2c154/Cargo.toml#L18).

To resolve this, we have updated `cargo-semver-checks` to the first version that supports rustdoc [v28](https://github.com/obi1kenobi/cargo-semver-checks/blob/94a491f0854f0bdbccbb301099db119201bff181/Cargo.toml#L18).

## Testing
Existing tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
