### PR TITLE
Use correct env var name in a doc comment for Assume Role session name

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.6"
+version = "1.5.8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.7"
+version = "1.5.8"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -19,7 +19,7 @@
 //! WebIdentityTokenCredentialProvider will load the following environment variables:
 //! - `AWS_WEB_IDENTITY_TOKEN_FILE`: **required**, location to find the token file containing a JWT token
 //! - `AWS_ROLE_ARN`: **required**, role ARN to assume
-//! - `AWS_IAM_ROLE_SESSION_NAME`: **optional**: Session name to use when assuming the role
+//! - `AWS_ROLE_SESSION_NAME`: **optional**: Session name to use when assuming the role
 //!
 //! ## AWS Profile Configuration
 //! _Note: Configuration of the web identity token provider via a shared profile is only supported


### PR DESCRIPTION
## Motivation and Context
The correct environment variable name for Assume Role session name is `AWS_ROLE_SESSION_NAME`. We do use the correct name throughout the codebase except for a doc comment. This PR will fix it.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
