### PR TITLE
deprecate http-02x presign APIs

### DIFF
--- a/.changelog/1725892046.md
+++ b/.changelog/1725892046.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- aajtodd
+references: []
+breaking: false
+new_feature: false
+bug_fix: false
+---
+deprecate http-02x presign APIs in favor of http-1x equivalents

--- a/aws/rust-runtime/aws-inlineable/src/presigning.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning.rs
@@ -225,11 +225,14 @@ impl PresignedRequest {
     }
 
     /// Given a body, produce an `http::Request` from this `PresignedRequest`
+    #[deprecated = "Prefer the `make_http_1x_request()` instead by enabling the `http-1x` feature."]
+    #[allow(deprecated)]
     pub fn make_http_02x_request<B>(&self, body: B) -> http::Request<B> {
         self.clone().into_http_02x_request(body)
     }
 
     /// Converts this `PresignedRequest` directly into an `http` request.
+    #[deprecated = "Prefer the `into_http_1x_request` instead by enabling the `http-1x` feature."]
     pub fn into_http_02x_request<B>(self, body: B) -> http::Request<B> {
         self.http_request
             .try_into_http02x()


### PR DESCRIPTION
## Motivation and Context
* https://github.com/smithy-lang/smithy-rs/issues/1925
* https://github.com/awslabs/aws-sdk-rust/issues/977

## Description
Deprecate http-02x APIs from inlineable `PresignedRequest` API. These should have been feature gated originally but they weren't. For now we'll mark them deprecated and encourage people to move to the 1.x equivalents.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
