### PR TITLE
Don't add `serde` feature unnecessarily

### DIFF
--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecorator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecorator.kt
@@ -33,19 +33,7 @@ class ClientSerdeDecorator : ClientCodegenDecorator {
     override fun extras(
         codegenContext: ClientCodegenContext,
         rustCrate: RustCrate,
-    ) {
-        rustCrate.mergeFeature(SerdeFeature)
-        val generator = SerializeImplGenerator(codegenContext)
-        rustCrate.withModule(SerdeModule) {
-            serializationRoots(codegenContext).forEach {
-                generator.generateRootSerializerForShape(
-                    it,
-                )(this)
-            }
-            addDependency(SupportStructures.serializeRedacted().toSymbol())
-            addDependency(SupportStructures.serializeUnredacted().toSymbol())
-        }
-    }
+    ) = extrasCommon(codegenContext, rustCrate)
 }
 
 class ServerSerdeDecorator : ServerCodegenDecorator {
@@ -55,14 +43,21 @@ class ServerSerdeDecorator : ServerCodegenDecorator {
     override fun extras(
         codegenContext: ServerCodegenContext,
         rustCrate: RustCrate,
-    ) {
+    ) = extrasCommon(codegenContext, rustCrate)
+}
+
+// Just a common function to keep things DRY.
+private fun extrasCommon(
+    codegenContext: CodegenContext,
+    rustCrate: RustCrate,
+) {
+    val roots = serializationRoots(codegenContext)
+    if (roots.isNotEmpty()) {
         rustCrate.mergeFeature(SerdeFeature)
         val generator = SerializeImplGenerator(codegenContext)
         rustCrate.withModule(SerdeModule) {
-            serializationRoots(codegenContext).forEach {
-                generator.generateRootSerializerForShape(
-                    it,
-                )(this)
+            roots.forEach {
+                generator.generateRootSerializerForShape(it)(this)
             }
             addDependency(SupportStructures.serializeRedacted().toSymbol())
             addDependency(SupportStructures.serializeUnredacted().toSymbol())


### PR DESCRIPTION
If the model is not using the `@smithy.rust#serde` trait, there's no
need for the code-generated crate to have a `serde` feature.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
