### PR TITLE
Add allowlist for audit errors to `sdk-lockfiles`

### DIFF
--- a/tools/ci-build/sdk-lockfiles/Cargo.lock
+++ b/tools/ci-build/sdk-lockfiles/Cargo.lock
@@ -933,16 +933,18 @@ dependencies = [
 
 [[package]]
 name = "sdk-lockfiles"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cargo-lock",
  "clap",
  "itertools",
+ "once_cell",
  "petgraph",
  "smithy-rs-tool-common",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -1386,6 +1388,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/tools/ci-build/sdk-lockfiles/Cargo.toml
+++ b/tools/ci-build/sdk-lockfiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdk-lockfiles"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = """
 A CLI tool to audit lockfiles for Smithy runtime crates, AWS runtime crates, `aws-config`, and the workspace containing
@@ -14,6 +14,7 @@ publish = false
 anyhow = "1.0.87"
 cargo-lock = { version = "9.0.0", features = ["dependency-tree"] }
 clap = { version = "4.4.11", features = ["derive", "env"] }
+once_cell = "1.15.0"
 petgraph = "0.6.5"
 smithy-rs-tool-common = { path = "../smithy-rs-tool-common" }
 tracing = "0.1.40"
@@ -21,3 +22,4 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]
 itertools = "0.13.0"
+tracing-test = "0.2.4"

--- a/tools/ci-build/sdk-lockfiles/false-positives.txt
+++ b/tools/ci-build/sdk-lockfiles/false-positives.txt
@@ -1,0 +1,2 @@
+aws-smithy-experimental -> pin-project
+aws-smithy-experimental -> pin-project-internal

--- a/tools/ci-build/sdk-lockfiles/src/audit.rs
+++ b/tools/ci-build/sdk-lockfiles/src/audit.rs
@@ -96,16 +96,13 @@ fn package_with_name(name: &str) -> Package {
 //
 // The following set serves as an allowlist whose entries should not be reported as audit errors.
 static FALSE_POSITIVES: Lazy<HashSet<SuspectDependency>> = Lazy::new(|| {
-    let mut false_positives = HashSet::new();
-    false_positives.insert(SuspectDependency::new(
-        package_with_name("aws-smithy-experimental"),
-        package_with_name("pin-project"),
-    ));
-    false_positives.insert(SuspectDependency::new(
-        package_with_name("aws-smithy-experimental"),
-        package_with_name("pin-project-internal"),
-    ));
-    false_positives
+    include_str!("../false-positives.txt")
+        .lines()
+        .map(|line| {
+            let parts: Vec<&str> = line.split("->").map(|s| s.trim()).collect();
+            SuspectDependency::new(package_with_name(parts[0]), package_with_name(parts[1]))
+        })
+        .collect()
 });
 
 // A list of the names of AWS runtime crates (crate versions do not need to match) must be in sync with

--- a/tools/ci-build/sdk-lockfiles/src/audit.rs
+++ b/tools/ci-build/sdk-lockfiles/src/audit.rs
@@ -7,14 +7,106 @@ use crate::AuditArgs;
 use anyhow::bail;
 use anyhow::{Context, Result};
 use cargo_lock::dependency::graph::{Graph, NodeIndex};
-use cargo_lock::{package::Package, Lockfile};
+use cargo_lock::{package::Package, Lockfile, Name, Version};
+use once_cell::sync::Lazy;
 use petgraph::visit::EdgeRef;
 use smithy_rs_tool_common::git::find_git_repository_root;
 use smithy_rs_tool_common::here;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::env;
+use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::iter;
 use std::path::PathBuf;
+use std::str::FromStr;
+
+// Struct representing a potential dependency that may eventually be reported as an error by `audit`,
+// indicating that the crate `to` is not covered by the SDK lockfile
+//
+// This dependency might be an indirect dependency where the crate `from` transitively depends on the crate `to`.
+// Given collected `SuspectDependency`s, `audit` consults `FALSE_POSITIVES`
+struct SuspectDependency {
+    from: Package,
+    to: Package,
+}
+
+impl fmt::Debug for SuspectDependency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "`SuspectDependency`: {} -> {}",
+            self.from.name.as_str(),
+            self.to.name.as_str()
+        )
+    }
+}
+
+impl PartialEq for SuspectDependency {
+    fn eq(&self, other: &Self) -> bool {
+        // `true` if two `SuspectDependency` share the same names `from`s and `to`s, ignoring package versions.
+        self.from.name == other.from.name || self.to.name == other.to.name
+    }
+}
+
+impl Eq for SuspectDependency {}
+
+impl Hash for SuspectDependency {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.from.name.as_str().hash(state);
+        self.to.name.as_str().hash(state);
+    }
+}
+
+impl SuspectDependency {
+    fn new(from: Package, to: Package) -> Self {
+        Self { from, to }
+    }
+}
+
+// Creates a `Package` where only the package name matters, while the other the fields do not matter
+//
+// An example of this is the equality of two `SuspectDependency` instances that relies solely on package names.
+fn package_with_name(name: &str) -> Package {
+    Package {
+        name: Name::from_str(name).expect("valid package name"),
+        version: Version::new(0, 0, 1),
+        source: None,
+        checksum: None,
+        dependencies: vec![],
+        replace: None,
+    }
+}
+
+// The tool has a limitation where `audit` may report false positives based on the contents of a lockfile.
+// For example, if a section of the file appears as follows:
+//
+//   pin-project v1.1.5
+//   ├── tower v0.4.13
+//   │   ├── aws-smithy-experimental v0.1.4
+//   │   ├── aws-smithy-http-server v0.63.3
+//   │   │   └── aws-smithy-http-server-python v0.63.2
+//   │   ├── aws-smithy-http-server-python v0.63.2
+//   ...
+//
+// The tool cannot identify which dependent crate of `tower` enables `tower`'s Cargo feature to include `pin-project`.
+// In the case above, `aws-smithy-experimental` does not enable this feature, while `aws-smithy-http-server` does.
+// When `aws-smithy-experimental` is compiled alone for a generated SDK without server-related Smithy runtime crates,
+// `pin-project` will not appear in the SDK lockfile. Therefore, the claim that `aws-smithy-experimental` depends
+// on `pin-project` in the above section is incorrect, and we need to teach the tool to recognize this.
+//
+// The following set serves as an allowlist whose entries should not be reported as audit errors.
+static FALSE_POSITIVES: Lazy<HashSet<SuspectDependency>> = Lazy::new(|| {
+    let mut false_positives = HashSet::new();
+    false_positives.insert(SuspectDependency::new(
+        package_with_name("aws-smithy-experimental"),
+        package_with_name("pin-project"),
+    ));
+    false_positives.insert(SuspectDependency::new(
+        package_with_name("aws-smithy-experimental"),
+        package_with_name("pin-project-internal"),
+    ));
+    false_positives
+});
 
 // A list of the names of AWS runtime crates (crate versions do not need to match) must be in sync with
 // https://github.com/smithy-lang/smithy-rs/blob/0f9b9aba386ea3063912a0464ba6a1fd7c596018/buildSrc/src/main/kotlin/CrateSet.kt#L42-L53
@@ -45,15 +137,18 @@ fn new_dependency_for_aws_sdk(crate_name: &str) -> bool {
             && !SERVER_SPECIFIC_RUNTIMES.contains(&crate_name))
 }
 
-// Recursively traverses a chain of dependencies originating from a potential new dependency. Returns true as soon as
-// it encounters a crate name that matches a runtime crate used by the AWS SDK.
+// Recursively traverses a chain of dependencies originating from a potential new dependency, populating
+// `suspect_dependencies` as it encounters a runtime crates used by the AWS SDK that appear to consume
+// `target_package`.
 fn is_consumed_by_aws_sdk(
     graph: &Graph,
+    target_package: &Package,
     node_index: NodeIndex,
-    visited: &mut BTreeSet<NodeIndex>,
-) -> bool {
+    suspect_dependencies: &mut HashSet<SuspectDependency>,
+    visited: &mut HashSet<NodeIndex>,
+) {
     if !visited.insert(node_index) {
-        return false;
+        return;
     }
 
     let consumers = graph
@@ -68,58 +163,90 @@ fn is_consumed_by_aws_sdk(
         let package = &graph[*consumer_node_index];
         tracing::debug!("visiting `{}`", package.name.as_str());
         if new_dependency_for_aws_sdk(package.name.as_str()) {
-            tracing::debug!("it's a new dependency for the AWS SDK!");
-            return true;
+            suspect_dependencies.insert(SuspectDependency::new(
+                package.clone(),
+                target_package.clone(),
+            ));
         }
-        if is_consumed_by_aws_sdk(graph, *consumer_node_index, visited) {
-            return true;
-        }
+        is_consumed_by_aws_sdk(
+            graph,
+            target_package,
+            *consumer_node_index,
+            suspect_dependencies,
+            visited,
+        )
     }
-
-    false
 }
 
-// Checks if the `target` dependency is introduced by a runtime crate used by the AWS SDK.
-//
-// This function considers `target` a new dependency if it is used by a runtime crate, whether directly or indirectly,
-// that is part of the AWS SDK.
-fn new_dependency(lockfile: &Lockfile, target: &str) -> bool {
+// Collects a set of `SuspectDependency` instances as it encounters cases where `target_package` appearing in `lockfile`
+// is introduced by a runtime crate used by the AWS SDK, whether directly or indirectly
+fn collect_suspect_dependencies(
+    lockfile: &Lockfile,
+    target_package: &Package,
+) -> HashSet<SuspectDependency> {
+    let target_package_name = target_package.name.as_str();
     tracing::debug!(
             "`{}` is not recorded in the SDK lockfile. Verifying whether it is a new dependency for the AWS SDK...",
-            target
+            target_package_name
     );
     let tree = lockfile.dependency_tree().unwrap();
     let package = lockfile
         .packages
         .iter()
-        .find(|pkg| pkg.name.as_str() == target)
-        .expect("{target} must be in dependencies listed in `lockfile`");
+        .find(|pkg| pkg.name.as_str() == target_package_name)
+        .expect("{target_package_name} must be in dependencies listed in `lockfile`");
     let indices = vec![tree.nodes()[&package.into()]];
 
+    let mut suspect_dependencies = HashSet::new();
+
     for index in &indices {
-        let mut visited: BTreeSet<NodeIndex> = BTreeSet::new();
-        tracing::debug!("traversing a dependency chain for `{}`...", target);
-        if is_consumed_by_aws_sdk(tree.graph(), *index, &mut visited) {
-            return true;
-        }
+        let mut visited: HashSet<NodeIndex> = HashSet::new();
+        tracing::debug!(
+            "traversing a dependency chain for `{}`...",
+            target_package_name
+        );
+        is_consumed_by_aws_sdk(
+            tree.graph(),
+            target_package,
+            *index,
+            &mut suspect_dependencies,
+            &mut visited,
+        );
     }
 
-    tracing::debug!("`{}` is not a new dependency for the AWS SDK", target);
-    false
+    suspect_dependencies
 }
 
-// Verifies if all dependencies listed in `runtime_lockfile` are present in `sdk_dependency_set`, and returns an
-// iterator that yields those not found in the set.
+// Verifies if all dependencies listed in `runtime_lockfile` are present in `sdk_dependency_set` and returns a set of
+// `SuspectDependency` instances after consulting the set against the provided `false_positives`
+//
+// Each entry in this set indicates that a crate represented by `SuspectDependency::to` will be reported as an audit
+// error, saying it appears in `runtime_lockfile` but is not covered by the SDK lockfile
 //
 // This check is based solely on crate names, ignoring other metadata such as versions or sources.
 fn audit_runtime_lockfile_covered_by_sdk_lockfile<'a>(
     runtime_lockfile: &'a Lockfile,
     sdk_dependency_set: &'a HashSet<&str>,
-) -> impl Iterator<Item = &'a Package> + 'a {
-    runtime_lockfile.packages.iter().filter(move |p| {
-        !sdk_dependency_set.contains(p.name.as_str())
-            && new_dependency(runtime_lockfile, p.name.as_str())
-    })
+    false_positives: Option<&HashSet<SuspectDependency>>,
+) -> HashSet<SuspectDependency> {
+    let mut suspect_dependencies = HashSet::new();
+    for package in &runtime_lockfile.packages {
+        if !sdk_dependency_set.contains(package.name.as_str()) {
+            suspect_dependencies
+                .extend(collect_suspect_dependencies(runtime_lockfile, package).into_iter());
+        }
+    }
+    if let Some(false_positives) = false_positives {
+        // Any entry in `false_positives` that is not reported in `suspect_dependencies` may be removed,
+        // as it is no longer considered a false positive.
+        for fp in false_positives.difference(&suspect_dependencies) {
+            tracing::warn!("{fp:?} may potentially be removed from `{false_positives:?}`");
+        }
+        suspect_dependencies.retain(|dep| !false_positives.contains(dep));
+        suspect_dependencies
+    } else {
+        suspect_dependencies
+    }
 }
 
 fn lockfile_for(
@@ -160,24 +287,42 @@ pub(super) fn audit(args: AuditArgs) -> Result<()> {
         lockfile_for(smithy_rs_root, "aws/rust-runtime/aws-config/Cargo.lock")?,
     ];
 
-    let mut uncovered = Vec::new();
+    let mut crates_to_report: Vec<(Package, &str)> = Vec::new();
 
     for (runtime_lockfile, path) in &runtime_lockfiles {
         tracing::info!(
             "checking whether `{}` is covered by the SDK lockfile...",
             path
         );
-        uncovered.extend(
-            audit_runtime_lockfile_covered_by_sdk_lockfile(runtime_lockfile, &sdk_dependency_set)
-                .zip(iter::repeat(path)),
+        // We can assume that the need to handle `FALSE_POSITIVES` arises only with the Smithy runtime lockfile,
+        // due to server-related runtime crates. All dependencies listed in the AWS runtime lockfile and the `aws-config`
+        // lockfile should be included in the SDK lockfile.
+        let crates_uncovered_by_sdk = if *path == "rust-runtime/Cargo.lock" {
+            audit_runtime_lockfile_covered_by_sdk_lockfile(
+                runtime_lockfile,
+                &sdk_dependency_set,
+                Some(&FALSE_POSITIVES),
+            )
+        } else {
+            audit_runtime_lockfile_covered_by_sdk_lockfile(
+                runtime_lockfile,
+                &sdk_dependency_set,
+                None,
+            )
+        };
+        crates_to_report.extend(
+            crates_uncovered_by_sdk
+                .into_iter()
+                .map(|c| c.to)
+                .zip(iter::repeat(*path)),
         );
     }
 
-    if uncovered.is_empty() {
+    if crates_to_report.is_empty() {
         println!("SUCCESS");
         Ok(())
     } else {
-        for (pkg, origin_lockfile) in uncovered {
+        for (pkg, origin_lockfile) in crates_to_report {
             eprintln!(
                 "`{}` ({}), used by `{}`, is not contained in the SDK lockfile!",
                 pkg.name.as_str(),
@@ -194,6 +339,7 @@ mod tests {
     use super::*;
     use itertools::Itertools;
     use std::str::FromStr;
+    use tracing_test::traced_test;
 
     // For simplicity, return an SDK dependency set with a small subset of crates. If a runtime crate used by
     // subsequent tests is omitted, it will not affect the functionality of the system under test,
@@ -247,9 +393,9 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
         assert!(audit_runtime_lockfile_covered_by_sdk_lockfile(
             &runtime_lockfile,
             &sdk_dependency_set(),
+            None,
         )
-        .next()
-        .is_none());
+        .is_empty());
     }
 
     #[test]
@@ -284,9 +430,9 @@ checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
         assert!(audit_runtime_lockfile_covered_by_sdk_lockfile(
             &runtime_lockfile,
             &sdk_dependency_set(),
+            None,
         )
-        .next()
-        .is_none());
+        .is_empty());
     }
 
     #[test]
@@ -329,8 +475,10 @@ checksum = "5f8e213c36148d828083ae01948eed271d03f95f7e72571fa242d78184029af2"
                 audit_runtime_lockfile_covered_by_sdk_lockfile(
                     &runtime_lockfile,
                     &sdk_dependency_set(),
+                    None,
                 )
-                .map(|p| p.name.as_str())
+                .into_iter()
+                .map(|suspect_dependency| suspect_dependency.to.name.as_str().to_owned())
                 .sorted()
                 .collect::<Vec<_>>(),
             );
@@ -410,11 +558,125 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
                 audit_runtime_lockfile_covered_by_sdk_lockfile(
                     &runtime_lockfile,
                     &sdk_dependency_set(),
+                    None,
                 )
-                .map(|p| p.name.as_str())
+                .into_iter()
+                .map(|suspect_dependency| suspect_dependency.to.name.as_str().to_owned())
                 .sorted()
                 .collect::<Vec<_>>(),
             );
         }
+    }
+
+    #[test]
+    fn test_false_positives() {
+        let mut sdk_dependency_set = HashSet::new();
+        sdk_dependency_set.insert("aws-smithy-experimental");
+        sdk_dependency_set.insert("tower");
+
+        let runtime_lockfile = Lockfile::from_str(
+            r#"
+[[package]]
+name = "aws-smithy-experimental"
+version = "0.1.4"
+dependencies = [
+ "tower",
+]
+
+[[package]]
+name = "aws-smithy-http-server"
+version = "0.63.2"
+dependencies = [
+ "tower",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "pin-project",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+"#,
+        )
+        .unwrap();
+
+        let mut false_positives = HashSet::new();
+        false_positives.insert(SuspectDependency::new(
+            package_with_name("aws-smithy-experimental"),
+            package_with_name("pin-project"),
+        ));
+
+        assert!(audit_runtime_lockfile_covered_by_sdk_lockfile(
+            &runtime_lockfile,
+            &sdk_dependency_set,
+            Some(&false_positives),
+        )
+        .is_empty());
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_warning_issued_when_false_positive_is_no_longer_false_positive() {
+        let mut sdk_dependency_set = HashSet::new();
+        sdk_dependency_set.insert("aws-smithy-experimental");
+        sdk_dependency_set.insert("tower");
+        sdk_dependency_set.insert("pin-project"); // include `pin-project` in the SDK lockfile
+
+        let runtime_lockfile = Lockfile::from_str(
+            r#"
+[[package]]
+name = "aws-smithy-experimental"
+version = "0.1.4"
+dependencies = [
+ "tower",
+]
+
+[[package]]
+name = "aws-smithy-http-server"
+version = "0.63.2"
+dependencies = [
+ "tower",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "pin-project",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+"#,
+        )
+        .unwrap();
+
+        let mut false_positives = HashSet::new();
+        false_positives.insert(SuspectDependency::new(
+            package_with_name("aws-smithy-experimental"),
+            package_with_name("pin-project"),
+        ));
+
+        assert!(audit_runtime_lockfile_covered_by_sdk_lockfile(
+            &runtime_lockfile,
+            &sdk_dependency_set,
+            Some(&false_positives),
+        )
+        .is_empty());
+
+        assert!(logs_contain("may potentially be removed from"));
     }
 }

--- a/tools/ci-build/sdk-lockfiles/src/audit.rs
+++ b/tools/ci-build/sdk-lockfiles/src/audit.rs
@@ -21,10 +21,12 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 // Struct representing a potential dependency that may eventually be reported as an error by `audit`,
-// indicating that the crate `to` is not covered by the SDK lockfile
+// indicating that the crate `to` is not covered by the SDK lockfile even though `to` is reported as a dependency
+// of the crate `from` in a runtime lockfile.
 //
-// This dependency might be an indirect dependency where the crate `from` transitively depends on the crate `to`.
-// Given collected `SuspectDependency`s, `audit` consults `FALSE_POSITIVES`
+// This dependency might be an indirect dependency, meaning that the crate `from` transitively depends on the crate `to`.
+// Given collected `SuspectDependency` instances, the `audit` subcommand refers to `FALSE_POSITIVES` to determine
+// whether a `SuspectDependency` should be reported as an audit error.
 struct SuspectDependency {
     from: Package,
     to: Package,


### PR DESCRIPTION
## Motivation and Context
Unblocks smithy-rs#3856

## Description
See [README](https://github.com/smithy-lang/smithy-rs/blob/d09d1213971f698cffa11caec0ccd3c1911bc12c/tools/ci-build/sdk-lockfiles/README.md#false-positives)

For those who may wonder why `sdk-lockfiles audit` returns `SUCCESS` with the lockfiles in the current main branch. That's because `pin-project` [is listed in the SDK lockfile](https://github.com/smithy-lang/smithy-rs/blob/3871e9aed7ed6fbecdc45a76c7a5b75f17a941b5/aws/sdk/Cargo.lock#L3256-L3263) due to the dependency chain: `hyper-util` -> `tower` -> `pin-project`. However, since the last `cargo update` in PR3856, a more recent version of `hyper-util` no longer depends on `pin-project`, so `pin-project` does not appear in the SDK lockfile.

## Testing
- Added unit tests for the tool
- Confirmed that this PR unblocks the target PR

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
