### PR TITLE
Update lockfiles

### DIFF
--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -30,7 +30,7 @@ env:
   apt_dependencies: libssl-dev gnuplot jq
   java_version: 17
   rust_toolchain_components: clippy,rustfmt
-  rust_nightly_version: nightly-2024-02-07
+  rust_nightly_version: nightly-2024-03-15
 
 jobs:
   generate-diff:

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "arbitrary"
@@ -75,13 +75,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "lru",
  "ring",
  "sha2",
@@ -170,7 +170,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -314,7 +314,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "hyper",
  "hyper-rustls",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -352,7 +352,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -443,9 +443,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -472,10 +472,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "bytes"
-version = "1.6.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bytes-utils"
@@ -514,13 +520,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -567,18 +573,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -586,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "const-oid"
@@ -617,15 +623,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -803,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -857,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -1015,6 +1021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1087,7 +1099,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1105,9 +1117,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1156,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1166,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -1192,33 +1204,33 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1255,15 +1267,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown",
 ]
@@ -1310,13 +1322,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1386,20 +1399,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -1412,9 +1415,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openssl-probe"
@@ -1465,7 +1468,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1532,9 +1535,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -1581,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1607,9 +1613,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1675,18 +1681,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1775,18 +1781,18 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags",
  "errno",
@@ -1906,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1919,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1941,9 +1947,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -1960,22 +1966,23 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2010,6 +2017,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2073,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2090,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2101,34 +2114,35 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2198,32 +2212,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2238,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2251,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2274,7 +2287,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2334,7 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2401,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -2413,9 +2426,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -2459,34 +2472,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2494,28 +2508,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2545,11 +2559,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2560,142 +2574,85 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xmlparser"
@@ -2711,22 +2668,23 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.4"
+version = "1.5.6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.1.5"
+version = "1.2.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -89,19 +89,21 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.1.5"
+version = "1.4.2"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -171,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.1.5"
+version = "1.2.3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -192,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.1.5"
+version = "1.2.1"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -201,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.5"
+version = "0.60.10"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -209,7 +211,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -219,28 +221,31 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.5"
+version = "0.60.7"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.60.5"
+version = "0.62.0"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
  "http 0.2.12",
  "pretty_assertions",
  "regex-lite",
  "roxmltree",
+ "serde_cbor",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.5"
+version = "0.60.7"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -248,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.1.5"
+version = "1.7.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -259,9 +264,12 @@ dependencies = [
  "fastrand",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
  "hyper",
  "hyper-rustls",
+ "indexmap",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -275,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.1.5"
+version = "1.7.2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -290,14 +298,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.5"
+version = "1.2.5"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
- "futures-core",
  "http 0.2.12",
- "http-body",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
  "itoa",
  "num-integer",
  "pin-project-lite",
@@ -309,29 +319,28 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.5"
+version = "0.60.8"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.1.5"
+version = "1.3.3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -360,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -374,10 +383,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytes"
-version = "1.6.0"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bytes"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bytes-utils"
@@ -390,16 +408,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.99"
+name = "cbor-diag"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half 2.4.1",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "cc"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "core-foundation"
@@ -413,18 +462,24 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -435,6 +490,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deranged"
@@ -463,21 +524,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "equivalent"
@@ -499,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fnv"
@@ -604,6 +654,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,10 +730,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.8.0"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -677,9 +766,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -687,7 +776,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -717,143 +806,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -864,21 +834,15 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "lock_api"
@@ -892,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -907,28 +871,45 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -939,6 +920,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -957,6 +948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,20 +968,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -1028,7 +1020,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1091,36 +1083,36 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1178,7 +1170,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1198,9 +1190,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -1260,7 +1252,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1281,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1294,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1309,32 +1301,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
-name = "serde"
-version = "1.0.203"
+name = "separator"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
+name = "serde"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.203"
+name = "serde_cbor"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1358,6 +1368,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1390,7 +1406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1400,16 +1416,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1424,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1434,34 +1444,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1505,43 +1504,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
+name = "tinyvec"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
- "displaydoc",
- "zerovec",
+ "tinyvec_macros",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.38.0"
+name = "tinyvec_macros"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1556,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1569,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1592,7 +1595,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1665,7 +1668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1681,10 +1684,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "untrusted"
@@ -1694,9 +1712,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1710,22 +1728,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -1735,9 +1741,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -1790,154 +1796,76 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xmlparser"
@@ -1952,74 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.5"
+version = "1.5.6"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/json_credentials.rs
+++ b/aws/rust-runtime/aws-config/src/json_credentials.rs
@@ -8,7 +8,6 @@ use aws_smithy_json::deserialize::{json_token_iter, EscapeError, Token};
 use aws_smithy_types::date_time::Format;
 use aws_smithy_types::DateTime;
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::time::SystemTime;

--- a/aws/rust-runtime/aws-config/src/sso/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/sso/credentials.rs
@@ -23,7 +23,6 @@ use aws_smithy_types::DateTime;
 use aws_types::os_shim_internal::{Env, Fs};
 use aws_types::region::Region;
 use aws_types::SdkConfig;
-use std::convert::TryInto;
 
 /// SSO Credentials Provider
 ///

--- a/aws/rust-runtime/aws-config/src/sts/util.rs
+++ b/aws/rust-runtime/aws-config/src/sts/util.rs
@@ -7,7 +7,6 @@ use aws_credential_types::provider::{self, error::CredentialsError};
 use aws_credential_types::Credentials as AwsCredentials;
 use aws_sdk_sts::types::Credentials as StsCredentials;
 
-use std::convert::TryFrom;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Convert STS credentials to aws_auth::Credentials

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -152,8 +152,6 @@ impl Storable for InvocationId {
 
 #[cfg(feature = "test-util")]
 mod test_util {
-    use std::sync::{Arc, Mutex};
-
     use super::*;
 
     impl InvocationId {

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -19,7 +19,6 @@ use http0::header::{AsHeaderName, HeaderName, HOST};
 use http0::{HeaderMap, HeaderValue, Uri};
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,9 +58,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "approx"
@@ -107,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -138,7 +144,7 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "blocking",
  "futures-lite 2.3.0",
@@ -167,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
@@ -177,11 +183,11 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.7.2",
- "rustix 0.38.34",
+ "polling 3.7.3",
+ "rustix 0.38.36",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -228,26 +234,26 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -295,7 +301,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -306,13 +312,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -329,26 +335,25 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.3"
+version = "1.5.5"
 dependencies = [
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
  "hex",
  "http 0.2.12",
- "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "ring",
  "serde",
@@ -364,25 +369,25 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "tokio",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
 ]
 
@@ -392,9 +397,9 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-http"
-version = "0.60.5"
+version = "0.60.6"
 dependencies = [
- "aws-runtime 1.3.0",
+ "aws-runtime 1.4.2",
 ]
 
 [[package]]
@@ -403,9 +408,9 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5cc4286676d121ca5a2ce89e0d4ddbc2d660ac24bb17bc49607d700f49f993"
+checksum = "33d41a5d02120c5eca009507574fa0d4885fa370cbda6b561d91ba463c3025a7"
 dependencies = [
  "bindgen",
  "cmake",
@@ -417,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7d844e282b4b56750b2d4e893b2205581ded8709fddd2b6aa5418c150ca877"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -430,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a2c29203f6bf296d01141cc8bb9dbd5ecd4c27843f2ee0767bcd5985a927da"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
 dependencies = [
  "bindgen",
  "cc",
@@ -445,27 +450,33 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.0"
+version = "1.4.2"
 dependencies = [
  "arbitrary",
- "aws-credential-types 1.2.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "bytes-utils",
+ "convert_case",
  "fastrand 2.0.2",
  "futures-util",
  "http 0.2.12",
+ "http 1.1.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "proptest",
+ "regex-lite",
  "serde",
  "serde_json",
  "tokio",
@@ -477,22 +488,24 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4a5e448145999d7de17bf44a886900ecb834953408dae8aaf90465ce91c1dd"
+checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
 dependencies = [
- "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-sigv4 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-credential-types 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-sigv4 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-types 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
  "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -505,18 +518,18 @@ version = "1.1.8"
 
 [[package]]
 name = "aws-sdk-accessanalyzer"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -528,18 +541,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-account"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -550,18 +563,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-acm"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -572,18 +585,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-acmpca"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -594,18 +607,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amp"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -617,18 +630,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amplify"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -639,18 +652,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amplifybackend"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -661,18 +674,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-amplifyuibuilder"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -684,18 +697,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apigateway"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -706,18 +719,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apigatewaymanagement"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -728,18 +741,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apigatewayv2"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -750,18 +763,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appconfig"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -772,18 +785,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appconfigdata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -794,18 +807,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appfabric"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -817,18 +830,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appflow"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -840,18 +853,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appintegrations"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -863,18 +876,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationautoscaling"
-version = "1.35.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -885,18 +898,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationcostprofiler"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -907,18 +920,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationdiscovery"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -930,18 +943,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationinsights"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -952,18 +965,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-applicationsignals"
-version = "1.3.0"
+version = "1.13.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -974,18 +987,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appmesh"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -997,18 +1010,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apprunner"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1019,18 +1032,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appstream"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1041,18 +1054,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-appsync"
-version = "1.37.0"
+version = "1.47.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1063,18 +1076,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apptest"
-version = "1.3.0"
+version = "1.11.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1086,18 +1099,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-arczonalshift"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1108,18 +1121,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-artifact"
-version = "1.21.0"
+version = "1.29.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1130,18 +1143,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-athena"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1153,18 +1166,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-auditmanager"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1175,20 +1188,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-autoscaling"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1198,18 +1211,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-autoscalingplans"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1220,18 +1233,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-b2bi"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1243,18 +1256,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-backup"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1266,18 +1279,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-backupgateway"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1288,18 +1301,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-batch"
-version = "1.39.0"
+version = "1.48.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1307,22 +1321,23 @@ dependencies = [
  "regex-lite",
  "tokio",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
 name = "aws-sdk-bcmdataexports"
-version = "1.31.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1333,18 +1348,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrock"
-version = "1.35.0"
+version = "1.48.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1356,18 +1371,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockagent"
-version = "1.37.0"
+version = "1.48.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1379,19 +1394,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockagentruntime"
-version = "1.36.0"
+version = "1.47.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1402,19 +1417,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.36.0"
+version = "1.48.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1425,18 +1440,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-billingconductor"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1448,18 +1463,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-braket"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1471,18 +1486,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-budgets"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1493,18 +1508,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chatbot"
-version = "1.20.0"
+version = "1.29.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1515,18 +1530,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chime"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1538,18 +1553,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkidentity"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1561,18 +1576,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkmediapipelines"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1584,18 +1599,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkmeetings"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1607,18 +1622,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkmessaging"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1630,18 +1645,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-chimesdkvoice"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1652,18 +1667,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cleanrooms"
-version = "1.36.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1674,18 +1689,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cleanroomsml"
-version = "1.31.0"
+version = "1.40.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1696,18 +1711,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloud9"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1718,18 +1733,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudcontrol"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1741,18 +1756,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-clouddirectory"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1763,20 +1778,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudformation"
-version = "1.38.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "fastrand 2.0.2",
  "http 0.2.12",
  "once_cell",
@@ -1787,19 +1802,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudfront"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1809,18 +1824,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudfrontkeyvaluestore"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1832,18 +1847,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudhsm"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1854,18 +1869,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudhsmv2"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1876,20 +1891,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudsearch"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1899,18 +1914,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudsearchdomain"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1921,18 +1936,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudtrail"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1943,18 +1958,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudtraildata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1965,21 +1980,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "1.37.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
  "aws-smithy-compression",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "flate2",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1991,18 +2006,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchevents"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2013,18 +2028,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "1.36.0"
+version = "1.47.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2036,18 +2051,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codeartifact"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2058,18 +2073,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codebuild"
-version = "1.42.0"
+version = "1.52.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2080,19 +2095,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codecatalyst"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
@@ -2107,18 +2122,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codecommit"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2130,18 +2145,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codeconnections"
-version = "1.15.0"
+version = "1.23.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2152,18 +2167,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codedeploy"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2174,18 +2189,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codeguruprofiler"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2197,18 +2212,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codegurureviewer"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2220,18 +2235,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codegurusecurity"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2243,18 +2258,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codepipeline"
-version = "1.36.0"
+version = "1.45.1"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2265,41 +2280,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-codestar"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "aws-sdk-codestarconnections"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2310,18 +2303,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-codestarnotifications"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2333,18 +2326,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cognitoidentity"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2355,18 +2348,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cognitoidentityprovider"
-version = "1.38.0"
+version = "1.48.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2377,18 +2370,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cognitosync"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2399,18 +2392,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-comprehend"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2422,18 +2415,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-comprehendmedical"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2445,18 +2438,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-computeoptimizer"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2467,18 +2460,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-config"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2489,18 +2482,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-connect"
-version = "1.47.0"
+version = "1.61.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2512,18 +2505,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-connectcampaigns"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2534,18 +2527,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-connectcases"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2557,18 +2550,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-connectcontactlens"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2579,18 +2572,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-connectparticipant"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2602,18 +2595,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-controlcatalog"
-version = "1.14.0"
+version = "1.23.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2624,18 +2617,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-controltower"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2646,18 +2639,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-costandusagereport"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2668,18 +2661,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-costexplorer"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2690,18 +2683,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-costoptimizationhub"
-version = "1.32.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2712,18 +2705,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-customerprofiles"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2734,18 +2727,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-databasemigration"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2756,18 +2749,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-databrew"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2778,18 +2771,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dataexchange"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2801,18 +2794,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-datapipeline"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2823,18 +2816,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-datasync"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2846,18 +2839,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-datazone"
-version = "1.37.0"
+version = "1.52.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2869,18 +2862,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dax"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2891,18 +2884,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-deadline"
-version = "1.15.0"
+version = "1.24.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2914,18 +2907,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-detective"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2936,18 +2929,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-devicefarm"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -2958,18 +2951,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-devopsguru"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -2981,18 +2974,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-directconnect"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3003,18 +2996,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-directory"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3025,18 +3018,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dlm"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3047,20 +3040,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-docdb"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3070,18 +3063,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-docdbelastic"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3093,18 +3086,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-drs"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3115,20 +3108,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "approx",
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "criterion",
  "fastrand 2.0.2",
@@ -3144,18 +3137,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodbstreams"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3166,19 +3159,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ebs"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3187,25 +3181,26 @@ dependencies = [
  "regex-lite",
  "tokio",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.53.0"
+version = "1.71.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
+ "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "fastrand 2.0.2",
  "futures-util",
  "http 0.2.12",
@@ -3219,18 +3214,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2instanceconnect"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3241,18 +3236,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3263,18 +3258,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecrpublic"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3285,18 +3280,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecs"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3308,18 +3303,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-efs"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3331,18 +3326,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-eks"
-version = "1.36.0"
+version = "1.48.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3354,18 +3349,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-eksauth"
-version = "1.31.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3376,20 +3371,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticache"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3399,20 +3394,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticbeanstalk"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3422,18 +3417,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticinference"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3444,20 +3439,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticloadbalancing"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3467,20 +3462,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticloadbalancingv2"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -3490,18 +3485,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticsearch"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3512,18 +3507,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elastictranscoder"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3534,18 +3529,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-emr"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3556,18 +3551,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-emrcontainers"
-version = "1.36.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3579,18 +3574,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-emrserverless"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3602,18 +3597,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-entityresolution"
-version = "1.35.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3624,18 +3619,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-eventbridge"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3646,18 +3641,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-evidently"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3668,18 +3663,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-finspace"
-version = "1.36.0"
+version = "1.44.1"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3691,18 +3686,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-finspacedata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3714,18 +3709,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.36.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3736,18 +3731,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-fis"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3759,18 +3754,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-fms"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3781,18 +3776,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-forecast"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3803,18 +3798,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-forecastquery"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3825,18 +3820,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-frauddetector"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3847,18 +3842,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-freetier"
-version = "1.31.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3869,18 +3864,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-fsx"
-version = "1.36.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3892,18 +3887,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-gamelift"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3914,20 +3909,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-glacier"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "futures-util",
  "hex",
@@ -3940,22 +3935,23 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
 name = "aws-sdk-globalaccelerator"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -3967,18 +3963,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-glue"
-version = "1.43.0"
+version = "1.58.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -3989,18 +3985,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-grafana"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4012,18 +4008,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-greengrass"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4034,18 +4030,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-greengrassv2"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4057,18 +4053,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-groundstation"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4079,18 +4075,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-guardduty"
-version = "1.38.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4102,18 +4098,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-health"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4124,18 +4120,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-healthlake"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4147,21 +4143,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iam"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
+ "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "futures-util",
  "http 0.2.12",
  "once_cell",
@@ -4174,18 +4170,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-identitystore"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4196,18 +4192,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-imagebuilder"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4219,18 +4215,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-inspector"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4241,18 +4237,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-inspector2"
-version = "1.37.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4264,18 +4260,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-inspectorscan"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4286,18 +4282,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-internetmonitor"
-version = "1.36.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4309,18 +4305,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iot"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4332,18 +4328,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iot1clickdevices"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4354,18 +4350,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iot1clickprojects"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4376,18 +4372,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotanalytics"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4398,18 +4394,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotdataplane"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4420,18 +4416,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotdeviceadvisor"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4442,18 +4438,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotevents"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4464,18 +4460,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ioteventsdata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4486,18 +4482,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotfleethub"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4509,18 +4505,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotfleetwise"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4531,18 +4527,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotjobsdataplane"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4553,18 +4549,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotsecuretunneling"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4575,18 +4571,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotsitewise"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4598,18 +4594,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotthingsgraph"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4620,18 +4616,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iottwinmaker"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4642,18 +4638,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iotwireless"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4665,18 +4661,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ivs"
-version = "1.36.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4687,18 +4683,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ivschat"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4709,18 +4705,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ivsrealtime"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4732,18 +4728,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kafka"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4754,18 +4750,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kafkaconnect"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4776,18 +4772,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kendra"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4799,18 +4795,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kendraranking"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -4822,18 +4818,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-keyspaces"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4844,18 +4840,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4866,18 +4862,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisanalytics"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4888,18 +4884,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisanalyticsv2"
-version = "1.34.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4910,18 +4906,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideo"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4932,18 +4928,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideoarchivedmedia"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4954,18 +4950,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideomedia"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4976,18 +4972,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideosignaling"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -4998,18 +4994,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesisvideowebrtcstorage"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5020,19 +5016,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -5046,18 +5042,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lakeformation"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5068,20 +5064,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -5095,18 +5091,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-launchwizard"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5117,18 +5113,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lexmodelbuilding"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5139,18 +5135,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lexmodelsv2"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5161,19 +5157,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lexruntime"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5184,23 +5180,23 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lexruntimev2"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "once_cell",
  "regex-lite",
  "tokio",
@@ -5209,18 +5205,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-licensemanager"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5231,18 +5227,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-licensemanagerlinuxsubscriptions"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5253,18 +5249,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-licensemanagerusersubscriptions"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5275,18 +5271,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lightsail"
-version = "1.37.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5297,18 +5293,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-location"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5319,18 +5315,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lookoutequipment"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5342,18 +5338,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lookoutmetrics"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5364,18 +5360,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lookoutvision"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5387,18 +5383,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-m2"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5410,18 +5406,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-machinelearning"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5432,18 +5428,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-macie2"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5455,18 +5451,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mailmanager"
-version = "1.8.0"
+version = "1.16.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5478,18 +5474,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-managedblockchain"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5501,18 +5497,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-managedblockchainquery"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5523,18 +5519,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-marketplaceagreement"
-version = "1.30.0"
+version = "1.38.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5545,18 +5541,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-marketplacecatalog"
-version = "1.37.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5568,18 +5564,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-marketplacecommerceanalytics"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5590,18 +5586,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-marketplacedeployment"
-version = "1.30.0"
+version = "1.38.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5613,18 +5609,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-marketplaceentitlement"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5635,18 +5631,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-marketplacemetering"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5657,18 +5653,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediaconnect"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5679,18 +5675,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediaconvert"
-version = "1.38.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5702,18 +5698,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-medialive"
-version = "1.39.0"
+version = "1.49.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5725,18 +5721,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediapackage"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5747,18 +5743,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediapackagev2"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5770,18 +5766,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediapackagevod"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5792,18 +5788,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediastore"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5814,19 +5810,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediastoredata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5837,18 +5833,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mediatailor"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5859,18 +5855,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-medicalimaging"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5882,18 +5878,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-memorydb"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5904,18 +5900,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mgn"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5927,18 +5923,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-migrationhub"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5949,18 +5945,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-migrationhubconfig"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -5971,18 +5967,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-migrationhuborchestrator"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -5994,18 +5990,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-migrationhubrefactorspaces"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6017,40 +6013,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-migrationhubstrategy"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-mobile"
-version = "1.33.0"
-dependencies = [
- "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6061,18 +6035,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mq"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6084,18 +6058,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mturk"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6106,18 +6080,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mwaa"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6128,20 +6102,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-neptune"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -6151,18 +6125,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-neptunedata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6173,18 +6147,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-neptunegraph"
-version = "1.30.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6195,18 +6169,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-networkfirewall"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6217,18 +6191,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-networkmanager"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6240,18 +6214,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-networkmonitor"
-version = "1.24.0"
+version = "1.32.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6263,18 +6237,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-nimble"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6286,18 +6260,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-oam"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6308,19 +6282,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-omics"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6332,18 +6306,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opensearch"
-version = "1.39.0"
+version = "1.50.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6354,18 +6328,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opensearchserverless"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6377,18 +6351,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opsworks"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6399,18 +6373,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-opsworkscm"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6421,18 +6395,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-organizations"
-version = "1.35.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6443,18 +6417,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-osis"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6465,18 +6439,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-outposts"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6487,18 +6461,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-panorama"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6509,18 +6483,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-paymentcryptography"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6531,18 +6505,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-paymentcryptographydata"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6553,18 +6527,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pcaconnectorad"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6576,18 +6550,41 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pcaconnectorscep"
-version = "1.3.0"
+version = "1.11.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-pcs"
+version = "1.2.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6599,18 +6596,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-personalize"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6621,18 +6618,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-personalizeevents"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6643,18 +6640,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-personalizeruntime"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6665,18 +6662,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pi"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6687,18 +6684,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pinpoint"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6709,18 +6706,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pinpointemail"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6731,18 +6728,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pinpointsmsvoice"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6753,18 +6750,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pinpointsmsvoicev2"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6776,18 +6773,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pipes"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6798,25 +6795,25 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-polly"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "futures-util",
  "http 0.2.12",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "once_cell",
  "regex-lite",
  "serde_json",
@@ -6827,18 +6824,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-pricing"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6849,18 +6846,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-privatenetworks"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6871,20 +6868,42 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-proton"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-qapps"
+version = "1.7.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
+ "bytes",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -6894,24 +6913,24 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qbusiness"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "once_cell",
  "regex-lite",
  "tokio",
@@ -6920,18 +6939,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qconnect"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -6943,18 +6962,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qldb"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -6965,19 +6984,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qldbsession"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -6991,18 +7010,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-quicksight"
-version = "1.40.0"
+version = "1.50.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7013,18 +7032,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ram"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7035,18 +7054,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rbin"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7057,20 +7076,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rds"
-version = "1.43.0"
+version = "1.52.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -7080,18 +7099,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rdsdata"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7102,20 +7121,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-redshift"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -7125,18 +7144,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-redshiftdata"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7148,18 +7167,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-redshiftserverless"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7170,18 +7189,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rekognition"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7193,18 +7212,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-repostspace"
-version = "1.31.0"
+version = "1.39.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7215,18 +7234,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-resiliencehub"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7238,18 +7257,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-resourceexplorer2"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7261,18 +7280,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-resourcegroups"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7283,18 +7302,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-resourcegroupstagging"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7305,18 +7324,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-robomaker"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7328,18 +7347,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rolesanywhere"
-version = "1.36.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7350,41 +7369,42 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "pretty_assertions",
  "regex-lite",
  "tokio",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
 name = "aws-sdk-route53domains"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7395,18 +7415,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53profiles"
-version = "1.12.0"
+version = "1.20.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7418,18 +7438,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53recoverycluster"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7440,18 +7460,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53recoverycontrolconfig"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7463,18 +7483,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53recoveryreadiness"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7485,18 +7505,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53resolver"
-version = "1.36.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7508,18 +7528,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-rum"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7530,61 +7550,26 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955365fd032cc94608c7e0f4aea36a9825399d6a1bf7b96f56cf157414b04c40"
-dependencies = [
- "ahash",
- "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-runtime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-sigv4 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-checksums 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "fastrand 2.0.2",
- "hex",
- "hmac",
- "http 0.2.12",
- "http-body 0.4.6",
- "lru",
- "once_cell",
- "percent-encoding",
- "regex-lite",
- "sha2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "1.38.0"
+version = "1.48.0"
 dependencies = [
  "ahash",
  "async-std",
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
- "aws-smithy-checksums 0.60.10",
+ "aws-smithy-checksums 0.60.12",
  "aws-smithy-eventstream 0.60.4",
  "aws-smithy-experimental",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "bytes",
  "bytes-utils",
  "fastrand 2.0.2",
@@ -7595,7 +7580,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "lru",
  "once_cell",
  "percent-encoding",
@@ -7614,21 +7599,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-s3"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a545b16c05af9302b0b4b38a7584f6f323749e407169aa3e9b210e7c0a808d"
+dependencies = [
+ "ahash",
+ "aws-credential-types 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-runtime 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-sigv4 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-checksums 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-types 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fastrand 2.0.2",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aws-sdk-s3control"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "fastrand 2.0.2",
  "futures-util",
  "http 0.2.12",
@@ -7644,18 +7664,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3outposts"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7666,18 +7686,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemaker"
-version = "1.55.0"
+version = "1.69.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7689,18 +7709,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakera2iruntime"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7711,18 +7731,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakeredge"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7733,18 +7753,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakerfeaturestoreruntime"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7755,18 +7775,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakergeospatial"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7778,18 +7798,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakermetrics"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7800,19 +7820,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sagemakerruntime"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7823,18 +7843,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-savingsplans"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7846,18 +7866,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-scheduler"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7869,18 +7889,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-schemas"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7892,18 +7912,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.37.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -7915,18 +7935,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-securityhub"
-version = "1.35.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7937,18 +7957,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-securitylake"
-version = "1.35.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7959,18 +7979,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-serverlessapplicationrepository"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -7981,18 +8001,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicecatalog"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8004,18 +8024,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicecatalogappregistry"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8027,18 +8047,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicediscovery"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8050,18 +8070,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-servicequotas"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8072,20 +8092,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ses"
-version = "1.33.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -8095,18 +8115,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sesv2"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8117,18 +8137,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sfn"
-version = "1.34.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8140,18 +8160,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-shield"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8162,18 +8182,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-signer"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8185,18 +8205,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-simspaceweaver"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8208,18 +8228,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sms"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8230,18 +8250,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-snowball"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8252,18 +8272,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-snowdevicemanagement"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8275,20 +8295,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sns"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -8298,18 +8318,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8320,18 +8340,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "1.36.0"
+version = "1.46.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8343,18 +8363,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssmcontacts"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8366,18 +8386,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssmincidents"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8388,19 +8408,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-ssmsap"
-version = "1.34.0"
+name = "aws-sdk-ssmquicksetup"
+version = "1.5.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssmsap"
+version = "1.43.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8411,17 +8453,17 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8432,18 +8474,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssoadmin"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8455,17 +8497,17 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8476,18 +8518,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-storagegateway"
-version = "1.36.0"
+version = "1.44.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8498,20 +8540,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
+ "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-query",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "futures-util",
  "http 0.2.12",
  "once_cell",
@@ -8524,18 +8566,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-supplychain"
-version = "1.24.0"
+version = "1.32.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8547,18 +8589,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-support"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8569,18 +8611,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-supportapp"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8591,18 +8633,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-swf"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8613,18 +8655,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-synthetics"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8635,18 +8677,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-taxsettings"
-version = "1.4.0"
+version = "1.13.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8657,18 +8699,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-textract"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8680,18 +8722,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-timestreaminfluxdb"
-version = "1.16.0"
+version = "1.24.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8702,19 +8744,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-timestreamquery"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
@@ -8729,18 +8771,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-timestreamwrite"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8752,18 +8794,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-tnb"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8774,18 +8816,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-transcribe"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8796,28 +8838,28 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-transcribestreaming"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "async-stream",
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "futures-core",
  "futures-util",
  "hound",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "once_cell",
  "regex-lite",
  "serde_json",
@@ -8828,18 +8870,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-transfer"
-version = "1.37.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8850,18 +8892,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-translate"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8873,18 +8915,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-trustedadvisor"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8895,18 +8937,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-verifiedpermissions"
-version = "1.39.0"
+version = "1.47.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8918,18 +8960,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-voiceid"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8941,18 +8983,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-vpclattice"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -8964,18 +9006,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-waf"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -8986,18 +9028,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-wafregional"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9008,18 +9050,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-wafv2"
-version = "1.37.0"
+version = "1.45.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9030,18 +9072,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-wellarchitected"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9053,18 +9095,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-wisdom"
-version = "1.34.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9076,18 +9118,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workdocs"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9098,18 +9140,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-worklink"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9120,18 +9162,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workmail"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9143,18 +9185,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workmailmessageflow"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9165,18 +9207,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workspaces"
-version = "1.34.0"
+version = "1.47.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9187,18 +9229,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workspacesthinclient"
-version = "1.33.0"
+version = "1.42.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9210,18 +9252,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-workspacesweb"
-version = "1.34.0"
+version = "1.43.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -9233,18 +9275,18 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-xray"
-version = "1.33.0"
+version = "1.41.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.0",
- "aws-runtime 1.3.0",
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.2",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -9259,13 +9301,13 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-http 0.60.8",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "criterion",
  "crypto-bigint 0.5.5",
@@ -9295,15 +9337,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
 dependencies = [
- "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-credential-types 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
@@ -9348,17 +9390,17 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.2",
+ "aws-smithy-types 1.2.4",
  "criterion",
  "minicbor",
 ]
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.10"
+version = "0.60.12"
 dependencies = [
- "aws-smithy-http 0.60.8",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "crc32c",
@@ -9378,12 +9420,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.10"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
+checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
 dependencies = [
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -9405,15 +9447,15 @@ version = "0.60.3"
 name = "aws-smithy-compression"
 version = "0.0.1"
 dependencies = [
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "flate2",
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "pretty_assertions",
@@ -9426,7 +9468,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.4"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -9439,27 +9481,27 @@ version = "0.60.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
 dependencies = [
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "crc32fast",
 ]
 
 [[package]]
 name = "aws-smithy-experimental"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "h2 0.4.5",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
+ "h2 0.4.6",
  "http 1.1.0",
- "hyper 1.3.1",
- "hyper-rustls 0.27.2",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
  "hyper-util",
  "once_cell",
  "pin-project-lite",
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "tokio",
  "tower",
  "tracing",
@@ -9467,19 +9509,19 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.8"
+version = "0.60.10"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "futures-core",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -9491,13 +9533,13 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.8"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
 dependencies = [
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -9522,7 +9564,7 @@ version = "0.60.3"
 name = "aws-smithy-json"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "proptest",
  "serde_json",
 ]
@@ -9533,45 +9575,51 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aws-smithy-mocks-experimental"
 version = "0.2.1"
 dependencies = [
- "aws-sdk-s3 1.37.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-sdk-s3 1.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "tokio",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.60.7"
+version = "0.62.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.0",
+ "aws-smithy-runtime-api 1.7.2",
+ "base64-simd",
+ "cbor-diag",
  "http 0.2.12",
  "pretty_assertions",
  "regex-lite",
  "roxmltree",
+ "serde_cbor",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.60.7"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31e8279cb24640c7349f2bda6ca818d5fcc85129386bd73c1d0999430d6ddf2"
+checksum = "495c940cd5c7232ac3f0945ff559096deadd2fc73e4418a0e98fe5836788bb39"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64-simd",
+ "cbor-diag",
  "http 0.2.12",
  "pretty_assertions",
  "regex-lite",
  "roxmltree",
+ "serde_cbor",
  "serde_json",
  "thiserror",
 ]
@@ -9580,20 +9628,20 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.0"
+version = "1.7.1"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "fastrand 2.0.2",
  "futures-util",
@@ -9601,9 +9649,9 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "indexmap",
  "once_cell",
@@ -9621,23 +9669,23 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db83b08939838d18e33b5dbaf1a0f048f28c10bd28071ab7ce6f245451855414"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-protocol-test 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-protocol-test 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "fastrand 2.0.2",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "indexmap",
  "once_cell",
@@ -9653,10 +9701,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.0"
+version = "1.7.2"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -9669,12 +9717,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b570ea39eb95bd32543f6e4032bce172cb6209b9bc8c83c770d08169e875afc"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -9686,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.2.4"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -9698,9 +9746,9 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "itoa",
  "lazy_static",
  "num-integer",
@@ -9720,9 +9768,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9731,7 +9779,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -9749,7 +9797,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.8"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "chrono",
  "futures-core",
  "time",
@@ -9759,9 +9807,9 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
- "aws-smithy-http 0.60.8",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "http 1.1.0",
  "tracing",
@@ -9772,7 +9820,7 @@ dependencies = [
 name = "aws-smithy-xml"
 version = "0.60.8"
 dependencies = [
- "aws-smithy-protocol-test 0.60.7",
+ "aws-smithy-protocol-test 0.62.0",
  "base64 0.13.1",
  "proptest",
  "xmlparser",
@@ -9789,13 +9837,13 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.6.0",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.4",
  "http 0.2.12",
  "hyper-rustls 0.24.2",
  "rustc_version",
@@ -9807,14 +9855,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
- "aws-credential-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-credential-types 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version",
  "tracing",
 ]
@@ -9829,7 +9877,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -9880,7 +9928,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -9893,7 +9941,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.77",
  "which",
 ]
 
@@ -9920,9 +9968,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -9947,6 +9995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9960,9 +10017,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bytes-utils"
@@ -9981,14 +10038,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cc"
-version = "1.0.99"
+name = "cbor-diag"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half 2.4.1",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "cc"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -10039,7 +10115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.4.1",
 ]
 
 [[package]]
@@ -10055,18 +10131,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -10074,15 +10150,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
 ]
@@ -10103,6 +10179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10114,15 +10199,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -10254,6 +10339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10280,7 +10371,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10302,9 +10393,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -10320,9 +10411,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -10437,12 +10528,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -10523,7 +10614,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10629,9 +10720,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -10645,6 +10736,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -10763,9 +10860,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -10780,15 +10877,15 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -10798,9 +10895,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -10822,16 +10919,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -10848,7 +10945,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -10859,16 +10956,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.10",
- "rustls-native-certs 0.7.0",
+ "rustls 0.23.12",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -10877,16 +10974,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -10907,9 +11004,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -10938,11 +11035,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -10973,18 +11070,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -11000,9 +11097,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -11012,9 +11109,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -11029,12 +11126,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11067,18 +11164,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown",
 ]
@@ -11120,9 +11217,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bdc119b1a405df86a8cde673295114179dbd0ebe18877c26ba89fb080365c2"
+checksum = "297ad6022c004a6c54f0fb28bbd2306314d5a4edc767e56b4b4cc48fc2371654"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11145,14 +11242,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11182,6 +11289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11197,6 +11314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11207,20 +11335,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -11233,9 +11351,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openssl-probe"
@@ -11292,7 +11410,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11324,7 +11442,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -11341,9 +11459,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
  "fastrand 2.0.2",
@@ -11406,17 +11524,17 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11427,9 +11545,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -11443,12 +11564,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -11477,22 +11598,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -11512,9 +11633,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -11580,18 +11701,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -11686,9 +11807,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -11709,11 +11830,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -11734,15 +11855,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -11761,12 +11882,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -11783,9 +11904,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -11793,9 +11914,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -11809,9 +11930,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -11887,11 +12008,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -11900,9 +12021,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -11915,33 +12036,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
-name = "serde"
-version = "1.0.203"
+name = "separator"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
+name = "serde"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.203"
+name = "serde_cbor"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -12072,9 +12210,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -12089,9 +12227,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12100,34 +12238,35 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.2",
- "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "once_cell",
+ "rustix 0.38.36",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -12183,9 +12322,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -12198,32 +12337,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -12242,16 +12380,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -12273,9 +12411,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -12302,15 +12440,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -12344,7 +12482,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -12417,7 +12555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -12460,6 +12598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12484,9 +12628,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -12502,9 +12646,9 @@ checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -12563,34 +12707,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -12600,9 +12745,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12610,28 +12755,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12652,7 +12797,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.36",
 ]
 
 [[package]]
@@ -12673,11 +12818,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12701,7 +12846,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12721,18 +12875,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -12743,9 +12897,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -12755,9 +12909,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12767,15 +12921,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -12785,9 +12939,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -12797,9 +12951,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -12809,9 +12963,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -12821,9 +12975,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -12831,7 +12985,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b37d270da94012e0ac490ac633ad5bdd76a10a3fb15069edb033c1b771ce931f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -12848,22 +13002,23 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -12883,5 +13038,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.77",
 ]

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -207,8 +207,8 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-eventstream 0.60.4",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.4",
@@ -236,13 +236,13 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-checksums 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-eventstream 0.60.4",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.4",
- "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-xml 0.60.8",
  "aws-types",
  "bytes",
  "fastrand",
@@ -266,8 +266,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-eventstream 0.60.4",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.4",
  "bytes",
@@ -314,7 +314,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "criterion",
  "minicbor",
 ]
@@ -323,8 +323,8 @@ dependencies = [
 name = "aws-smithy-checksums"
 version = "0.60.12"
 dependencies = [
- "aws-smithy-http 0.60.10",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "bytes-utils",
  "crc32c",
@@ -348,7 +348,7 @@ version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
 dependencies = [
- "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-types 1.2.4",
  "bytes",
  "crc32c",
@@ -372,7 +372,7 @@ name = "aws-smithy-compression"
 version = "0.0.1"
 dependencies = [
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -390,18 +390,6 @@ dependencies = [
 [[package]]
 name = "aws-smithy-eventstream"
 version = "0.60.4"
-dependencies = [
- "arbitrary",
- "aws-smithy-types 1.2.5",
- "bytes",
- "bytes-utils",
- "crc32fast",
- "derive_arbitrary",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.60.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
 dependencies = [
@@ -411,13 +399,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.5"
+dependencies = [
+ "arbitrary",
+ "aws-smithy-types 1.2.6",
+ "bytes",
+ "bytes-utils",
+ "crc32fast",
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "aws-smithy-experimental"
 version = "0.1.4"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime 1.7.1",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "h2 0.4.6",
  "http 1.1.0",
  "hyper 1.4.1",
@@ -434,11 +434,32 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
+dependencies = [
+ "aws-smithy-eventstream 0.60.4",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
 dependencies = [
  "async-stream",
- "aws-smithy-eventstream 0.60.4",
+ "aws-smithy-eventstream 0.60.5",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -456,27 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.60.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
-dependencies = [
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.4",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-http-auth"
 version = "0.60.3"
 
@@ -485,11 +485,11 @@ name = "aws-smithy-http-server"
 version = "0.63.3"
 dependencies = [
  "aws-smithy-cbor",
- "aws-smithy-http 0.60.10",
+ "aws-smithy-http 0.60.11",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
- "aws-smithy-xml 0.60.8",
+ "aws-smithy-types 1.2.6",
+ "aws-smithy-xml 0.60.9",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -513,13 +513,13 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-python"
-version = "0.63.1"
+version = "0.63.2"
 dependencies = [
- "aws-smithy-http 0.60.10",
+ "aws-smithy-http 0.60.11",
  "aws-smithy-http-server",
  "aws-smithy-json 0.60.7",
- "aws-smithy-types 1.2.5",
- "aws-smithy-xml 0.60.8",
+ "aws-smithy-types 1.2.6",
+ "aws-smithy-xml 0.60.9",
  "bytes",
  "futures",
  "futures-util",
@@ -558,7 +558,7 @@ version = "0.60.3"
 name = "aws-smithy-json"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "proptest",
  "serde_json",
 ]
@@ -578,7 +578,7 @@ version = "0.2.1"
 dependencies = [
  "aws-sdk-s3",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "tokio",
 ]
 
@@ -622,7 +622,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "urlencoding",
 ]
 
@@ -632,10 +632,10 @@ version = "1.7.1"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.10",
+ "aws-smithy-http 0.60.11",
  "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "fastrand",
  "futures-util",
@@ -668,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-protocol-test 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.4",
@@ -698,7 +698,7 @@ name = "aws-smithy-runtime-api"
 version = "1.7.2"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -791,7 +791,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.8"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "chrono",
  "futures-core",
  "time",
@@ -801,9 +801,9 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
- "aws-smithy-http 0.60.10",
+ "aws-smithy-http 0.60.11",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "http 1.1.0",
  "tracing",
@@ -813,19 +813,19 @@ dependencies = [
 [[package]]
 name = "aws-smithy-xml"
 version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
 dependencies = [
- "aws-smithy-protocol-test 0.62.0",
- "base64 0.13.1",
- "proptest",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+version = "0.60.9"
 dependencies = [
+ "aws-smithy-protocol-test 0.62.0",
+ "base64 0.13.1",
+ "proptest",
  "xmlparser",
 ]
 
@@ -2001,12 +2001,12 @@ version = "0.1.0"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-compression",
- "aws-smithy-http 0.60.10",
+ "aws-smithy-http 0.60.11",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime 1.7.1",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.5",
- "aws-smithy-xml 0.60.8",
+ "aws-smithy-types 1.2.6",
+ "aws-smithy-xml 0.60.9",
  "bytes",
  "fastrand",
  "futures-util",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,9 +58,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "approx"
@@ -112,7 +118,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -140,21 +146,21 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5cc4286676d121ca5a2ce89e0d4ddbc2d660ac24bb17bc49607d700f49f993"
+checksum = "33d41a5d02120c5eca009507574fa0d4885fa370cbda6b561d91ba463c3025a7"
 dependencies = [
  "bindgen",
  "cmake",
@@ -166,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7d844e282b4b56750b2d4e893b2205581ded8709fddd2b6aa5418c150ca877"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -179,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a2c29203f6bf296d01141cc8bb9dbd5ecd4c27843f2ee0767bcd5985a927da"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
 dependencies = [
  "bindgen",
  "cc",
@@ -194,22 +200,24 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4a5e448145999d7de17bf44a886900ecb834953408dae8aaf90465ce91c1dd"
+checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -218,22 +226,22 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.34.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
+checksum = "00a545b16c05af9302b0b4b38a7584f6f323749e407169aa3e9b210e7c0a808d"
 dependencies = [
  "ahash",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-checksums 0.60.10",
+ "aws-smithy-checksums 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.5.5",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-types",
  "bytes",
@@ -253,15 +261,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
@@ -306,30 +314,9 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "criterion",
  "minicbor",
-]
-
-[[package]]
-name = "aws-smithy-checksums"
-version = "0.60.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
-dependencies = [
- "aws-smithy-http 0.60.8",
- "aws-smithy-types 1.2.0",
- "bytes",
- "crc32c",
- "crc32fast",
- "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
- "pin-project-lite",
- "sha1",
- "sha2",
- "tracing",
 ]
 
 [[package]]
@@ -337,7 +324,7 @@ name = "aws-smithy-checksums"
 version = "0.60.12"
 dependencies = [
  "aws-smithy-http 0.60.10",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "bytes-utils",
  "crc32c",
@@ -356,6 +343,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.60.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
+dependencies = [
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-client"
 version = "0.60.3"
 
@@ -364,14 +372,14 @@ name = "aws-smithy-compression"
 version = "0.0.1"
 dependencies = [
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "bytes-utils",
  "flate2",
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "pretty_assertions",
@@ -384,7 +392,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.4"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -397,7 +405,7 @@ version = "0.60.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "crc32fast",
 ]
@@ -409,38 +417,17 @@ dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime 1.7.1",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
- "h2 0.4.5",
+ "aws-smithy-types 1.2.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper-rustls 0.27.3",
  "hyper-util",
  "once_cell",
  "pin-project-lite",
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "tokio",
  "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.60.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
-dependencies = [
- "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
  "tracing",
 ]
 
@@ -451,20 +438,41 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.4",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "bytes-utils",
  "futures-core",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
  "proptest",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
+dependencies = [
+ "aws-smithy-eventstream 0.60.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
  "tracing",
 ]
 
@@ -480,13 +488,13 @@ dependencies = [
  "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "lambda_http",
  "mime",
  "nom",
@@ -510,13 +518,13 @@ dependencies = [
  "aws-smithy-http 0.60.10",
  "aws-smithy-http-server",
  "aws-smithy-json 0.60.7",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "futures",
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "lambda_http",
  "num_cpus",
@@ -550,7 +558,7 @@ version = "0.60.3"
 name = "aws-smithy-json"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "proptest",
  "serde_json",
 ]
@@ -561,7 +569,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
 ]
 
 [[package]]
@@ -570,24 +578,8 @@ version = "0.2.1"
 dependencies = [
  "aws-sdk-s3",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "tokio",
-]
-
-[[package]]
-name = "aws-smithy-protocol-test"
-version = "0.60.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31e8279cb24640c7349f2bda6ca818d5fcc85129386bd73c1d0999430d6ddf2"
-dependencies = [
- "assert-json-diff",
- "aws-smithy-runtime-api 1.7.0",
- "http 0.2.12",
- "pretty_assertions",
- "regex-lite",
- "roxmltree",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -608,42 +600,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-query"
-version = "0.60.7"
+name = "aws-smithy-protocol-test"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495c940cd5c7232ac3f0945ff559096deadd2fc73e4418a0e98fe5836788bb39"
 dependencies = [
- "aws-smithy-types 1.2.4",
- "urlencoding",
+ "assert-json-diff",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64-simd",
+ "cbor-diag",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_cbor",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
-name = "aws-smithy-runtime"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d3965f6417a92a6d1009c5958a67042f57e46342afb37ca58f9ad26744ec73"
+name = "aws-smithy-query"
+version = "0.60.7"
 dependencies = [
- "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.8",
- "aws-smithy-protocol-test 0.60.7",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
- "bytes",
- "fastrand",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.0",
- "hyper 0.14.29",
- "hyper-rustls 0.24.2",
- "indexmap 2.2.6",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls 0.21.12",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
+ "aws-smithy-types 1.2.5",
+ "urlencoding",
 ]
 
 [[package]]
@@ -655,7 +635,7 @@ dependencies = [
  "aws-smithy-http 0.60.10",
  "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "fastrand",
  "futures-util",
@@ -663,11 +643,11 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -682,20 +662,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-runtime-api"
-version = "1.7.0"
+name = "aws-smithy-runtime"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b570ea39eb95bd32543f6e4032bce172cb6209b9bc8c83c770d08169e875afc"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-protocol-test 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
  "bytes",
+ "fastrand",
+ "h2 0.3.26",
  "http 0.2.12",
- "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "indexmap 2.5.0",
+ "once_cell",
  "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
- "zeroize",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -703,7 +698,7 @@ name = "aws-smithy-runtime-api"
 version = "1.7.2"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -715,10 +710,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.2.0"
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -727,7 +739,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -742,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -754,9 +766,9 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "itoa",
  "lazy_static",
  "num-integer",
@@ -779,7 +791,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.8"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "chrono",
  "futures-core",
  "time",
@@ -791,7 +803,7 @@ version = "0.1.3"
 dependencies = [
  "aws-smithy-http 0.60.10",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "bytes",
  "http 1.1.0",
  "tracing",
@@ -819,14 +831,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.0",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.4",
  "rustc_version",
  "tracing",
 ]
@@ -857,7 +869,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -914,7 +926,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -927,7 +939,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.67",
+ "syn 2.0.77",
  "which",
 ]
 
@@ -954,9 +966,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -983,10 +995,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "bytes"
-version = "1.6.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -1028,13 +1046,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -1116,21 +1134,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstyle",
- "clap_lex 0.7.1",
+ "clap_lex 0.7.2",
 ]
 
 [[package]]
@@ -1144,15 +1162,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
 ]
@@ -1184,15 +1202,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1224,7 +1242,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.7",
+ "clap 4.5.17",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -1356,7 +1374,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1378,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -1396,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -1481,12 +1499,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1566,7 +1584,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1655,7 +1673,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1664,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1674,7 +1692,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1727,6 +1745,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1787,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1804,7 +1828,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1838,9 +1862,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1869,9 +1893,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1888,7 +1912,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1898,16 +1922,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.10",
- "rustls-native-certs 0.7.0",
+ "rustls 0.23.12",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -1924,7 +1948,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
@@ -1956,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1981,7 +2005,7 @@ dependencies = [
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime 1.7.1",
  "aws-smithy-runtime-api 1.7.2",
- "aws-smithy-types 1.2.4",
+ "aws-smithy-types 1.2.5",
  "aws-smithy-xml 0.60.8",
  "bytes",
  "fastrand",
@@ -2007,11 +2031,11 @@ checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2042,18 +2066,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2071,7 +2095,7 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "lambda_runtime",
  "mime",
  "percent-encoding",
@@ -2095,7 +2119,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "http-serde",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "lambda_runtime_api_client",
  "serde",
  "serde_json",
@@ -2113,16 +2137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "690c5ae01f3acac8c9c3348b556fc443054e9b7f1deaf53e9ebab716282bf0ed"
 dependencies = [
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "tokio",
  "tower-service",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -2132,18 +2156,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2170,15 +2194,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -2235,13 +2259,13 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bdc119b1a405df86a8cde673295114179dbd0ebe18877c26ba89fb080365c2"
+checksum = "297ad6022c004a6c54f0fb28bbd2306314d5a4edc767e56b4b4cc48fc2371654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2260,14 +2284,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2354,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -2369,9 +2403,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openssl-probe"
@@ -2428,7 +2462,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2469,7 +2503,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2530,9 +2564,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -2546,12 +2583,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2589,13 +2626,13 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -2714,9 +2751,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2794,18 +2831,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2915,20 +2952,20 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2949,15 +2986,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -2976,12 +3013,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -2998,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -3008,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -3024,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.8",
@@ -3102,11 +3139,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3115,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3137,9 +3174,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -3156,23 +3193,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3321,9 +3359,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3338,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3349,20 +3387,21 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3382,22 +3421,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3453,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3473,7 +3512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81294c017957a1a69794f506723519255879e15a870507faf45dfed288b763dd"
 dependencies = [
  "futures-util",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "pin-project-lite",
  "thiserror",
  "tokio",
@@ -3482,32 +3521,31 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3526,16 +3564,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3557,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3604,15 +3642,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower-test"
@@ -3660,7 +3698,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3733,7 +3771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3812,9 +3850,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "rand",
@@ -3828,9 +3866,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -3883,34 +3921,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3918,28 +3957,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3975,11 +4014,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3990,142 +4029,85 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -4133,7 +4115,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b37d270da94012e0ac490ac633ad5bdd76a10a3fb15069edb033c1b771ce931f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -4159,22 +4141,23 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4194,5 +4177,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.77",
 ]

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
 # <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.4"
+version = "0.60.5"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -13,7 +13,6 @@ use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
 use aws_smithy_types::str_bytes::StrBytes;
 use aws_smithy_types::DateTime;
 use bytes::{Buf, BufMut};
-use std::convert::{TryFrom, TryInto};
 use std::error::Error as StdError;
 use std::fmt;
 use std::mem::size_of;

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.63.1"
+version = "0.63.2"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server-python/src/error.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/error.rs
@@ -13,7 +13,7 @@ use aws_smithy_http_server::{
     response::IntoResponse,
 };
 use aws_smithy_types::date_time::{ConversionError, DateTimeParseError};
-use pyo3::{create_exception, exceptions::PyException as BasePyException, prelude::*, PyErr};
+use pyo3::{create_exception, exceptions::PyException as BasePyException, prelude::*};
 use thiserror::Error;
 
 /// Python error that implements foreign errors.

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.60.10"
+version = "0.60.11"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-http/src/header.rs
+++ b/rust-runtime/aws-smithy-http/src/header.rs
@@ -10,7 +10,6 @@ use aws_smithy_types::primitive::Parse;
 use aws_smithy_types::DateTime;
 use http_02x::header::{HeaderMap, HeaderName, HeaderValue};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 use std::str::FromStr;

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.2.5"
+version = "1.2.6"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -10,7 +10,6 @@ use crate::date_time::format::DateTimeParseErrorKind;
 use num_integer::div_mod_floor;
 use num_integer::Integer;
 use std::cmp::Ordering;
-use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::fmt;
 use std::fmt::Display;
@@ -44,7 +43,6 @@ const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 /// # fn doc_fn() -> Result<(), aws_smithy_types::date_time::ConversionError> {
 /// # use aws_smithy_types::date_time::DateTime;
 /// # use std::time::SystemTime;
-/// use std::convert::TryFrom;
 ///
 /// let the_millennium_as_system_time = SystemTime::try_from(DateTime::from_secs(946_713_600))?;
 /// let now_as_date_time = DateTime::from(SystemTime::now());
@@ -394,7 +392,6 @@ mod test {
     use crate::date_time::Format;
     use crate::DateTime;
     use proptest::proptest;
-    use std::convert::TryFrom;
     use std::time::SystemTime;
     use time::format_description::well_known::Rfc3339;
     use time::OffsetDateTime;

--- a/rust-runtime/aws-smithy-types/src/str_bytes.rs
+++ b/rust-runtime/aws-smithy-types/src/str_bytes.rs
@@ -6,7 +6,6 @@
 //! UTF-8 string byte buffer representation with validation amortization.
 
 use bytes::Bytes;
-use std::convert::TryFrom;
 use std::str::Utf8Error;
 
 /// UTF-8 string byte buffer representation with validation amortization.
@@ -27,7 +26,6 @@ use std::str::Utf8Error;
 /// ```rust
 /// use bytes::Bytes;
 /// use aws_smithy_types::str_bytes::StrBytes;
-/// use std::convert::TryInto;
 ///
 /// let bytes = Bytes::from_static(b"example");
 /// let value: StrBytes = bytes.try_into().expect("valid utf-8");
@@ -120,7 +118,6 @@ impl TryFrom<Bytes> for StrBytes {
 mod tests {
     use crate::str_bytes::StrBytes;
     use bytes::Bytes;
-    use std::convert::TryInto;
     use std::str::Utf8Error;
 
     #[test]

--- a/rust-runtime/aws-smithy-xml/Cargo.toml
+++ b/rust-runtime/aws-smithy-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-xml"
-version = "0.60.8"
+version = "0.60.9"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "XML parsing logic for Smithy protocols."
 edition = "2021"

--- a/rust-runtime/aws-smithy-xml/src/decode.rs
+++ b/rust-runtime/aws-smithy-xml/src/decode.rs
@@ -5,7 +5,6 @@
 
 use crate::unescape::unescape;
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use xmlparser::{ElementEnd, Token, Tokenizer};

--- a/rust-runtime/inlineable/src/ec2_query_errors.rs
+++ b/rust-runtime/inlineable/src/ec2_query_errors.rs
@@ -5,7 +5,6 @@
 
 use aws_smithy_types::error::metadata::{Builder as ErrorMetadataBuilder, ErrorMetadata};
 use aws_smithy_xml::decode::{try_data, Document, ScopedDecoder, XmlDecodeError};
-use std::convert::TryFrom;
 
 #[allow(unused)]
 pub fn body_is_error(body: &[u8]) -> Result<bool, XmlDecodeError> {
@@ -69,7 +68,6 @@ mod test {
     use super::{body_is_error, parse_error_metadata};
     use crate::ec2_query_errors::error_scope;
     use aws_smithy_xml::decode::Document;
-    use std::convert::TryFrom;
 
     #[test]
     fn parse_wrapped_error() {

--- a/rust-runtime/inlineable/src/rest_xml_unwrapped_errors.rs
+++ b/rust-runtime/inlineable/src/rest_xml_unwrapped_errors.rs
@@ -8,7 +8,6 @@
 
 use aws_smithy_types::error::metadata::{Builder as ErrorMetadataBuilder, ErrorMetadata};
 use aws_smithy_xml::decode::{try_data, Document, ScopedDecoder, XmlDecodeError};
-use std::convert::TryFrom;
 
 #[allow(unused)]
 pub fn body_is_error(body: &[u8]) -> Result<bool, XmlDecodeError> {

--- a/rust-runtime/inlineable/src/rest_xml_wrapped_errors.rs
+++ b/rust-runtime/inlineable/src/rest_xml_wrapped_errors.rs
@@ -5,7 +5,6 @@
 
 use aws_smithy_types::error::metadata::{Builder as ErrorMetadataBuilder, ErrorMetadata};
 use aws_smithy_xml::decode::{try_data, Document, ScopedDecoder, XmlDecodeError};
-use std::convert::TryFrom;
 
 #[allow(unused)]
 pub fn body_is_error(body: &[u8]) -> Result<bool, XmlDecodeError> {
@@ -64,7 +63,6 @@ mod test {
     use super::{body_is_error, parse_error_metadata};
     use crate::rest_xml_wrapped_errors::error_scope;
     use aws_smithy_xml::decode::Document;
-    use std::convert::TryFrom;
 
     #[test]
     fn parse_wrapped_error() {

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -7,7 +7,7 @@
 
 ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2023
 ARG rust_stable_version=1.78.0
-ARG rust_nightly_version=nightly-2024-02-07
+ARG rust_nightly_version=nightly-2024-03-15
 
 FROM ${base_image} AS bare_base_image
 RUN yum -y updateinfo


### PR DESCRIPTION
## Description
This PR updates lockfiles by running:
```
./gradlew aws:sdk:generateAllLockfiles -Paws-sdk-rust-path=/Users/awsaito/src/aws-sdk-rust
```
However, due to [the minicbor issue](https://github.com/smithy-lang/smithy-rs/pull/3818), we still pin it to 0.24.2 by running the following on `rust-runtime/Cargo.lock` and `aws/sdk/Cargo.lock`:
```
RUSTFLAGS="--cfg aws_sdk_unstable" cargo update -p minicbor --precise 0.24.2
```

The rest of the changes handle miscellaneous scenarios:
- **Updated nightly version**: Upgraded to `nightly-2024-03-15` to address a [compatibility issue](https://github.com/serde-rs/serde/issues/2770) introduced by the updated serde library.
- **Cleaned up use statements**: Removed redundant use statements, which were flagged as warnings by the new nightly version.

## Testing
Tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
