### PR TITLE
Add -L to the curl command to download openssl-1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,11 +307,11 @@ jobs:
             "OPENSSL_INCLUDE_DIR",
         ]
         [target.powerpc-unknown-linux-gnu]
-        pre-build = ["curl -L -s -o /tmp/openssl.sh https://github.com/cross-rs/cross/raw/c183ee37a9dc6b0e6b6a6ac9c918173137bad4ef/docker/openssl.sh && bash /tmp/openssl.sh linux-ppc powerpc-linux-gnu-"]
+        pre-build = ["curl -L -s https://github.com/cross-rs/cross/raw/c183ee37a9dc6b0e6b6a6ac9c918173137bad4ef/docker/openssl.sh | sed 's/curl https/curl -L https/' > /tmp/openssl.sh && bash /tmp/openssl.sh linux-ppc powerpc-linux-gnu-"]
         [target.powerpc-unknown-linux-gnu.env]
         passthrough = ["OPENSSL_DIR"]
         [target.powerpc64-unknown-linux-gnu]
-        pre-build = ["curl -L -s -o /tmp/openssl.sh https://github.com/cross-rs/cross/raw/c183ee37a9dc6b0e6b6a6ac9c918173137bad4ef/docker/openssl.sh && bash /tmp/openssl.sh linux-ppc64 powerpc64-linux-gnu-"]
+        pre-build = ["curl -L -s https://github.com/cross-rs/cross/raw/c183ee37a9dc6b0e6b6a6ac9c918173137bad4ef/docker/openssl.sh | sed 's/curl https/curl -L https/' > /tmp/openssl.sh && bash /tmp/openssl.sh linux-ppc64 powerpc64-linux-gnu-"]
         [target.powerpc64-unknown-linux-gnu.env]
         passthrough = ["OPENSSL_DIR"]
         EOF


### PR DESCRIPTION
The GitHub workflow for `exotic platform` downloads the `openssl.sh` script, which tries to download `https://www.openssl.org/source/openssl-1.0.2t.tar.gz`, but the file has been permanently moved. This PR updates the `curl` command to include the `-L` option.