### PR TITLE
Fixing docs for `tags` in Timestream client's create_database

### DIFF
--- a/aws/sdk/aws-models/timestream-write.json
+++ b/aws/sdk/aws-models/timestream-write.json
@@ -503,7 +503,7 @@
                 "Tags": {
                     "target": "com.amazonaws.timestreamwrite#TagList",
                     "traits": {
-                        "smithy.api#documentation": "<p> A list of key-value pairs to label the table. </p>"
+                        "smithy.api#documentation": "<p> A list of key-value pairs to label the database. </p>"
                     }
                 }
             },


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

Docs fix

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
