### PR TITLE
Update Jmespath shape traversal codegen to support multi-select lists following projection expressions

### DIFF
--- a/aws/sdk/integration-tests/dynamodb/tests/test-error-classification.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/test-error-classification.rs
@@ -62,6 +62,7 @@ async fn assert_error_not_transient(error: ReplayedEvent) {
     let client = Client::from_conf(config);
     let _item = client
         .get_item()
+        .table_name("arn:aws:dynamodb:us-east-2:333333333333:table/table_name")
         .key("foo", AttributeValue::Bool(true))
         .send()
         .await

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
@@ -154,6 +154,8 @@ internal class EndpointResolverGenerator(
             "clippy::comparison_to_empty",
             // we generate `if let Some(_) = ... { ... }`
             "clippy::redundant_pattern_matching",
+            // we generate `if (s.as_ref() as &str) == ("arn:") { ... }`, and `s` can be either `String` or `&str`
+            "clippy::useless_asref",
         )
     private val context = Context(registry, runtimeConfig)
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
@@ -36,14 +36,15 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.SafeNamer
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.asRef
 import software.amazon.smithy.rust.codegen.core.rustlang.plus
 import software.amazon.smithy.rust.codegen.core.rustlang.render
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
-import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
@@ -254,6 +255,18 @@ sealed class TraversalBinding {
 typealias TraversalBindings = List<TraversalBinding>
 
 /**
+ * Bag of metadata accessible from the generate* methods that can affect how the resulting Rust code should be generated.
+ *
+ * [retainOption] determines whether `Option`s are preserved in the context of a projected list.
+ * Specifically, when applying selectors (used in multi-select lists) to each entity on the left-hand side of a
+ * projection, we want the resulting map function to return `Option<Vec<Option<&T>>>` (when `retainOption` is true)
+ * rather than `Option<Vec<&T>>` (when it is false).
+ * This distinction is crucial because the latter could incorrectly result in `None` if any of the selectors
+ * refer to a field with a `None` value.
+ */
+data class TraversalContext(val retainOption: Boolean)
+
+/**
  * Indicates a feature that's part of the JmesPath spec, but that we explicitly decided
  * not to support in smithy-rs due to the complexity of code generating it for Rust.
  */
@@ -292,24 +305,25 @@ class RustJmespathShapeTraversalGenerator(
     fun generate(
         expr: JmespathExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
         fun String.attachExpression() =
             this.substringBefore("\nExpression:") + "\nExpression: ${ExpressionSerializer().serialize(expr)}"
         try {
             val result =
                 when (expr) {
-                    is ComparatorExpression -> generateComparator(expr, bindings)
-                    is FunctionExpression -> generateFunction(expr, bindings)
-                    is FieldExpression -> generateField(expr, bindings)
+                    is ComparatorExpression -> generateComparator(expr, bindings, context)
+                    is FunctionExpression -> generateFunction(expr, bindings, context)
+                    is FieldExpression -> generateField(expr, bindings, context)
                     is LiteralExpression -> generateLiteral(expr)
-                    is MultiSelectListExpression -> generateMultiSelectList(expr, bindings)
-                    is AndExpression -> generateAnd(expr, bindings)
-                    is OrExpression -> generateOr(expr, bindings)
-                    is NotExpression -> generateNot(expr, bindings)
-                    is ObjectProjectionExpression -> generateObjectProjection(expr, bindings)
-                    is FilterProjectionExpression -> generateFilterProjection(expr, bindings)
-                    is ProjectionExpression -> generateProjection(expr, bindings)
-                    is Subexpression -> generateSubexpression(expr, bindings)
+                    is MultiSelectListExpression -> generateMultiSelectList(expr, bindings, context)
+                    is AndExpression -> generateAnd(expr, bindings, context)
+                    is OrExpression -> generateOr(expr, bindings, context)
+                    is NotExpression -> generateNot(expr, bindings, context)
+                    is ObjectProjectionExpression -> generateObjectProjection(expr, bindings, context)
+                    is FilterProjectionExpression -> generateFilterProjection(expr, bindings, context)
+                    is ProjectionExpression -> generateProjection(expr, bindings, context)
+                    is Subexpression -> generateSubexpression(expr, bindings, context)
                     is CurrentExpression -> throw JmesPathTraversalCodegenBugException("current expression must be handled in each expression type that can have one")
                     is ExpressionTypeExpression -> throw UnsupportedJmesPathException("Expression type expressions are not supported by smithy-rs")
                     is IndexExpression -> throw UnsupportedJmesPathException("Index expressions are not supported by smithy-rs")
@@ -338,15 +352,20 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateComparator(
         expr: ComparatorExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
-        val left = generate(expr.left, bindings)
-        val right = generate(expr.right, bindings)
+        // When applying a comparator to the left and right operands, both must be non-optional types.
+        // For this, we avoid retaining `Option` values, even when `generateComparator` is invoked
+        // further down the chain from a projection expression.
+        val left = generate(expr.left, bindings, context.copy(retainOption = false))
+        val right = generate(expr.right, bindings, context.copy(retainOption = false))
         return generateCompare(safeNamer, left, right, expr.comparator.toString())
     }
 
     private fun generateFunction(
         expr: FunctionExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
         val ident = safeNamer.safeName("_ret")
         return when (expr.name) {
@@ -354,7 +373,7 @@ class RustJmespathShapeTraversalGenerator(
                 if (expr.arguments.size != 1) {
                     throw InvalidJmesPathTraversalException("Length function takes exactly one argument")
                 }
-                val arg = generate(expr.arguments[0], bindings)
+                val arg = generate(expr.arguments[0], bindings, context)
                 if (!arg.isArray() && !arg.isString()) {
                     throw InvalidJmesPathTraversalException("Argument to `length` function must be a collection or string type")
                 }
@@ -374,14 +393,14 @@ class RustJmespathShapeTraversalGenerator(
                 if (expr.arguments.size != 2) {
                     throw InvalidJmesPathTraversalException("Contains function takes exactly two arguments")
                 }
-                val left = generate(expr.arguments[0], bindings)
+                val left = generate(expr.arguments[0], bindings, context)
                 if (!left.isArray() && !left.isString()) {
                     throw InvalidJmesPathTraversalException("First argument to `contains` function must be a collection or string type")
                 }
                 if (expr.arguments[1].isLiteralNull()) {
                     throw UnsupportedJmesPathException("Checking for null with `contains` is not supported in smithy-rs")
                 }
-                val right = generate(expr.arguments[1], bindings)
+                val right = generate(expr.arguments[1], bindings, context)
                 if (!right.isBool() && !right.isNumber() && !right.isString() && !right.isEnum()) {
                     throw UnsupportedJmesPathException("Checking for anything other than booleans, numbers, strings, or enums in the `contains` function is not supported in smithy-rs")
                 }
@@ -415,7 +434,8 @@ class RustJmespathShapeTraversalGenerator(
                                                     outputType =
                                                         RustType.Reference(
                                                             lifetime = null,
-                                                            member = left.outputType.collectionValue(),
+                                                            member =
+                                                                left.outputType.collectionValue(),
                                                         ),
                                                     output = writable {},
                                                 ),
@@ -435,7 +455,7 @@ class RustJmespathShapeTraversalGenerator(
                 if (expr.arguments.size != 1) {
                     throw InvalidJmesPathTraversalException("Keys function takes exactly one argument")
                 }
-                val arg = generate(expr.arguments[0], bindings)
+                val arg = generate(expr.arguments[0], bindings, context)
                 if (!arg.isObject()) {
                     throw InvalidJmesPathTraversalException("Argument to `keys` function must be an object type")
                 }
@@ -446,8 +466,7 @@ class RustJmespathShapeTraversalGenerator(
                     output =
                         writable {
                             arg.output(this)
-                            val outputShape = arg.outputShape.shape
-                            when (outputShape) {
+                            when (val outputShape = arg.outputShape.shape) {
                                 is StructureShape -> {
                                     // Can't iterate a struct in Rust so source the keys from smithy
                                     val keys =
@@ -473,6 +492,7 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateField(
         expr: FieldExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
         val globalBinding = bindings.find { it is TraversalBinding.Global }
         val namedBinding = bindings.find { it is TraversalBinding.Named && it.jmespathName == expr.name }
@@ -495,21 +515,50 @@ class RustJmespathShapeTraversalGenerator(
             val targetSym = symbolProvider.toSymbol(target)
 
             val ident = safeNamer.safeName("_fld")
-            return GeneratedExpression(
-                identifier = ident,
-                outputShape = TraversedShape.from(model, target),
-                outputType = targetSym.rustType().asRef(),
-                output =
-                    writable {
-                        rust(
-                            if (memberSym.isOptional()) {
-                                "let $ident = ${globalBinding.rustName}.${memberSym.name}.as_ref()?;"
-                            } else {
-                                "let $ident = &${globalBinding.rustName}.${memberSym.name};"
-                            },
-                        )
-                    },
-            )
+            if (context.retainOption) {
+                return GeneratedExpression(
+                    identifier = ident,
+                    outputShape = TraversedShape.from(model, target),
+                    outputType = RustType.Option(targetSym.rustType().asRef()),
+                    output =
+                        writable {
+                            rustTemplate(
+                                if (globalBinding.rustName.startsWith("_fld")) {
+                                    if (memberSym.isOptional()) {
+                                        // This ensures that `ident` has a type with a single level of `Option`, rather than being
+                                        // doubly nested as `Option<Option<...>>`.
+                                        "let $ident = ${globalBinding.rustName}.and_then(|v| v.${memberSym.name}.as_ref());"
+                                    } else {
+                                        "let $ident = ${globalBinding.rustName}.map(|v| &v.${memberSym.name});"
+                                    }
+                                } else {
+                                    if (memberSym.isOptional()) {
+                                        "let $ident = ${globalBinding.rustName}.${memberSym.name}.as_ref();"
+                                    } else {
+                                        "let $ident = #{Some}(&${globalBinding.rustName}.${memberSym.name});"
+                                    }
+                                },
+                                *preludeScope,
+                            )
+                        },
+                )
+            } else {
+                return GeneratedExpression(
+                    identifier = ident,
+                    outputShape = TraversedShape.from(model, target),
+                    outputType = targetSym.rustType().asRef(),
+                    output =
+                        writable {
+                            rust(
+                                if (memberSym.isOptional()) {
+                                    "let $ident = ${globalBinding.rustName}.${memberSym.name}.as_ref()?;"
+                                } else {
+                                    "let $ident = &${globalBinding.rustName}.${memberSym.name};"
+                                },
+                            )
+                        },
+                )
+            }
         } else if (namedBinding != null || globalBinding != null) {
             throw InvalidJmesPathTraversalException("Cannot look up fields in non-struct shapes")
         } else {
@@ -566,10 +615,11 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateMultiSelectList(
         expr: MultiSelectListExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
         val expressions =
             expr.expressions.map { subexpr ->
-                generate(subexpr, bindings)
+                generate(subexpr, bindings, context)
             }
         // If we wanted to support mixed-types, we would need to use tuples, add tuple support to RustType,
         // and update supported functions such as `contains` to operate on tuples.
@@ -596,20 +646,23 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateAnd(
         expr: AndExpression,
         bindings: TraversalBindings,
-    ): GeneratedExpression = generateBooleanOp(expr, "&&", bindings)
+        context: TraversalContext,
+    ): GeneratedExpression = generateBooleanOp(expr, "&&", bindings, context)
 
     private fun generateOr(
         expr: OrExpression,
         bindings: TraversalBindings,
-    ): GeneratedExpression = generateBooleanOp(expr, "||", bindings)
+        context: TraversalContext,
+    ): GeneratedExpression = generateBooleanOp(expr, "||", bindings, context)
 
     private fun generateBooleanOp(
         expr: BinaryExpression,
         op: String,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
-        val left = generate(expr.left, bindings)
-        val right = generate(expr.right, bindings)
+        val left = generate(expr.left, bindings, context)
+        val right = generate(expr.right, bindings, context)
         if (!left.isBool() || !right.isBool()) {
             throw UnsupportedJmesPathException("Applying the `$op` operation doesn't support non-boolean types in smithy-rs")
         }
@@ -632,8 +685,9 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateNot(
         expr: NotExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
-        val inner = generate(expr.expression, bindings)
+        val inner = generate(expr.expression, bindings, context)
         if (!inner.isBool()) {
             throw UnsupportedJmesPathException("Negation of a non-boolean type is not supported by smithy-rs")
         }
@@ -655,36 +709,35 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateProjection(
         expr: ProjectionExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
         val maybeFlatten = expr.left
         if (maybeFlatten is SliceExpression) {
             throw UnsupportedJmesPathException("Slice expressions are not supported by smithy-rs")
         }
-        if (maybeFlatten !is FlattenExpression) {
-            throw UnsupportedJmesPathException("Only projection expressions with flattens are supported by smithy-rs")
-        }
-        val left = generate(maybeFlatten.expression, bindings)
-        val leftTarget =
-            (
-                left.outputShape as? TraversedShape.Array
-                    ?: throw InvalidJmesPathTraversalException("Left side of the flatten projection MUST resolve to a list or set shape")
-            ).member
-        val leftTargetSym: Any = (leftTarget.shape?.let { symbolProvider.toSymbol(it) }) ?: left.outputType
+        val left =
+            when (maybeFlatten) {
+                is FlattenExpression -> generate(maybeFlatten.expression, bindings, context)
+                else -> generate(expr.left, bindings, context)
+            }
 
         // Short-circuit in the case where the projection is unnecessary
         if (left.isArray() && expr.right is CurrentExpression) {
             return left
         }
 
-        val right = generate(expr.right, listOf(TraversalBinding.Global("v", leftTarget)))
+        val leftTarget =
+            (
+                left.outputShape as? TraversedShape.Array
+                    ?: throw InvalidJmesPathTraversalException("Left side of the flatten projection MUST resolve to a list or set shape")
+            ).member
+        val leftTargetSym: Any = (leftTarget.shape?.let { symbolProvider.toSymbol(it) }) ?: left.outputType
+        val leftBinding = "_v"
 
-        // If the right expression results in a collection type, then the resulting vec will need to get flattened.
-        // Otherwise, you'll get `Vec<&Vec<T>>` instead of `Vec<&T>`, which causes later projections to fail to compile.
-        val (projectionType, flattenNeeded) =
-            when {
-                right.isArray() -> right.outputType.stripOuter<RustType.Reference>() to true
-                else -> RustType.Vec(right.outputType.asRef()) to false
-            }
+        val right =
+            generate(expr.right, listOf(TraversalBinding.Global(leftBinding, leftTarget)), context.copy(retainOption = true))
+
+        val (projectionType, flattenNeeded) = projectionType(right)
 
         return safeNamer.safeName("_prj").let { ident ->
             GeneratedExpression(
@@ -696,19 +749,15 @@ class RustJmespathShapeTraversalGenerator(
                         writable {
                             rust("let $ident = ${left.identifier}.iter()")
                             withBlock(".flat_map(|v| {", "})") {
-                                rustBlockTemplate(
-                                    "fn map(v: &#{Left}) -> #{Option}<#{Right}>",
-                                    *preludeScope,
-                                    "Left" to leftTargetSym,
-                                    "Right" to right.outputType,
-                                ) {
-                                    right.output(this)
-                                    rustTemplate("#{Some}(${right.identifier})", *preludeScope)
-                                }
+                                renderMapToProject(this, leftBinding, leftTargetSym, right)
                                 rust("map(v)")
                             }
                             if (flattenNeeded) {
                                 rust(".flatten()")
+                                // Eliminate temporary `Option` introduced by `retainOption = true` above.
+                                if (right.outputType.isCollectionOfOptions()) {
+                                    rust(".flatten()")
+                                }
                             }
                             rustTemplate(".collect::<#{Vec}<_>>();", *preludeScope)
                         },
@@ -719,35 +768,40 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateFilterProjection(
         expr: FilterProjectionExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
-        val left = generate(expr.left, bindings)
+        val left = generate(expr.left, bindings, context)
         if (!left.isArray()) {
             throw UnsupportedJmesPathException("Filter projections can only be done on lists or sets in smithy-rs")
         }
 
         val leftTarget = (left.outputShape as TraversedShape.Array).member
         val leftTargetSym = symbolProvider.toSymbol(leftTarget.shape)
+        val leftBinding = "_v"
 
         val right =
             if (expr.right is CurrentExpression) {
                 left.copy(
                     outputType = left.outputType.collectionValue().asRef(),
+                    outputShape = leftTarget,
                     output = writable {},
                 )
             } else {
-                generate(expr.right, listOf(TraversalBinding.Global("_v", leftTarget)))
+                generate(expr.right, listOf(TraversalBinding.Global(leftBinding, leftTarget)), context.copy(retainOption = true))
             }
 
-        val comparison = generate(expr.comparison, listOf(TraversalBinding.Global("_v", leftTarget)))
+        val comparison = generate(expr.comparison, listOf(TraversalBinding.Global("_v", leftTarget)), context)
         if (!comparison.isBool()) {
             throw InvalidJmesPathTraversalException("The filter expression comparison must result in a boolean")
         }
+
+        val (projectionType, flattenNeeded) = projectionType(right)
 
         return safeNamer.safeName("_fprj").let { ident ->
             GeneratedExpression(
                 identifier = ident,
                 outputShape = TraversedShape.Array(null, right.outputShape),
-                outputType = RustType.Vec(right.outputType),
+                outputType = projectionType,
                 output =
                     left.output +
                         writable {
@@ -765,16 +819,15 @@ class RustJmespathShapeTraversalGenerator(
                             }
                             if (expr.right !is CurrentExpression) {
                                 withBlock(".flat_map({", "})") {
-                                    rustBlockTemplate(
-                                        "fn map(_v: &#{Left}) -> #{Option}<#{Right}>",
-                                        *preludeScope,
-                                        "Left" to leftTargetSym,
-                                        "Right" to right.outputType,
-                                    ) {
-                                        right.output(this)
-                                        rustTemplate("#{Some}(${right.identifier})", *preludeScope)
-                                    }
+                                    renderMapToProject(this, leftBinding, leftTargetSym, right)
                                     rust("map")
+                                }
+                                if (flattenNeeded) {
+                                    rust(".flatten()")
+                                    // Eliminate temporary `Option` introduced by `retainOption = true` above.
+                                    if (right.outputType.isCollectionOfOptions()) {
+                                        rust(".flatten()")
+                                    }
                                 }
                             }
                             rustTemplate(".collect::<#{Vec}<_>>();", *preludeScope)
@@ -786,11 +839,12 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateObjectProjection(
         expr: ObjectProjectionExpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
         if (expr.left is CurrentExpression) {
             throw UnsupportedJmesPathException("Object projection cannot be done on computed maps in smithy-rs")
         }
-        val left = generate(expr.left, bindings)
+        val left = generate(expr.left, bindings, context)
         if (!left.outputType.isMap()) {
             throw UnsupportedJmesPathException("Object projection is only supported on map types in smithy-rs")
         }
@@ -800,41 +854,45 @@ class RustJmespathShapeTraversalGenerator(
 
         val leftTarget = model.expectShape((left.outputShape.shape as MapShape).value.target)
         val leftTargetSym = symbolProvider.toSymbol(leftTarget)
+        val leftBinding = "_v"
 
         val right =
             if (expr.right is CurrentExpression) {
                 left.copy(
-                    outputType = left.outputType.collectionValue().asRef(),
+                    outputType =
+                        left.outputType.collectionValue().asRef(),
+                    outputShape = TraversedShape.from(model, leftTarget),
                     output = writable {},
                 )
             } else {
-                generate(expr.right, listOf(TraversalBinding.Global("_v", TraversedShape.from(model, leftTarget))))
+                generate(expr.right, listOf(TraversalBinding.Global(leftBinding, TraversedShape.from(model, leftTarget))), context.copy(retainOption = true))
             }
+
+        val (projectionType, flattenNeeded) = projectionType(right)
 
         val ident = safeNamer.safeName("_oprj")
         return GeneratedExpression(
             identifier = ident,
             outputShape = TraversedShape.Array(null, right.outputShape),
-            outputType = RustType.Vec(right.outputType),
+            outputType = projectionType,
             output =
                 left.output +
                     writable {
                         if (expr.right is CurrentExpression) {
                             rustTemplate("let $ident = ${left.identifier}.values().collect::<#{Vec}<_>>();", *preludeScope)
                         } else {
-                            rustBlock("let $ident = ${left.identifier}.values().flat_map(") {
-                                rustBlockTemplate(
-                                    "fn map(_v: &#{Left}) -> #{Option}<#{Right}>",
-                                    *preludeScope,
-                                    "Left" to leftTargetSym,
-                                    "Right" to right.outputType,
-                                ) {
-                                    right.output(this)
-                                    rustTemplate("#{Some}(${right.identifier})", *preludeScope)
-                                }
+                            withBlock("let $ident = ${left.identifier}.values().flat_map({", "})") {
+                                renderMapToProject(this, leftBinding, leftTargetSym, right)
                                 rust("map")
                             }
-                            rustTemplate(").collect::<#{Vec}<_>>();", *preludeScope)
+                            if (flattenNeeded) {
+                                rust(".flatten()")
+                                if (right.outputType.isCollectionOfOptions()) {
+                                    // Eliminate temporary `Option` introduced by `retainOption = true` above.
+                                    rust(".flatten()")
+                                }
+                            }
+                            rustTemplate(".collect::<#{Vec}<_>>();", *preludeScope)
                         }
                     },
         )
@@ -843,9 +901,10 @@ class RustJmespathShapeTraversalGenerator(
     private fun generateSubexpression(
         expr: Subexpression,
         bindings: TraversalBindings,
+        context: TraversalContext,
     ): GeneratedExpression {
-        val left = generate(expr.left, bindings)
-        val right = generate(expr.right, listOf(TraversalBinding.Global(left.identifier, left.outputShape)))
+        val left = generate(expr.left, bindings, context)
+        val right = generate(expr.right, listOf(TraversalBinding.Global(left.identifier, left.outputShape)), context)
         return GeneratedExpression(
             identifier = right.identifier,
             outputShape = right.outputShape,
@@ -899,6 +958,57 @@ internal fun generateCompare(
         }
     }
 
+private fun renderMapToProject(
+    writer: RustWriter,
+    leftBinding: String,
+    leftTargetSym: Any,
+    right: GeneratedExpression,
+) {
+    writer.apply {
+        Attribute.AllowClippyLetAndReturn.render(this)
+        rustBlockTemplate(
+            if (right.outputType is RustType.Option) {
+                "fn map($leftBinding: &#{Left}) -> #{Right}"
+            } else {
+                "fn map($leftBinding: &#{Left}) -> #{Option}<#{Right}>"
+            },
+            *preludeScope,
+            "Left" to leftTargetSym,
+            "Right" to right.outputType,
+        ) {
+            right.output(this)
+            if (right.outputType is RustType.Option) {
+                rust(right.identifier)
+            } else {
+                rustTemplate("#{Some}(${right.identifier})", *preludeScope)
+            }
+        }
+    }
+}
+
+/**
+ * This function takes the `GeneratedExpression` of a projection expression's right-hand side (RHS)
+ * and returns a pair:
+ * - A `RustType` representing the final evaluation of the projection expression.
+ * - A `Boolean` indicating whether the resulting vector needs to be flattened.
+ *   Flattening ensures you get `Vec<&T>` instead of `Vec<&Vec<T>>`, which would otherwise cause
+ *   subsequent projections to fail to compile.
+ */
+private fun projectionType(right: GeneratedExpression) =
+    when {
+        right.isArray() && right.outputType is RustType.Vec -> {
+            // A case like `lists.structs[].[integer]` where RHS output type (`[integer]`) is `Vec<Option<&T>>`, and we want Vec<&T>
+            RustType.Vec(right.outputType.member.stripOuter<RustType.Option>()) to true
+        }
+        right.isArray() && right.outputType is RustType.Option -> {
+            // A case like `maps.structs[].strings` where RHS (strings) output type (`[strings]`) is `Option<&Vec<T>>`, and we want Vec<&T>
+            RustType.Vec(right.outputType.member.stripOuter<RustType.Reference>().stripOuter<RustType.Vec>().asRef()) to true
+        }
+        else -> {
+            RustType.Vec(right.outputType.stripOuter<RustType.Option>()) to false
+        }
+    }
+
 private fun RustType.dereference(): RustType =
     if (this is RustType.Reference) {
         this.member.dereference()
@@ -915,6 +1025,13 @@ private fun RustType.isStr(): Boolean = this.dereference().let { it is RustType.
 private fun RustType.isNumber(): Boolean = this.dereference().let { it is RustType.Integer || it is RustType.Float }
 
 private fun RustType.isDoubleReference(): Boolean = this is RustType.Reference && this.member is RustType.Reference
+
+private fun RustType.isCollectionOfOptions(): Boolean =
+    try {
+        collectionValue() is RustType.Option
+    } catch (_: RuntimeException) {
+        false
+    }
 
 private fun RustType.collectionValue(): RustType =
     when (this) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustWaiterMatcherGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustWaiterMatcherGenerator.kt
@@ -109,6 +109,7 @@ class RustWaiterMatcherGenerator(
             RustJmespathShapeTraversalGenerator(codegenContext).generate(
                 pathExpression,
                 listOf(TraversalBinding.Global("_output", TraversedShape.from(model, outputShape))),
+                TraversalContext(retainOption = false),
             )
 
         generatePathTraversalMatcher(
@@ -132,6 +133,7 @@ class RustWaiterMatcherGenerator(
                     TraversalBinding.Named("input", "_input", TraversedShape.from(model, inputShape)),
                     TraversalBinding.Named("output", "_output", TraversedShape.from(model, outputShape)),
                 ),
+                TraversalContext(retainOption = false),
             )
 
         generatePathTraversalMatcher(

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGeneratorTest.kt
@@ -76,7 +76,7 @@ internal class ExprGeneratorTest {
             rust("assert_eq!(true, #W);", gen.generate(Expression.of(true)))
             rust("assert_eq!(false, #W);", gen.generate(Expression.of(false)))
             rust("""assert_eq!("blah", #W);""", gen.generate(Expression.of("blah")))
-            rust("""assert_eq!("helloworld: rust", #W);""", gen.generate(Expression.of("{ref}: rust")))
+            rust("""assert_eq!("helloworld: rust", #W);""", gen.generate(Expression.of("{extra}: rust")))
             rustTemplate(
                 """
                 let mut expected = std::collections::HashMap::new();
@@ -94,6 +94,6 @@ internal class ExprGeneratorTest {
                         ),
                     ),
             )
-        }
+        }.compileAndTest(runClippy = true)
     }
 }


### PR DESCRIPTION
## Motivation and Context
Adds support for JMESPath multi-select lists following projection expressions such as `lists.structs[].[optionalInt, requiredInt]` (list projection followed by multi-select lists), `lists.structs[<some filter condition>].[optionalInt, requiredInt]` (filter projection followed by multi-select lists), and `maps.*.[optionalInt, requiredInt]` (object projection followed by multi-select lists).

## Description
This PR adds support for the said functionality. Prior to the PR, the expressions above ended up the codegen either failing to generate code (for list projection) or generating the incorrect Rust code (for filter & object projection).

All the code changes except for `RustJmespathShapeTraversalGenerator.kt` are primarily adjusting the existing code based on the updates made to  `RustJmespathShapeTraversalGenerator.kt`.

The gist of the code changes in `RustJmespathShapeTraversalGenerator.kt` is as follows:
- `generateProjection` now supports `MultiSelectListExpression` on the right-hand side (RHS).
- Previously, given `MultiSelectListExpression` on RHS, the `map` function applied to the result of the left-hand side of a projection expression (regardless of whether it's list, filter, or object projection) returned a type `Option<Vec<&T>>`, and the `map` function body used the `?` operator to return early as soon as it encountered a field value that was `None`. That did not yield the desired behavior. Given the snippet `lists.structs[].[optionalInt, requiredInt]` in the `Motivation and Context` above for instance, the `map` function used to look like this:
```
fn map(_v: &crate::types::Struct) -> Option<Vec<&i32>> {
    let _fld_1 = _v.optional_int.as_ref()?;
    let _fld_2 = _v.required_int;
    let _msl = vec![_fld_1, _fld_2];
    Some(_msl)
```
This meant if the `optional_int` in a `Struct` was `None`, we lost the chance to access the `required_int` field when we should've. Instead, the `map` function now looks like:
```
fn map(_v: &crate::types::Struct) -> Option<Vec<Option<&i32>>> {
    let _fld_1 = _v.optional_int.as_ref();
    let _fld_2 = Some(_v.required_int);
    let _msl = vec![_fld_1, _fld_2];
    Some(_msl)
```
This way, the `map` function body has a chance to access all the fields of `Struct` even when any of the optional fields in a `Struct` is `None`.
- Given the update to the signature of the `map` function above, `generate*Projection` functions have adjusted their implementations (such as [preserving the output type of the whole projection expression](https://github.com/smithy-lang/smithy-rs/blob/01fed784d5fc2ef6743a336496d91a51f01e6ab2/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt#L989-L1010) and performing [additional flattening for `Option`s](https://github.com/smithy-lang/smithy-rs/blob/01fed784d5fc2ef6743a336496d91a51f01e6ab2/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt#L757-L760)).
 
Note that the output type of the whole projection expression stays the same before and after this PR; it's just that the inner `map` function used by the projection expression has been tweaked.

## Testing
- Confirmed existing tests continued working (CI and release pipeline).
- Added additional JMESPath codegen tests in `RustJmespathShapeTraversalGeneratorTest.kt`.
- Confirmed that the updated service model with a JMESPath expression like `Items[*].[A.Name, B.Name, C.Name, D.Name][]` generated the expected Rust code and behaved as expected.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
