### PR TITLE
Update some deps in `pokemon-service-tls` example

### DIFF
--- a/examples/pokemon-service-tls/Cargo.toml
+++ b/examples/pokemon-service-tls/Cargo.toml
@@ -13,9 +13,11 @@ tokio = "1.26.0"
 tracing = "0.1"
 
 # These dependencies are only required for the `pokemon-service-tls` program.
-tls-listener = { version = "0.7.0", features = ["rustls", "hyper-h2"] }
-tokio-rustls = "0.24.0"
-rustls-pemfile = "1.0.2"
+
+# Latest version supporting hyper 0.x
+tls-listener = { version = "0.8", features = ["rustls", "hyper-h2"] }
+tokio-rustls = "0.24"
+rustls-pemfile = "1"
 futures-util = { version = "0.3.29", default-features = false }
 
 # Local paths
@@ -27,8 +29,8 @@ assert_cmd = "2.0"
 serial_test = "3.1.1"
 
 # These dependencies are only required for testing the `pokemon-service-tls` program.
-hyper-rustls = { version = "0.24", features = ["http2"] }
-hyper-tls = { version = "0.5" }
+hyper-rustls = { version = "0.27", features = ["http2"] }
+hyper-tls = { version = "0.6" }
 
 # Local paths
 aws-smithy-http = { path = "../../rust-runtime/aws-smithy-http/" }
@@ -37,4 +39,3 @@ aws-smithy-types = { path = "../../rust-runtime/aws-smithy-types/" }
 pokemon-service-client = { path = "../pokemon-service-client/", features = [
     "behavior-version-latest",
 ] }
-

--- a/examples/pokemon-service-tls/src/main.rs
+++ b/examples/pokemon-service-tls/src/main.rs
@@ -131,6 +131,7 @@ pub async fn main() {
         acceptor,
         hyper::server::conn::AddrIncoming::bind(&addr).expect("could not bind"),
     )
+    .connections()
     .filter(|conn| {
         if let Err(err) = conn {
             eprintln!("connection error: {:?}", err);


### PR DESCRIPTION
tls-listener 0.7.0 is vulnerable to CVE-2024-28854, GHSA-2qph-qpvm-2qf7, and RUSTSEC-2024-0341
rustls 0.20.9 is vulnerable to CVE-2024-32650, GHSA-6g7w-8wpp-frhj, and RUSTSEC-2024-0336

We can't update them to the latest versions because we still require
hyper 0.x.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
