### PR TITLE
Exclude `transfer-encoding` header from sigv4(a) signing

### DIFF
--- a/.changelog/transfer-encoding-signing.md
+++ b/.changelog/transfer-encoding-signing.md
@@ -1,0 +1,10 @@
+---
+applies_to: ["aws-sdk-rust"]
+authors: ["landonxjames"]
+references: ["smithy-rs#3991"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Exclude `transfer-encoding` header from sigv4(a) signing since it is a hop by hop header that can be modified or removed by a proxy.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -228,7 +228,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.2.7"
+version = "1.2.8"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -877,7 +877,7 @@ mod tests {
         assert_eq!(creq.values.signed_headers().as_str(), "host;x-amz-date");
     }
 
-    // It should exclude authorization, user-agent, x-amzn-trace-id headers from presigning
+    // It should exclude authorization, user-agent, x-amzn-trace-id, and transfer-encoding headers from presigning
     #[test]
     fn non_presigning_header_exclusion() {
         let request = http0::Request::builder()
@@ -888,6 +888,7 @@ mod tests {
             .header("user-agent", "test-user-agent")
             .header("x-amzn-trace-id", "test-trace-id")
             .header("x-amz-user-agent", "test-user-agent")
+            .header("transfer-encoding", "chunked")
             .body("")
             .unwrap()
             .into();
@@ -909,7 +910,7 @@ mod tests {
         );
     }
 
-    // It should exclude authorization, user-agent, x-amz-user-agent, x-amzn-trace-id headers from presigning
+    // It should exclude authorization, user-agent, x-amz-user-agent, x-amzn-trace-id, and transfer-encoding headers from presigning
     #[test]
     fn presigning_header_exclusion() {
         let request = http0::Request::builder()
@@ -920,6 +921,7 @@ mod tests {
             .header("user-agent", "test-user-agent")
             .header("x-amzn-trace-id", "test-trace-id")
             .header("x-amz-user-agent", "test-user-agent")
+            .header("transfer-encoding", "chunked")
             .body("")
             .unwrap()
             .into();

--- a/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use http0::header::{AUTHORIZATION, USER_AGENT};
+use http0::header::{AUTHORIZATION, TRANSFER_ENCODING, USER_AGENT};
 use std::borrow::Cow;
 use std::time::Duration;
 
@@ -126,6 +126,8 @@ impl Default for SigningSettings {
                 Cow::Borrowed(USER_AGENT.as_str()),
                 // Changes based on the request from the client
                 Cow::Borrowed(HEADER_NAME_X_RAY_TRACE_ID),
+                // Hop by hop header, can be erased by Cloudfront
+                Cow::Borrowed(TRANSFER_ENCODING.as_str()),
             ]
             .to_vec(),
         );


### PR DESCRIPTION
Add changelog

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Exclude `transfer-encoding` header from sigv4(a) signing. It is a hop by hop header and can be erased or modified by a proxy (in our particular case Cloudfront)

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the existing tests for excluded headers.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
