### PR TITLE
Fix s3 checksum-mode header in presigned requests

### DIFF
--- a/tools/ci-cdk/canary-lambda/src/latest/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/latest/s3_canary.rs
@@ -8,7 +8,9 @@ use crate::{mk_canary, CanaryEnv};
 use anyhow::{Context, Error};
 use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
-use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier};
+use aws_sdk_s3::types::{
+    CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier, RequestPayer,
+};
 use s3::config::Region;
 use s3::presigning::PresigningConfig;
 use s3::primitives::ByteStream;
@@ -31,6 +33,7 @@ mk_canary!("s3", |sdk_config: &SdkConfig, env: &CanaryEnv| {
 /// Runs canary exercising S3 APIs against a regular bucket
 pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Result<()> {
     let test_key = Uuid::new_v4().as_u128().to_string();
+    let presigned_test_key = test_key.clone().push_str("_presigned");
 
     // Look for the test object and expect that it doesn't exist
     match client
@@ -74,21 +77,42 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
         .await
         .context("s3::GetObject[2]")?;
 
-    // repeat the test with a presigned url
-    let uri = client
-        .get_object()
+    // Repeat the GET/PUT tests with a presigned url
+    let reqwest_client = reqwest::Client::new();
+
+    let presigned_put = client
+        .put_object()
         .bucket(&s3_bucket_name)
-        .key(&test_key)
+        .key(&presigned_test_key)
         .presigned(PresigningConfig::expires_in(Duration::from_secs(120)).unwrap())
         .await
         .unwrap();
-    let response = reqwest::get(uri.uri().to_string())
+    let http_put = presigned_request.make_http_1x_request("presigned_test");
+    let reqwest_put = reqwest::Request::try_from(http_put).unwrap();
+    let put_resp = reqwest_client.execute(reqwest_put).await?;
+    if put_resp.is_err() {
+        return Err(CanaryError(format!("presigned put failed: {:?}", put_resp)).into());
+    }
+
+    let presigned_get = client
+        .get_object()
+        .bucket(&s3_bucket_name)
+        .key(&presigned_test_key)
+        // Ensure a header is included that isn't in the query string
+        .request_payer(RequestPayer::Requester)
+        .presigned(PresigningConfig::expires_in(Duration::from_secs(120)).unwrap())
+        .await
+        .unwrap();
+    let headers = presigned_get.make_http_1x_request("").headers().clone();
+    let get_resp = reqwest_client
+        .get(presigned_get.uri().to_string())
+        .headers(headers)
         .await
         .context("s3::presigned")?
         .text()
         .await?;
-    if response != "test" {
-        return Err(CanaryError(format!("presigned URL returned bad data: {:?}", response)).into());
+    if get_resp != "presigned_test" {
+        return Err(CanaryError(format!("presigned URL returned bad data: {:?}", get_resp)).into());
     }
 
     let metadata_value = output

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -153,7 +153,7 @@ arbitrary = "=1.3.2"
 lazy_static! {
     static ref REQUIRED_SDK_CRATES: Vec<RequiredDependency> = vec![
         RequiredDependency::new("aws-config").with_features(["behavior-version-latest"]),
-        RequiredDependency::new("aws-sdk-s3"),
+        RequiredDependency::new("aws-sdk-s3").with_features(["http-1x"]),
         RequiredDependency::new("aws-sdk-ec2"),
         RequiredDependency::new("aws-sdk-transcribestreaming"),
         RequiredDependency::new("aws-smithy-wasm"),


### PR DESCRIPTION
Also update our presigned canary tests to do both PUT and GET and have extra headers included that aren't in the query string

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
