### PR TITLE
Add RDS URL signer

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "aws-types",
  "bytes",
  "fastrand",
  "hex",
@@ -145,6 +146,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -195,7 +197,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -240,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.12"
+version = "0.60.13"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -286,17 +288,17 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
  "base64-simd",
  "cbor-diag",
+ "ciborium",
  "http 0.2.12",
  "pretty_assertions",
  "regex-lite",
  "roxmltree",
- "serde_cbor",
  "serde_json",
  "thiserror",
 ]
@@ -508,7 +510,7 @@ dependencies = [
  "bs58",
  "chrono",
  "data-encoding",
- "half 2.4.1",
+ "half",
  "nom",
  "num-bigint",
  "num-rational",
@@ -568,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.4.1",
+ "half",
 ]
 
 [[package]]
@@ -987,12 +989,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -1961,16 +1957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -228,17 +228,17 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
  "base64-simd",
  "cbor-diag",
+ "ciborium",
  "http 0.2.12",
  "pretty_assertions",
  "regex-lite",
  "roxmltree",
- "serde_cbor",
  "serde_json",
  "thiserror",
 ]
@@ -416,7 +416,7 @@ dependencies = [
  "bs58",
  "chrono",
  "data-encoding",
- "half 2.4.1",
+ "half",
  "nom",
  "num-bigint",
  "num-rational",
@@ -448,6 +448,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -652,12 +679,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -1322,16 +1343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -19,9 +19,10 @@ http_1x = ["dep:http-1x", "dep:http-body-1x", "aws-smithy-runtime-api/http-1x"]
 # https://github.com/tkaitchuck/aHash/issues/200
 # when built with `cargo update -Z minimal-versions`
 ahash = { version = "0.8.11", default-features = false }
-aws-credential-types = { path = "../aws-credential-types" }
+aws-credential-types = { path = "../aws-credential-types", features = ["test-util"] }
 aws-runtime = { path = "../aws-runtime", features = ["http-02x"] }
 aws-sigv4 = { path = "../aws-sigv4" }
+aws-types = { path = "../aws-types" }
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["rt-tokio"] }
 aws-smithy-checksums = { path = "../../../rust-runtime/aws-smithy-checksums" }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
@@ -41,6 +42,7 @@ ring = "0.17.5"
 sha2 = "0.10"
 tokio = "1.23.1"
 tracing = "0.1"
+url = "2.5.2"
 
 [dev-dependencies]
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["test-util"] }

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -65,3 +65,5 @@ pub mod s3_expires_interceptor;
 /// allow docs to work
 #[derive(Debug)]
 pub struct Client;
+
+pub mod rds_signer;

--- a/aws/rust-runtime/aws-inlineable/src/rds_signer.rs
+++ b/aws/rust-runtime/aws-inlineable/src/rds_signer.rs
@@ -1,0 +1,242 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Code related to creating signed URLs for logging in to RDS.
+//!
+//! For more information, see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html
+
+use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
+use aws_sigv4::http_request;
+use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings};
+use aws_sigv4::sign::v4;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::identity::Identity;
+use aws_types::region::Region;
+use std::fmt::Debug;
+use std::time::Duration;
+
+const ACTION: &str = "connect";
+const SERVICE: &str = "rds-db";
+
+/// A signer that generates an auth token for a database.
+#[derive(Debug)]
+pub struct Signer {
+    config: SignerConfig,
+}
+
+impl Signer {
+    /// Given a `SignerConfig`, create a new RDS database login URL signer.
+    pub fn new(config: SignerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Return a signed URL usable as an auth token.
+    pub async fn get_auth_token(
+        &self,
+        config: &aws_types::sdk_config::SdkConfig,
+    ) -> Result<String, BoxError> {
+        let credentials = self
+            .config
+            .credentials()
+            .or(config.credentials_provider().as_ref())
+            .ok_or("credentials are required to create an RDS login URL")?
+            .provide_credentials()
+            .await?;
+        let identity: Identity = credentials.into();
+        let region = self
+            .config
+            .region()
+            .or(config.region())
+            .cloned()
+            .unwrap_or_else(|| Region::new("us-east-1"));
+        let time = config.time_source().ok_or("a time source is required")?;
+
+        let mut signing_settings = SigningSettings::default();
+        signing_settings.expires_in = Some(Duration::from_secs(900));
+        signing_settings.signature_location = http_request::SignatureLocation::QueryParams;
+
+        let signing_params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(region.as_ref())
+            .name(SERVICE)
+            .time(time.now())
+            .settings(signing_settings)
+            .build()?;
+
+        let url = format!(
+            "https://{}:{}/?Action={}&DBUser={}",
+            self.config.hostname(),
+            self.config.port(),
+            ACTION,
+            self.config.username()
+        );
+
+        let signable_request =
+            SignableRequest::new("GET", &url, std::iter::empty(), SignableBody::empty())
+                .expect("signable request");
+
+        let (signing_instructions, _signature) =
+            http_request::sign(signable_request, &signing_params.into())?.into_parts();
+
+        let mut url = url::Url::parse(&url).unwrap();
+        for (name, value) in signing_instructions.params() {
+            url.query_pairs_mut().append_pair(name, &value);
+        }
+
+        let response = url.to_string().split_off("https://".len());
+
+        Ok(response)
+    }
+}
+
+/// Configuration for an RDS auth URL signer.
+#[derive(Debug)]
+pub struct SignerConfig {
+    /// The AWS credentials to sign requests with. Uses the default credential provider chain if not specified.
+    credentials: Option<SharedCredentialsProvider>,
+
+    /// The hostname of the database to connect to.
+    hostname: String,
+
+    /// The port number the database is listening on.
+    port: u32,
+
+    /// The region the database is located in. Uses the region inferred from the runtime if omitted.
+    region: Option<Region>,
+
+    /// The username to login as.
+    username: String,
+}
+
+impl SignerConfig {
+    /// Create a new `SignerConfigBuilder`.
+    pub fn builder() -> SignerConfigBuilder {
+        SignerConfigBuilder::default()
+    }
+
+    /// The AWS credentials to sign requests with.
+    pub fn credentials(&self) -> Option<&SharedCredentialsProvider> {
+        self.credentials.as_ref()
+    }
+
+    /// The hostname of the database to connect to.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// The port number the database is listening on.
+    pub fn port(&self) -> u32 {
+        self.port
+    }
+
+    /// The region to sign requests with.
+    pub fn region(&self) -> Option<&Region> {
+        self.region.as_ref()
+    }
+
+    /// The DB username to login as.
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+}
+
+/// A builder for [`SignerConfig`]s.
+#[derive(Debug, Default)]
+pub struct SignerConfigBuilder {
+    /// The AWS credentials to sign requests with. Uses the default credential provider chain if not specified.
+    credentials: Option<SharedCredentialsProvider>,
+
+    /// The hostname of the database to connect to.
+    hostname: Option<String>,
+
+    /// The port number the database is listening on.
+    port: Option<u32>,
+
+    /// The region the database is located in. Uses the region inferred from the runtime if omitted.
+    region: Option<Region>,
+
+    /// The database username to login as.
+    username: Option<String>,
+}
+
+impl SignerConfigBuilder {
+    /// Set the AWS credentials to sign requests with. Uses the default credential provider chain if not specified.
+    pub fn credentials(mut self, credentials: SharedCredentialsProvider) -> Self {
+        self.credentials = Some(credentials);
+        self
+    }
+
+    /// The hostname of the database to connect to.
+    pub fn hostname(mut self, hostname: impl Into<String>) -> Self {
+        self.hostname = Some(hostname.into());
+        self
+    }
+
+    /// The port number the database is listening on.
+    pub fn port(mut self, port: u32) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    /// The region the database is located in. Uses the region inferred from the runtime if omitted.
+    pub fn region(mut self, region: Region) -> Self {
+        self.region = Some(region);
+        self
+    }
+
+    /// The database username to login as.
+    pub fn username(mut self, username: impl Into<String>) -> Self {
+        self.username = Some(username.into());
+        self
+    }
+
+    /// Consume this builder, returning an error if required fields are missing.
+    /// Otherwise, return a new `SignerConfig`.
+    pub fn build(self) -> Result<SignerConfig, BoxError> {
+        Ok(SignerConfig {
+            credentials: self.credentials,
+            hostname: self.hostname.ok_or("A hostname is required")?,
+            port: self.port.ok_or("a port is required")?,
+            region: self.region,
+            username: self.username.ok_or("a username is required")?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Signer, SignerConfig};
+    use aws_credential_types::provider::SharedCredentialsProvider;
+    use aws_credential_types::Credentials;
+    use aws_smithy_async::test_util::ManualTimeSource;
+    use aws_types::region::Region;
+    use aws_types::SdkConfig;
+    use std::time::SystemTime;
+
+    #[tokio::test]
+    async fn signing_works() {
+        // Should generate the same result as running the following AWS CLI command:
+        // aws rds generate-db-auth-token \
+        // --hostname iamauth-databasecluster.cluster-abcdefg222hq.us-east-1.rds.amazonaws.com \
+        // --port 3306 --username mydbuser --region us-east-1
+        let time_source = ManualTimeSource::new(SystemTime::UNIX_EPOCH);
+        let sdk_config = SdkConfig::builder()
+            .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
+            .time_source(time_source)
+            .build();
+        let signer = Signer::new(
+            SignerConfig::builder()
+                .hostname("dontcare.fake-region-1.rds.amazonaws.com")
+                .port(3306)
+                .region(Region::new("fake-region-1"))
+                .username("mydbuser")
+                .build()
+                .unwrap(),
+        );
+
+        let signed_url = signer.get_auth_token(&sdk_config).await.unwrap();
+        assert_eq!(signed_url, "dontcare.fake-region-1.rds.amazonaws.com:3306/?Action=connect&DBUser=mydbuser&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F19700101%2Ffake-region-1%2Frds-db%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=32562254e5a540b51186f885e7df18188f5e963133f081c95668f8ce6d17c6c1");
+    }
+}

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -93,6 +93,13 @@ pub enum SignableBody<'a> {
     StreamingUnsignedPayloadTrailer,
 }
 
+impl SignableBody<'_> {
+    /// Create a new empty signable body
+    pub fn empty() -> SignableBody<'static> {
+        SignableBody::Bytes(&[])
+    }
+}
+
 /// Instructions for applying a signature to an HTTP request.
 #[derive(Debug)]
 pub struct SigningInstructions {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.rustsdk.customize.ec2.Ec2Decorator
 import software.amazon.smithy.rustsdk.customize.glacier.GlacierDecorator
 import software.amazon.smithy.rustsdk.customize.lambda.LambdaDecorator
 import software.amazon.smithy.rustsdk.customize.onlyApplyTo
+import software.amazon.smithy.rustsdk.customize.rds.RdsDecorator
 import software.amazon.smithy.rustsdk.customize.route53.Route53Decorator
 import software.amazon.smithy.rustsdk.customize.s3.S3Decorator
 import software.amazon.smithy.rustsdk.customize.s3.S3ExpiresDecorator
@@ -77,6 +78,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
         Ec2Decorator().onlyApplyTo("com.amazonaws.ec2#AmazonEC2"),
         GlacierDecorator().onlyApplyTo("com.amazonaws.glacier#Glacier"),
         LambdaDecorator().onlyApplyTo("com.amazonaws.lambda#AWSGirApiService"),
+        RdsDecorator().onlyApplyTo("com.amazonaws.rds#AmazonRDSv19"),
         Route53Decorator().onlyApplyTo("com.amazonaws.route53#AWSDnsV20130401"),
         "com.amazonaws.s3#AmazonS3".applyDecorators(
             S3Decorator(),

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/rds/RdsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/rds/RdsDecorator.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.rustsdk.customize.rds
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rustsdk.AwsCargoDependency
+import software.amazon.smithy.rustsdk.InlineAwsDependency
+
+class RdsDecorator : ClientCodegenDecorator {
+    override val name: String = "RDS"
+    override val order: Byte = 0
+
+    override fun extras(
+        codegenContext: ClientCodegenContext,
+        rustCrate: RustCrate,
+    ) {
+        val rc = codegenContext.runtimeConfig
+
+        rustCrate.lib {
+            // We should have a better way of including an inline dependency.
+            rust(
+                "// include #T;",
+                RuntimeType.forInlineDependency(
+                    InlineAwsDependency.forRustFile(
+                        "rds_signer",
+                        Visibility.PUBLIC,
+                        AwsCargoDependency.awsSigv4(rc),
+                        CargoDependency.smithyRuntimeApiClient(rc),
+                        CargoDependency.smithyAsync(rc),
+                        CargoDependency.smithyAsync(rc).toDevDependency().withFeature("test-util"),
+                        CargoDependency.Url,
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -580,9 +580,11 @@ dependencies = [
 [[package]]
 name = "aws-smithy-protocol-test"
 version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495c940cd5c7232ac3f0945ff559096deadd2fc73e4418a0e98fe5836788bb39"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-simd",
  "cbor-diag",
  "http 0.2.12",
@@ -596,19 +598,17 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495c940cd5c7232ac3f0945ff559096deadd2fc73e4418a0e98fe5836788bb39"
+version = "0.63.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.2",
  "base64-simd",
  "cbor-diag",
+ "ciborium",
  "http 0.2.12",
  "pretty_assertions",
  "regex-lite",
  "roxmltree",
- "serde_cbor",
  "serde_json",
  "thiserror",
 ]
@@ -628,7 +628,7 @@ dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",
  "aws-smithy-http 0.60.11",
- "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-protocol-test 0.63.0",
  "aws-smithy-runtime-api 1.7.2",
  "aws-smithy-types 1.2.7",
  "bytes",
@@ -664,7 +664,7 @@ checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
 dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-http 0.60.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-protocol-test 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-protocol-test 0.62.0",
  "aws-smithy-runtime-api 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
@@ -809,7 +809,7 @@ dependencies = [
 name = "aws-smithy-xml"
 version = "0.60.9"
 dependencies = [
- "aws-smithy-protocol-test 0.62.0",
+ "aws-smithy-protocol-test 0.63.0",
  "base64 0.13.1",
  "proptest",
  "xmlparser",

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.60.12"
+version = "0.60.13"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-checksums/src/lib.rs
+++ b/rust-runtime/aws-smithy-checksums/src/lib.rs
@@ -220,7 +220,7 @@ impl Checksum for Sha1 {
 }
 
 #[derive(Debug, Default)]
-struct Sha256 {
+pub struct Sha256 {
     hasher: sha2::Sha256,
 }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
[aws-sdk-rust/951](https://github.com/awslabs/aws-sdk-rust/issues/951)

## Description
<!--- Describe your changes in detail -->
Adds a struct for generating signed URLs for logging in to RDS. See [this doc](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html) for more info.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a test.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
