### PR TITLE
Fix directly constrained `List` shape with indirectly constrained aggregate type member shape

### DIFF
--- a/codegen-core/common-test-models/constraints.smithy
+++ b/codegen-core/common-test-models/constraints.smithy
@@ -17,6 +17,7 @@ service ConstraintsService {
         ConstrainedHttpBoundShapesOperation,
         ConstrainedHttpPayloadBoundShapeOperation,
         ConstrainedRecursiveShapesOperation,
+        ConstrainedListWithIndirectlyConstrainedAggregateOperation,
 
         // `httpQueryParams` and `httpPrefixHeaders` are structurually
         // exclusive, so we need one operation per target shape type
@@ -80,6 +81,13 @@ operation ConstrainedHttpPayloadBoundShapeOperation {
 operation ConstrainedRecursiveShapesOperation {
     input: ConstrainedRecursiveShapesOperationInputOutput,
     output: ConstrainedRecursiveShapesOperationInputOutput,
+    errors: [ValidationException]
+}
+
+@http(uri: "/constrained-list-with-indirectly-constrained-aggregate", method: "POST")
+operation ConstrainedListWithIndirectlyConstrainedAggregateOperation {
+    input: ConstrainedListWithIndirectlyConstrainedAggregateInputOutput,
+    output: ConstrainedListWithIndirectlyConstrainedAggregateInputOutput,
     errors: [ValidationException]
 }
 
@@ -333,6 +341,28 @@ structure ConstrainedHttpPayloadBoundShapeOperationInputOutput {
     @required
     @httpPayload
     httpPayloadBoundConstrainedShape: ConA
+}
+
+structure ConstrainedListWithIndirectlyConstrainedAggregateInputOutput {
+    a: ListWithIndirectlyConstrainedList,
+    b: ListWithIndirectlyConstrainedMap
+}
+
+@length(min:1, max: 10)
+list ListWithIndirectlyConstrainedList {
+    member: IndirectlyConstrainedList
+}
+list IndirectlyConstrainedList {
+    member: LengthString
+}
+
+@length(min:1, max: 10)
+list ListWithIndirectlyConstrainedMap {
+    member: IndirectlyConstrainedMap
+}
+map IndirectlyConstrainedMap {
+    key: LengthString,
+    value: LengthString
 }
 
 structure QueryParamsTargetingMapOfPatternStringOperationInputOutput {


### PR DESCRIPTION
This PR fixes a bug in the code generation for a directly constrained List shape that has an indirectly constrained aggregate type as a member shape.

For example, in the following model:

```smithy
        @http(uri: "/sample", method: "POST")
        operation SampleOp {
            input := {
                a: ItemList
            }
            errors: [ValidationException]
        }
        @length(min: 1 max: 100)
        list ItemList {
            member: Item
        }
        map Item {
            key: ItemName
            value: ItemDescription
        }
        @length(min: 0 max: 65535)
        string ItemName
        string ItemDescription
```

Fixes issue #:3885