### PR TITLE
Fix trivial mistake in error message.

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "arbitrary",
  "aws-credential-types",

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.5.2"
+version = "1.5.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/env_config/parse.rs
+++ b/aws/rust-runtime/aws-runtime/src/env_config/parse.rs
@@ -204,7 +204,7 @@ impl<'a> Parser<'a> {
         let line = prepare_line(line, false);
         let profile_name = line
             .strip_prefix('[')
-            .ok_or_else(|| self.make_error("Profile definition must start with ]"))?
+            .ok_or_else(|| self.make_error("Profile definition must start with '['"))?
             .strip_suffix(']')
             .ok_or_else(|| self.make_error("Profile definition must end with ']'"))?;
         if !self.data.contains_key(profile_name) {


### PR DESCRIPTION
## Motivation and Context
This commit fixes a bad error message.

## Description
In `read_profile_line()`, when `.strip_prefix('[')` fails, the original error message was `Profile definition must start with ]`, which is obviously wrong.  This commit fixes the error message to be `Profile definition must start with '['`, which corrects the mistake in the original error message (fixing `]` to be `[`), and adds the single quotes to match the formatting of the error message used when `.strip_suffix(']')` fails (`Profile definition must end with ']'`).

## Testing
No testing is needed here; this is solely a change to a hardcoded error message string.

## Checklist
This is a trivial fix.  Is it really interesting enough to mention in a changelog?

- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
