### PR TITLE
Add support for SSLKEYLOGFILE

### DIFF
--- a/.changelog/1726086334.md
+++ b/.changelog/1726086334.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- client
+authors:
+- paul.dagnelie
+references: []
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add support for the SSLKEYLOGFILE environment variable

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -19,6 +19,7 @@ default = ["client-hyper", "rustls", "rt-tokio", "credentials-process", "sso"]
 rt-tokio = ["aws-smithy-async/rt-tokio", "aws-smithy-runtime/rt-tokio", "tokio/rt"]
 rustls = ["aws-smithy-runtime/tls-rustls", "client-hyper"]
 sso = ["dep:aws-sdk-sso", "dep:aws-sdk-ssooidc", "dep:ring", "dep:hex", "dep:zeroize", "aws-smithy-runtime-api/http-auth"]
+sslkeylogging = ["rustls", "aws-smithy-runtime/sslkeylogging"]
 
 # deprecated: this feature does nothing
 allow-compilation = []

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -15,6 +15,7 @@ http-auth = ["aws-smithy-runtime-api/http-auth"]
 connector-hyper-0-14-x = ["dep:hyper-0-14", "hyper-0-14?/client", "hyper-0-14?/http2", "hyper-0-14?/http1", "hyper-0-14?/tcp", "hyper-0-14?/stream", "dep:h2"]
 tls-rustls = ["dep:hyper-rustls", "dep:rustls", "connector-hyper-0-14-x"]
 rt-tokio = ["tokio/rt"]
+sslkeylogging = ["tls-rustls"]
 
 # Features for testing
 test-util = ["aws-smithy-runtime-api/test-util", "dep:aws-smithy-protocol-test", "dep:tracing-subscriber", "dep:serde", "dep:serde_json", "dep:indexmap"]

--- a/rust-runtime/aws-smithy-runtime/src/client/http/hyper_014.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/hyper_014.rs
@@ -46,27 +46,32 @@ mod default_connector {
     > = once_cell::sync::Lazy::new(default_tls);
 
     fn default_tls() -> hyper_rustls::HttpsConnector<hyper_0_14::client::HttpConnector> {
+        let mut tls_config = rustls::ClientConfig::builder()
+            .with_cipher_suites(&[
+                // TLS1.3 suites
+                rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
+                rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+                // TLS1.2 suites
+                rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            ])
+            .with_safe_default_kx_groups()
+            .with_safe_default_protocol_versions()
+            .expect("Error with the TLS configuration. Please file a bug report under https://github.com/smithy-lang/smithy-rs/issues.")
+            .with_native_roots()
+            .with_no_client_auth();
+        #[cfg(feature = "sslkeylogging")]
+        {
+            use rustls::KeyLogFile;
+            use std::sync::Arc;
+            tls_config.key_log = Arc::new(KeyLogFile::new());
+        }
         use hyper_rustls::ConfigBuilderExt;
         hyper_rustls::HttpsConnectorBuilder::new()
-               .with_tls_config(
-                rustls::ClientConfig::builder()
-                    .with_cipher_suites(&[
-                        // TLS1.3 suites
-                        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
-                        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
-                        // TLS1.2 suites
-                        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-                        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-                        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-                    ])
-                    .with_safe_default_kx_groups()
-                    .with_safe_default_protocol_versions()
-                    .expect("Error with the TLS configuration. Please file a bug report under https://github.com/smithy-lang/smithy-rs/issues.")
-                    .with_native_roots()
-                    .with_no_client_auth()
-            )
+            .with_tls_config(tls_config)
             .https_or_http()
             .enable_http1()
             .enable_http2()


### PR DESCRIPTION
## Motivation and Context
When attempting to use a packet capture to diagnose issues, it is necessary to use the SSL keys to decrypt the traffic so that the actual requests can be seen. This is usually done by means of an environment variable, SSLKEYLOGFILE. rustls has support for this variable via the `key_log` parameter, though it is not manipulable via the various config builders.

## Description
I slightly refactored the code so that the tls config is created and can be modified separately from the HttpsConnectorBuilder. We then modify the `key_log` parameter if a new feature is enabled. This may not be necessary, so the feature half of this change can be stripped (or changed to a deafult feature) if people are okay with this being a default behavior.

## Testing
Unfortunately, I could not figure out how to use my standard approach to test this crate (have my larger project use my github branch as the source of the crate, rather than the published version) because of the dependency on the generated code. I instead tested it by manually copying the default_tls code and using it to create an http client, and then used it instead of the default client. When the final program was run, SSLKEYLOGFILE was respected, and the contents look correct. This also meant I was unable to test the feature code's conditional compilation. If there is a way to do this "properly", I would be more than happy to run that testing again.

I did run the local tests for `rust-runtime` and `aws/rust-runtime` to verify that they pass.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
