### PR TITLE
Fix deterministic codegen check for `SmokeTestsDecorator`

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecorator.kt
@@ -71,16 +71,20 @@ class SmokeTestsDecorator : ClientCodegenDecorator {
             codegenContext.model.getOperationShapesWithTrait(SmokeTestsTrait::class.java).toList()
         val supportedTests =
             smokeTestedOperations.map { operationShape ->
-                // filter out unsupported smoke tests, logging a warning for each one.
+                // filter out unsupported smoke tests, logging a warning for each one, and sort the remaining tests by
+                // case ID. This ensures deterministic rendering, meaning the test methods are always rendered in a
+                // consistent order.
                 val testCases =
                     operationShape.expectTrait<SmokeTestsTrait>().testCases.filter { smokeTestCase ->
                         isSmokeTestSupported(smokeTestCase)
-                    }
+                    }.sortedBy { smokeTestCase -> smokeTestCase.id }
 
                 operationShape to testCases
             }
                 // filter out operations with no supported smoke tests
                 .filter { (_, testCases) -> testCases.isNotEmpty() }
+                // Similar to sorting test cases above, sort operations by name to ensure consistent ordering.
+                .sortedBy { (operationShape, _) -> operationShape.id.name }
         // Return if there are no supported smoke tests across all operations
         if (supportedTests.isEmpty()) return
 


### PR DESCRIPTION
## Motivation and Context
Attempts to fix [a release blocker](https://github.com/smithy-lang/smithy-rs/actions/runs/10601508703/job/29381493978)

## Description
This PR ensures that `SmokeTestsDecorator` renders test functions into `smoketests` in a consistent order, e.g. sorted first by operation name and then within that operation, sorted by test case ID.

## Testing
- [x] Existing tests in CI (specifically `check-deterministic-codegen`)

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
