### PR TITLE
Avoid logging signable body by default whose data can be very large

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -184,7 +184,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -106,7 +106,9 @@ impl<'a> Debug for SignableBody<'a> {
                 if should_log_signable_body {
                     f.debug_tuple("Bytes").field(arg0).finish()
                 } else {
-                    f.debug_tuple("Bytes").finish()
+                    f.debug_tuple("Bytes")
+                        .field(&"** REDACTED **. To print, set LOG_SIGNABLE_BODY=true")
+                        .finish()
                 }
             }
             Self::UnsignedPayload => write!(f, "UnsignedPayload"),
@@ -114,7 +116,9 @@ impl<'a> Debug for SignableBody<'a> {
                 if should_log_signable_body {
                     f.debug_tuple("Precomputed").field(arg0).finish()
                 } else {
-                    f.debug_tuple("Precomputed").finish()
+                    f.debug_tuple("Precomputed")
+                        .field(&"** REDACTED **. To print, set LOG_SIGNABLE_BODY=true")
+                        .finish()
                 }
             }
             Self::StreamingUnsignedPayloadTrailer => {
@@ -1156,13 +1160,19 @@ mod tests {
     #[test]
     fn test_debug_signable_body() {
         let sut = SignableBody::Bytes(b"hello signable body");
-        assert_eq!("Bytes", format!("{sut:?}"));
+        assert_eq!(
+            "Bytes(\"** REDACTED **. To print, set LOG_SIGNABLE_BODY=true\")",
+            format!("{sut:?}")
+        );
 
         let sut = SignableBody::UnsignedPayload;
         assert_eq!("UnsignedPayload", format!("{sut:?}"));
 
         let sut = SignableBody::Precomputed("precomputed".to_owned());
-        assert_eq!("Precomputed", format!("{sut:?}"));
+        assert_eq!(
+            "Precomputed(\"** REDACTED **. To print, set LOG_SIGNABLE_BODY=true\")",
+            format!("{sut:?}")
+        );
 
         let sut = SignableBody::StreamingUnsignedPayloadTrailer;
         assert_eq!("StreamingUnsignedPayloadTrailer", format!("{sut:?}"));


### PR DESCRIPTION
## Motivation and Context
While investigating a connect timeout issue for uploading object(s) in [`aws-s3-transfer-manager-rs`](https://github.com/awslabs/aws-s3-transfer-manager-rs), we saw that the size of trace log was about 70 GB and that the last 1 GB only had 30 lines, with each line having couple MB's body to be logged (due to [this location](https://github.com/awslabs/aws-sdk-rust/blob/953cd6c7af04f02938a0dcf36f793ebe7a06cc57/sdk/aws-sigv4/src/http_request/sign.rs#L224)).

## Description
This PR disables logging the actual body data in `SignableBody` by default. Customers can set the `LOG_SIGNABLE_BODY` environment variable to log the body data if they want to, as described in the comment within the `Debug` implementation.

## Testing
- Added a small unit test
- Tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
