### PR TITLE
Update Smoketest codegen to be endpoint param aware

### DIFF
--- a/.changelog/smoketestcodegen.md
+++ b/.changelog/smoketestcodegen.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+  - smithy-rs
+authors:
+  - landonxjames
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Update Smoketest codegeneration to be endpoint built-in aware.

--- a/.changelog/smoketestcodegen.md
+++ b/.changelog/smoketestcodegen.md
@@ -1,9 +1,9 @@
 ---
 applies_to:
-  - smithy-rs
+  - aws-sdk-rust
 authors:
   - landonxjames
-references: []
+references: [smithy-rs#3836]
 breaking: false
 new_feature: false
 bug_fix: true

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecorator.kt
@@ -44,6 +44,7 @@ import software.amazon.smithy.smoketests.traits.SmokeTestCase
 import software.amazon.smithy.smoketests.traits.SmokeTestsTrait
 import java.util.Optional
 import java.util.logging.Logger
+import kotlin.jvm.optionals.getOrElse
 
 class SmokeTestsDecorator : ClientCodegenDecorator {
     override val name: String = "SmokeTests"
@@ -174,7 +175,7 @@ class SmokeTestsInstantiator(
         val rulesOrNull = index.endpointRulesForService(codegenContext.serviceShape)
         val builtInParams: Parameters = (rulesOrNull?.parameters ?: Parameters.builder().build())
         val temp: MutableList<String> = mutableListOf()
-        builtInParams.forEach { temp.add(it.builtIn.get()) }
+        builtInParams.forEach { temp.add(it.builtIn.getOrElse { "" }) }
         temp
     }
     private val fipsName = "AWS::UseFIPS"


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Smoketests for service were failing because the smoke test assumed that `use_dual_stack` would be present. But the service's endpoint rules did not use that bulit-in so it was not.

## Description
<!--- Describe your changes in detail -->
Check if the service actually uses the fips or dual stack built-ins before adding them to the test.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Did not add tests for this because the current `SmokeTestsDecoratorTest` isn't actually working and fixing it is going to be a bit of work. Want to get this in to unblock customer ASAP and will go back and update the tests once they are unblocked. 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
