### PR TITLE
 Only support T as an allowed separator in RFC-3339 dates

### DIFF
--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -21,8 +21,6 @@ val properties = PropertyRetriever(rootProject, project)
 val pluginName = "rust-server-codegen"
 val workingDirUnderBuildDir = "smithyprojections/codegen-server-test/"
 
-val checkedInSmithyRuntimeLockfile = rootProject.projectDir.resolve("rust-runtime/Cargo.lock")
-
 dependencies {
     implementation(project(":codegen-server"))
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
@@ -106,10 +104,9 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
 project.registerGenerateSmithyBuildTask(rootProject, pluginName, allCodegenTests)
 project.registerGenerateCargoWorkspaceTask(rootProject, pluginName, allCodegenTests, workingDirUnderBuildDir)
 project.registerGenerateCargoConfigTomlTask(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
-project.registerCopyCheckedInCargoLockfileTask(checkedInSmithyRuntimeLockfile, layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
 
 tasks["smithyBuild"].dependsOn("generateSmithyBuild")
-tasks["assemble"].finalizedBy("generateCargoWorkspace", "copyCheckedInCargoLockfile", "generateCargoConfigToml")
+tasks["assemble"].finalizedBy("generateCargoWorkspace", "generateCargoConfigToml")
 
 project.registerModifyMtimeTask()
 project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.2.9"
+version = "1.2.10"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",


### PR DESCRIPTION
This PR modifies `aws-smithy-types::DateTime` to enforce the use of 'T' (or 't') as the date-time separator. A [recent merge](https://github.com/time-rs/time/pull/700/files#diff-78a73b9911c88961601784e674a20c89e7050de9f8763522bbaa88ed28311b51R524) in the 'time' crate introduced support for space characters as separators. While ISO 8601 does allow spaces, RFC 3339 strictly requires 'T' (or 't') as the separator. 

This change restores the behavior to match how it was before `time = 0.3.37`.

This PR also removes the temporary pinning of the time crate in protocol tests.