### PR TITLE
Update parsing of headers to be infallible (by parsing failed UTF-8 headers as ISO-8859)

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -151,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "zeroize",
 ]
@@ -210,7 +210,7 @@ dependencies = [
  "aws-smithy-eventstream 0.60.4",
  "aws-smithy-http 0.60.10",
  "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "aws-types",
  "bytes",
@@ -240,7 +240,7 @@ dependencies = [
  "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
  "aws-types",
@@ -268,7 +268,7 @@ dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream 0.60.4",
  "aws-smithy-http 0.60.10",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "bytes",
  "crypto-bigint 0.5.5",
@@ -371,7 +371,7 @@ version = "0.60.3"
 name = "aws-smithy-compression"
 version = "0.0.1"
 dependencies = [
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "bytes",
  "bytes-utils",
@@ -416,7 +416,7 @@ version = "0.1.4"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime 1.7.1",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "h2 0.4.6",
  "http 1.1.0",
@@ -438,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
 dependencies = [
  "aws-smithy-eventstream 0.60.4",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
@@ -458,7 +458,7 @@ version = "0.60.11"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.5",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "bytes",
  "bytes-utils",
@@ -487,7 +487,7 @@ dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-http 0.60.11",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "aws-smithy-xml 0.60.9",
  "bytes",
@@ -577,7 +577,7 @@ name = "aws-smithy-mocks-experimental"
 version = "0.2.1"
 dependencies = [
  "aws-sdk-s3",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "tokio",
 ]
@@ -587,7 +587,7 @@ name = "aws-smithy-protocol-test"
 version = "0.62.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "base64-simd",
  "cbor-diag",
  "http 0.2.12",
@@ -606,7 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495c940cd5c7232ac3f0945ff559096deadd2fc73e4418a0e98fe5836788bb39"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "base64-simd",
  "cbor-diag",
  "http 0.2.12",
@@ -634,7 +634,7 @@ dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-http 0.60.11",
  "aws-smithy-protocol-test 0.62.0",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "bytes",
  "fastrand",
@@ -670,7 +670,7 @@ dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-http 0.60.10",
  "aws-smithy-protocol-test 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "bytes",
  "fastrand",
@@ -696,22 +696,6 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.7.2"
-dependencies = [
- "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.6",
- "bytes",
- "http 0.2.12",
- "http 1.1.0",
- "pin-project-lite",
- "proptest",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
 dependencies = [
@@ -721,6 +705,22 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.3"
+dependencies = [
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-types 1.2.6",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "proptest",
  "tokio",
  "tracing",
  "zeroize",
@@ -802,7 +802,7 @@ name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
  "aws-smithy-http 0.60.11",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "bytes",
  "http 1.1.0",
@@ -837,7 +837,7 @@ checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.4",
  "rustc_version",
  "tracing",
@@ -2004,7 +2004,7 @@ dependencies = [
  "aws-smithy-http 0.60.11",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime 1.7.1",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.6",
  "aws-smithy-xml 0.60.9",
  "bytes",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.7.2"
+version = "1.7.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/http/error.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/error.rs
@@ -42,6 +42,7 @@ pub(super) struct NonUtf8Header {
 }
 
 impl NonUtf8Header {
+    #[allow(dead_code)]
     #[cfg(any(feature = "http-1x", feature = "http-02x"))]
     pub(super) fn new(name: String, value: Vec<u8>, error: Utf8Error) -> Self {
         Self {

--- a/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
@@ -555,6 +555,80 @@ mod tests {
             .is_err());
     }
 
+    #[test]
+    fn iso_8859_header_parses_correctly_from_http_1x() {
+        // Contains the ISO-8859 single byte multiplication symbol 215
+        let iso_8859_header_bytes: &[u8] = &[
+            105, 110, 108, 105, 110, 101, 59, 32, 102, 105, 108, 101, 110, 97, 109, 101, 61, 115,
+            97, 109, 112, 108, 101, 95, 54, 52, 48, 215, 52, 50, 54, 46, 106, 112, 101, 103,
+        ];
+
+        // This replaces the ISO-8859 single byte multiplication character with the two byte
+        // UTF-8 codepoint `[195, 151]` for the multiplication symbol
+        let utf8_header_bytes: &[u8] = &[
+            105, 110, 108, 105, 110, 101, 59, 32, 102, 105, 108, 101, 110, 97, 109, 101, 61, 115,
+            97, 109, 112, 108, 101, 95, 54, 52, 48, 195, 151, 52, 50, 54, 46, 106, 112, 101, 103,
+        ];
+
+        let mut http_1_headers = http_1x::HeaderMap::new();
+
+        let header_value =
+            http_1x::HeaderValue::from_bytes(iso_8859_header_bytes).expect("valid header bytes");
+        http_1_headers.insert("content-disposition", header_value);
+
+        let aws_headers = Headers::try_from(http_1_headers);
+
+        assert!(aws_headers.is_ok());
+
+        let aws_headers = aws_headers.unwrap();
+
+        let parsed_header_bytes = aws_headers
+            .headers
+            .get("content-disposition")
+            .unwrap()
+            .as_str()
+            .as_bytes();
+
+        assert_eq!(parsed_header_bytes, utf8_header_bytes);
+    }
+
+    #[test]
+    fn iso_8859_header_parses_correctly_from_http_02x() {
+        // Contains the ISO-8859 single byte multiplication symbol 215
+        let iso_8859_header_bytes: &[u8] = &[
+            105, 110, 108, 105, 110, 101, 59, 32, 102, 105, 108, 101, 110, 97, 109, 101, 61, 115,
+            97, 109, 112, 108, 101, 95, 54, 52, 48, 215, 52, 50, 54, 46, 106, 112, 101, 103,
+        ];
+
+        // This replaces the ISO-8859 single byte multiplication character with the two byte
+        // UTF-8 codepoint `[195, 151]` for the multiplication symbol
+        let utf8_header_bytes: &[u8] = &[
+            105, 110, 108, 105, 110, 101, 59, 32, 102, 105, 108, 101, 110, 97, 109, 101, 61, 115,
+            97, 109, 112, 108, 101, 95, 54, 52, 48, 195, 151, 52, 50, 54, 46, 106, 112, 101, 103,
+        ];
+
+        let mut http_02_headers = http_02x::HeaderMap::new();
+
+        let header_value =
+            http_02x::HeaderValue::from_bytes(iso_8859_header_bytes).expect("valid header bytes");
+        http_02_headers.insert("content-disposition", header_value);
+
+        let aws_headers = Headers::try_from(http_02_headers);
+
+        assert!(aws_headers.is_ok());
+
+        let aws_headers = aws_headers.unwrap();
+
+        let parsed_header_bytes = aws_headers
+            .headers
+            .get("content-disposition")
+            .unwrap()
+            .as_str()
+            .as_bytes();
+
+        assert_eq!(parsed_header_bytes, utf8_header_bytes);
+    }
+
     proptest::proptest! {
         #[test]
         fn insert_header_prop_test(input in ".*") {

--- a/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
@@ -469,6 +469,7 @@ fn header_value(value: MaybeStatic, panic_safe: bool) -> Result<HeaderValue, Htt
 }
 
 /// Interpret each byte as a unicode codepoint and then build a `String` from these codepoints
+#[allow(dead_code)]
 fn iso_8859_to_string(s: &[u8]) -> String {
     s.iter().map(|&c| c as char).collect::<String>()
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Some users have encountered an issue with where the SDK fails when parsing the `content-disposition` header from S3's `GetObject` because the header contain bytes for ISO-8859 encoded strings rather than the UTF-8 we were expecting. This is difficult to handle because the SDK has been designed to assume that all headers are UTF-8 and so they are all represented as Rust `String` types that only support UTF-8.

This PR implements fallback parsing where bytes that fail to parse as UTF-8 are instead parsed as ISO-8859 in an infallible way.   

This is just meant as a jumping off point for discussions of how to handle this problem and should **_NOT BE MERGED_** without a group consensus.

## Description
<!--- Describe your changes in detail -->
Update the `TryFrom` impls for `HeaderMap` from `http_1x` and `http_02x` to fallback to parsing headers as ISO-8859 when UTF-8 parsing fails. This is done by replacing bytes that are outside the `0-127` ASCII range with a two byte UTF-8 codepoint. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new tests confirming that ISO-8859 headers are correctly parsed to UTF-8.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
