### PR TITLE
Remove `create-session-mode` header for internally used CreateSession API in S3 Express

### DIFF
--- a/.changelog/1738340700.md
+++ b/.changelog/1738340700.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#3992
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Stop populating `SessionMode` by default for the `CreateSession` API internally used by S3 Express. This will allow the service to choose a default value for `SessionMode` field based on bucket/access point being used.

--- a/aws/rust-runtime/aws-inlineable/src/s3_express.rs
+++ b/aws/rust-runtime/aws-inlineable/src/s3_express.rs
@@ -553,12 +553,7 @@ pub(crate) mod identity_provider {
             config_builder.runtime_components = rc_builder;
 
             let client = crate::Client::from_conf(config_builder.build());
-            let response = client
-                .create_session()
-                .bucket(bucket_name)
-                .session_mode(crate::types::SessionMode::ReadWrite)
-                .send()
-                .await?;
+            let response = client.create_session().bucket(bucket_name).send().await?;
 
             response
                 .credentials

--- a/aws/sdk/integration-tests/s3/tests/data/express/mixed-auths.json
+++ b/aws/sdk/integration-tests/s3/tests/data/express/mixed-auths.json
@@ -8,10 +8,7 @@
             "uri": "https://s3express-test-bucket--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com/?session",
             "headers": {
               "authorization": [
-                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/s3express/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-create-session-mode;x-amz-date;x-amz-user-agent, Signature=38991fe77e65f7e9ffba9ddaeb0ba457d8673bb5c11068eaeb53a4f5fa7c4136"
-              ],
-              "x-amz-create-session-mode": [
-                "ReadWrite"
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/s3express/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, Signature=41c2b04a140b0973d5f82d18c412c21a2328d86435b5568e4fbdf6af5d99ebb5"
               ],
               "amz-sdk-request": [
                 "attempt=1; max=3"
@@ -308,13 +305,10 @@
                 "20090213T233130Z"
               ],
               "authorization": [
-                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/s3express/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-create-session-mode;x-amz-date;x-amz-user-agent, Signature=9e664e775f458662091e9df58f1f37f66cb74e21ac19fd9a618a9189285ca152"
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/s3express/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, Signature=44d20d3ee77ea1d7d0dd871e27b862b48803e1810ac4ae4debed958ceef3af4e"
               ],
               "x-amz-content-sha256": [
                 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-              ],
-              "x-amz-create-session-mode": [
-                "ReadWrite"
               ]
             },
             "method": "GET"

--- a/aws/sdk/integration-tests/s3/tests/express.rs
+++ b/aws/sdk/integration-tests/s3/tests/express.rs
@@ -51,8 +51,8 @@ async fn create_session_request_should_not_include_x_amz_s3session_token() {
 
     let req = request.expect_request();
     assert!(
-        req.headers().get("x-amz-create-session-mode").is_some(),
-        "`x-amz-create-session-mode` should appear in headers of the first request when an express bucket is specified"
+        req.headers().get("x-amz-create-session-mode").is_none(),
+        "`x-amz-create-session-mode` should not appear in headers of the first request when an express bucket is specified"
     );
     assert!(req.headers().get("x-amz-security-token").is_some());
     assert!(req.headers().get("x-amz-s3session-token").is_none());
@@ -109,7 +109,6 @@ async fn mixed_auths() {
 fn create_session_request() -> http::Request<SdkBody> {
     http::Request::builder()
         .uri("https://s3express-test-bucket--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com/?session")
-        .header("x-amz-create-session-mode", "ReadWrite")
         .method("GET")
         .body(SdkBody::empty())
         .unwrap()


### PR DESCRIPTION
## Motivation and Context
This PR stops populating `SessionMode` by default for the `CreateSession` API internally used by S3 Express, as the value already matched the service-side default and it was already not sent by other SDKs.

## Testing
- Existing tests in CI (i.e. canary)
- Updated S3 Express integration tests to verify that no `SessionMode` header is present by the `CreateSession` API internally used by S3 Express

## Checklist
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
