### PR TITLE
Stop pinning `idna` and `url` crates

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -503,8 +503,6 @@ fun Project.registerDowngradeFor(
             val crateNameToLastKnownWorkingVersions =
                 mapOf(
                     "minicbor" to "0.24.2",
-                    "idna" to "0.5.0", // TODO(MSRV): remove when ugrading MSRV to (or past) 1.81
-                    "url" to "2.5.2", // TODO(MSRV): remove when ugrading MSRV to (or past) 1.81
                     "libfuzzer-sys" to "0.4.7" // TODO(https://github.com/rust-fuzz/libfuzzer/issues/126)
                     )
 


### PR DESCRIPTION
## Motivation and Context
Now that we're on MSRV 1.8.1 we can addresses [these TODOs](https://github.com/smithy-lang/smithy-rs/blob/main/aws/sdk/build.gradle.kts#L506-L507).

## Testing
Manually ran
```
./gradlew aws:sdk:cargoUpdateAllLockfiles 
```
and bulit `aws-sdk-s3` (can be any SDK crate) with updated `idna` and `url` crates:
```
➜  s3 git:(ysaito/remove-pinning-idna-and-url) ✗ cargo check --all-features
...
    Checking idna v1.0.3
...
    Checking url v2.5.4
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15.56s
```

I didn't include updated lockfiles in this PR as they will be updated automatically next week by the bot's weekly PR to update lockfiles.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
