### PR TITLE
lock canary version of regalloc2 to 0.9.3

### DIFF
--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -602,6 +602,9 @@ wit-bindgen = { version = "0.16.0", features = ["macros", "realloc"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }
 wasmtime-wasi = "17.0.1"
 wasmtime-wasi-http = "17.0.1"
+
+# The maintainers of this crate made breaking changes in v0.9.4 so we lock this.
+regalloc2 = "=0.9.3"
 aws-config = { path = "some/sdk/path/aws-config", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { path = "some/sdk/path/s3" }
 aws-sdk-ec2 = { path = "some/sdk/path/ec2" }
@@ -660,6 +663,9 @@ wit-bindgen = { version = "0.16.0", features = ["macros", "realloc"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }
 wasmtime-wasi = "17.0.1"
 wasmtime-wasi-http = "17.0.1"
+
+# The maintainers of this crate made breaking changes in v0.9.4 so we lock this.
+regalloc2 = "=0.9.3"
 aws-config = { version = "0.46.0", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "0.20.0" }
 aws-sdk-ec2 = { version = "0.19.0" }

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -143,6 +143,9 @@ wit-bindgen = { version = "0.16.0", features = ["macros", "realloc"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }
 wasmtime-wasi = "17.0.1"
 wasmtime-wasi-http = "17.0.1"
+
+# The maintainers of this crate made breaking changes in v0.9.4 so we lock this.
+regalloc2 = "=0.9.3"
 "#;
 
 lazy_static! {


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
