### PR TITLE
Fix EcsCredentialsProvider to respect query params

### DIFF
--- a/.changelog/1737491439.md
+++ b/.changelog/1737491439.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- aws-sdk-rust#1248
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix `EcsCredentialsProvider` to include query params passed via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`.

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.14"
+version = "1.5.15"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/aws-sdk-rust/issues/1248, and implemented the fix as prescribed.

## Testing
Added a request matching unit test to the `ecs` module to ensure that query params are included in credential's HTTP request.

## Checklist
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
