### PR TITLE
Fix library dependency issues

### DIFF
--- a/aws/sdk-adhoc-test/build.gradle.kts
+++ b/aws/sdk-adhoc-test/build.gradle.kts
@@ -85,16 +85,10 @@ val allCodegenTests = listOf(
 project.registerGenerateSmithyBuildTask(rootProject, pluginName, allCodegenTests)
 project.registerGenerateCargoWorkspaceTask(rootProject, pluginName, allCodegenTests, workingDirUnderBuildDir)
 project.registerGenerateCargoConfigTomlTask(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
-
-tasks.register<Copy>("copyCheckedInSdkLockfile") {
-    description = "Copy the checked-in SDK lockfile to the build directory"
-    this.outputs.upToDateWhen { false }
-    from(checkedInSdkLockfile)
-    into(layout.buildDirectory.dir(workingDirUnderBuildDir))
-}
+project.registerCopyCheckedInCargoLockfileTask(checkedInSdkLockfile, layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
 
 tasks["smithyBuild"].dependsOn("generateSmithyBuild")
-tasks["assemble"].dependsOn("generateCargoWorkspace").finalizedBy("copyCheckedInSdkLockfile")
+tasks["assemble"].dependsOn("generateCargoWorkspace").finalizedBy("copyCheckedInCargoLockfile")
 
 project.registerModifyMtimeTask()
 project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)

--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -4,6 +4,7 @@
  */
 
 import org.gradle.api.Project
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Exec
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.register
@@ -292,6 +293,17 @@ fun Project.registerGenerateCargoConfigTomlTask(outputDir: File) {
                     """.trimIndent(),
                 )
         }
+    }
+}
+
+fun Project.registerCopyCheckedInCargoLockfileTask(
+    lockfile: File,
+    destinationDir: File,
+) {
+    this.tasks.register<Copy>("copyCheckedInCargoLockfile") {
+        description = "copy checked-in `Cargo.lock` to the destination directory"
+        from(lockfile)
+        into(destinationDir)
     }
 }
 

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -21,6 +21,8 @@ fun getSmithyRuntimeMode(): String = properties.get("smithy.runtime.mode") ?: "o
 val pluginName = "rust-client-codegen"
 val workingDirUnderBuildDir = "smithyprojections/codegen-client-test/"
 
+val checkedInSmithyRuntimeLockfile = rootProject.projectDir.resolve("rust-runtime/Cargo.lock")
+
 dependencies {
     implementation(project(":codegen-client"))
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
@@ -124,11 +126,12 @@ val allCodegenTests = listOf(
 project.registerGenerateSmithyBuildTask(rootProject, pluginName, allCodegenTests)
 project.registerGenerateCargoWorkspaceTask(rootProject, pluginName, allCodegenTests, workingDirUnderBuildDir)
 project.registerGenerateCargoConfigTomlTask(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
+project.registerCopyCheckedInCargoLockfileTask(checkedInSmithyRuntimeLockfile, layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
 
 tasks["generateSmithyBuild"].inputs.property("smithy.runtime.mode", getSmithyRuntimeMode())
 
 tasks["smithyBuild"].dependsOn("generateSmithyBuild")
-tasks["assemble"].finalizedBy("generateCargoWorkspace")
+tasks["assemble"].dependsOn("generateCargoWorkspace").finalizedBy("copyCheckedInCargoLockfile")
 
 project.registerModifyMtimeTask()
 project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -131,7 +131,7 @@ project.registerCopyCheckedInCargoLockfileTask(checkedInSmithyRuntimeLockfile, l
 tasks["generateSmithyBuild"].inputs.property("smithy.runtime.mode", getSmithyRuntimeMode())
 
 tasks["smithyBuild"].dependsOn("generateSmithyBuild")
-tasks["assemble"].dependsOn("generateCargoWorkspace").finalizedBy("copyCheckedInCargoLockfile")
+tasks["assemble"].finalizedBy("generateCargoWorkspace", "copyCheckedInCargoLockfile")
 
 project.registerModifyMtimeTask()
 project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -143,6 +143,11 @@ wit-bindgen = { version = "0.16.0", features = ["macros", "realloc"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }
 wasmtime-wasi = "17.0.1"
 wasmtime-wasi-http = "17.0.1"
+
+# TODO(MSRV): Version 1.4.0 uses `error_in_core` and is considered unstable library feature in our MSRV of 1.78.0.
+# Remove this version constraint once we upgrade to a future MSRV that stabilizes `error_in_core`.
+arbitrary = "=1.3.2"
+
 "#;
 
 lazy_static! {
@@ -599,6 +604,11 @@ wit-bindgen = { version = "0.16.0", features = ["macros", "realloc"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }
 wasmtime-wasi = "17.0.1"
 wasmtime-wasi-http = "17.0.1"
+
+# TODO(MSRV): Version 1.4.0 uses `error_in_core` and is considered unstable library feature in our MSRV of 1.78.0.
+# Remove this version constraint once we upgrade to a future MSRV that stabilizes `error_in_core`.
+arbitrary = "=1.3.2"
+
 aws-config = { path = "some/sdk/path/aws-config", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { path = "some/sdk/path/s3" }
 aws-sdk-ec2 = { path = "some/sdk/path/ec2" }
@@ -657,6 +667,11 @@ wit-bindgen = { version = "0.16.0", features = ["macros", "realloc"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }
 wasmtime-wasi = "17.0.1"
 wasmtime-wasi-http = "17.0.1"
+
+# TODO(MSRV): Version 1.4.0 uses `error_in_core` and is considered unstable library feature in our MSRV of 1.78.0.
+# Remove this version constraint once we upgrade to a future MSRV that stabilizes `error_in_core`.
+arbitrary = "=1.3.2"
+
 aws-config = { version = "0.46.0", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "0.20.0" }
 aws-sdk-ec2 = { version = "0.19.0" }

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -24,6 +24,9 @@ runtime-versioner patch-runtime \
   --sdk-path "$(pwd)/aws-sdk-rust" \
   --smithy-rs-path "$(pwd)/smithy-rs"
 
+echo -e "${C_YELLOW}# Copying the SDK lockfile to aws-sdk-rust...${C_RESET}"
+cp "$(pwd)/smithy-rs/aws/sdk/Cargo.lock" "$(pwd)/aws-sdk-rust/"
+
 echo -e "${C_YELLOW}# Testing SDK...${C_RESET}"
 for sdk in aws-sdk-rust/sdk/*; do
   if ls "$sdk/tests" | grep -v '^endpoint_tests\.rs$'; then

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -44,7 +44,6 @@ def main(skip_generation=False):
         elif get_cmd_status(f'git cat-file -e base:{sdk_directory}/{path}/Cargo.toml') != 0:
             eprint(f'skipping {path} because it does not exist in base')
         else:
-            get_cmd_output('cargo generate-lockfile', quiet=True)
             (_, out, _) = get_cmd_output('cargo pkgid', cwd=path, quiet=True)
             pkgid = parse_package_id(out)
             (status, out, err) = get_cmd_output(f'cargo semver-checks check-release '


### PR DESCRIPTION
## Motivation and Context
Smithy-rs CI and our release pipeline have exposed another place, [sdk-adhoc-test](https://github.com/smithy-lang/smithy-rs/tree/main/aws/sdk-adhoc-test), where we should place a Cargo lockfile but we currently don't. Specifically, running `./gradlew aws:sdk-adhoc-test:check`on the current main is encountering the following error:
```
error[E0658]: use of unstable library feature 'error_in_core'
  --> /opt/cargo/registry/src/index.crates.io-6f17d22bba15001f/idna-1.0.3/src/lib.rs:78:6
   |
78 | impl core::error::Error for Errors {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information
```
We're supposed to pin `idna` to 0.5.0 ([example](https://github.com/smithy-lang/smithy-rs/blob/62caa4639497bc9b18f57e51a30265899d9b511e/aws/sdk/Cargo.lock#L2812-L2819)), but `sdk-adhoc-test` uses 1.0.3.

This PR will fix the problem by copying the checked-in SDK lockfile to `sdk-adhoc-test`.

## Testing
- [x] `./gradlew aws:sdk-adhoc-test:check` from the repo root has passed
- [ ] Tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
