### PR TITLE
Get all extra metadata information

### DIFF
--- a/rust-runtime/aws-smithy-types/src/error/metadata.rs
+++ b/rust-runtime/aws-smithy-types/src/error/metadata.rs
@@ -128,6 +128,10 @@ impl ErrorMetadata {
             .as_ref()
             .and_then(|extras| extras.get(key).map(|k| k.as_str()))
     }
+    /// Returns all additional information about the error if it's present.
+    pub fn extras(&self) -> Option<HashMap<&'static str, String>> {
+        self.extras
+    }
 
     /// Creates an `Error` builder.
     pub fn builder() -> Builder {


### PR DESCRIPTION
Add `extras` function inside `ErrorMetadata` to get all extra error metadata without knowing the key.

## Motivation and Context
I'm using the `ProvideErrorMetadata` trait to get as much information generically from Smithy Rust errors. I can't get the info inside this hashmap without using the Display trait, but I don't want to get the code and message mixed in there, since I want each of those inside its own field in my code. 

## Description
I want to get the entire extras hashmap without using the display trait

## Testing
Did not test outside this repo's CI/CD

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
