### PR TITLE
Check direct rust-runtime dependency minimum versions

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -650,18 +650,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2216,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "separator"
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2765,15 +2765,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "aws-smithy-async",
@@ -157,7 +157,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-inlineable"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.0"
+version = "0.63.1"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-inlineable"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
 dependencies = [
  "bindgen",
  "cc",
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1723,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "separator"
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2186,15 +2186,15 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Types for AWS SDK credentials."
 edition = "2021"
@@ -15,7 +15,7 @@ test-util = ["aws-smithy-runtime-api/test-util"]
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client", "http-auth"] }
-zeroize = "1"
+zeroize = "1.7.0"
 
 [dev-dependencies]
 async-trait = "0.1.74" # used to test compatibility

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-inlineable"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = """
 The modules of this crate are intended to be inlined directly into the SDK as needed. The dependencies here
@@ -25,19 +25,19 @@ aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
 aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", features = ["client"] }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types", features = ["http-body-0-4-x"] }
-bytes = "1"
+bytes = "1.4.0"
 fastrand = "2.0.0"
 hex = "0.4.3"
 http = "0.2.9"
 http-body = "0.4.5"
-http-1x = { package = "http", version = "1", optional = true }
+http-1x = { package = "http", version = "1.1.0", optional = true }
 http-body-1x = { package = "http-body", version = "1", optional = true }
 hmac = "0.12"
 lru = "0.12.5"
 ring = "0.17.5"
 sha2 = "0.10"
-tokio = "1.23.1"
-tracing = "0.1"
+tokio = "1.40.0"
+tracing = "0.1.40"
 url = "2.5.4"
 
 [dev-dependencies]

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-inlineable"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = """
 The modules of this crate are intended to be inlined directly into the SDK as needed. The dependencies here

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -25,17 +25,17 @@ aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", featur
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-types = { path = "../aws-types" }
-bytes = "1.1"
+bytes = "1.4.0"
 fastrand = "2.0.0"
-http-02x = { package = "http", version = "0.2.3" }
+http-02x = { package = "http", version = "0.2.9" }
 http-body-04x = { package = "http-body", version = "0.4.5" }
 http-1x = { package = "http", version = "1.1.0", optional = true }
 http-body-1x = { package = "http-body", version = "1.0.0", optional = true }
-once_cell = "1.18.0"
-percent-encoding = "2.1.0"
-pin-project-lite = "0.2.9"
+once_cell = "1.20.1"
+percent-encoding = "2.3.1"
+pin-project-lite = "0.2.14"
 regex-lite = { version = "0.1.5", optional = true }
-tracing = "0.1"
+tracing = "0.1.40"
 uuid = { version = "1" }
 
 [dev-dependencies]

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -22,22 +22,22 @@ aws-smithy-eventstream = { path = "../../../rust-runtime/aws-smithy-eventstream"
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
-bytes = "1"
-form_urlencoded = { version = "1.0", optional = true }
-hex = "0.4"
+bytes = "1.4.0"
+form_urlencoded = { version = "1.2.1", optional = true }
+hex = "0.4.3"
 hmac = "0.12"
-http0 = { version = "0.2", optional = true, package = "http" }
-http = { version = "1", optional = true }
-once_cell = "1.8"
+http0 = { version = "0.2.9", optional = true, package = "http" }
+http = { version = "1.1.0", optional = true }
+once_cell = "1.20.1"
 p256 = { version = "0.11", features = ["ecdsa"], optional = true }
-percent-encoding = { version = "2.1", optional = true }
+percent-encoding = { version = "2.3.1", optional = true }
 ring = { version = "0.17.5", optional = true }
 sha2 = "0.10"
 crypto-bigint = { version = "0.5.4", optional = true }
 subtle = { version = "2.5.0", optional = true }
 time = "0.3.5"
-tracing = "0.1"
-zeroize = { version = "^1", optional = true }
+tracing = "0.1.40"
+zeroize = { version = "^1.7.0", optional = true }
 
 [dev-dependencies]
 aws-credential-types = { path = "../aws-credential-types", features = ["test-util", "hardcoded-credentials"] }

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -17,7 +17,7 @@ aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", optional = true }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
-tracing = "0.1"
+tracing = "0.1.40"
 # cargo does not support optional test dependencies, so to completely disable rustls
 # we need to add the webpki-roots feature here.
 # https://github.com/rust-lang/cargo/issues/1596

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -435,25 +435,24 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59057b878509d88952425fe694a2806e468612bde2d71943f3cd8034935b5032"
+checksum = "f8c7557f6c81ecd3e38582996b31a0f329900586abaae5f092e756686958f22c"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
  "paste",
  "regex",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -463,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
 dependencies = [
  "bindgen",
  "cc",
@@ -955,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.69.0"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a88f1c30e4ffa2464f910297c24736ff68cca9e8d2b7d52596b54efd99b9c1e"
+checksum = "3d781684ce9da2f82da4e23eaf753310d5ddb05efe2d91cd59033828727218f5"
 dependencies = [
  "aws-credential-types 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-runtime 1.5.4",
@@ -1481,7 +1480,7 @@ dependencies = [
 name = "aws-smithy-mocks-experimental"
 version = "0.2.1"
 dependencies = [
- "aws-sdk-s3 1.69.0",
+ "aws-sdk-s3 1.70.0",
  "aws-smithy-runtime-api 1.7.4",
  "aws-smithy-types 1.3.0",
  "tokio",
@@ -1964,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -2037,18 +2036,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3100,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -4105,9 +4104,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "separator"
@@ -4137,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4763,15 +4762,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -184,25 +184,24 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59057b878509d88952425fe694a2806e468612bde2d71943f3cd8034935b5032"
+checksum = "f8c7557f6c81ecd3e38582996b31a0f329900586abaae5f092e756686958f22c"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
  "paste",
  "regex",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -212,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
 dependencies = [
  "bindgen",
  "cc",
@@ -252,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.69.0"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a88f1c30e4ffa2464f910297c24736ff68cca9e8d2b7d52596b54efd99b9c1e"
+checksum = "3d781684ce9da2f82da4e23eaf753310d5ddb05efe2d91cd59033828727218f5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -512,7 +511,7 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.5",
  "hyper-util",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "once_cell",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -690,7 +689,7 @@ dependencies = [
  "httparse",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -1063,9 +1062,9 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
 dependencies = [
- "clap 4.5.26",
+ "clap 4.5.27",
  "heck",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "log",
  "proc-macro2",
  "quote",
@@ -1097,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -1185,18 +1184,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1336,7 +1335,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.26",
+ "clap 4.5.27",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -1784,7 +1783,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1803,7 +1802,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2221,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3404,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "separator"
@@ -3436,11 +3435,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3906,7 +3905,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4170,9 +4169,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
  "rand",
@@ -4180,9 +4179,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -395,7 +395,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-smithy-compression"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "aws-smithy-runtime-api 1.7.4",
  "aws-smithy-types 1.3.0",
@@ -496,7 +496,7 @@ name = "aws-smithy-http-client"
 version = "1.0.0"
 dependencies = [
  "aws-smithy-async 1.2.5",
- "aws-smithy-protocol-test 0.63.0",
+ "aws-smithy-protocol-test 0.63.1",
  "aws-smithy-runtime-api 1.7.4",
  "aws-smithy-types 1.3.0",
  "bytes",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.63.3"
+version = "0.63.4"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-http 0.62.0",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-python"
-version = "0.63.2"
+version = "0.63.3"
 dependencies = [
  "aws-smithy-http 0.62.0",
  "aws-smithy-http-server",
@@ -628,9 +628,11 @@ dependencies = [
 [[package]]
 name = "aws-smithy-protocol-test"
 version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b92b62199921f10685c6b588fdbeb81168ae4e7950ae3e5f50145a01bb5f1ad"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.4",
+ "aws-smithy-runtime-api 1.7.3",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -644,12 +646,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b92b62199921f10685c6b588fdbeb81168ae4e7950ae3e5f50145a01bb5f1ad"
+version = "0.63.1"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.3",
+ "aws-smithy-runtime-api 1.7.4",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -677,7 +677,7 @@ checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
 dependencies = [
  "aws-smithy-async 1.2.4",
  "aws-smithy-http 0.60.12",
- "aws-smithy-protocol-test 0.63.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-protocol-test 0.63.0",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.12",
  "bytes",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types-convert"
-version = "0.60.8"
+version = "0.60.9"
 dependencies = [
  "aws-smithy-async 1.2.5",
  "aws-smithy-types 1.3.0",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-wasm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aws-smithy-http 0.62.0",
  "aws-smithy-runtime-api 1.7.4",
@@ -851,7 +851,7 @@ dependencies = [
 name = "aws-smithy-xml"
 version = "0.60.9"
 dependencies = [
- "aws-smithy-protocol-test 0.63.0",
+ "aws-smithy-protocol-test 0.63.1",
  "base64 0.13.1",
  "proptest",
  "xmlparser",

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -12,8 +12,8 @@ rt-tokio = ["tokio/time"]
 test-util = ["rt-tokio", "tokio/rt"]
 
 [dependencies]
-pin-project-lite = "0.2"
-tokio = { version = "1.23.1", features = ["sync"] }
+pin-project-lite = "0.2.14"
+tokio = { version = "1.40.0", features = ["sync"] }
 futures-util = { version = "0.3.29", default-features = false }
 
 [dev-dependencies]

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -15,17 +15,17 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 [dependencies]
 aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
-bytes = "1"
+bytes = "1.4.0"
 crc32c = "0.6.8"
 crc32fast = "1.3"
 hex = "0.4.3"
-http = "0.2.8"
-http-body = "0.4.4"
+http = "0.2.9"
+http-body = "0.4.5"
 md-5 = "0.10"
-pin-project-lite = "0.2.9"
+pin-project-lite = "0.2.14"
 sha1 = "0.10"
 sha2 = "0.10"
-tracing = "0.1"
+tracing = "0.1.40"
 crc64fast-nvme = "1.1.1"
 
 [dev-dependencies]

--- a/rust-runtime/aws-smithy-compression/Cargo.toml
+++ b/rust-runtime/aws-smithy-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-compression"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-compression/Cargo.toml
+++ b/rust-runtime/aws-smithy-compression/Cargo.toml
@@ -35,7 +35,7 @@ http-0-2 = { package = "http", version = "0.2.9", optional = true }
 http-1-0 = { package = "http", version = "1", optional = true }
 http-body-0-4 = { package = "http-body", version = "0.4.5", optional = true }
 http-body-1-0 = { package = "http-body", version = "1", optional = true }
-http-body-util = { version = "0.1.1", optional = true }
+http-body-util = { version = "0.1.2", optional = true }
 pin-project-lite = "0.2.14"
 tracing = "0.1.40"
 

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -15,7 +15,7 @@ derive-arbitrary = ["arbitrary", "derive_arbitrary"]
 [dependencies]
 arbitrary = { version = "1.3", optional = true }
 aws-smithy-types = { path = "../aws-smithy-types" }
-bytes = "1"
+bytes = "1.4.0"
 crc32fast = "1.3"
 derive_arbitrary = { version = "1.3", optional = true }
 

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -70,14 +70,14 @@ aws-smithy-async = { path = "../aws-smithy-async" }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client"] }
 aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test", optional = true }
-h2 = { version = "0.4", default-features = false }
+h2 = { version = "0.4.2", default-features = false }
 tokio = { version = "1.40", features = [] }
 once_cell = "1.20.1"
 pin-project-lite = "0.2.14"
-tracing = "0.1"
+tracing = "0.1.40"
 
 # hyper 1.x stack
-hyper = { version = "1", features = ["client", "http1", "http2"], optional = true }
+hyper = { version = "1.4.0", features = ["client", "http1", "http2"], optional = true }
 hyper-util = { version = "0.1.7", features = ["http1", "http2"], optional = true }
 http-1x = { package = "http", version = "1" , optional = true }
 http-body-1x = { package = "http-body", version = "1", optional = true}
@@ -87,15 +87,15 @@ tower = { version = "0.5.1", optional = true }
 # end hyper 1.x stack deps
 
 # legacy hyper-0.14.x stack the SDK/runtime GA'd with
-http-02x = { package = "http", version = "0.2.8", optional = true}
-http-body-04x = { package = "http-body", version = "0.4.4" , optional = true}
+http-02x = { package = "http", version = "0.2.9", optional = true}
+http-body-04x = { package = "http-body", version = "0.4.5" , optional = true}
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, features = ["client", "http1", "http2", "tcp", "stream"], optional = true }
 legacy-hyper-rustls = { package = "hyper-rustls", version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
 legacy-rustls = { package = "rustls", version = "0.21.8", optional = true }
 # end legacy stack deps
 
 # test util stack
-bytes = { version = "1", optional = true }
+bytes = { version = "1.4.0", optional = true }
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 serde_json = { version = "1.0.128", features = ["preserve_order"], optional = true }
 indexmap = { version = "2.6.0", features = ["serde"], optional = true }

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -18,27 +18,27 @@ aws-smithy-http-server = { path = "../aws-smithy-http-server", features = ["aws-
 aws-smithy-json = { path = "../aws-smithy-json" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["byte-stream-poll-next", "http-body-0-4-x"] }
 aws-smithy-xml = { path = "../aws-smithy-xml" }
-bytes = "1.2"
+bytes = "1.4.0"
 futures = "0.3"
-http = "0.2"
+http = "0.2.9"
 hyper = { version = "0.14.26", features = ["server", "http1", "http2", "tcp", "stream"] }
 tls-listener = { version = "0.7.0", features = ["rustls", "hyper-h2"] }
 rustls-pemfile = "1.0.1"
 tokio-rustls = "0.24.0"
-lambda_http = { version = "0.8.0" }
+lambda_http = { version = "0.8.3" }
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
-pin-project-lite = "0.2"
+pin-project-lite = "0.2.14"
 pyo3 = "0.18.2"
 pyo3-asyncio = { version = "0.18.0", features = ["tokio-runtime"] }
 signal-hook = { version = "0.3.14", features = ["extended-siginfo"] }
-socket2 = { version = "0.5.2", features = ["all"] }
-thiserror = "1.0.32"
-tokio = { version = "1.20.1", features = ["full"] }
-tokio-stream = "0.1"
+socket2 = { version = "0.5.5", features = ["all"] }
+thiserror = "1.0.40"
+tokio = { version = "1.40.0", features = ["full"] }
+tokio-stream = "0.1.2"
 tower = { version = "0.4.13", features = ["util"] }
-tracing = "0.1.36"
-tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 tracing-appender = { version = "0.2.2"}
 
 [dev-dependencies]

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.63.2"
+version = "0.63.3"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.63.3"
+version = "0.63.4"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -24,24 +24,24 @@ aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["http
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-0-4-x", "hyper-0-14-x"] }
 aws-smithy-xml = { path = "../aws-smithy-xml" }
 aws-smithy-cbor = { path = "../aws-smithy-cbor" }
-bytes = "1.1"
+bytes = "1.4.0"
 futures-util = { version = "0.3.29", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = "0.2.9"
+http-body = "0.4.5"
 hyper = { version = "0.14.26", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = { version = "0.8.0", optional = true }
+lambda_http = { version = "0.8.3", optional = true }
 mime = "0.3.17"
-nom = "7"
-once_cell = "1.13"
-pin-project-lite = "0.2"
+nom = "7.1.3"
+once_cell = "1.20.1"
+pin-project-lite = "0.2.14"
 regex = "1.5.5"
 serde_urlencoded = "0.7"
 thiserror = "1.0.40"
-tokio = { version = "1.23.1", features = ["full"] }
-tower = { version = "0.4.11", features = ["util", "make"], default-features = false }
+tokio = { version = "1.40.0", features = ["full"] }
+tower = { version = "0.4.13", features = ["util", "make"], default-features = false }
 tower-http = { version = "0.3", features = ["add-extension", "map-response-body"] }
-tracing = "0.1.35"
-uuid = { version = "1", features = ["v4", "fast-rng"], optional = true }
+tracing = "0.1.40"
+uuid = { version = "1.1.2", features = ["v4", "fast-rng"], optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -18,20 +18,20 @@ rt-tokio = ["aws-smithy-types/rt-tokio"]
 aws-smithy-eventstream = { path = "../aws-smithy-eventstream", optional = true }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client", "http-02x"] }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["byte-stream-poll-next", "http-body-0-4-x"] }
-bytes = "1"
+bytes = "1.4.0"
 bytes-utils = "0.1"
 # TODO(hyper1) - Complete the breaking changes by updating to http 1.x ecosystem fully in this crate. Also remove hyper 0.14 from dev
-http-02x = { package = "http", version = "0.2.3" }
+http-02x = { package = "http", version = "0.2.9" }
 http-1x = { package = "http", version = "1" }
-http-body-04x = { package = "http-body", version = "0.4.4" }
-once_cell = "1.10"
-percent-encoding = "2.1.0"
-pin-project-lite = "0.2.9"
+http-body-04x = { package = "http-body", version = "0.4.5" }
+once_cell = "1.20.1"
+percent-encoding = "2.3.1"
+pin-project-lite = "0.2.14"
 pin-utils = "0.1.0"
-tracing = "0.1"
+tracing = "0.1.40"
 
 # For an adapter to enable the `Stream` trait for `aws_smithy_types::byte_stream::ByteStream`
-futures-core = "0.3.29"
+futures-core = "0.3.31"
 
 [dev-dependencies]
 async-stream = "0.3"

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -13,11 +13,11 @@ assert-json-diff = "1.1"
 base64-simd = "0.8"
 cbor-diag = "0.1.12"
 ciborium = "0.2"
-http = "0.2.1"
+http = "0.2.9"
 pretty_assertions = "1.3"
 regex-lite = "0.1.5"
 roxmltree = "0.14.1"
-serde_json = "1"
+serde_json = "1.0.128"
 thiserror = "1.0.40"
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client"] }
 

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-protocol-test"
-version = "0.63.0"
+version = "0.63.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "A collection of library functions to validate HTTP requests against Smithy protocol tests."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -20,13 +20,13 @@ http-1x = []
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
 aws-smithy-types = { path = "../aws-smithy-types" }
-bytes = "1"
+bytes = "1.4.0"
 http-02x = { package = "http", version = "0.2.9" }
 http-1x = { package = "http", version = "1" }
-pin-project-lite = "0.2"
-tokio = { version = "1.25", features = ["sync"] }
-tracing = "0.1"
-zeroize = { version = "1", optional = true }
+pin-project-lite = "0.2.14"
+tokio = { version = "1.40.0", features = ["sync"] }
+tracing = "0.1.40"
+zeroize = { version = "1.7.0", optional = true }
 
 [dev-dependencies]
 proptest = "1"

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -49,21 +49,21 @@ aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-0-4-x"] }
 aws-smithy-http-client = { path = "../aws-smithy-http-client", optional = true }
-bytes = "1"
+bytes = "1.4.0"
 # Make sure to update `fastrand` in [dev-dependencies] if we bump the major version
 # We probably need to update unit tests using the `fastrand` crate when that happens
 fastrand = "2.0.0"
-http-02x = { package = "http", version = "0.2.8" }
+http-02x = { package = "http", version = "0.2.9" }
 http-1x = { package = "http", version = "1" }
-http-body-04x = { package = "http-body", version = "0.4.4" }
+http-body-04x = { package = "http-body", version = "0.4.5" }
 http-body-1x = { package = "http-body", version = "1" }
 # This avoids bringing `httparse` 1.9.0 and 1.9.1 through `hyper-0-14` that break unit tests of runtime crates
 httparse = "1.8.0"
-once_cell = "1.18.0"
-pin-project-lite = "0.2.7"
+once_cell = "1.20.1"
+pin-project-lite = "0.2.14"
 pin-utils = "0.1.0"
-tokio = { version = "1.25", features = [] }
-tracing = "0.1.37"
+tokio = { version = "1.40.0", features = [] }
+tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter", "fmt", "json"] }
 
 [dev-dependencies]

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -17,7 +17,7 @@ aws-smithy-types = { path = "../aws-smithy-types", optional = true }
 aws-smithy-async = { path = "../aws-smithy-async", optional = true }
 chrono = { version = "0.4.35", optional = true, default-features = false, features = ["std"] }
 time = { version = "0.3.4", optional = true }
-futures-core = { version = "0.3.0", optional = true }
+futures-core = { version = "0.3.31", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types-convert"
-version = "0.60.8"
+version = "0.60.9"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Conversion of types from aws-smithy-types to other libraries."
 edition = "2021"

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -32,25 +32,25 @@ serde-deserialize = []
 
 [dependencies]
 base64-simd = "0.8"
-bytes = "1"
+bytes = "1.4.0"
 bytes-utils = "0.1"
-http = { version = "0.2.3", optional = true }
+http = { version = "0.2.9", optional = true }
 http-1x = { package = "http", version = "1", optional = true }
-http-body-0-4 = { package = "http-body", version = "0.4.4", optional = true }
+http-body-0-4 = { package = "http-body", version = "0.4.5", optional = true }
 http-body-1-0 = { package = "http-body", version = "1", optional = true }
-http-body-util = { version = "0.1.0", optional = true }
+http-body-util = { version = "0.1.2", optional = true }
 hyper-0-14 = { package = "hyper", version = "0.14.26", optional = true }
 itoa = "1.0.0"
 num-integer = "0.1.44"
-pin-project-lite = "0.2.9"
+pin-project-lite = "0.2.14"
 pin-utils = "0.1.0"
 ryu = "1.0.5"
 time = { version = "0.3.4", features = ["parsing"] }
 
 # ByteStream internals
-futures-core = { version = "0.3.29", optional = true }
-tokio = { version = "1.23.1", optional = true }
-tokio-util = { version = "0.7", optional = true }
+futures-core = { version = "0.3.31", optional = true }
+tokio = { version = "1.40.0", optional = true }
+tokio-util = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 base64 = "0.13.0"
@@ -91,7 +91,7 @@ name = "base64"
 harness = false
 
 [target."cfg(aws_sdk_unstable)".dependencies.serde]
-version = "1"
+version = "1.0.210"
 features = ["derive"]
 
 [lints.rust]

--- a/rust-runtime/aws-smithy-wasm/Cargo.toml
+++ b/rust-runtime/aws-smithy-wasm/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["http-1x"]}
 aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
-bytes = "1"
+bytes = "1.4.0"
 http = "1.0.0"
 tracing = "0.1.40"
 # Note the wasi crate will only build for target wasm32-wasi, but having a target

--- a/rust-runtime/aws-smithy-wasm/Cargo.toml
+++ b/rust-runtime/aws-smithy-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-wasm"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Eduardo Rodrigues <16357187+eduardomourar@users.noreply.github.com>",

--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -25,17 +25,17 @@ aws-smithy-runtime = { path = "../aws-smithy-runtime", features = ["client"] }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client", "test-util"] }
 aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-xml = { path = "../aws-smithy-xml" }
-bytes = "1"
+bytes = "1.4.0"
 fastrand = "2.0.0"
-futures-util = "0.3.29"
-http = "0.2.1"
-http-body = "0.4"
+futures-util = "0.3.31"
+http = "0.2.9"
+http-body = "0.4.5"
 md-5 = "0.10.0"
-once_cell = "1.16.0"
-percent-encoding = "2.2.0"
-pin-project-lite = "0.2"
+once_cell = "1.20.1"
+percent-encoding = "2.3.1"
+pin-project-lite = "0.2.14"
 regex-lite = "0.1.5"
-tracing = "0.1.37"
+tracing = "0.1.40"
 url = "2.5.4"
 
 [dev-dependencies]

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -35,8 +35,10 @@ do
 
     echo -e "## ${C_YELLOW}Running 'cargo minimal-versions check' on ${runtime_path}...${C_RESET}"
     # Print out the cargo tree with minimal versions for easier debugging
-    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions tree || echo "cargo minimal-versions tree failed"
-    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --all-features
+    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions tree --direct || echo "cargo minimal-versions tree failed"
+    # The `--direct` flag is used to test only direct dependencies, rather than all transitive dependencies. See:
+    # https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions
+    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --direct --all-features
 
     for crate_path in *; do
         if [[ -f "${crate_path}/external-types.toml" ]]; then


### PR DESCRIPTION
## Motivation and Context
The smithy-rs minimal-versions test currently checks all transitive dependencies, which makes it difficult to satisfy the test requirements given that the minimum dependency versions specified in transitive dependencies can't be controlled. This PR updates this test to only check for direct dependencies.

## Description
The smithy-rs CI [runs the cargo minimal-versions test](https://github.com/smithy-lang/smithy-rs/blob/e41f7d7dfa84b38b1524823bdcac56f0dcc9dddc/tools/ci-scripts/check-rust-runtimes#L39) in the rust-runtime and aws/rust-runtime workspaces to make sure that the rust-runtime crates can still build even when the lowest possible version of each dependency is used. However, the minimal-versions test is not recommended by Rust:

> https://doc.rust-lang.org/cargo/reference/unstable.html#minimal-versions
Note: It is not recommended to use this feature. Because it enforces minimal versions for all transitive dependencies, its usefulness is limited since not all external dependencies declare proper lower version bounds. It is intended that it will be changed in the future to only enforce minimal versions for direct dependencies.


`direct-minimal-versions` can be used instead, which tests the minimum versions of only direct dependencies. This PR updates this test to use the `direct` variant of minimal-versions.

### Dependency minimum version changes
For some reason, the direct minimal-versions check seems to be more strict about direct minimum versions than the transitive variant. Switching to the direct variant caused many cargo update issues like the following:

<details>
<summary>Cargo update failure example</summary>
<pre>
<code>
❯ cargo minimal-versions check --direct
info: running `cargo update -Z direct-minimal-versions`
    Updating crates.io index
error: failed to select a version for `tokio-stream`.
    ... required by package `lambda_runtime v0.8.0`
    ... which satisfies dependency `lambda_runtime = "^0.8"` of package `lambda_http v0.8.0`
    ... which satisfies dependency `lambda_http = "^0.8.0"` of package `aws-smithy-http-server-python v0.63.2 (/Users/vclarksa/w/smithy-rs-fork/rust-runtime/aws-smithy-http-server-python)`
versions that meet the requirements `^0.1.2` are: 0.1.17, 0.1.16, 0.1.15, 0.1.14, 0.1.12, 0.1.11, 0.1.10, 0.1.9, 0.1.8, 0.1.7, 0.1.6, 0.1.5, 0.1.4, 0.1.3, 0.1.2

all possible versions conflict with previously selected packages.

  previously selected package `tokio-stream v0.1.0`
    ... which satisfies dependency `tokio-stream = "^0.1"` of package `aws-smithy-http-server-python v0.63.2 (/Users/vclarksa/w/smithy-rs-fork/rust-runtime/aws-smithy-http-server-python)`

failed to select a version for `tokio-stream` which could resolve this conflict
error: process didn't exit successfully: `/Users/vclarksa/.rustup/toolchains/1.81.0-x86_64-apple-darwin/bin/cargo update -Z direct-minimal-versions` (exit status: 101)
</code>
</pre>
</details>

It seems that direct-minimal-versions requires that all direct dependencies within an environment be specified with the same minimum version. Additionally, if there is a direct dependency that is also specified by a transitive dependency, the direct dependency must specify a minimum version at least as high as the transitive dependency.

I resolved all such cargo update failures by choosing the highest minimum version specified somewhere in the environment, and applying this version everywhere the dependency is specified.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The modified `check-rust-runtimes` test should succeed.

Some of the CI jobs are still failing. However, they appear to be unrelated to this change. These jobs also failed in the last hyper1 commit:
- [Verify TLS configuration](https://github.com/smithy-lang/smithy-rs/actions/runs/12915992501/job/36020683438?pr=3980) failed for the [previous commit](https://github.com/smithy-lang/smithy-rs/actions/runs/12892906077/job/35948169972).
- [Check for semver hazards](https://github.com/smithy-lang/smithy-rs/actions/runs/12915992496/job/36020736423?pr=3980) failed for the [previous commit](https://github.com/smithy-lang/smithy-rs/actions/runs/12892906281/job/35948248556)
- [Check PR semver compliance](https://github.com/smithy-lang/smithy-rs/actions/runs/12915992521/job/36020685637?pr=3980) failed for the [previous commit](https://github.com/smithy-lang/smithy-rs/actions/runs/12892906281/job/35948247678).

Also, [the canary will need to be run manually](https://github.com/smithy-lang/smithy-rs/actions/runs/12915992496/job/36020737577?pr=3980) if necessary for this change.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
