### PR TITLE
Fix mock_client macro

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,18 +165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-credential-types"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
-dependencies = [
- "aws-smithy-async 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize",
-]
-
-[[package]]
 name = "aws-lc-fips-sys"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,95 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551566d462b47c3e49b330f1b86e69e7dc6e4d4efb1959e28c5c82d22e79f7c"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-checksums 0.62.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-json 0.61.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-xml 0.60.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "hmac",
- "http 0.2.12",
- "http-body 0.4.6",
- "lru",
- "once_cell",
- "percent-encoding",
- "regex-lite",
- "sha2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc5bbd1e4a2648fd8c5982af03935972c24a2f9846b396de661d351ee3ce837"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-eventstream 0.60.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "crypto-bigint 0.5.5",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.2.0",
- "once_cell",
- "p256",
- "percent-encoding",
- "ring 0.17.8",
- "sha2",
- "subtle",
- "time",
- "tracing",
- "zeroize",
-]
-
-[[package]]
 name = "aws-smithy-async"
 version = "1.2.4"
 dependencies = [
@@ -324,21 +217,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-async"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "aws-smithy-cbor"
 version = "0.61.0"
 dependencies = [
- "aws-smithy-types 1.2.13",
+ "aws-smithy-types",
  "criterion",
  "minicbor",
 ]
@@ -347,8 +229,8 @@ dependencies = [
 name = "aws-smithy-checksums"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-http 0.60.12",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "crc32c",
@@ -368,28 +250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-checksums"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f45a1c384d7a393026bc5f5c177105aa9fa68e4749653b985707ac27d77295"
-dependencies = [
- "aws-smithy-http 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "crc32c",
- "crc32fast",
- "crc64fast-nvme",
- "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
- "pin-project-lite",
- "sha1",
- "sha2",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-client"
 version = "0.60.3"
 
@@ -397,8 +257,8 @@ version = "0.60.3"
 name = "aws-smithy-compression"
 version = "0.0.2"
 dependencies = [
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -419,7 +279,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.6"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -427,24 +287,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-eventstream"
-version = "0.60.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b18559a41e0c909b77625adf2b8c50de480a8041e5e4a3f5f7d177db70abc5a"
-dependencies = [
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "crc32fast",
-]
-
-[[package]]
 name = "aws-smithy-experimental"
 version = "0.1.5"
 dependencies = [
- "aws-smithy-async 1.2.4",
- "aws-smithy-runtime 1.7.8",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-async",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "h2 0.4.7",
  "http 1.2.0",
  "hyper 1.6.0",
@@ -463,9 +312,9 @@ name = "aws-smithy-http"
 version = "0.60.12"
 dependencies = [
  "async-stream",
- "aws-smithy-eventstream 0.60.6",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -483,27 +332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
-dependencies = [
- "aws-smithy-eventstream 0.60.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-http-auth"
 version = "0.60.3"
 
@@ -512,11 +340,11 @@ name = "aws-smithy-http-server"
 version = "0.63.3"
 dependencies = [
  "aws-smithy-cbor",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json 0.61.2",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
- "aws-smithy-xml 0.60.9",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -542,11 +370,11 @@ dependencies = [
 name = "aws-smithy-http-server-python"
 version = "0.63.2"
 dependencies = [
- "aws-smithy-http 0.60.12",
+ "aws-smithy-http",
  "aws-smithy-http-server",
- "aws-smithy-json 0.61.2",
- "aws-smithy-types 1.2.13",
- "aws-smithy-xml 0.60.9",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-smithy-xml",
  "bytes",
  "futures",
  "futures-util",
@@ -585,27 +413,17 @@ version = "0.60.3"
 name = "aws-smithy-json"
 version = "0.61.2"
 dependencies = [
- "aws-smithy-types 1.2.13",
+ "aws-smithy-types",
  "proptest",
  "serde_json",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
-dependencies = [
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aws-smithy-mocks-experimental"
 version = "0.2.2"
 dependencies = [
- "aws-sdk-s3",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "tokio",
 ]
 
@@ -614,26 +432,7 @@ name = "aws-smithy-protocol-test"
 version = "0.63.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.7.3",
- "base64-simd",
- "cbor-diag",
- "ciborium",
- "http 0.2.12",
- "pretty_assertions",
- "regex-lite",
- "roxmltree",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "aws-smithy-protocol-test"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b92b62199921f10685c6b588fdbeb81168ae4e7950ae3e5f50145a01bb5f1ad"
-dependencies = [
- "assert-json-diff",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -649,7 +448,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.7"
 dependencies = [
- "aws-smithy-types 1.2.13",
+ "aws-smithy-types",
  "urlencoding",
 ]
 
@@ -658,11 +457,11 @@ name = "aws-smithy-runtime"
 version = "1.7.8"
 dependencies = [
  "approx",
- "aws-smithy-async 1.2.4",
- "aws-smithy-http 0.60.12",
- "aws-smithy-protocol-test 0.63.0",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-protocol-test",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bytes",
  "fastrand",
  "futures-util",
@@ -689,65 +488,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-runtime"
-version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d526a12d9ed61fadefda24abe2e682892ba288c2018bcb38b1b4c111d13f6d92"
-dependencies = [
- "aws-smithy-async 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.60.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-protocol-test 0.63.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "fastrand",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "httparse",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "indexmap 2.7.1",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls 0.21.12",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "aws-smithy-runtime-api"
 version = "1.7.3"
 dependencies = [
- "aws-smithy-async 1.2.4",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-async",
+ "aws-smithy-types",
  "bytes",
  "http 0.2.12",
  "http 1.2.0",
  "pin-project-lite",
  "proptest",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
-dependencies = [
- "aws-smithy-async 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "http 0.2.12",
- "http 1.2.0",
- "pin-project-lite",
  "tokio",
  "tracing",
  "zeroize",
@@ -788,37 +538,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b8a53819e42f10d0821f56da995e1470b199686a1809168db6ca485665f042"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.2.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "aws-smithy-types-convert"
 version = "0.60.8"
 dependencies = [
- "aws-smithy-async 1.2.4",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-async",
+ "aws-smithy-types",
  "chrono",
  "futures-core",
  "time",
@@ -828,9 +552,9 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
- "aws-smithy-http 0.60.12",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bytes",
  "http 1.2.0",
  "tracing",
@@ -841,33 +565,10 @@ dependencies = [
 name = "aws-smithy-xml"
 version = "0.60.9"
 dependencies = [
- "aws-smithy-protocol-test 0.63.0",
+ "aws-smithy-protocol-test",
  "base64 0.13.1",
  "proptest",
  "xmlparser",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbd0a668309ec1f66c0f6bda4840dd6d4796ae26d699ebc266d7cc95c6d040f"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version",
- "tracing",
 ]
 
 [[package]]
@@ -902,12 +603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,12 +629,6 @@ dependencies = [
  "outref",
  "vsimd",
 ]
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -1233,12 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,28 +1076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,16 +1090,6 @@ name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -1474,7 +1125,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1495,42 +1145,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
-]
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct",
- "crypto-bigint 0.4.9",
- "der",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -1582,16 +1200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,12 +1214,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "form_urlencoded"
@@ -1763,17 +1365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,11 +1423,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "heck"
@@ -1870,15 +1456,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "home"
@@ -2242,12 +1819,12 @@ version = "0.1.0"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-compression",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json 0.61.2",
- "aws-smithy-runtime 1.7.8",
- "aws-smithy-runtime-api 1.7.3",
- "aws-smithy-types 1.2.13",
- "aws-smithy-xml 0.60.9",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
  "bytes",
  "fastrand",
  "futures-util",
@@ -2448,15 +2025,6 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.2",
-]
 
 [[package]]
 name = "matchers"
@@ -2666,17 +2234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,16 +2308,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "plotters"
@@ -3154,17 +2701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,20 +2920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,16 +3089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,16 +3124,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "stable_deref_trait"

--- a/rust-runtime/aws-smithy-mocks-experimental/Cargo.toml
+++ b/rust-runtime/aws-smithy-mocks-experimental/Cargo.toml
@@ -12,7 +12,6 @@ aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client", "http-02x"] }
 
 [dev-dependencies]
-# aws-sdk-s3 = { version = "1", features = ["test-util"] }
 tokio = { version = "1", features = ["full"]}
 
 [package.metadata.docs.rs]

--- a/rust-runtime/aws-smithy-mocks-experimental/Cargo.toml
+++ b/rust-runtime/aws-smithy-mocks-experimental/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-mocks-experimental"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Experimental testing utilities for smithy-rs generated clients"
 edition = "2021"
@@ -12,7 +12,7 @@ aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client", "http-02x"] }
 
 [dev-dependencies]
-aws-sdk-s3 = { version = "1", features = ["test-util"] }
+# aws-sdk-s3 = { version = "1", features = ["test-util"] }
 tokio = { version = "1", features = ["full"]}
 
 [package.metadata.docs.rs]

--- a/rust-runtime/aws-smithy-mocks-experimental/src/lib.rs
+++ b/rust-runtime/aws-smithy-mocks-experimental/src/lib.rs
@@ -118,10 +118,10 @@ macro_rules! mock {
 #[macro_export]
 macro_rules! mock_client {
     ($aws_crate: ident, $rules: expr) => {
-        mock_client!($aws_crate, $crate::RuleMode::Sequential, $rules)
+        $crate::mock_client!($aws_crate, $crate::RuleMode::Sequential, $rules)
     };
     ($aws_crate: ident, $rule_mode: expr, $rules: expr) => {{
-        mock_client!($aws_crate, $rule_mode, $rules, |conf| conf)
+        $crate::mock_client!($aws_crate, $rule_mode, $rules, |conf| conf)
     }};
     ($aws_crate: ident, $rule_mode: expr, $rules: expr, $additional_configuration: expr) => {{
         let mut mock_response_interceptor =

--- a/rust-runtime/aws-smithy-mocks-experimental/tests/macros.rs
+++ b/rust-runtime/aws-smithy-mocks-experimental/tests/macros.rs
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// Basic test of using the mock_client macro from an "external" crate
+
+mod fake_crate {
+    pub(crate) mod client {
+        use crate::fake_crate::config;
+
+        pub(crate) struct Client {}
+        impl Client {
+            pub(crate) fn from_conf(_conf: config::Config) -> Self {
+                Self {}
+            }
+        }
+    }
+
+    pub(crate) mod config {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+
+        pub(crate) struct Config {}
+        impl Config {
+            pub(crate) fn builder() -> Builder {
+                Builder {}
+            }
+        }
+        pub(crate) struct Builder {}
+        impl Builder {
+            pub fn build(self) -> Config {
+                Config {}
+            }
+            pub fn region(self, _region: crate::fake_crate::config::Region) -> Self {
+                Self {}
+            }
+            pub fn with_test_defaults(self) -> Self {
+                Self {}
+            }
+
+            pub fn interceptor(self, _interceptor: impl Intercept + 'static) -> Self {
+                self
+            }
+        }
+
+        pub(crate) struct Region {}
+        impl Region {
+            pub fn from_static(_region: &'static str) -> Self {
+                Self {}
+            }
+        }
+    }
+}
+#[test]
+fn mock_client() {
+    aws_smithy_mocks_experimental::mock_client!(fake_crate, &[]);
+}


### PR DESCRIPTION
## Motivation and Context
There was downstream breakage (the macro was always broken, but #4001 made it more likely to happen) 

## Description
- Use `$crate` to fix the issue when `mock_client` was not otherwise in scope
- Add a test
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
