### PR TITLE
Add feature ID for S3 Transfer Manager

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "arbitrary",
  "aws-credential-types",

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/lib.rs
+++ b/aws/rust-runtime/aws-runtime/src/lib.rs
@@ -38,6 +38,7 @@ pub mod invocation_id;
 /// Supporting code for request metadata headers in the AWS SDK.
 pub mod request_info;
 
+/// AWS SDK feature identifies.
 #[doc(hidden)]
 pub mod sdk_feature;
 

--- a/aws/rust-runtime/aws-runtime/src/lib.rs
+++ b/aws/rust-runtime/aws-runtime/src/lib.rs
@@ -38,6 +38,9 @@ pub mod invocation_id;
 /// Supporting code for request metadata headers in the AWS SDK.
 pub mod request_info;
 
+#[doc(hidden)]
+pub mod sdk_feature;
+
 /// Interceptor that determines the clock skew between the client and service.
 pub mod service_clock_skew;
 

--- a/aws/rust-runtime/aws-runtime/src/sdk_feature.rs
+++ b/aws/rust-runtime/aws-runtime/src/sdk_feature.rs
@@ -9,7 +9,7 @@ use aws_smithy_types::config_bag::{Storable, StoreAppend};
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AwsSdkFeature {
-    /// Indicates that an operation called using the S3 Transfer Manager
+    /// Indicates that an operation was called by the S3 Transfer Manager
     S3Transfer,
 }
 

--- a/aws/rust-runtime/aws-runtime/src/sdk_feature.rs
+++ b/aws/rust-runtime/aws-runtime/src/sdk_feature.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_types::config_bag::{Storable, StoreAppend};
+
+/// IDs for the features that may be used in the AWS SDK
+#[non_exhaustive]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AwsSdkFeature {
+    /// Indicates that an operation called using the S3 Transfer Manager
+    S3Transfer,
+}
+
+impl Storable for AwsSdkFeature {
+    type Storer = StoreAppend<Self>;
+}

--- a/aws/rust-runtime/aws-runtime/src/user_agent/interceptor.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent/interceptor.rs
@@ -20,6 +20,7 @@ use aws_smithy_types::config_bag::ConfigBag;
 use aws_types::app_name::AppName;
 use aws_types::os_shim_internal::Env;
 
+use crate::sdk_feature::AwsSdkFeature;
 use crate::user_agent::metrics::ProvideBusinessMetric;
 use crate::user_agent::{AdditionalMetadata, ApiMetadata, AwsUserAgent, InvalidMetadataValue};
 
@@ -134,6 +135,13 @@ impl Intercept for UserAgentInterceptor {
         let smithy_sdk_features = cfg.load::<SmithySdkFeature>();
         for smithy_sdk_feature in smithy_sdk_features {
             smithy_sdk_feature
+                .provide_business_metric()
+                .map(|m| ua.add_business_metric(m));
+        }
+
+        let aws_sdk_features = cfg.load::<AwsSdkFeature>();
+        for aws_sdk_feature in aws_sdk_features {
+            aws_sdk_feature
                 .provide_business_metric()
                 .map(|m| ua.add_business_metric(m));
         }

--- a/aws/rust-runtime/aws-runtime/src/user_agent/metrics.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent/metrics.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::sdk_feature::AwsSdkFeature;
 use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
@@ -151,6 +152,15 @@ impl ProvideBusinessMetric for SmithySdkFeature {
                 );
                 None
             }
+        }
+    }
+}
+
+impl ProvideBusinessMetric for AwsSdkFeature {
+    fn provide_business_metric(&self) -> Option<BusinessMetric> {
+        use AwsSdkFeature::*;
+        match self {
+            S3Transfer => Some(BusinessMetric::S3Transfer),
         }
     }
 }

--- a/aws/sdk/integration-tests/s3/tests/business_metrics.rs
+++ b/aws/sdk/integration-tests/s3/tests/business_metrics.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_config::Region;
+use aws_runtime::{
+    sdk_feature::AwsSdkFeature, user_agent::test_util::assert_ua_contains_metric_values,
+};
+use aws_sdk_s3::{
+    config::{Intercept, IntoShared},
+    primitives::ByteStream,
+    Client, Config,
+};
+use aws_smithy_runtime::client::http::test_util::capture_request;
+
+#[derive(Debug)]
+struct TransferManagerFeatureInterceptor;
+
+impl Intercept for TransferManagerFeatureInterceptor {
+    fn name(&self) -> &'static str {
+        "TransferManagerFeature"
+    }
+
+    fn read_before_execution(
+        &self,
+        _ctx: &aws_sdk_s3::config::interceptors::BeforeSerializationInterceptorContextRef<'_>,
+        cfg: &mut aws_sdk_s3::config::ConfigBag,
+    ) -> Result<(), aws_sdk_s3::error::BoxError> {
+        cfg.interceptor_state()
+            .store_append(AwsSdkFeature::S3Transfer);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_track_metric_for_s3_transfer_manager() {
+    let (http_client, captured_request) = capture_request(None);
+    let mut conf_builder = Config::builder()
+        .region(Region::new("us-east-1"))
+        .http_client(http_client.clone())
+        .with_test_defaults();
+    // The S3 Transfer Manager uses a passed-in S3 client SDK for operations.
+    // By configuring an interceptor at the client level to track metrics,
+    // all operations executed by the client will automatically include the metric.
+    // This eliminates the need to apply `.config_override` on individual operations
+    // to insert the `TransferManagerFeatureInterceptor`.
+    conf_builder.push_interceptor(TransferManagerFeatureInterceptor.into_shared());
+    let client = Client::from_conf(conf_builder.build());
+
+    let _ = client
+        .put_object()
+        .bucket("doesnotmatter")
+        .key("doesnotmatter")
+        .body(ByteStream::from_static("Hello, world".as_bytes()))
+        .send()
+        .await
+        .unwrap();
+
+    let expected_req = captured_request.expect_request();
+    let user_agent = expected_req.headers().get("x-amz-user-agent").unwrap();
+    assert_ua_contains_metric_values(user_agent, &["G"]);
+}

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-eventstream 0.60.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-http 0.60.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.7.3",
  "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-types",
@@ -221,7 +221,7 @@ dependencies = [
  "aws-smithy-eventstream 0.60.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-http 0.60.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-json 0.60.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.7.3",
  "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-types 1.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-xml 0.60.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,7 +398,7 @@ name = "aws-smithy-experimental"
 version = "0.1.5"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-runtime 1.7.3",
+ "aws-smithy-runtime 1.7.4",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.9",
  "h2 0.4.6",
@@ -612,6 +612,38 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime"
 version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+dependencies = [
+ "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.60.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-protocol-test 0.63.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fastrand",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.31",
+ "hyper-rustls 0.24.2",
+ "indexmap 2.6.0",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.4"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.1",
@@ -642,38 +674,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
-dependencies = [
- "aws-smithy-async 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-protocol-test 0.63.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "fastrand",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "httparse",
- "hyper 0.14.31",
- "hyper-rustls 0.24.2",
- "indexmap 2.6.0",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls 0.21.12",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1980,7 +1980,7 @@ dependencies = [
  "aws-smithy-compression",
  "aws-smithy-http 0.60.11",
  "aws-smithy-json 0.60.7",
- "aws-smithy-runtime 1.7.3",
+ "aws-smithy-runtime 1.7.4",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.9",
  "aws-smithy-xml 0.60.9",

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client.rs
@@ -47,7 +47,9 @@ pub mod interceptors;
 /// Stalled stream protection for clients
 pub mod stalled_stream_protection;
 
+/// Generic Smithy SDK feature identifies.
 #[doc(hidden)]
 pub mod sdk_feature;
+
 /// Smithy support-code for code generated waiters.
 pub mod waiters;


### PR DESCRIPTION
## Motivation and Context
This PR introduces the `AwsSdkFeature` enum, which will be used for AWS SDK-specific feature identifiers. For now, it includes a single ID for the S3 Transfer Manager. This approach is similar to the existing [SmithySdkFeature](https://github.com/smithy-lang/smithy-rs/blob/aac9becfd469e2479f68c61fd4c8074ddf755482/rust-runtime/aws-smithy-runtime/src/client/sdk_feature.rs#L10) in terms of its module and crate structure (that is for generic client but `AwsSdkFeature` is AWS specific); the `sdk_feature` module is hidden as it is intended for internal use only.

## Testing
Added an integration test to verify tracking a business metric for Transfer Manager. Since Transfer Manager is a high-level library, we do not track its business metric directly within the `smithy-rs` repository. Instead, [an s3 client](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/aws-s3-transfer-manager/src/config.rs#L21) used in [aws-s3-transfer-manager-rs](https://github.com/awslabs/aws-s3-transfer-manager-rs) can configure the s3 client as demonstrated in the integration test to track the metric.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
