### PR TITLE
Pin `minicbor` to 0.24.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
   check-semver-hazards:
     name: Check for semver hazards
     runs-on: smithy_ubuntu-latest_8-core
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
       with:

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -9345,6 +9345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-cbor"
+version = "0.60.7"
+dependencies = [
+ "aws-smithy-types 1.2.2",
+ "criterion",
+ "minicbor",
+]
+
+[[package]]
 name = "aws-smithy-checksums"
 version = "0.60.10"
 dependencies = [
@@ -11098,6 +11107,27 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minicbor"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8e213c36148d828083ae01948eed271d03f95f7e72571fa242d78184029af2"
+dependencies = [
+ "half 2.4.1",
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6bdc119b1a405df86a8cde673295114179dbd0ebe18877c26ba89fb080365c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "minimal-lexical"


### PR DESCRIPTION
**Will merge to the release branch**

## Motivation and Context
Fixes a failure observed in our release pipeline

## Description
A lockfile located at `aws/sdk/Cargo.lock` did not include the `minicbor` crate that was introduced as part of RPC V2 CBOR. This has caused a build failure in our release pipeline due to a new version of `minicbor` 0.24.3 uploaded to crates.io.
```
error: unsupported output in build script of `minicbor v0.24.3`: `cargo::rustc-check-cfg=cfg(atomic64, atomic32)`
```

To address this issue, this PR pins `minicbor` to 0.24.2 in `aws/sdk/Cargo.lock` (`rust-runtime/Cargo.lock` already pins it to 0.24.2)

The change in `aws/sdk/Cargo.lock` was obtained by
1. running `git pull` in `/Users/awsaito/src/aws-sdk-rust`
2. running `./gradlew aws:sdk:generateAllLockfiles -Paws-sdk-rust-path=/Users/awsaito/src/aws-sdk-rust`
3. retaining the portion only relevant to `minicbor`

In addition, since the release of aws-sdk-rust the other day, smoke tests have started getting rendered and compiled in cargo-semver-checks. This has caused cargo-semver-checks to exceed the previous timeout of 20 minutes. To address it, we have increased the timeout to 30 minutes.

## Testing
- [x] Tests in CI
- [x] End-to-end tests in our release pipeline

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
