### PR TITLE
chore: add Into conversions for Blob to [u8]

### DIFF
--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.2.7"
+version = "1.2.8"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/blob.rs
+++ b/rust-runtime/aws-smithy-types/src/blob.rs
@@ -31,21 +31,21 @@ impl AsRef<[u8]> for Blob {
     }
 }
 
-impl Into<Vec<u8>> for Blob {
-    fn into(self) -> Vec<u8> {
-        self.into_inner()
+impl From<Vec<u8>> for Blob {
+    fn from(value: Vec<u8>) -> Self {
+        Blob::new(value)
     }
 }
 
-impl Into<Blob> for Vec<u8> {
-    fn into(self) -> Blob {
-        Blob::new(self)
+impl From<Blob> for Vec<u8> {
+    fn from(value: Blob) -> Self {
+        value.into_inner()
     }
 }
 
-impl Into<Blob> for &[u8] {
-    fn into(self) -> Blob {
-        Blob::new(self)
+impl From<&[u8]> for Blob {
+    fn from(value: &[u8]) -> Self {
+        Blob::new(value)
     }
 }
 
@@ -121,6 +121,25 @@ mod serde_deserialize {
 }
 
 #[cfg(test)]
+mod test {
+    use crate::Blob;
+
+    #[test]
+    fn blob_conversion() {
+        let my_bytes: &[u8] = &[1u8, 2u8, 3u8];
+        let my_vec = vec![1u8, 2u8, 3u8];
+        let orig_vec = my_vec.clone();
+
+        let blob1: Blob = my_bytes.into();
+        let vec1: Vec<u8> = blob1.into();
+        assert_eq!(orig_vec, vec1);
+
+        let blob2: Blob = my_vec.into();
+        let vec2: Vec<u8> = blob2.into();
+        assert_eq!(orig_vec, vec2);
+    }
+}
+
 #[cfg(all(
     aws_sdk_unstable,
     feature = "serde-serialize",

--- a/rust-runtime/aws-smithy-types/src/blob.rs
+++ b/rust-runtime/aws-smithy-types/src/blob.rs
@@ -31,6 +31,24 @@ impl AsRef<[u8]> for Blob {
     }
 }
 
+impl Into<Vec<u8>> for Blob {
+    fn into(self) -> Vec<u8> {
+        self.into_inner()
+    }
+}
+
+impl Into<Blob> for Vec<u8> {
+    fn into(self) -> Blob {
+        Blob::new(self)
+    }
+}
+
+impl Into<Blob> for &[u8] {
+    fn into(self) -> Blob {
+        Blob::new(self)
+    }
+}
+
 #[cfg(all(aws_sdk_unstable, feature = "serde-serialize"))]
 mod serde_serialize {
     use super::*;


### PR DESCRIPTION
## Motivation and Context
Often I have a &[u8] or a Vec<u8>, but the sdk function takes a Blob.
It would be convenient to pass the my_vec instead of aws_smithy_types::Blob::new(my_vec)

## Description
In blob.rs I added
Into<Vec<u8>> for Blob
Into<Blob> for Vec<u8>
Into<Blob> for &[u8]


## Testing
Added a test to blob.rs to test the various scenarios.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
