### PR TITLE
Add missing lifetime annotation to `EscapedStr::as_escaped_str`

### DIFF
--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.61.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -25,7 +25,7 @@ impl<'a> EscapedStr<'a> {
     }
 
     /// Returns the escaped string value
-    pub fn as_escaped_str(&self) -> &str {
+    pub fn as_escaped_str(&self) -> &'a str {
         self.0
     }
 


### PR DESCRIPTION
`JsonTokenIterator` parses and returns `Token`s from a provided u8 slice. `EscapedStr` is used as a member field in several token variants, such as `ObjectKey` and `ValueString`. While `as_escaped_str` returns a reference to the underlying `&'a str`, the lifetime annotation was missing from its return type.

This PR adds the missing lifetime annotation.
