### PR TITLE
Fix AWS SDK generation examples in  `aws/sdk` README

### DIFF
--- a/.changelog/1728064252.md
+++ b/.changelog/1728064252.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- client
+authors:
+- ysaito1001
+references:
+- smithy-rs#3852
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix AWS SDK generation examples in README in the `aws/sdk` directory.

--- a/aws/sdk/README.md
+++ b/aws/sdk/README.md
@@ -22,19 +22,24 @@ Controlling service generation
 
 You can use gradle properties to opt/out of generating specific services:
 ```bash
-# Generate only s3,ec2,sts
-./gradlew -Paws.services=+s3,+ec2,+sts :aws:sdk:assemble
+# Generate only S3,EC2
+# sts, sso, and ssooidc must be included, as they are internally used by S3 and EC2
+./gradlew -Paws.services=+s3,+ec2,+sts,+sso,+ssooidc :aws:sdk:assemble
 
 # Generate all AWS services using models from the aws-sdk-rust repo
 ./gradlew \
-  -Paws.sdk.models.path=../aws-sdk-rust/aws-models \
+  -Paws.sdk.models.path=<absolute path to the aws-sdk-rust repo>/aws-models \
   :aws:sdk:assemble
 
 # Generate only S3 from using the model from the aws-sdk-rust repo
+# sts, sso, and ssooidc must be included, as they are internally used by S3
 ./gradlew \
-  -Paws.sdk.models.path=../aws-sdk-rust/aws-models \
-  -Paws.services=+s3 \
+  -Paws.sdk.models.path=<absolute path to the aws-sdk-rust repo>/aws-models \
+  -Paws.services=+s3,+sts,+sso,+ssooidc \
   :aws:sdk:assemble
+
+# Start with a clean slate
+./gradlew aws:sdk:clean
 ```
 
 The generation logic is as follows:


### PR DESCRIPTION
## Motivation and Context
#3852 

## Testing
Manually executed the updated examples and confirmed they passed on my mac.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

Even though the fix is for AWS SDK code generation examples, I think the release notes for the fix should only appear in the `smithy-rs` repository. Customers subscribing to the `aws-sdk-rust` repository should not need to know.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
