### PR TITLE
Update aws-smithy-http-server version to use latest aws-smithy-json

### DIFF
--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.63.3"
+version = "0.63.4"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
`aws-smithy-http-server` depends on an older version of `aws-smithy-json`, which causes an error in the generated SDK. 

This PR bumps the minor version to pick up the new `aws-smithy-json` version.