### PR TITLE
Disable smoke tests code generation

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -64,7 +64,8 @@ val DECORATORS: List<ClientCodegenDecorator> =
             TokenProvidersDecorator(),
             ServiceEnvConfigDecorator(),
             HttpRequestCompressionDecorator(),
-            SmokeTestsDecorator(),
+            // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved
+            // SmokeTestsDecorator(),
         ),
         // S3 needs `AwsErrorCodeClassifier` to handle an `InternalError` as a transient error. We need to customize
         // that behavior for S3 in a way that does not conflict with the globally applied `RetryClassifierDecorator`.

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecoratorTest.kt
@@ -198,22 +198,26 @@ class SmokeTestsDecoratorTest {
 
     @Test
     fun smokeTestSdkCodegen() {
-        testSmokeTestsWithModel(model)
+        // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved
+        // testSmokeTestsWithModel(model)
     }
 
     @Test
     fun smokeTestSdkCodegenNoDualStack() {
-        testSmokeTestsWithModel(modelWithNoDualStack)
+        // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved
+        // testSmokeTestsWithModel(modelWithNoDualStack)
     }
 
     @Test
     fun smokeTestSdkCodegenNoFips() {
-        testSmokeTestsWithModel(modelWithNoFips)
+        // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved
+        // testSmokeTestsWithModel(modelWithNoFips)
     }
 
     @Test
     fun smokeTestSdkCodegenNeitherBuiltIn() {
-        testSmokeTestsWithModel(modelWithNeitherBuiltIn)
+        // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved
+        // testSmokeTestsWithModel(modelWithNeitherBuiltIn)
     }
 
     fun testSmokeTestsWithModel(model: Model) {


### PR DESCRIPTION
## Motivation and Context
`SmokeTestsDecorator` needs more test cases for it to be used reliably. Till #3863 has been resolved, we will stop code generating service smoke tests.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
