### PR TITLE
Synchronize the SDK lockfile during release

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -88,6 +88,7 @@ RUN set -eux; \
     cargo install --locked --path tools/ci-build/publisher; \
     cargo install --locked --path tools/ci-build/runtime-versioner; \
     cargo install --locked --path tools/ci-build/sdk-lints; \
+    cargo install --locked --path tools/ci-build/sdk-lockfiles; \
     cargo install --locked --path tools/ci-build/sdk-versioner; \
     chmod g+rw -R /opt/cargo/registry
 

--- a/tools/ci-scripts/generate-smithy-rs-release
+++ b/tools/ci-scripts/generate-smithy-rs-release
@@ -31,6 +31,18 @@ git diff --staged --quiet || \
         -c "user.email=aws-sdk-rust-primary@amazon.com" \
         commit \
         -am "Update changelog"
+
+echo "Synchronizing the SDK lockfile with runtime lockfiles and with crate dependencies specified in CargoDependency.kt..."
+./gradlew aws:sdk:syncAwsSdkLockfile
+# Verify that crate dependencies in runtime lockfiles are covered by the updated SDK lockfile
+sdk-lockfiles audit
+# Commit the updated SDK lockfile
+git add aws/sdk/Cargo.lock
+git -c 'user.name=AWS SDK Rust Bot' \
+    -c 'user.email=aws-sdk-rust-primary@amazon.com' \
+    commit aws/sdk/Cargo.lock \
+    -m "Synchronize the SDK lockfile"
+
 # Generate the crates to publish
 ./gradlew rust-runtime:assemble
 popd

--- a/tools/ci-scripts/generate-smithy-rs-release
+++ b/tools/ci-scripts/generate-smithy-rs-release
@@ -38,12 +38,11 @@ echo "Synchronizing the SDK lockfile with runtime lockfiles and with crate depen
 sdk-lockfiles audit
 # Commit the updated SDK lockfile
 git add aws/sdk/Cargo.lock
-git diff --staged --quiet && \
+git diff --staged --quiet || \
   git -c 'user.name=AWS SDK Rust Bot' \
       -c 'user.email=aws-sdk-rust-primary@amazon.com' \
       commit aws/sdk/Cargo.lock \
-      -m "Synchronize the SDK lockfile" \
-  || true
+      -m "Synchronize the SDK lockfile"
 
 # Generate the crates to publish
 ./gradlew rust-runtime:assemble

--- a/tools/ci-scripts/generate-smithy-rs-release
+++ b/tools/ci-scripts/generate-smithy-rs-release
@@ -34,14 +34,14 @@ git diff --staged --quiet || \
 
 echo "Synchronizing the SDK lockfile with runtime lockfiles and with crate dependencies specified in CargoDependency.kt..."
 ./gradlew aws:sdk:syncAwsSdkLockfile
-# Verify that crate dependencies in runtime lockfiles are covered by the updated SDK lockfile
-sdk-lockfiles audit
 # Commit the updated SDK lockfile
 git add aws/sdk/Cargo.lock
-git -c 'user.name=AWS SDK Rust Bot' \
-    -c 'user.email=aws-sdk-rust-primary@amazon.com' \
-    commit aws/sdk/Cargo.lock \
-    -m "Synchronize the SDK lockfile"
+git diff --staged --quiet && \
+  git -c 'user.name=AWS SDK Rust Bot' \
+      -c 'user.email=aws-sdk-rust-primary@amazon.com' \
+      commit aws/sdk/Cargo.lock \
+      -m "Synchronize the SDK lockfile" \
+  || true
 
 # Generate the crates to publish
 ./gradlew rust-runtime:assemble

--- a/tools/ci-scripts/generate-smithy-rs-release
+++ b/tools/ci-scripts/generate-smithy-rs-release
@@ -34,6 +34,8 @@ git diff --staged --quiet || \
 
 echo "Synchronizing the SDK lockfile with runtime lockfiles and with crate dependencies specified in CargoDependency.kt..."
 ./gradlew aws:sdk:syncAwsSdkLockfile
+# Verify that crate dependencies in runtime lockfiles are covered by the updated SDK lockfile
+sdk-lockfiles audit
 # Commit the updated SDK lockfile
 git add aws/sdk/Cargo.lock
 git diff --staged --quiet && \


### PR DESCRIPTION
## Description
This PR introduces an additional step to the `generate-smithy-rs-release` script to synchronize the SDK lockfile with the runtime lockfiles and the Cargo dependencies specified in [CargoDependency.kt](https://github.com/smithy-lang/smithy-rs/blob/main/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt). For more details on why we synchronize the SDK lockfile, please refer to the sdk-lockfiles [README](https://github.com/smithy-lang/smithy-rs/tree/main/tools/ci-build/sdk-lockfiles).

We've decided to synchronize the SDK lockfile during release for the following reasons:
- Synchronization occurs behind the scenes, avoiding disruptions to the development workflow, unlike enforcing this check during pre-commit
- It is a single-sourced place for synchronizing the SDK lockfile

## Testing
Tested with the following scenario:
1. Added a dummy dependency to `aws-smithy-runtime` and updated `rust-runtime/Cargo.lock`
```
--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.7.1"
+version = "1.7.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -41,6 +41,7 @@ hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"],
 once_cell = "1.18.0"
 pin-project-lite = "0.2.7"
 pin-utils = "0.1.0"
+predicates = "3.1.2"
```
2. `sdk-lockfiles audit` failed as expected
```
➜  smithy-rs git:(ysaito/sync-sdk-lockfile-during-release) sdk-lockfiles audit
2024-09-17T21:48:12.346747Z  INFO sdk_lockfiles::audit: checking whether `rust-runtime/Cargo.lock` is covered by the SDK lockfile...
2024-09-17T21:48:12.381919Z  INFO sdk_lockfiles::audit: checking whether `aws/rust-runtime/Cargo.lock` is covered by the SDK lockfile...
2024-09-17T21:48:12.382360Z  INFO sdk_lockfiles::audit: checking whether `aws/rust-runtime/aws-config/Cargo.lock` is covered by the SDK lockfile...
`difflib` (0.4.0), used by `rust-runtime/Cargo.lock`, is not contained in the SDK lockfile!
`float-cmp` (0.9.0), used by `rust-runtime/Cargo.lock`, is not contained in the SDK lockfile!
`normalize-line-endings` (0.3.0), used by `rust-runtime/Cargo.lock`, is not contained in the SDK lockfile!
`predicates` (3.1.2), used by `rust-runtime/Cargo.lock`, is not contained in the SDK lockfile!
`predicates-core` (1.0.8), used by `rust-runtime/Cargo.lock`, is not contained in the SDK lockfile!
Error: there are lockfile audit failures
```
3. Ran [a dry-run release](https://github.com/smithy-lang/smithy-rs/actions/runs/10914801466)
4. Confirmed that [the SDK lockfile was synchronized during Generate release artifacts](https://github.com/smithy-lang/smithy-rs/actions/runs/10914801466/job/30294275147#step:4:390)
5. Confirmed that [the diffs in the SDK lockfile](https://github.com/smithy-lang/smithy-rs/commit/d57a7896d3cde43e17ef7ad927c9c8ee0c758def) only contained updating the `aws-smithy-runtime` crate version and adding dummy dependencies.
6. `sdk-lockfiles audit` succeeded in the release artifacts
```
➜  smithy-rs git:(ysaito/sync-sdk-lockfile-during-release) ✗ sdk-lockfiles audit --smithy-rs-path ~/Downloads/smithy-rs-release/smithy-rs
2024-09-17T21:54:15.491070Z  INFO sdk_lockfiles::audit: checking whether `rust-runtime/Cargo.lock` is covered by the SDK lockfile...
2024-09-17T21:54:15.521851Z  INFO sdk_lockfiles::audit: checking whether `aws/rust-runtime/Cargo.lock` is covered by the SDK lockfile...
2024-09-17T21:54:15.522278Z  INFO sdk_lockfiles::audit: checking whether `aws/rust-runtime/aws-config/Cargo.lock` is covered by the SDK lockfile...
SUCCESS
```
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
