### PR TITLE
For enum values starting with a digit, prefix the generated symbol with an underscore.

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWords.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWords.kt
@@ -78,7 +78,7 @@ class RustReservedWordSymbolProvider(
                     return base.toSymbol(shape)
                 }
                 val previousName = base.toMemberName(shape)
-                val escapedName = this.toMemberName(shape)
+                val escapedName = this.toMemberName(shape).replace(Regex("^(_*\\d)"), "_$1")
                 // if the names don't match and it isn't a simple escaping with `r#`, record a rename
                 renamedSymbol.toBuilder().name(escapedName)
                     .letIf(escapedName != previousName && !escapedName.contains("r#")) {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
@@ -102,7 +102,7 @@ class EnumMemberModel(
             parentShape: Shape,
             definition: EnumDefinition,
         ): MaybeRenamed? {
-            val name = definition.name.orNull()?.toPascalCase() ?: return null
+            val name = definition.name.orNull()?.toPascalCase()?.replace(Regex("^(_*\\d)"), "_$1") ?: return null
             // Create a fake member shape for symbol look up until we refactor to use EnumShape
             val fakeMemberShape =
                 MemberShape.builder().id(parentShape.id.withMember(name)).target("smithy.api#String").build()


### PR DESCRIPTION
## Motivation and Context
If an enum uses values which start with a digit, the generated symbols are invalid, causing both Smithy errors and Rust errors.

## Description
Prefixes invalid symbols starting with a digit with underscores to make the symbols valid.

## Testing
This commit fixes the Smithy error that I was getting for an enum using a value of "2DBarcode", and also fixes the generated Rust code to use "_2DBarcode" as the enum value instead of "2DBarcode".

## Checklist
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
