### PR TITLE
enable hyper1 behind BMV

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -14,14 +14,15 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 [features]
 behavior-version-latest = []
 credentials-process = ["tokio/process"]
-default = ["default-http-connector", "rt-tokio", "credentials-process", "sso"]
+default = ["default-https-client", "rt-tokio", "credentials-process", "sso"]
 rt-tokio = ["aws-smithy-async/rt-tokio", "aws-smithy-runtime/rt-tokio", "tokio/rt"]
 # NOTE: `client-hyper` and `rustls` were proxies for enabling the default HTTP client plugin of `aws-smithy-runtime`
 # there is no direct usage otherwise on hyper or rustls in this crate. These are superceded by the more appropriately
-# named `default-http-connector` feature and `client-hyper` and `rustls` are now synonyms for the same
-client-hyper = ["aws-smithy-runtime/default-http-connector"]
+# named `default-https-client` feature and `client-hyper` and `rustls` are now synonyms for the same
+# TODO(hyper1) - deprecate legacy `client-hyper` and `rustls` features when available in cargo: https://github.com/rust-lang/cargo/issues/7130
+client-hyper = ["aws-smithy-runtime/default-https-client"]
 rustls = ["client-hyper"]
-default-http-connector = ["aws-smithy-runtime/default-http-connector"]
+default-https-client = ["aws-smithy-runtime/default-https-client"]
 sso = ["dep:aws-sdk-sso", "dep:aws-sdk-ssooidc", "dep:ring", "dep:hex", "dep:zeroize", "aws-smithy-runtime-api/http-auth"]
 test-util = ["aws-runtime/test-util"]
 
@@ -64,7 +65,7 @@ proc-macro2 = { version = "1.0.92", optional = true }
 [dev-dependencies]
 aws-smithy-async = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-async", features = ["rt-tokio", "test-util"] }
 aws-smithy-runtime = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-runtime", features = ["client", "test-util"] }
-aws-smithy-http-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http-client", features = ["hyper-1", "test-util"] }
+aws-smithy-http-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http-client", features = ["default-client", "test-util"] }
 aws-smithy-runtime-api = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-runtime-api", features = ["test-util"] }
 futures-util = { version = "0.3.29", default-features = false }
 tracing-test = "0.2.4"

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -14,7 +14,7 @@ use crate::meta::credentials::CredentialsProviderChain;
 use crate::meta::region::ProvideRegion;
 use crate::provider_config::ProviderConfig;
 
-#[cfg(any(feature = "default-http-connector", feature = "rustls"))]
+#[cfg(any(feature = "default-https-client", feature = "rustls"))]
 /// Default Credentials Provider chain
 ///
 /// The region from the default region provider will be used
@@ -170,7 +170,7 @@ impl Builder {
     /// Creates a `DefaultCredentialsChain`
     ///
     /// ## Panics
-    /// This function will panic if no connector has been set or the `default-http-connector`
+    /// This function will panic if no connector has been set or the `default-https-client`
     /// feature has been disabled.
     pub async fn build(self) -> DefaultCredentialsChain {
         let region = match self.region_override {

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -984,7 +984,7 @@ pub(crate) mod test {
     #[cfg_attr(windows, ignore)]
     /// Verify that the end-to-end real client has a 1-second connect timeout
     #[tokio::test]
-    #[cfg(feature = "default-http-connector")]
+    #[cfg(feature = "default-https-client")]
     async fn one_second_connect_timeout() {
         use crate::imds::client::ImdsError;
         use aws_smithy_types::error::display::DisplayErrorContext;

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -418,7 +418,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "default-http-connector")]
+    #[cfg(feature = "default-https-client")]
     async fn read_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials() {
         let client = crate::imds::Client::builder()
             // 240.* can never be resolved
@@ -436,7 +436,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "default-http-connector")]
+    #[cfg(feature = "default-https-client")]
     async fn read_timeout_during_credentials_refresh_should_error_without_last_retrieved_credentials(
     ) {
         let client = crate::imds::Client::builder()
@@ -458,7 +458,7 @@ mod test {
     // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
-    #[cfg(feature = "default-http-connector")]
+    #[cfg(feature = "default-https-client")]
     async fn external_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials() {
         use aws_smithy_async::rt::sleep::AsyncSleep;
         let client = crate::imds::Client::builder()

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -1135,7 +1135,7 @@ mod loader {
             assert_eq!(Some(&app_name), conf.app_name());
         }
 
-        #[cfg(feature = "default-http-connector")]
+        #[cfg(feature = "default-https-client")]
         #[tokio::test]
         async fn disable_default_credentials() {
             let config = defaults(BehaviorVersion::latest())
@@ -1145,7 +1145,7 @@ mod loader {
             assert!(config.credentials_provider().is_none());
         }
 
-        #[cfg(feature = "default-http-connector")]
+        #[cfg(feature = "default-https-client")]
         #[tokio::test]
         async fn identity_cache_defaulted() {
             let config = defaults(BehaviorVersion::latest()).load().await;
@@ -1153,7 +1153,7 @@ mod loader {
             assert!(config.identity_cache().is_some());
         }
 
-        #[cfg(feature = "default-http-connector")]
+        #[cfg(feature = "default-https-client")]
         #[allow(deprecated)]
         #[tokio::test]
         async fn identity_cache_old_behavior_version() {

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -891,6 +891,7 @@ mod loader {
 
             let identity_cache = match self.identity_cache {
                 None => match self.behavior_version {
+                    #[allow(deprecated)]
                     Some(bv) if bv.is_at_least(BehaviorVersion::v2024_03_28()) => {
                         Some(IdentityCache::lazy().build())
                     }

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -73,7 +73,7 @@ impl CredentialsProviderChain {
     }
 
     /// Add a fallback to the default provider chain
-    #[cfg(any(feature = "default-http-connector", feature = "rustls"))]
+    #[cfg(any(feature = "default-https-client", feature = "rustls"))]
     pub async fn or_default_provider(self) -> Self {
         self.or_else(
             "DefaultProviderChain",
@@ -82,7 +82,7 @@ impl CredentialsProviderChain {
     }
 
     /// Creates a credential provider chain that starts with the default provider
-    #[cfg(any(feature = "default-http-connector", feature = "rustls"))]
+    #[cfg(any(feature = "default-https-client", feature = "rustls"))]
     pub async fn default_provider() -> Self {
         Self::first_try(
             "DefaultProviderChain",

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -91,7 +91,7 @@ pub(crate) mod repr;
 ///         future::ProvideCredentials::new(self.load_credentials())
 ///     }
 /// }
-/// # if cfg!(feature = "default-http-connector") {
+/// # if cfg!(feature = "default-https-client") {
 /// let provider = ProfileFileCredentialsProvider::builder()
 ///     .with_custom_provider("Custom", MyCustomProvider)
 ///     .build();

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -128,7 +128,7 @@ impl ProviderConfig {
     ///
     /// # Examples
     /// ```no_run
-    /// # #[cfg(feature = "default-http-connector")]
+    /// # #[cfg(feature = "default-https-client")]
     /// # fn example() {
     /// use aws_config::provider_config::ProviderConfig;
     /// use aws_sdk_sts::config::Region;

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -318,7 +318,7 @@ where
     O: for<'a> Deserialize<'a> + Secrets + PartialEq + Debug,
     E: Error,
 {
-    #[cfg(feature = "default-http-connector")]
+    #[cfg(feature = "default-https-client")]
     #[allow(unused)]
     /// Record a test case from live (remote) HTTPS traffic
     ///

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -67,7 +67,13 @@ class AwsFluentClientDecorator : ClientCodegenDecorator {
         rustCrate.withModule(ClientRustModule.client) {
             AwsFluentClientExtensions(codegenContext, types).render(this)
         }
-        rustCrate.mergeFeature(Feature("rustls", default = true, listOf("aws-smithy-runtime/default-http-connector")))
+
+        // TODO(hyper1): disable rustls as a default feature in future release
+        // NOTE: We enable both rustls and default-https-client as default features. This keeps the legacy hyper+rustls
+        // stack working as is and lets BehaviorVersion control which client you get. In a future release we will
+        // break this and disable the rustls feature by default (and break old BMV versions w.r.t http client default).
+        rustCrate.mergeFeature(Feature("rustls", default = true, listOf("aws-smithy-runtime/tls-rustls")))
+        rustCrate.mergeFeature(Feature("default-https-client", default = true, listOf("aws-smithy-runtime/default-https-client")))
     }
 
     override fun libRsCustomizations(

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/HttpChecksumTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/HttpChecksumTest.kt
@@ -167,6 +167,15 @@ internal class HttpChecksumTest {
             // Note about the `//#{PresigningMarker}` below. The `RequestChecksumInterceptor` relies on the `PresigningMarker` type from
             // the presigning inlineable. The decorator for that inlineable doesn't play nicely with the test model from the SEP, so we
             // use this as a kind of blunt way to include the presigning inlineable without actually wiring it up with the model.
+            // We also have to ensure the `http-1x` feature the presigning inlineable expects is present on the generated crate.
+            rustCrate.mergeFeature(
+                Feature(
+                    "http-1x",
+                    default = false,
+                    listOf("dep:http-body-1x", "aws-smithy-runtime-api/http-1x"),
+                ),
+            )
+
             val testBase =
                 writable {
                     rustTemplate(
@@ -290,6 +299,7 @@ internal class HttpChecksumTest {
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
+                "http_1x" to CargoDependency.Http1x.toType(),
             )
         }
     }
@@ -368,6 +378,7 @@ internal class HttpChecksumTest {
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
+                "http_1x" to CargoDependency.Http1x.toType(),
             )
         }
     }
@@ -389,7 +400,7 @@ internal class HttpChecksumTest {
                 ##[::tokio::test]
                 async fn ${algoLower}_response_checksums_works() {
                     let (http_client, _rx) = #{capture_request}(Some(
-                        http::Response::builder()
+                        #{http_1x}::Response::builder()
                             .header("x-amz-checksum-$algoLower", "${testDef.checksumHeaderValue}")
                             .body(SdkBody::from("${testDef.responsePayload}"))
                             .unwrap(),
@@ -414,6 +425,7 @@ internal class HttpChecksumTest {
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
+                "http_1x" to CargoDependency.Http1x.toType(),
             )
         }
     }
@@ -435,7 +447,7 @@ internal class HttpChecksumTest {
                 ##[::tokio::test]
                 async fn ${algoLower}_response_checksums_fail_correctly() {
                     let (http_client, _rx) = #{capture_request}(Some(
-                        http::Response::builder()
+                        #{http_1x}::Response::builder()
                             .header("x-amz-checksum-$algoLower", "${testDef.checksumHeaderValue}")
                             .body(SdkBody::from("${testDef.responsePayload}"))
                             .unwrap(),
@@ -476,6 +488,7 @@ internal class HttpChecksumTest {
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
+                "http_1x" to CargoDependency.Http1x.toType(),
             )
         }
     }
@@ -537,6 +550,7 @@ internal class HttpChecksumTest {
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
+                "http_1x" to CargoDependency.Http1x.toType(),
             )
         }
     }
@@ -613,7 +627,7 @@ internal class HttpChecksumTest {
                 ##[::tokio::test]
                 async fn response_config_ua_supported() {
                     let (http_client, rx) = #{capture_request}(Some(
-                        http::Response::builder()
+                        #{http_1x}::Response::builder()
                             .header("x-amz-checksum-crc32", "i9aeUg==")
                             .body(SdkBody::from("Hello world"))
                             .unwrap(),
@@ -645,7 +659,7 @@ internal class HttpChecksumTest {
                 ##[::tokio::test]
                 async fn response_config_ua_required() {
                     let (http_client, rx) = #{capture_request}(Some(
-                        http::Response::builder()
+                        #{http_1x}::Response::builder()
                             .header("x-amz-checksum-crc32", "i9aeUg==")
                             .body(SdkBody::from("Hello world"))
                             .unwrap(),
@@ -680,6 +694,7 @@ internal class HttpChecksumTest {
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
+                "http_1x" to CargoDependency.Http1x.toType(),
             )
         }
     }

--- a/aws/sdk/integration-tests/no-default-features/tests/client-construction.rs
+++ b/aws/sdk/integration-tests/no-default-features/tests/client-construction.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 // the connector being enabled transitively
 #[tokio::test]
 #[should_panic(
-    expected = "Enable the `default-http-connector` crate feature or configure an HTTP client to fix this."
+    expected = "Enable the `default-https-client` crate feature or configure an HTTP client to fix this."
 )]
 async fn test_clients_from_sdk_config() {
     aws_config::load_defaults(BehaviorVersion::latest()).await;
@@ -58,8 +58,8 @@ async fn test_clients_from_service_config() {
         .expect_err("it should fail to send a request because there is no HTTP client");
     let msg = format!("{}", DisplayErrorContext(err));
     assert!(
-        msg.contains("No HTTP client was available to send this request. Enable the `default-http-connector` crate feature or configure an HTTP client to fix this."),
-        "expected '{msg}' to contain 'No HTTP client was available to send this request. Enable the `default-http-connector` crate feature or set an HTTP client to fix this.'"
+        msg.contains("No HTTP client was available to send this request. Enable the `default-https-client` crate feature or configure an HTTP client to fix this."),
+        "expected '{msg}' to contain 'No HTTP client was available to send this request. Enable the `default-https-client` crate feature or set an HTTP client to fix this.'"
     );
 }
 

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -26,7 +26,7 @@ aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol
 aws-smithy-runtime = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime", features = ["test-util"] }
 aws-smithy-runtime-api = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime-api", features = ["test-util", "http-1x"] }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
-aws-smithy-http-client = { path = "../../build/aws-sdk/sdk/aws-smithy-http-client", features = ["hyper-1", "rustls-ring", "test-util", "wire-mock"] }
+aws-smithy-http-client = { path = "../../build/aws-sdk/sdk/aws-smithy-http-client", features = ["default-client", "rustls-ring", "test-util", "wire-mock"] }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 bytes = "1"
 bytes-utils = "0.1.2"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDecorator.kt
@@ -51,12 +51,12 @@ class FluentClientDecorator : ClientCodegenDecorator {
             customizations = listOf(GenericFluentClient(codegenContext)),
         ).render(rustCrate)
 
-        // For backwards compat reasons we have to leave this feature as `rustls` which really historically was
-        // used to enable the `default_http_client` plugin to work (as rustls feature meant enabling both connector-hyper-0-14 + rustls)
-        //
-        // When we moved to hyper-1.x as default we re-purposed this feature flag to still (1) enable a default HTTP
-        // client and (2) still mean rustls (albeit now with aws-lc instead of ring)
-        rustCrate.mergeFeature(Feature("rustls", default = true, listOf("aws-smithy-runtime/default-http-connector")))
+        // TODO(hyper1): disable rustls as a default feature in future release
+        // NOTE: We enable both rustls and default-https-client as default features. This keeps the legacy hyper+rustls
+        // stack working as is and lets BehaviorVersion control which client you get. In a future release we will
+        // break this and disable the rustls feature by default (and break old BMV versions w.r.t http client default).
+        rustCrate.mergeFeature(Feature("rustls", default = true, listOf("aws-smithy-runtime/tls-rustls")))
+        rustCrate.mergeFeature(Feature("default-https-client", default = true, listOf("aws-smithy-runtime/default-https-client")))
     }
 
     override fun libRsCustomizations(

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -16,8 +16,7 @@ hyper-014 = [
     "dep:hyper-0-14",
 ]
 
-# FIXME(hyper1) - rename feature
-hyper-1 = [
+default-client = [
     "aws-smithy-runtime-api/http-1x",
     "aws-smithy-types/http-body-1-x",
     "dep:hyper",
@@ -29,7 +28,7 @@ hyper-1 = [
 
 wire-mock = [
     "test-util",
-    "hyper-1",
+    "default-client",
     "hyper-util?/server",
     "hyper-util?/server-auto",
     "hyper-util?/service",
@@ -61,9 +60,9 @@ legacy-test-util = [
 
 legacy-rustls-ring = ["dep:legacy-hyper-rustls", "dep:legacy-rustls", "hyper-014"]
 
-rustls-ring = ["dep:rustls", "rustls?/ring", "dep:hyper-rustls", "hyper-1"]
-rustls-aws-lc = ["dep:rustls", "rustls?/aws_lc_rs", "dep:hyper-rustls", "hyper-1"]
-rustls-aws-lc-fips = ["dep:rustls", "rustls?/fips", "dep:hyper-rustls", "hyper-1"]
+rustls-ring = ["dep:rustls", "rustls?/ring", "dep:hyper-rustls", "default-client"]
+rustls-aws-lc = ["dep:rustls", "rustls?/aws_lc_rs", "dep:hyper-rustls", "default-client"]
+rustls-aws-lc-fips = ["dep:rustls", "rustls?/fips", "dep:hyper-rustls", "default-client"]
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
@@ -130,7 +129,7 @@ stable = true
 [package.metadata.docs.rs]
 all-features = false
 features = [
-    "hyper-1 ",
+    "default-client ",
     "wire-mock",
     "test-util",
     "rustls-ring",

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -45,26 +45,6 @@ use std::fmt;
 use std::sync::RwLock;
 use std::time::Duration;
 
-/// Creates an HTTPS client using the default TLS provider
-pub fn default_client() -> Option<SharedHttpClient> {
-    #[cfg(feature = "rustls-aws-lc")]
-    {
-        tracing::trace!("creating a new default hyper 1.x client using rustls<aws-lc>");
-        Some(
-            Builder::new()
-                .tls_provider(tls::Provider::Rustls(
-                    tls::rustls_provider::CryptoMode::AwsLc,
-                ))
-                .build_https(),
-        )
-    }
-    #[cfg(not(feature = "rustls-aws-lc"))]
-    {
-        tracing::trace!("no default connector available");
-        None
-    }
-}
-
 /// Given `HttpConnectorSettings` and an `SharedAsyncSleep`, create a `SharedHttpConnector` from defaults depending on what cargo features are activated.
 pub fn default_connector(
     settings: &HttpConnectorSettings,

--- a/rust-runtime/aws-smithy-http-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-client/src/lib.rs
@@ -42,7 +42,7 @@ pub mod hyper_014 {
 #[cfg(feature = "default-client")]
 pub(crate) mod client;
 #[cfg(feature = "default-client")]
-pub use client::{default_client, default_connector, tls, Builder, Connector, ConnectorBuilder};
+pub use client::{default_connector, tls, Builder, Connector, ConnectorBuilder};
 
 #[cfg(feature = "test-util")]
 pub mod test_util;

--- a/rust-runtime/aws-smithy-http-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-client/src/lib.rs
@@ -11,7 +11,10 @@
 //!
 //! # Crate Features
 //!
-//! - `default-tls`: Enable default TLS provider (used by `default_client()` to provide a default configured HTTPS client)
+//! - `default-client`: Enable default HTTP client implementation (based on hyper 1.x).
+//! - `rustls-ring`: Enable TLS provider based on `rustls` using `ring` as the crypto provider
+//! - `rustls-aws-lc`: Enable TLS provider based on `rustls` using `aws-lc` as the crypto provider
+//! - `rustls-aws-lc-fips`: Same as `rustls-aws-lc` feature but using a FIPS compliant version of `aws-lc`
 //! - `hyper-014`: (Deprecated) HTTP client implementation based on hyper-0.14.x.
 //! - `test-util`: Enables utilities for unit tests. DO NOT ENABLE IN PRODUCTION.
 
@@ -36,9 +39,9 @@ pub mod hyper_014 {
 }
 
 /// Default HTTP and TLS connectors
-#[cfg(feature = "hyper-1")]
+#[cfg(feature = "default-client")]
 pub(crate) mod client;
-#[cfg(feature = "hyper-1")]
+#[cfg(feature = "default-client")]
 pub use client::{default_client, default_connector, tls, Builder, Connector, ConnectorBuilder};
 
 #[cfg(feature = "test-util")]

--- a/rust-runtime/aws-smithy-http-client/src/test_util.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util.rs
@@ -12,7 +12,7 @@
 //! respond with a given response, then capture request can also be useful since
 //! you can optionally give it a response to return.
 #![cfg_attr(
-    feature = "hyper-1",
+    feature = "default-client",
     doc = "- [`dvr`]: If you want to record real-world traffic and then replay it later, then DVR's"
 )]
 //! [`RecordingClient`](dvr::RecordingClient) and [`ReplayingClient`](dvr::ReplayingClient)
@@ -29,7 +29,7 @@
 //! - [`NeverClient`]: Useful for testing timeouts, where you want the client to never respond.
 //!
 #![cfg_attr(
-    any(feature = "hyper-014", feature = "hyper-1"),
+    any(feature = "hyper-014", feature = "default-client"),
     doc = "
 There is also the [`NeverTcpConnector`], which makes it easy to test connect/read timeouts.
 
@@ -59,9 +59,9 @@ pub mod legacy_infallible;
 mod never;
 pub use never::NeverClient;
 
-#[cfg(any(feature = "hyper-014", feature = "hyper-1"))]
+#[cfg(any(feature = "hyper-014", feature = "default-client"))]
 pub use never::NeverTcpConnector;
 
 mod body;
-#[cfg(all(feature = "hyper-1", feature = "wire-mock"))]
+#[cfg(all(feature = "default-client", feature = "wire-mock"))]
 pub mod wire;

--- a/rust-runtime/aws-smithy-http-client/src/test_util/never.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/never.rs
@@ -62,11 +62,11 @@ impl HttpClient for NeverClient {
 
 /// A TCP connector that never connects.
 // In the future, this can be available for multiple hyper version feature flags, with the impls gated between individual features
-#[cfg(any(feature = "hyper-014", feature = "hyper-1"))]
+#[cfg(any(feature = "hyper-014", feature = "default-client"))]
 #[derive(Clone, Debug, Default)]
 pub struct NeverTcpConnector;
 
-#[cfg(any(feature = "hyper-014", feature = "hyper-1"))]
+#[cfg(any(feature = "hyper-014", feature = "default-client"))]
 impl NeverTcpConnector {
     /// Creates a new `NeverTcpConnector`.
     pub fn new() -> Self {
@@ -97,7 +97,7 @@ impl hyper_0_14::service::Service<http_02x::Uri> for NeverTcpConnector {
     }
 }
 
-#[cfg(feature = "hyper-1")]
+#[cfg(feature = "default-client")]
 mod hyper1_support {
     use super::NeverTcpConnector;
     use aws_smithy_async::future::never::Never;
@@ -220,7 +220,7 @@ mod test {
         assert!(dbg!(err).is_timeout());
     }
 
-    #[cfg(feature = "hyper-1")]
+    #[cfg(feature = "default-client")]
     #[tokio::test]
     async fn never_tcp_connector_plugs_into_hyper_1() {
         use super::NeverTcpConnector;

--- a/rust-runtime/aws-smithy-http-client/tests/smoke_test_clients.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/smoke_test_clients.rs
@@ -54,13 +54,6 @@ async fn aws_lc_client() {
     smoke_test_client(&client).await.unwrap();
 }
 
-#[cfg(feature = "default-tls")]
-#[tokio::test]
-async fn default_tls_client() {
-    let client = aws_smithy_http_client::default_client().expect("default TLS client created");
-    smoke_test_client(&client).await.unwrap();
-}
-
 #[cfg(feature = "rustls-ring")]
 #[tokio::test]
 async fn custom_dns_client() {

--- a/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
@@ -20,6 +20,7 @@ enum Inner {
     // IMPORTANT: Order matters here for the `Ord` derive. Newer versions go to the bottom.
     V2023_11_09,
     V2024_03_28,
+    V2025_01_17,
 }
 
 impl BehaviorVersion {
@@ -32,9 +33,26 @@ impl BehaviorVersion {
     /// If, however, you're writing a service that is very latency sensitive, or that has written
     /// code to tune Rust SDK behaviors, consider pinning to a specific major version.
     ///
-    /// The latest version is currently [`BehaviorVersion::v2024_03_28`]
+    /// The latest version is currently [`BehaviorVersion::v2025_01_17`]
     pub fn latest() -> Self {
-        Self::v2024_03_28()
+        Self::v2025_01_17()
+    }
+
+    /// Behavior version for January 17th, 2025
+    ///
+    /// This version updates the default HTTP client and TLS stack. SDKs shipped with
+    /// a pre 1.x version of hyper and rustls originally. This behavior version updates
+    /// the HTTP+TLS stack to maintained versions.
+    ///
+    /// <div class="warning">
+    /// NOTE: In a future release behavior versions prior to this will require enabling
+    /// feature flags manually to keep the legacy Hyper stack as the default. Specifically the
+    /// `aws-smithy-runtime/tls-rustls` feature flag combined with an older behavior version.
+    /// </div>
+    pub fn v2025_01_17() -> Self {
+        Self {
+            inner: Inner::V2025_01_17,
+        }
     }
 
     /// Behavior version for March 28th, 2024.
@@ -42,6 +60,10 @@ impl BehaviorVersion {
     /// This version enables stalled stream protection for uploads (request bodies) by default.
     ///
     /// When a new behavior major version is released, this method will be deprecated.
+    #[deprecated(
+        since = "1.8.0",
+        note = "Superseded by v2025_01_17, which updates the default HTTPS client stack."
+    )]
     pub fn v2024_03_28() -> Self {
         Self {
             inner: Inner::V2024_03_28,
@@ -51,7 +73,7 @@ impl BehaviorVersion {
     /// Behavior version for November 9th, 2023.
     #[deprecated(
         since = "1.4.0",
-        note = "Superceded by v2024_03_28, which enabled stalled stream protection for uploads (request bodies) by default."
+        note = "Superseded by v2024_03_28, which enabled stalled stream protection for uploads (request bodies) by default."
     )]
     pub fn v2023_11_09() -> Self {
         Self {
@@ -81,11 +103,14 @@ mod tests {
         assert!(BehaviorVersion::latest() == BehaviorVersion::latest());
         assert!(BehaviorVersion::v2023_11_09() == BehaviorVersion::v2023_11_09());
         assert!(BehaviorVersion::v2024_03_28() != BehaviorVersion::v2023_11_09());
+        assert!(BehaviorVersion::v2025_01_17() != BehaviorVersion::v2024_03_28());
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::latest()));
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2023_11_09()));
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2024_03_28()));
+        assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2025_01_17()));
         assert!(!BehaviorVersion::v2023_11_09().is_at_least(BehaviorVersion::v2024_03_28()));
         assert!(Inner::V2024_03_28 > Inner::V2023_11_09);
         assert!(Inner::V2023_11_09 < Inner::V2024_03_28);
+        assert!(Inner::V2024_03_28 < Inner::V2025_01_17);
     }
 }

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -16,7 +16,7 @@ http-auth = ["aws-smithy-runtime-api/http-auth"]
 # NOTE: connector-hyper-0-14-x and tls-rustls are "legacy" features related to default HTTP client based on hyper 0.14.x ecosystem
 connector-hyper-0-14-x = ["dep:aws-smithy-http-client", "aws-smithy-http-client?/hyper-014"]
 tls-rustls = ["dep:aws-smithy-http-client", "aws-smithy-http-client?/legacy-rustls-ring", "connector-hyper-0-14-x"]
-default-http-connector = ["dep:aws-smithy-http-client", "aws-smithy-http-client?/rustls-aws-lc"]
+default-https-client = ["dep:aws-smithy-http-client", "aws-smithy-http-client?/rustls-aws-lc"]
 rt-tokio = ["tokio/rt"]
 
 # Features for testing

--- a/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
@@ -52,15 +52,47 @@ where
 }
 
 /// Runtime plugin that provides a default connector.
+#[deprecated(
+    since = "1.8.0",
+    note = "This function wasn't intended to be public, and didn't take the behavior major version as an argument, so it couldn't be evolved over time."
+)]
 pub fn default_http_client_plugin() -> Option<SharedRuntimePlugin> {
-    let _default: Option<SharedHttpClient> = None;
     #[allow(deprecated)]
-    #[cfg(feature = "connector-hyper-0-14-x")]
-    let _default = crate::client::http::hyper_014::default_client();
+    default_http_client_plugin_v2(BehaviorVersion::v2024_03_28())
+}
 
-    // takes precedence over legacy connector if enabled
-    #[cfg(feature = "default-http-connector")]
-    let _default = aws_smithy_http_client::default_client();
+/// Runtime plugin that provides a default HTTPS connector.
+pub fn default_http_client_plugin_v2(
+    behavior_version: BehaviorVersion,
+) -> Option<SharedRuntimePlugin> {
+    let mut _default: Option<SharedHttpClient> = None;
+
+    if behavior_version.is_at_least(BehaviorVersion::v2025_01_17()) {
+        // the latest https stack takes precedence if the config flag
+        // is enabled otherwise try to fall back to the legacy connector
+        // if that feature flag is available.
+        #[cfg(all(
+            feature = "connector-hyper-0-14-x",
+            not(feature = "default-https-client")
+        ))]
+        #[allow(deprecated)]
+        {
+            _default = crate::client::http::hyper_014::default_client();
+        }
+
+        // takes precedence over legacy connector if enabled
+        #[cfg(feature = "default-https-client")]
+        {
+            _default = aws_smithy_http_client::default_client();
+        }
+    } else {
+        // fallback to legacy hyper client for given behavior version
+        #[cfg(feature = "connector-hyper-0-14-x")]
+        #[allow(deprecated)]
+        {
+            _default = crate::client::http::hyper_014::default_client();
+        }
+    }
 
     _default.map(|default| {
         default_plugin("default_http_client_plugin", |components| {
@@ -203,6 +235,7 @@ fn default_stalled_stream_protection_config_plugin_v2(
             let mut config =
                 StalledStreamProtectionConfig::enabled().grace_period(Duration::from_secs(5));
             // Before v2024_03_28, upload streams did not have stalled stream protection by default
+            #[allow(deprecated)]
             if !behavior_version.is_at_least(BehaviorVersion::v2024_03_28()) {
                 config = config.upload_enabled(false);
             }
@@ -282,7 +315,7 @@ pub fn default_plugins(
         .unwrap_or_else(BehaviorVersion::latest);
 
     [
-        default_http_client_plugin(),
+        default_http_client_plugin_v2(behavior_version),
         default_identity_cache_plugin(),
         default_retry_config_plugin(
             params

--- a/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
@@ -83,7 +83,9 @@ pub fn default_http_client_plugin_v2(
         // takes precedence over legacy connector if enabled
         #[cfg(feature = "default-https-client")]
         {
-            _default = aws_smithy_http_client::default_client();
+            let opts = crate::client::http::DefaultClientOptions::default()
+                .with_behavior_version(behavior_version);
+            _default = crate::client::http::default_https_client(opts);
         }
     } else {
         // fallback to legacy hyper client for given behavior version

--- a/rust-runtime/aws-smithy-runtime/src/client/http.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http.rs
@@ -44,7 +44,7 @@ pub mod test_util {
 /// This module is named after the hyper version number since we anticipate
 /// needing to provide equivalent functionality for hyper 1.x in the future.
 #[cfg(feature = "connector-hyper-0-14-x")]
-#[deprecated = "hyper 0.14.x connector is deprecated, please use the connector-hyper-1-x feature instead"]
+#[deprecated = "hyper 0.14.x connector is deprecated, please use the `aws-smithy-http-client` crate directly instead."]
 pub mod hyper_014 {
     #[allow(deprecated)]
     pub use aws_smithy_http_client::hyper_014::*;

--- a/rust-runtime/aws-smithy-runtime/src/client/http.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
+#[cfg(feature = "default-https-client")]
 use aws_smithy_runtime_api::client::http::SharedHttpClient;
 
 /// Interceptor for connection poisoning.
@@ -59,21 +60,22 @@ pub mod body;
 /// Configuration options for the default HTTPS client
 #[derive(Debug, Clone)]
 pub(crate) struct DefaultClientOptions {
-    behavior_version: BehaviorVersion,
+    _behavior_version: BehaviorVersion,
 }
 
 impl Default for DefaultClientOptions {
     fn default() -> Self {
         DefaultClientOptions {
-            behavior_version: BehaviorVersion::latest(),
+            _behavior_version: BehaviorVersion::latest(),
         }
     }
 }
 
 impl DefaultClientOptions {
     /// Set the behavior version to use
+    #[allow(unused)]
     pub(crate) fn with_behavior_version(mut self, behavior_version: BehaviorVersion) -> Self {
-        self.behavior_version = behavior_version;
+        self._behavior_version = behavior_version;
         self
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/http.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http.rs
@@ -2,6 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
+use aws_smithy_runtime_api::client::http::SharedHttpClient;
 
 /// Interceptor for connection poisoning.
 pub mod connection_poisoning;
@@ -52,3 +54,40 @@ pub mod hyper_014 {
 
 /// HTTP body and body-wrapper types
 pub mod body;
+
+// NOTE: We created default client options to evolve defaults over time (e.g. allow passing a different DNS resolver)
+/// Configuration options for the default HTTPS client
+#[derive(Debug, Clone)]
+pub(crate) struct DefaultClientOptions {
+    behavior_version: BehaviorVersion,
+}
+
+impl Default for DefaultClientOptions {
+    fn default() -> Self {
+        DefaultClientOptions {
+            behavior_version: BehaviorVersion::latest(),
+        }
+    }
+}
+
+impl DefaultClientOptions {
+    /// Set the behavior version to use
+    pub(crate) fn with_behavior_version(mut self, behavior_version: BehaviorVersion) -> Self {
+        self.behavior_version = behavior_version;
+        self
+    }
+}
+
+/// Creates an HTTPS client using the default TLS provider
+#[cfg(feature = "default-https-client")]
+pub(crate) fn default_https_client(_options: DefaultClientOptions) -> Option<SharedHttpClient> {
+    use aws_smithy_http_client::{tls, Builder};
+    tracing::trace!("creating a new default hyper 1.x client using rustls<aws-lc>");
+    Some(
+        Builder::new()
+            .tls_provider(tls::Provider::Rustls(
+                tls::rustls_provider::CryptoMode::AwsLc,
+            ))
+            .build_https(),
+    )
+}

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -379,7 +379,7 @@ async fn try_attempt(
         trace!(request = ?request, "transmitting request");
         let http_client = halt_on_err!([ctx] => runtime_components.http_client().ok_or_else(||
             OrchestratorError::other("No HTTP client was available to send this request. \
-                Enable the `default-http-connector` crate feature or configure an HTTP client to fix this.")
+                Enable the `default-https-client` crate feature or configure an HTTP client to fix this.")
         ));
         let timeout_config = cfg.load::<TimeoutConfig>().expect("timeout config must be set");
         let settings = {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
@@ -400,7 +400,7 @@ impl<I, O, E> OperationBuilder<I, O, E> {
 
             assert!(
                 components.http_client().is_some(),
-                "a http_client is required. Enable the `default-http-connector` crate feature or configure an HTTP client to fix this."
+                "a http_client is required. Enable the `default-https-client` crate feature or configure an HTTP client to fix this."
             );
             assert!(
                 components.endpoint_resolver().is_some(),

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -95,8 +95,7 @@ RUN set -eux; \
     chmod g+rw -R /opt/cargo/registry
 
 FROM install_rust AS cargo_deny
-# FIXME(hyper1) - update to 0.16.2 to fix panic (requires rustc 1.81 though)
-ARG cargo_deny_version=0.16.1
+ARG cargo_deny_version=0.16.4
 RUN cargo install cargo-deny --locked --version ${cargo_deny_version}
 
 FROM install_rust AS cargo_udeps

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -42,11 +42,11 @@ cargo hack check --feature-powerset --exclude-all-features --exclude-features al
 
 echo "${C_YELLOW}## Testing each feature in isolation${C_RESET}"
 # these features are missed by the following check because they are grouped
-cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls,default-http-connector --exclude-no-default-features
+cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls,default-https-client --exclude-no-default-features
 
 # This check will check other individual features and no-default-features
 # grouping these features because they don't interact
-cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-http-connector
+cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client
 
 echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasip1 targets${C_RESET}"
 cargo check --target wasm32-unknown-unknown --no-default-features


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
* https://github.com/smithy-lang/smithy-rs/issues/1925
* https://github.com/awslabs/aws-sdk-rust/issues/977


## Description
<!--- Describe your changes in detail -->
Follow up to https://github.com/smithy-lang/smithy-rs/pull/3939 to change how we enable hyper1 as the default.

* This approach adds a new cargo feature flag on generated SDK packages (`default-https-client`) and restores the `rustls` feature to mean what it did before. Both will remain enabled as `default` features for some undetermined amount of time with the intent to remove `rustls` as a default feature as a breaking change in the future.
* Renamed feature flags to be consistent. We settled on `default-https-client`. This new flag when enabled and the appropriate min BMV is set will result in the new HTTPS stack being the default for clients. Otherwise we fallback to the old behavior (still requires `rustls` and `connector-hyper-0-14` features enabled)


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
