### PR TITLE
Fix serde on constrained blobs

### DIFF
--- a/.changelog/1729878769.md
+++ b/.changelog/1729878769.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["server"]
+authors: ["rcoh"]
+references: ["smithy-rs#3890"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix bug in `serde` decorator that generated non-compiling code on some models

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
@@ -462,8 +462,8 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
         }
 
     private fun serializeBlob(shape: BlobShape): RuntimeType =
-        RuntimeType.forInlineFun("SerializeBlob", Companion.PrimitiveShapesModule) {
-            implSerializeConfigured(codegenContext.symbolProvider.toSymbol(shape)) {
+        RuntimeType.forInlineFun("SerializeBlob", PrimitiveShapesModule) {
+            implSerializeConfigured(RuntimeType.blob(codegenContext.runtimeConfig).toSymbol()) {
                 rustTemplate(
                     """
                     if serializer.is_human_readable() {
@@ -478,7 +478,7 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
         }
 
     private fun serializeByteStream(shape: BlobShape): RuntimeType =
-        RuntimeType.forInlineFun("SerializeByteStream", Companion.PrimitiveShapesModule) {
+        RuntimeType.forInlineFun("SerializeByteStream", PrimitiveShapesModule) {
             implSerializeConfigured(RuntimeType.byteStream(codegenContext.runtimeConfig).toSymbol()) {
                 // This doesn't work yet—there is no way to get data out of a ByteStream from a sync context
                 rustTemplate(
@@ -498,7 +498,7 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
         }
 
     private fun serializeDocument(shape: DocumentShape): RuntimeType =
-        RuntimeType.forInlineFun("SerializeDocument", Companion.PrimitiveShapesModule) {
+        RuntimeType.forInlineFun("SerializeDocument", PrimitiveShapesModule) {
             implSerializeConfigured(codegenContext.symbolProvider.toSymbol(shape)) {
                 rustTemplate(
                     """

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rust.codegen.serde
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute.Companion.cfg
@@ -190,22 +191,22 @@ class SerdeDecoratorTest {
             namespace com.example
             use smithy.rust#serde
             use aws.protocols#awsJson1_0
-            
+
             @awsJson1_0
             @serde
             service MyResourceService {
                 resources: [MyResource]
             }
-            
+
             resource MyResource {
                 read: ReadMyResource
             }
-            
+
             @readonly
             operation ReadMyResource {
                 input := { }
             }
-        """.asSmithyModel(smithyVersion = "2")
+            """.asSmithyModel(smithyVersion = "2")
 
         val params =
             IntegrationTestParams(cargoCommand = "cargo test --all-features", service = "com.example#MyResourceService")
@@ -241,14 +242,14 @@ class SerdeDecoratorTest {
             """
             namespace com.example
             use aws.protocols#awsJson1_0
-            
+
             @awsJson1_0
             service MyService {
                 operations: [MyOperation]
             }
-            
+
             operation MyOperation { }
-        """.asSmithyModel(smithyVersion = "2")
+            """.asSmithyModel(smithyVersion = "2")
 
         val params =
             IntegrationTestParams(cargoCommand = "cargo test --all-features", service = "com.example#MyService")
@@ -258,6 +259,48 @@ class SerdeDecoratorTest {
                     rust("assert!(false);")
                 }
             }
+        }
+    }
+
+    val onlyConstrained =
+        """
+        namespace com.example
+        use smithy.rust#serde
+        use aws.protocols#awsJson1_0
+        use smithy.framework#ValidationException
+        @awsJson1_0
+        service HelloService {
+            operations: [SayHello],
+            version: "1"
+        }
+        @serde
+        operation SayHello {
+            input: TestInput
+            errors: [ValidationException]
+        }
+        structure TestInput {
+            @length(max: 10)
+            shortBlob: Blob
+        }
+        """.asSmithyModel(smithyVersion = "2")
+
+    // There is a "race condition" where if the first blob shape serialized is constrained, it triggered unexpected
+    // behavior where the constrained shape was used instead. This test verifies the fix.
+    // Fixes https://github.com/smithy-lang/smithy-rs/issues/3890
+    @Test
+    fun compilesOnlyConstrainedModel() {
+        val constrainedShapesSettings =
+            Node.objectNodeBuilder().withMember(
+                "codegen",
+                Node.objectNodeBuilder()
+                    .withMember("publicConstrainedTypes", true)
+                    .withMember("includeFluentClient", false)
+                    .build(),
+            ).build()
+        serverIntegrationTest(
+            onlyConstrained,
+            params.copy(additionalSettings = constrainedShapesSettings),
+        ) { clientCodegenContext, rustCrate ->
         }
     }
 


### PR DESCRIPTION
## Motivation and Context
#3890 

## Description
Replace the computed type (which will be a constrained shape, not what we want!) with an absolute type.

## Testing
- [x] New unit test that fails without this fix applied.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
