### PR TITLE
Add server codegen flag addValidationExceptionToConstrainedOperations

### DIFF
--- a/.changelog/4619777.md
+++ b/.changelog/4619777.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["server"]
+authors: ["drganjoo"]
+references: ["smithy-rs#3803"]
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Setting the `addValidationExceptionToConstrainedOperations` codegen flag adds `aws.smithy.framework#ValidationException` to operations with constrained inputs that do not already have this exception added.

--- a/.changelog/4619777.md
+++ b/.changelog/4619777.md
@@ -7,3 +7,20 @@ new_feature: true
 bug_fix: false
 ---
 Setting the `addValidationExceptionToConstrainedOperations` codegen flag adds `aws.smithy.framework#ValidationException` to operations with constrained inputs that do not already have this exception added.
+
+Sample `smithy-build-template.json`:
+
+```
+{
+    "...",
+    "plugins": {
+        "rust-server-codegen": {
+            "service": "ServiceToGenerateSDKFor",
+                "module": "amzn-sample-server-sdk",
+                "codegen": {
+                    "addValidationExceptionToConstrainedOperations": true,
+                }
+        }
+    }
+}
+```

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
@@ -49,21 +49,15 @@ data class IntegrationTestParams(
 sealed class AdditionalSettings {
     abstract fun toObjectNode(): ObjectNode
 
-    abstract class CoreAdditionalSettings protected constructor(settings: List<AdditionalSettings>) : AdditionalSettings() {
-        private val mergedSettings = MergedSettings(settings)
+    abstract class CoreAdditionalSettings protected constructor(val settings: List<AdditionalSettings>) : AdditionalSettings() {
+        override fun toObjectNode(): ObjectNode {
+            val merged =
+                settings.map { it.toObjectNode() }
+                    .reduce { acc, next -> acc.merge(next) }
 
-        override fun toObjectNode(): ObjectNode = mergedSettings.toObjectNode()
-
-        private data class MergedSettings(val settings: List<AdditionalSettings>) : AdditionalSettings() {
-            override fun toObjectNode(): ObjectNode {
-                val merged =
-                    settings.map { it.toObjectNode() }
-                        .reduce { acc, next -> acc.merge(next) }
-
-                return ObjectNode.builder()
-                    .withMember("codegen", merged)
-                    .build()
-            }
+            return ObjectNode.builder()
+                .withMember("codegen", merged)
+                .build()
         }
 
         abstract class Builder<T : CoreAdditionalSettings> : AdditionalSettings() {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
@@ -101,7 +101,7 @@ class ServerAdditionalSettings private constructor(settings: List<AdditionalSett
     AdditionalSettings.CoreAdditionalSettings(settings) {
         class Builder : CoreAdditionalSettings.Builder<ServerAdditionalSettings>() {
             fun publicConstrainedTypes(enabled: Boolean = true): Builder {
-                settings.add(PublicConstrainedType(enabled))
+                settings.add(PublicConstrainedTypes(enabled))
                 return this
             }
 
@@ -113,7 +113,7 @@ class ServerAdditionalSettings private constructor(settings: List<AdditionalSett
             override fun build(): ServerAdditionalSettings = ServerAdditionalSettings(settings)
         }
 
-        private data class PublicConstrainedType(val enabled: Boolean) : AdditionalSettings() {
+        private data class PublicConstrainedTypes(val enabled: Boolean) : AdditionalSettings() {
             override fun toObjectNode(): ObjectNode =
                 ObjectNode.builder()
                     .withMember("publicConstrainedTypes", enabled)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
@@ -39,10 +39,11 @@ data class IntegrationTestParams(
  *         serverIntegrationTest(
  *             model,
  *             IntegrationTestParams(
- *                  additionalSettings = ServerAdditionalSettings.builder()
- *                      .generateCodegenComments()
- *                      .publicConstrainedTypes()
- *                      .toObjectNode()
+ *                  additionalSettings =
+ *                      ServerAdditionalSettings.builder()
+ *                          .generateCodegenComments()
+ *                          .publicConstrainedTypes()
+ *                          .toObjectNode()
  *             )),
  * ```
  */
@@ -100,7 +101,7 @@ class ServerAdditionalSettings private constructor(settings: List<AdditionalSett
     AdditionalSettings.CoreAdditionalSettings(settings) {
         class Builder : CoreAdditionalSettings.Builder<ServerAdditionalSettings>() {
             fun publicConstrainedTypes(enabled: Boolean = true): Builder {
-                settings.add(PublicConstraintType(enabled))
+                settings.add(PublicConstrainedType(enabled))
                 return this
             }
 
@@ -112,7 +113,7 @@ class ServerAdditionalSettings private constructor(settings: List<AdditionalSett
             override fun build(): ServerAdditionalSettings = ServerAdditionalSettings(settings)
         }
 
-        private data class PublicConstraintType(val enabled: Boolean) : AdditionalSettings() {
+        private data class PublicConstrainedType(val enabled: Boolean) : AdditionalSettings() {
             override fun toObjectNode(): ObjectNode =
                 ObjectNode.builder()
                     .withMember("publicConstrainedTypes", enabled)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
@@ -36,15 +36,15 @@ data class IntegrationTestParams(
  * Usage:
  *
  * ```kotlin
- *         serverIntegrationTest(
- *             model,
- *             IntegrationTestParams(
- *                  additionalSettings =
- *                      ServerAdditionalSettings.builder()
- *                          .generateCodegenComments()
- *                          .publicConstrainedTypes()
- *                          .toObjectNode()
- *             )),
+ * serverIntegrationTest(
+ *     model,
+ *     IntegrationTestParams(
+ *         additionalSettings =
+ *             ServerAdditionalSettings.builder()
+ *                 .generateCodegenComments()
+ *                 .publicConstrainedTypes()
+ *                 .toObjectNode()
+ * )),
  * ```
  */
 sealed class AdditionalSettings {
@@ -90,7 +90,7 @@ class ClientAdditionalSettings private constructor(settings: List<AdditionalSett
             override fun build(): ClientAdditionalSettings = ClientAdditionalSettings(settings)
         }
 
-        // Additional settings that are specific to client generation should be defined here
+        // Additional settings that are specific to client generation should be defined here.
 
         companion object {
             fun builder() = Builder()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -86,7 +86,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.Ser
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.protocols.ServerProtocolLoader
 import software.amazon.smithy.rust.codegen.server.smithy.traits.isReachableFromOperationInput
-import software.amazon.smithy.rust.codegen.server.smithy.transformers.AttachValidationExceptionToConstrainedOperationInputsInAllowList
+import software.amazon.smithy.rust.codegen.server.smithy.transformers.AttachValidationExceptionToConstrainedOperationInputs
 import software.amazon.smithy.rust.codegen.server.smithy.transformers.ConstrainedMemberTransform
 import software.amazon.smithy.rust.codegen.server.smithy.transformers.RecursiveConstraintViolationBoxer
 import software.amazon.smithy.rust.codegen.server.smithy.transformers.RemoveEbsModelValidationException
@@ -204,10 +204,8 @@ open class ServerCodegenVisitor(
             // Remove the EBS model's own `ValidationException`, which collides with `smithy.framework#ValidationException`
             .let(RemoveEbsModelValidationException::transform)
             // Attach the `smithy.framework#ValidationException` error to operations whose inputs are constrained,
-            // if they belong to a service in an allowlist
-            .let {
-                AttachValidationExceptionToConstrainedOperationInputsInAllowList.transform(it, settings.codegenConfig)
-            }
+            // if either the operation belongs to a service in the allowlist, or the codegen flag to add the exception has been set.
+            .let { AttachValidationExceptionToConstrainedOperationInputs.transform(it, settings) }
             // Tag aggregate shapes reachable from operation input
             .let(ShapesReachableFromOperationInputTagger::transform)
             // Normalize event stream operations

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -205,7 +205,9 @@ open class ServerCodegenVisitor(
             .let(RemoveEbsModelValidationException::transform)
             // Attach the `smithy.framework#ValidationException` error to operations whose inputs are constrained,
             // if they belong to a service in an allowlist
-            .let(AttachValidationExceptionToConstrainedOperationInputsInAllowList::transform)
+            .let {
+                AttachValidationExceptionToConstrainedOperationInputsInAllowList.transform(it, settings.codegenConfig)
+            }
             // Tag aggregate shapes reachable from operation input
             .let(ShapesReachableFromOperationInputTagger::transform)
             // Normalize event stream operations

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -96,6 +96,7 @@ data class ServerCodegenConfig(
      *  able to define the converters in their Rust application code.
      */
     val experimentalCustomValidationExceptionWithReasonPleaseDoNotUse: String? = defaultExperimentalCustomValidationExceptionWithReasonPleaseDoNotUse,
+    val addValidationExceptionToConstrainedOperations: Boolean = DEFAULT_ADD_VALIDATION_EXCEPTION_TO_CONSTRAINED_OPERATIONS,
 ) : CoreCodegenConfig(
         formatTimeoutSeconds, debugMode,
     ) {
@@ -103,6 +104,7 @@ data class ServerCodegenConfig(
         private const val DEFAULT_PUBLIC_CONSTRAINED_TYPES = true
         private const val DEFAULT_IGNORE_UNSUPPORTED_CONSTRAINTS = false
         private val defaultExperimentalCustomValidationExceptionWithReasonPleaseDoNotUse = null
+        private const val DEFAULT_ADD_VALIDATION_EXCEPTION_TO_CONSTRAINED_OPERATIONS = false
 
         fun fromCodegenConfigAndNode(
             coreCodegenConfig: CoreCodegenConfig,
@@ -114,6 +116,7 @@ data class ServerCodegenConfig(
                 publicConstrainedTypes = node.get().getBooleanMemberOrDefault("publicConstrainedTypes", DEFAULT_PUBLIC_CONSTRAINED_TYPES),
                 ignoreUnsupportedConstraints = node.get().getBooleanMemberOrDefault("ignoreUnsupportedConstraints", DEFAULT_IGNORE_UNSUPPORTED_CONSTRAINTS),
                 experimentalCustomValidationExceptionWithReasonPleaseDoNotUse = node.get().getStringMemberOrDefault("experimentalCustomValidationExceptionWithReasonPleaseDoNotUse", defaultExperimentalCustomValidationExceptionWithReasonPleaseDoNotUse),
+                addValidationExceptionToConstrainedOperations = node.get().getBooleanMemberOrDefault("addValidationExceptionToConstrainedOperations", DEFAULT_ADD_VALIDATION_EXCEPTION_TO_CONSTRAINED_OPERATIONS),
             )
         } else {
             ServerCodegenConfig(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/AttachValidationExceptionToConstrainedOperationInputs.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/AttachValidationExceptionToConstrainedOperationInputs.kt
@@ -108,7 +108,7 @@ object AttachValidationExceptionToConstrainedOperationInputsBasedOnCodegenFlag {
  * Attaches the `smithy.framework#ValidationException` error to operations with constrained inputs
  * if either of the following conditions is met:
  * 1. The operation belongs to a service in the allowlist.
- * 2. The codegen flag to add ValidationException has been set.
+ * 2. The codegen flag `addValidationExceptionToConstrainedOperations` has been set.
  *
  * The error is only attached if the operation does not already have `ValidationException` added.
  */

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/AttachValidationExceptionToConstrainedOperationInputsInAllowList.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/AttachValidationExceptionToConstrainedOperationInputsInAllowList.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.core.smithy.DirectedWalker
 import software.amazon.smithy.rust.codegen.core.util.inputShape
+import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenConfig
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionConversionGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.hasConstraintTrait
 
@@ -49,11 +50,16 @@ object AttachValidationExceptionToConstrainedOperationInputsInAllowList {
             // ShapeId.from("com.amazonaws.machinelearning#AmazonML_20141212"),
         )
 
-    fun transform(model: Model): Model {
+    fun transform(
+        model: Model,
+        runtimeConfig: ServerCodegenConfig,
+    ): Model {
         val walker = DirectedWalker(model)
         val operationsWithConstrainedInputWithoutValidationException =
             model.serviceShapes
-                .filter { sherviceShapeIdAllowList.contains(it.toShapeId()) }
+                .filter {
+                    sherviceShapeIdAllowList.contains(it.toShapeId()) || runtimeConfig.addValidationExceptionToConstrainedOperations
+                }
                 .flatMap { it.operations }
                 .map { model.expectShape(it, OperationShape::class.java) }
                 .filter { operationShape ->

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/AttachValidationExceptionToConstrainedOperationInputsInAllowList.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/AttachValidationExceptionToConstrainedOperationInputsInAllowList.kt
@@ -8,14 +8,40 @@ package software.amazon.smithy.rust.codegen.server.smithy.transformers
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.SetShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.core.smithy.DirectedWalker
 import software.amazon.smithy.rust.codegen.core.util.inputShape
-import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenConfig
+import software.amazon.smithy.rust.codegen.server.smithy.ServerRustSettings
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionConversionGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.hasConstraintTrait
+
+private fun addValidationExceptionToMatchingServiceShapes(
+    model: Model,
+    filterPredicate: (ServiceShape) -> Boolean,
+): Model {
+    val walker = DirectedWalker(model)
+    val operationsWithConstrainedInputWithoutValidationException =
+        model.serviceShapes
+            .filter(filterPredicate)
+            .flatMap { it.operations }
+            .map { model.expectShape(it, OperationShape::class.java) }
+            .filter { operationShape ->
+                walker.walkShapes(operationShape.inputShape(model))
+                    .any { it is SetShape || it is EnumShape || it.hasConstraintTrait() }
+            }
+            .filter { !it.errors.contains(SmithyValidationExceptionConversionGenerator.SHAPE_ID) }
+
+    return ModelTransformer.create().mapShapes(model) { shape ->
+        if (shape is OperationShape && operationsWithConstrainedInputWithoutValidationException.contains(shape)) {
+            shape.toBuilder().addError(SmithyValidationExceptionConversionGenerator.SHAPE_ID).build()
+        } else {
+            shape
+        }
+    }
+}
 
 /**
  * Attach the `smithy.framework#ValidationException` error to operations whose inputs are constrained, if they belong
@@ -33,7 +59,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.hasConstraintTrait
  *  `disableDefaultValidation` set to `true`, allowing service owners to map from constraint violations to operation errors.
  */
 object AttachValidationExceptionToConstrainedOperationInputsInAllowList {
-    private val sherviceShapeIdAllowList =
+    private val serviceShapeIdAllowList =
         setOf(
             // These we currently generate server SDKs for.
             ShapeId.from("aws.protocoltests.restjson#RestJson"),
@@ -50,31 +76,48 @@ object AttachValidationExceptionToConstrainedOperationInputsInAllowList {
             // ShapeId.from("com.amazonaws.machinelearning#AmazonML_20141212"),
         )
 
+    fun transform(model: Model): Model {
+        return addValidationExceptionToMatchingServiceShapes(
+            model,
+        ) { serviceShapeIdAllowList.contains(it.toShapeId()) }
+    }
+}
+
+/**
+ * Attach the `smithy.framework#ValidationException` error to operations with constrained inputs if the
+ * codegen flag `addValidationExceptionToConstrainedOperations` has been set.
+ */
+object AttachValidationExceptionToConstrainedOperationInputsBasedOnCodegenFlag {
     fun transform(
         model: Model,
-        runtimeConfig: ServerCodegenConfig,
+        settings: ServerRustSettings,
     ): Model {
-        val walker = DirectedWalker(model)
-        val operationsWithConstrainedInputWithoutValidationException =
-            model.serviceShapes
-                .filter {
-                    sherviceShapeIdAllowList.contains(it.toShapeId()) || runtimeConfig.addValidationExceptionToConstrainedOperations
-                }
-                .flatMap { it.operations }
-                .map { model.expectShape(it, OperationShape::class.java) }
-                .filter { operationShape ->
-                    // Walk the shapes reachable via this operation input.
-                    walker.walkShapes(operationShape.inputShape(model))
-                        .any { it is SetShape || it is EnumShape || it.hasConstraintTrait() }
-                }
-                .filter { !it.errors.contains(SmithyValidationExceptionConversionGenerator.SHAPE_ID) }
-
-        return ModelTransformer.create().mapShapes(model) { shape ->
-            if (shape is OperationShape && operationsWithConstrainedInputWithoutValidationException.contains(shape)) {
-                shape.toBuilder().addError(SmithyValidationExceptionConversionGenerator.SHAPE_ID).build()
-            } else {
-                shape
-            }
+        if (!settings.codegenConfig.addValidationExceptionToConstrainedOperations) {
+            return model
         }
+
+        val service = settings.getService(model)
+
+        return addValidationExceptionToMatchingServiceShapes(
+            model,
+        ) { it == service }
+    }
+}
+
+/**
+ * Attaches the `smithy.framework#ValidationException` error to operations with constrained inputs
+ * if either of the following conditions is met:
+ * 1. The operation belongs to a service in the allowlist.
+ * 2. The codegen flag to add ValidationException has been set.
+ *
+ * The error is only attached if the operation does not already have `ValidationException` added.
+ */
+object AttachValidationExceptionToConstrainedOperationInputs {
+    fun transform(
+        model: Model,
+        settings: ServerRustSettings,
+    ): Model {
+        val allowListTransformedModel = AttachValidationExceptionToConstrainedOperationInputsInAllowList.transform(model)
+        return AttachValidationExceptionToConstrainedOperationInputsBasedOnCodegenFlag.transform(allowListTransformedModel, settings)
     }
 }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/AddValidationExceptionToConstrainedOperationsTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/AddValidationExceptionToConstrainedOperationsTest.kt
@@ -1,0 +1,128 @@
+package software.amazon.smithy.rust.codegen.server.smithy.customizations
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
+import software.amazon.smithy.rust.codegen.core.testutil.ServerAdditionalSettings
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
+
+/**
+ * Tests whether the server `codegen` flag `addValidationExceptionToConstrainedOperations` works as expected.
+ */
+internal class AddValidationExceptionToConstrainedOperationsTest {
+    private val testModelWithValidationExceptionImported =
+        """
+        namespace test
+
+        use smithy.framework#ValidationException
+        use aws.protocols#restJson1
+        use aws.api#data
+
+        @restJson1
+        service ConstrainedService {
+            operations: [SampleOperationWithValidation, SampleOperationWithoutValidation]
+        }
+
+        @http(uri: "/anOperationWithValidation", method: "POST")
+        operation SampleOperationWithValidation {
+            output: SampleInputOutput
+            input: SampleInputOutput
+            errors: [ValidationException, ErrorWithMemberConstraint]
+        }
+        @http(uri: "/anOperationWithoutValidation", method: "POST")
+        operation SampleOperationWithoutValidation {
+            output: SampleInputOutput
+            input: SampleInputOutput
+            errors: []
+        }
+        structure SampleInputOutput {
+            constrainedInteger : RangedInteger
+            @range(min: 2, max:100)
+            constrainedMemberInteger : RangedInteger
+            patternString : PatternString
+        }
+        @pattern("^[a-m]+${'$'}")
+        string PatternString
+        @range(min: 0, max:1000)
+        integer RangedInteger
+
+        @error("server")
+        structure ErrorWithMemberConstraint {
+            @range(min: 100, max: 999)
+            statusCode: Integer
+        }
+        """.asSmithyModel(smithyVersion = "2")
+
+    private val testModelWithoutValidationExceptionImported =
+        """
+        namespace test
+
+        use aws.protocols#restJson1
+        use aws.api#data
+
+        @restJson1
+        service ConstrainedService {
+            operations: [SampleOperationWithoutValidation]
+        }
+        @http(uri: "/anOperationWithoutValidation", method: "POST")
+        operation SampleOperationWithoutValidation {
+            output: SampleInputOutput
+            input: SampleInputOutput
+            errors: []
+        }
+        structure SampleInputOutput {
+            constrainedInteger : RangedInteger
+            @range(min: 2, max:100)
+            constrainedMemberInteger : RangedInteger
+            patternString : PatternString
+        }
+        @pattern("^[a-m]+${'$'}")
+        string PatternString
+        @range(min: 0, max:1000)
+        integer RangedInteger
+
+        @error("server")
+        structure ErrorWithMemberConstraint {
+            @range(min: 100, max: 999)
+            statusCode: Integer
+        }
+        """.asSmithyModel(smithyVersion = "2")
+
+    @Test
+    fun `without setting the codegen flag, the model should fail to compile`() {
+        assertThrows<CodegenException> {
+            serverIntegrationTest(
+                testModelWithValidationExceptionImported,
+                IntegrationTestParams(),
+            )
+        }
+    }
+
+    @Test
+    fun `operations that do not have ValidationException will automatically have one added to them`() {
+        serverIntegrationTest(
+            testModelWithValidationExceptionImported,
+            IntegrationTestParams(
+                additionalSettings =
+                    ServerAdditionalSettings.builder()
+                        .addValidationExceptionToConstrainedOperations()
+                        .toObjectNode(),
+            ),
+        )
+    }
+
+    @Test
+    fun `the model, which does not have Smithy's ValidationException imported, should work when the codegen parameter is set`() {
+        serverIntegrationTest(
+            testModelWithoutValidationExceptionImported,
+            IntegrationTestParams(
+                additionalSettings =
+                    ServerAdditionalSettings.builder()
+                        .addValidationExceptionToConstrainedOperations()
+                        .toObjectNode(),
+            ),
+        )
+    }
+}

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/AddValidationExceptionToConstrainedOperationsTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/AddValidationExceptionToConstrainedOperationsTest.kt
@@ -60,41 +60,6 @@ internal class AddValidationExceptionToConstrainedOperationsTest {
         }
         """.asSmithyModel(smithyVersion = "2")
 
-    private val testModelWithoutValidationExceptionImported =
-        """
-        namespace test
-
-        use aws.protocols#restJson1
-        use aws.api#data
-
-        @restJson1
-        service ConstrainedService {
-            operations: [SampleOperationWithoutValidation]
-        }
-        @http(uri: "/anOperationWithoutValidation", method: "POST")
-        operation SampleOperationWithoutValidation {
-            output: SampleInputOutput
-            input: SampleInputOutput
-            errors: []
-        }
-        structure SampleInputOutput {
-            constrainedInteger : RangedInteger
-            @range(min: 2, max:100)
-            constrainedMemberInteger : RangedInteger
-            patternString : PatternString
-        }
-        @pattern("^[a-m]+${'$'}")
-        string PatternString
-        @range(min: 0, max:1000)
-        integer RangedInteger
-
-        @error("server")
-        structure ErrorWithMemberConstraint {
-            @range(min: 100, max: 999)
-            statusCode: Integer
-        }
-        """.asSmithyModel(smithyVersion = "2")
-
     @Test
     fun `without setting the codegen flag, the model should fail to compile`() {
         assertThrows<CodegenException> {
@@ -109,19 +74,6 @@ internal class AddValidationExceptionToConstrainedOperationsTest {
     fun `operations that do not have ValidationException will automatically have one added to them`() {
         serverIntegrationTest(
             testModelWithValidationExceptionImported,
-            IntegrationTestParams(
-                additionalSettings =
-                    ServerAdditionalSettings.builder()
-                        .addValidationExceptionToConstrainedOperations()
-                        .toObjectNode(),
-            ),
-        )
-    }
-
-    @Test
-    fun `the model, which does not have Smithy's ValidationException imported, should work when the codegen parameter is set`() {
-        serverIntegrationTest(
-            testModelWithoutValidationExceptionImported,
             IntegrationTestParams(
                 additionalSettings =
                     ServerAdditionalSettings.builder()

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/AddValidationExceptionToConstrainedOperationsTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/AddValidationExceptionToConstrainedOperationsTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.rust.codegen.server.smithy.customizations
 
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
The Server SDK requires the model to include `aws.smithy.framework#ValidationException` in each operation that can access a constrained member shape. This becomes problematic when generating the server SDK for a model not owned by the team creating the SDK, as they cannot easily modify the model.

This PR introduces a codegen flag, `addValidationExceptionToConstrainedOperations`. When set in `smithy-build-template.json`, this flag will automatically add `ValidationException` to operations that require it but do not already list it among their errors.

Closes Issue: [3802](https://github.com/smithy-lang/smithy-rs/issues/3802)

Sample `smithy-build-template.json`
```
"plugins": {
            "rust-server-codegen": {
                "service": "ServiceToGenerateSDKFor",
                "module": "amzn-sample-server-sdk",
                "codegen": {
                    "addValidationExceptionToConstrainedOperations": true,
                }
            }
        }
```