### PR TITLE
Fix Rust 1.83.0 "elided_named_lifetimes" warning.

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.12"
+version = "1.5.13"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -114,7 +114,7 @@ impl CredentialsProviderChain {
 }
 
 impl ProvideCredentials for CredentialsProviderChain {
-    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'_>
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
     where
         Self: 'a,
     {

--- a/aws/rust-runtime/aws-config/src/meta/token.rs
+++ b/aws/rust-runtime/aws-config/src/meta/token.rs
@@ -105,7 +105,7 @@ impl TokenProviderChain {
 }
 
 impl ProvideToken for TokenProviderChain {
-    fn provide_token<'a>(&'a self) -> future::ProvideToken<'_>
+    fn provide_token<'a>(&'a self) -> future::ProvideToken<'a>
     where
         Self: 'a,
     {

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -314,7 +314,7 @@ impl Inner {
 }
 
 impl ProvideCredentials for AssumeRoleProvider {
-    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'_>
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
     where
         Self: 'a,
     {


### PR DESCRIPTION
   Compiling aws-config v1.5.12 (.../aws-config)
warning: elided lifetime has a name
   --> .../aws-config/src/meta/credentials/chain.rs:117:72
    |
117 |     fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'_>
    |                            -- lifetime `'a` declared here              ^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default

warning: elided lifetime has a name
   --> .../aws-config/src/meta/token.rs:108:60
    |
108 |     fn provide_token<'a>(&'a self) -> future::ProvideToken<'_>
    |                      -- lifetime `'a` declared here        ^^ this elided lifetime gets resolved as `'a`

warning: elided lifetime has a name
   --> .../aws-config/src/sts/assume_role.rs:317:72
    |
317 |     fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'_>
    |                            -- lifetime `'a` declared here              ^^ this elided lifetime gets resolved as `'a`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
