### PR TITLE
Fix registerGenerateCargoWorkspaceTask() to declare the output file.

### DIFF
--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -271,9 +271,10 @@ fun Project.registerGenerateCargoWorkspaceTask(
     val properties = PropertyRetriever(rootProject, this)
     project.tasks.register("generateCargoWorkspace") {
         description = "generate Cargo.toml workspace file"
+        val path = project.buildDir.resolve("$workingDirUnderBuildDir/Cargo.toml")
+        outputs.file(path)
         doFirst {
-            project.buildDir.resolve("$workingDirUnderBuildDir/Cargo.toml")
-                .writeText(generateCargoWorkspace(pluginName, codegenTests(properties, allCodegenTests)))
+            path.writeText(generateCargoWorkspace(pluginName, codegenTests(properties, allCodegenTests)))
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context
When I tried to build the main branch with `./gradlew assemble`, I got the following error.  This commit fixes the problem.
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':aws:sdk-adhoc-test:generateCargoWorkspace'.
> java.io.FileNotFoundException: /home/deven/git/smithy-rs/aws/sdk-adhoc-test/build/smithyprojections/sdk-adhoc-test/Cargo.toml (No such file or directory)
```

## Description
Fixes `registerGenerateCargoWorkspaceTask()` to declare the output file correctly when creating the `Cargo.toml` file, so Gradle can track the dependencies properly.

## Testing
Without this change, `./gradlew clean; ./gradlew assemble` failed every time.  With this change, it works.

## Checklist

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
