### PR TITLE
Handle initial-request for event stream operations with RPC-bound protocols

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
@@ -99,7 +99,7 @@ class IntegrationTestDependencies(
                             CargoDependency.smithyTypes(runtimeConfig)
                                 .copy(features = setOf("test-util"), scope = DependencyScope.Dev)
                         addDependency(awsRuntime(runtimeConfig).toDevDependency().withFeature("test-util"))
-                        addDependency(FuturesUtil)
+                        addDependency(FuturesUtil.toDevDependency())
                         addDependency(SerdeJson)
                         addDependency(smithyAsync)
                         addDependency(smithyProtocolTestHelpers(runtimeConfig))

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
@@ -48,8 +48,8 @@ import software.amazon.smithy.rust.codegen.core.util.CommandError
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.isEventStream
-import software.amazon.smithy.rust.codegen.core.util.isRpcBoundProtocol
 import software.amazon.smithy.rust.codegen.core.util.letIf
+import software.amazon.smithy.rust.codegen.core.util.needsToHandleEventStreamInitialMessage
 import software.amazon.smithy.rust.codegen.core.util.runCommand
 import software.amazon.smithy.rust.codegen.core.util.serviceNameOrDefault
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
@@ -234,10 +234,7 @@ class ClientCodegenVisitor(
 
                         implBlock(symbolProvider.toSymbol(shape)) {
                             BuilderGenerator.renderConvenienceMethod(this, symbolProvider, shape)
-                            val hasNonEventStreamMemberInRpcBoundProtocol =
-                                shape.members().size > 1 && shape.members().any { it.isEventStream(model) } &&
-                                    codegenContext.protocol.isRpcBoundProtocol
-                            if (hasNonEventStreamMemberInRpcBoundProtocol) {
+                            if (shape.needsToHandleEventStreamInitialMessage(codegenContext.model, codegenContext.protocol)) {
                                 BuilderGenerator.renderIntoBuilderMethod(this, symbolProvider, shape)
                             }
                         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentBuilderGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentBuilderGenerator.kt
@@ -210,7 +210,7 @@ class FluentBuilderGenerator(
                         #{SdkBody}::empty()))
                 }
 
-                let message = output.$eventStreamMemberName.try_recv_initial().await.map_err(response_error)?;
+                let message = output.$eventStreamMemberName.try_recv_initial_response().await.map_err(response_error)?;
 
                 match message {
                     #{Some}(_message) => {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -7,15 +7,21 @@ package software.amazon.smithy.rust.codegen.client.smithy.protocols
 
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.http.HttpMessageType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolPayloadGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.EventStreamBodyParams
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBoundProtocolPayloadGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
+import software.amazon.smithy.rust.codegen.core.util.inputShape
+import software.amazon.smithy.rust.codegen.core.util.needsToHandleEventStreamInitialMessage
 
 class ClientHttpBoundProtocolPayloadGenerator(
-    codegenContext: ClientCodegenContext,
+    private val codegenContext: ClientCodegenContext,
     protocol: Protocol,
 ) : ProtocolPayloadGenerator by HttpBoundProtocolPayloadGenerator(
         codegenContext, protocol, HttpMessageType.REQUEST,
@@ -27,9 +33,7 @@ class ClientHttpBoundProtocolPayloadGenerator(
                     let marshaller = #{marshallerConstructorFn}();
                     let (signer, signer_sender) = #{DeferredSigner}::new();
                     _cfg.interceptor_state().store_put(signer_sender);
-                    let adapter: #{aws_smithy_http}::event_stream::MessageStreamAdapter<_, _> =
-                        ${params.outerName}.${params.memberName}.into_body_stream(marshaller, error_marshaller, signer);
-                    #{SdkBody}::from_body_0_4(#{hyper}::Body::wrap_stream(adapter))
+                    #{SdkBody}::from_body_0_4(#{hyper}::Body::wrap_stream(#{event_stream:W}))
                 }
                 """,
                 "hyper" to CargoDependency.HyperWithStream.toType(),
@@ -37,9 +41,60 @@ class ClientHttpBoundProtocolPayloadGenerator(
                     CargoDependency.smithyTypes(codegenContext.runtimeConfig).withFeature("http-body-0-4-x")
                         .toType().resolve("body::SdkBody"),
                 "aws_smithy_http" to RuntimeType.smithyHttp(codegenContext.runtimeConfig),
-                "DeferredSigner" to RuntimeType.smithyEventStream(codegenContext.runtimeConfig).resolve("frame::DeferredSigner"),
-                "marshallerConstructorFn" to params.marshallerConstructorFn,
+                "DeferredSigner" to
+                    RuntimeType.smithyEventStream(codegenContext.runtimeConfig)
+                        .resolve("frame::DeferredSigner"),
+                "marshallerConstructorFn" to params.eventStreamMarshallerGenerator.render(),
                 "errorMarshallerConstructorFn" to params.errorMarshallerConstructorFn,
+                "event_stream" to (
+                    eventStreamWithInitialRequest(codegenContext, protocol, params)
+                        ?: messageStreamAdaptor(params.outerName, params.memberName)
+                ),
             )
         },
     )
+
+private fun eventStreamWithInitialRequest(
+    codegenContext: ClientCodegenContext,
+    protocol: Protocol,
+    params: EventStreamBodyParams,
+): Writable? {
+    val parser = protocol.structuredDataSerializer().operationInputSerializer(params.operationShape) ?: return null
+
+    if (!params.operationShape.inputShape(codegenContext.model)
+            .needsToHandleEventStreamInitialMessage(codegenContext.model, codegenContext.protocol)
+    ) {
+        return null
+    }
+
+    return writable {
+        rustTemplate(
+            """
+            {
+                use #{futures_util}::StreamExt;
+                let body = #{parser}(&input)?;
+                let initial_message = #{initial_message}(body);
+                let mut buffer = Vec::new();
+                #{write_message_to}(&initial_message, &mut buffer)?;
+                let initial_message_stream = futures_util::stream::iter(vec![Ok(buffer.into())]);
+                let adapter = #{message_stream_adaptor:W};
+                initial_message_stream.chain(adapter)
+            }
+            """,
+            "futures_util" to CargoDependency.FuturesUtil.toType(),
+            "initial_message" to params.eventStreamMarshallerGenerator.renderInitialMessageGenerator(params.payloadContentType),
+            "message_stream_adaptor" to messageStreamAdaptor(params.outerName, params.memberName),
+            "parser" to parser,
+            "write_message_to" to
+                RuntimeType.smithyEventStream(codegenContext.runtimeConfig)
+                    .resolve("frame::write_message_to"),
+        )
+    }
+}
+
+private fun messageStreamAdaptor(
+    outerName: String,
+    memberName: String,
+) = writable {
+    rust("$outerName.$memberName.into_body_stream(marshaller, error_marshaller, signer)")
+}

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamMarshallerGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamMarshallerGeneratorTest.kt
@@ -10,10 +10,25 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.EventStreamMarshallTestCases.writeMarshallTestCases
 import software.amazon.smithy.rust.codegen.core.testutil.EventStreamTestModels
+import software.amazon.smithy.rust.codegen.core.testutil.EventStreamUnmarshallTestCases.generateRustPayloadInitializer
+import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.testModule
+import software.amazon.smithy.rust.codegen.core.testutil.tokioTest
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.isRpcBoundProtocol
+import software.amazon.smithy.rust.codegen.core.util.lookup
 import java.util.stream.Stream
 
 class ClientEventStreamMarshallerGeneratorTest {
@@ -26,9 +41,210 @@ class ClientEventStreamMarshallerGeneratorTest {
             }
         }
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(RpcEventStreamTestCasesProvider::class)
+    fun rpcEventStreamTest(rpcEventStreamTestCase: RpcEventStreamTestCase) {
+        fun RustWriter.writeTestBody(
+            codegenContext: CodegenContext,
+            initialRequestAssertion: Writable,
+            setInput: Writable,
+        ) {
+            rustTemplate(
+                """
+                use aws_smithy_http::event_stream::EventStreamSender;
+                use aws_smithy_types::body::SdkBody;
+                use #{futures_util}::StreamExt;
+
+                let (http_client, rx) = #{capture_request}(None);
+                let conf = crate::Config::builder()
+                    .endpoint_url("http://localhost:1234")
+                    .http_client(http_client.clone())
+                    .behavior_version_latest()
+                    .build();
+                let client = crate::Client::from_conf(conf);
+
+                let event = TestStream::MessageWithString(
+                    MessageWithString::builder().data("hello, world!").build(),
+                );
+                let stream = #{futures_util}::stream::iter(vec![Ok(event)]);
+                let _ = client
+                    .test_stream_op()
+                    #{set_input:W}
+                    .value(EventStreamSender::from(stream))
+                    .send()
+                    .await
+                    .unwrap();
+
+                let mut request = rx.expect_request();
+
+                let mut body = ::aws_smithy_types::body::SdkBody::taken();
+                std::mem::swap(&mut body, request.body_mut());
+
+                let unmarshaller = crate::event_stream_serde::TestStreamUnmarshaller::new();
+                let mut event_receiver = crate::event_receiver::EventReceiver::new(
+                    ::aws_smithy_http::event_stream::Receiver::new(unmarshaller, body)
+                );
+
+                #{assert_initial_request:W}
+
+                if let Some(event) = event_receiver.recv().await.unwrap() {
+                    match event {
+                        TestStream::MessageWithString(message_with_string) => {
+                            assert_eq!("hello, world!", message_with_string.data().unwrap())
+                        }
+                        otherwise => panic!("matched on unexpected variant {otherwise:?}"),
+                    }
+                } else {
+                    panic!("should receive at least one frame");
+                }
+                """,
+                "assert_initial_request" to initialRequestAssertion,
+                "capture_request" to RuntimeType.captureRequest(codegenContext.runtimeConfig),
+                "futures_util" to CargoDependency.FuturesUtil.toType(),
+                "set_input" to setInput,
+            )
+        }
+
+        val testCase = rpcEventStreamTestCase.inner
+        clientIntegrationTest(
+            testCase.model,
+            IntegrationTestParams(service = "test#TestService", addModuleToEventStreamAllowList = true),
+        ) { codegenContext, rustCrate ->
+            rustCrate.testModule {
+                rust("##![allow(unused_imports, dead_code)]")
+
+                val typesModule =
+                    codegenContext.symbolProvider.moduleForShape(codegenContext.model.lookup("test#TestStruct"))
+                rust(
+                    """
+                    use aws_smithy_eventstream::frame::{UnmarshallMessage, UnmarshalledMessage};
+                    use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
+                    use aws_smithy_types::{Blob, DateTime};
+                    use ${typesModule.fullyQualifiedPath()}::*;
+                    """,
+                )
+
+                if (rpcEventStreamTestCase.nonEventStreamMember == NonEventStreamMemberInOutput.NONE) {
+                    tokioTest("without_initial_request") {
+                        writeTestBody(
+                            codegenContext,
+                            initialRequestAssertion =
+                                writable {
+                                    rust("assert!(event_receiver.try_recv_initial_request().await.unwrap().is_none());")
+                                },
+                            setInput = writable {},
+                        )
+                    }
+                } else {
+                    tokioTest("with_initial_request") {
+                        writeTestBody(
+                            codegenContext,
+                            initialRequestAssertion =
+                                writable {
+                                    rust(
+                                        """
+                                        let msg = event_receiver
+                                            .try_recv_initial_request()
+                                            .await
+                                            .unwrap()
+                                            .expect("should receive initial-request");
+                                        assert!(msg
+                                            .headers()
+                                            .iter()
+                                            .find(|p| p.value().as_string().unwrap().as_str() == "initial-request")
+                                            .is_some());
+                                        assert_eq!(
+                                            msg.payload(),
+                                            &bytes::Bytes::from_static(${testCase.generateRustPayloadInitializer(rpcEventStreamTestCase.expectedInInitialRequest)})
+                                        );
+                                        """,
+                                    )
+                                },
+                            setInput =
+                                if (rpcEventStreamTestCase.nonEventStreamMember == NonEventStreamMemberInOutput.OPTIONAL_UNSET) {
+                                    writable {}
+                                } else {
+                                    writable {
+                                        rust(""".test_string("this is test")""")
+                                    }
+                                },
+                        )
+                    }
+                }
+            }
+        }
+    }
 }
 
 class TestCasesProvider : ArgumentsProvider {
     override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
         EventStreamTestModels.TEST_CASES.map { Arguments.of(it) }.stream()
+}
+
+/**
+ * Enum indicating the presence and state of a non-event stream member in [EventStreamTestModels] in `TestStreamInputOutput`.
+ *
+ * * `OPTIONAL_SET`: The non-stream member is optional and has a value set (input setter is called for input, or response payload is provided for output).
+ * * `OPTIONAL_UNSET`: The non-stream member is optional but has no value set (no input setter is called for input, and no response payload is included for output).
+ * * `REQUIRED`: The non-stream member is required and must be present.
+ * * `NONE`: The non-stream member does not exist in `TestStreamInputOutput`.
+ */
+enum class NonEventStreamMemberInOutput {
+    OPTIONAL_SET,
+    OPTIONAL_UNSET,
+    REQUIRED,
+    NONE,
+}
+
+data class RpcEventStreamTestCase(
+    val inner: EventStreamTestModels.TestCase,
+    val nonEventStreamMember: NonEventStreamMemberInOutput,
+    val expectedInInitialRequest: String = "",
+    val expectedInInitialResponse: String = "",
+)
+
+class RpcEventStreamTestCasesProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
+        EventStreamTestModels.TEST_CASES.filter { testCase: EventStreamTestModels.TestCase ->
+            ShapeId.from(testCase.protocolShapeId)?.isRpcBoundProtocol ?: false
+        }.flatMap { testCase: EventStreamTestModels.TestCase ->
+            val key = "testString"
+            val value = "this is test"
+
+            fun payload(jsonString: String): String =
+                if (testCase.protocolShapeId == "smithy.protocols#rpcv2Cbor") {
+                    EventStreamTestModels.base64EncodeJson(jsonString)
+                } else {
+                    jsonString
+                }
+            listOf(
+                RpcEventStreamTestCase(
+                    inner = testCase,
+                    nonEventStreamMember = NonEventStreamMemberInOutput.NONE,
+                ),
+                RpcEventStreamTestCase(
+                    inner =
+                        testCase.withNonEventStreamMembers("""@httpHeader("X-Test-String")$key: String,"""),
+                    nonEventStreamMember = NonEventStreamMemberInOutput.OPTIONAL_UNSET,
+                    expectedInInitialRequest = payload("{}"),
+                ),
+                RpcEventStreamTestCase(
+                    inner =
+                        testCase.withNonEventStreamMembers("""@httpHeader("X-Test-String")$key: String,""")
+                            .copy(eventStreamInitialResponsePayload = payload("""{"$key":"$value"}""")),
+                    nonEventStreamMember = NonEventStreamMemberInOutput.OPTIONAL_SET,
+                    expectedInInitialRequest = payload("""{"$key":"$value"}"""),
+                    expectedInInitialResponse = "Some(${value.dq()})",
+                ),
+                RpcEventStreamTestCase(
+                    inner =
+                        testCase.withNonEventStreamMembers("""@required@httpHeader("X-Test-String")$key: String,""")
+                            .copy(eventStreamInitialResponsePayload = payload("""{"$key":"$value"}""")),
+                    nonEventStreamMember = NonEventStreamMemberInOutput.REQUIRED,
+                    expectedInInitialRequest = payload("""{"$key":"$value"}"""),
+                    expectedInInitialResponse = value.dq(),
+                ),
+            )
+        }.map { Arguments.of(it) }.stream()
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamUnmarshallerGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamUnmarshallerGeneratorTest.kt
@@ -5,12 +5,8 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.protocols.eventstream
 
-import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
-import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
@@ -29,8 +25,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.testModule
 import software.amazon.smithy.rust.codegen.core.testutil.tokioTest
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 import software.amazon.smithy.rust.codegen.core.util.dq
-import software.amazon.smithy.rust.codegen.core.util.isRpcBoundProtocol
-import java.util.stream.Stream
 
 class ClientEventStreamUnmarshallerGeneratorTest {
     @ParameterizedTest
@@ -129,7 +123,7 @@ class ClientEventStreamUnmarshallerGeneratorTest {
 
                 // This is dummy stream to satisfy input validation for the test service
                 let stream = #{futures_util}::stream::iter(vec![Ok(event)]);
-                let mut res = client
+                let mut response = client
                     .test_stream_op()
                     .value(EventStreamSender::from(stream))
                     .send()
@@ -138,12 +132,12 @@ class ClientEventStreamUnmarshallerGeneratorTest {
 
                 #{assert_initial_response:W}
 
-                if let Some(v) = res.value.recv().await.unwrap() {
-                    match v {
+                if let Some(event) = response.value.recv().await.unwrap() {
+                    match event {
                         TestStream::MessageWithString(message_with_string) => {
                             assert_eq!("hello, world!", message_with_string.data().unwrap())
                         }
-                        _ => panic!("matched on unexpected variant"),
+                        otherwise => panic!("matched on unexpected variant {otherwise:?}"),
                     }
                 } else {
                     panic!("should receive at least one frame");
@@ -165,121 +159,71 @@ class ClientEventStreamUnmarshallerGeneratorTest {
                 rust("##![allow(unused_imports, dead_code)]")
                 writeUnmarshallTestUtil(codegenContext)
 
-                if (rpcEventStreamTestCase.nonEventStreamMember != NonEventStreamMemberInOutput.NONE) {
-                    tokioTest("with_initial_response") {
-                        writeTestBody(
-                            codegenContext,
-                            initialResponseStreamGenerator =
-                                writable {
-                                    val testCase = rpcEventStreamTestCase.inner
-                                    rust(
-                                        """
-                                        let initial_response = msg(
-                                            "event",
-                                            "initial-response",
-                                            ${testCase.eventStreamMessageContentType.dq()},
-                                            ${testCase.generateRustPayloadInitializer(testCase.eventStreamInitialResponsePayload!!)},
-                                        );
-                                        let mut buffer = vec![];
-                                        aws_smithy_eventstream::frame::write_message_to(&initial_response, &mut buffer).unwrap();
-                                        let chunks: Vec<Result<bytes::Bytes, _>> = vec![Ok(buffer.into())];
-                                        let initial_response_stream = futures_util::stream::iter(chunks);
-                                        """,
-                                    )
-                                },
-                            eventStreamGenerator =
-                                writable {
-                                    rust("let event_stream = initial_response_stream.chain(futures_util::stream::iter(chunks));")
-                                },
-                            initialResponseAssertion =
-                                writable {
-                                    rust("assert_eq!(${rpcEventStreamTestCase.expectedValueInInitialResponse}, res.test_string());")
-                                },
-                        )
+                when (rpcEventStreamTestCase.nonEventStreamMember) {
+                    NonEventStreamMemberInOutput.OPTIONAL_SET, NonEventStreamMemberInOutput.REQUIRED -> {
+                        tokioTest("with_initial_response") {
+                            writeTestBody(
+                                codegenContext,
+                                initialResponseStreamGenerator =
+                                    writable {
+                                        val testCase = rpcEventStreamTestCase.inner
+                                        rust(
+                                            """
+                                            let initial_response = msg(
+                                                "event",
+                                                "initial-response",
+                                                ${testCase.eventStreamMessageContentType.dq()},
+                                                ${testCase.generateRustPayloadInitializer(testCase.eventStreamInitialResponsePayload!!)},
+                                            );
+                                            let mut buffer = vec![];
+                                            aws_smithy_eventstream::frame::write_message_to(&initial_response, &mut buffer).unwrap();
+                                            let chunks: Vec<Result<bytes::Bytes, _>> = vec![Ok(buffer.into())];
+                                            let initial_response_stream = futures_util::stream::iter(chunks);
+                                            """,
+                                        )
+                                    },
+                                eventStreamGenerator =
+                                    writable {
+                                        rust("let event_stream = initial_response_stream.chain(futures_util::stream::iter(chunks));")
+                                    },
+                                initialResponseAssertion =
+                                    writable {
+                                        rust("assert_eq!(${rpcEventStreamTestCase.expectedInInitialResponse}, response.test_string());")
+                                    },
+                            )
+                        }
                     }
-                }
-
-                if (rpcEventStreamTestCase.nonEventStreamMember == NonEventStreamMemberInOutput.OPTIONAL) {
-                    tokioTest("without_initial_response") {
-                        writeTestBody(
-                            codegenContext,
-                            initialResponseStreamGenerator = writable {},
-                            eventStreamGenerator =
-                                writable {
-                                    rust("let event_stream = futures_util::stream::iter(chunks);")
-                                },
-                            initialResponseAssertion =
-                                writable {
-                                    rust("assert!(res.test_string().is_none());")
-                                },
-                        )
+                    NonEventStreamMemberInOutput.OPTIONAL_UNSET -> {
+                        tokioTest("without_initial_response") {
+                            writeTestBody(
+                                codegenContext,
+                                initialResponseStreamGenerator = writable {},
+                                eventStreamGenerator =
+                                    writable {
+                                        rust("let event_stream = futures_util::stream::iter(chunks);")
+                                    },
+                                initialResponseAssertion =
+                                    writable {
+                                        rust("assert!(response.test_string().is_none());")
+                                    },
+                            )
+                        }
                     }
-                }
-
-                if (rpcEventStreamTestCase.nonEventStreamMember == NonEventStreamMemberInOutput.NONE) {
-                    tokioTest("event_stream_member_only") {
-                        writeTestBody(
-                            codegenContext,
-                            initialResponseStreamGenerator = writable {},
-                            eventStreamGenerator =
-                                writable {
-                                    rust("let event_stream = futures_util::stream::iter(chunks);")
-                                },
-                            initialResponseAssertion = writable {},
-                        )
+                    NonEventStreamMemberInOutput.NONE -> {
+                        tokioTest("event_stream_member_only") {
+                            writeTestBody(
+                                codegenContext,
+                                initialResponseStreamGenerator = writable {},
+                                eventStreamGenerator =
+                                    writable {
+                                        rust("let event_stream = futures_util::stream::iter(chunks);")
+                                    },
+                                initialResponseAssertion = writable {},
+                            )
+                        }
                     }
                 }
             }
         }
     }
 }
-
-private class RpcEventStreamTestCasesProvider : ArgumentsProvider {
-    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
-        EventStreamTestModels.TEST_CASES.filter { testCase: EventStreamTestModels.TestCase ->
-            ShapeId.from(testCase.protocolShapeId)?.isRpcBoundProtocol ?: false
-        }.flatMap { testCase: EventStreamTestModels.TestCase ->
-            val key = "testString"
-            val value = "this is test"
-            val payload =
-                if (testCase.protocolShapeId == "smithy.protocols#rpcv2Cbor") {
-                    EventStreamTestModels.base64EncodeJson("""{"$key":"$value"}""")
-                } else {
-                    """{"$key":"$value"}"""
-                }
-            listOf(
-                RpcEventStreamTestCase(
-                    inner = testCase,
-                    nonEventStreamMember = NonEventStreamMemberInOutput.NONE,
-                    // doesn't matter since it's unreachable
-                    expectedValueInInitialResponse = "",
-                ),
-                RpcEventStreamTestCase(
-                    inner =
-                        testCase.withNonEventStreamMembers("""@httpHeader("X-Test-String")$key: String,""")
-                            .copy(eventStreamInitialResponsePayload = payload),
-                    nonEventStreamMember = NonEventStreamMemberInOutput.OPTIONAL,
-                    expectedValueInInitialResponse = "Some(${value.dq()})",
-                ),
-                RpcEventStreamTestCase(
-                    inner =
-                        testCase.withNonEventStreamMembers("""@required@httpHeader("X-Test-String")$key: String,""")
-                            .copy(eventStreamInitialResponsePayload = payload),
-                    nonEventStreamMember = NonEventStreamMemberInOutput.REQUIRED,
-                    expectedValueInInitialResponse = value.dq(),
-                ),
-            )
-        }.map { Arguments.of(it) }.stream()
-}
-
-enum class NonEventStreamMemberInOutput {
-    OPTIONAL,
-    REQUIRED,
-    NONE,
-}
-
-data class RpcEventStreamTestCase(
-    val inner: EventStreamTestModels.TestCase,
-    val nonEventStreamMember: NonEventStreamMemberInOutput,
-    val expectedValueInInitialResponse: String,
-)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -279,6 +279,8 @@ data class CargoDependency(
         val BytesUtils: CargoDependency = CargoDependency("bytes-utils", CratesIo("0.1.0"))
         val FastRand: CargoDependency = CargoDependency("fastrand", CratesIo("2.0.0"))
         val Flate2: CargoDependency = CargoDependency("flate2", CratesIo("1.0.30"))
+        val FuturesUtil: CargoDependency =
+            CargoDependency("futures-util", CratesIo("0.3.25"), defaultFeatures = false, features = setOf("alloc"))
         val Hex: CargoDependency = CargoDependency("hex", CratesIo("0.4.3"))
         val Hmac: CargoDependency = CargoDependency("hmac", CratesIo("0.12"))
         val LazyStatic: CargoDependency = CargoDependency("lazy_static", CratesIo("1.4.0"))
@@ -302,8 +304,6 @@ data class CargoDependency(
         val Ciborium: CargoDependency = CargoDependency("ciborium", CratesIo("0.2"), DependencyScope.Dev)
         val Criterion: CargoDependency = CargoDependency("criterion", CratesIo("0.5.0"), DependencyScope.Dev)
         val FuturesCore: CargoDependency = CargoDependency("futures-core", CratesIo("0.3.25"), DependencyScope.Dev)
-        val FuturesUtil: CargoDependency =
-            CargoDependency("futures-util", CratesIo("0.3.25"), DependencyScope.Dev, defaultFeatures = false, features = setOf("alloc"))
         val HdrHistogram: CargoDependency = CargoDependency("hdrhistogram", CratesIo("7.5.2"), DependencyScope.Dev)
         val Hound: CargoDependency = CargoDependency("hound", CratesIo("3.4.0"), DependencyScope.Dev)
         val PrettyAssertions: CargoDependency =

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
@@ -65,6 +65,7 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.isPrimitive
 import software.amazon.smithy.rust.codegen.core.util.isStreaming
+import software.amazon.smithy.rust.codegen.core.util.needsToHandleEventStreamInitialMessage
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 import software.amazon.smithy.rust.codegen.core.util.redactIfNecessary
 
@@ -507,6 +508,14 @@ class HttpBindingGenerator(
             }
 
         if (headerBindings.isEmpty() && prefixHeaderBinding == null) {
+            return null
+        }
+
+        // Skip if we need to serialize operation input's members in an initial message of event stream
+        if (shape is OperationShape &&
+            shape.inputShape(codegenContext.model)
+                .needsToHandleEventStreamInitialMessage(codegenContext.model, codegenContext.protocol)
+        ) {
             return null
         }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/HttpBoundProtocolPayloadGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/HttpBoundProtocolPayloadGenerator.kt
@@ -45,8 +45,10 @@ import software.amazon.smithy.rust.codegen.core.util.outputShape
 data class EventStreamBodyParams(
     val outerName: String,
     val memberName: String,
-    val marshallerConstructorFn: RuntimeType,
+    val operationShape: OperationShape,
+    val eventStreamMarshallerGenerator: EventStreamMarshallerGenerator,
     val errorMarshallerConstructorFn: RuntimeType,
+    val payloadContentType: String,
     val additionalPayloadContext: AdditionalPayloadContext,
 )
 
@@ -198,6 +200,7 @@ class HttpBoundProtocolPayloadGenerator(
             val payloadMember = operationShape.inputShape(model).expectMember(payloadMemberName)
             writer.serializeViaEventStream(
                 payloadMember,
+                operationShape,
                 serializerGenerator,
                 shapeName,
                 additionalPayloadContext,
@@ -206,6 +209,7 @@ class HttpBoundProtocolPayloadGenerator(
             val payloadMember = operationShape.outputShape(model).expectMember(payloadMemberName)
             writer.serializeViaEventStream(
                 payloadMember,
+                operationShape,
                 serializerGenerator,
                 "output",
                 additionalPayloadContext,
@@ -238,6 +242,7 @@ class HttpBoundProtocolPayloadGenerator(
 
     private fun RustWriter.serializeViaEventStream(
         memberShape: MemberShape,
+        operationShape: OperationShape,
         serializerGenerator: StructuredDataSerializerGenerator,
         outerName: String,
         additionalPayloadContext: AdditionalPayloadContext,
@@ -259,7 +264,8 @@ class HttpBoundProtocolPayloadGenerator(
                 serializerGenerator,
                 payloadContentType,
             ).render()
-        val marshallerConstructorFn =
+
+        val eventStreamMarshallerGenerator =
             EventStreamMarshallerGenerator(
                 model,
                 target,
@@ -268,17 +274,19 @@ class HttpBoundProtocolPayloadGenerator(
                 unionShape,
                 serializerGenerator,
                 payloadContentType,
-            ).render()
+            )
 
-        // TODO(EventStream): [RPC] RPC protocols need to send an initial message with the
+        // TODO(EventStream): [RPC] For server, RPC protocols need to send an initial message with the
         //  parameters that are not `@eventHeader` or `@eventPayload`.
         renderEventStreamBody(
             this,
             EventStreamBodyParams(
                 outerName,
                 memberName,
-                marshallerConstructorFn,
+                operationShape,
+                eventStreamMarshallerGenerator,
                 errorMarshallerConstructorFn,
+                payloadContentType,
                 additionalPayloadContext,
             ),
         )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Smithy.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Smithy.kt
@@ -170,3 +170,12 @@ private val RPC_BOUND_PROTOCOLS =
  */
 val ShapeId.isRpcBoundProtocol
     get() = RPC_BOUND_PROTOCOLS.contains(name)
+
+/**
+ * Determines whether serialization/deserialization of this shape (inputShape or outputShape) needs to handle initial
+ * messages of event stream
+ */
+fun Shape.needsToHandleEventStreamInitialMessage(
+    model: Model,
+    protocol: ShapeId,
+) = members().size > 1 && hasEventStreamMember(model) && protocol.isRpcBoundProtocol

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -140,7 +140,7 @@ class ServerHttpBoundProtocolPayloadGenerator(
                 """,
                 "aws_smithy_http" to RuntimeType.smithyHttp(codegenContext.runtimeConfig),
                 "NoOpSigner" to RuntimeType.smithyEventStream(codegenContext.runtimeConfig).resolve("frame::NoOpSigner"),
-                "marshallerConstructorFn" to params.marshallerConstructorFn,
+                "marshallerConstructorFn" to params.eventStreamMarshallerGenerator.render(),
                 "errorMarshallerConstructorFn" to params.errorMarshallerConstructorFn,
             )
         },
@@ -858,13 +858,13 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                                             val expectedRequestContentType = httpBindingResolver.requestContentType(operationShape)!!
                                             rustTemplate(
                                                 """
-                                                    if !bytes.is_empty() {
-                                                        #{SmithyHttpServer}::protocol::content_type_header_classifier_smithy(
-                                                            &headers,
-                                                            Some("$expectedRequestContentType"),
-                                                        )?;
-                                                    }
-                                                    """,
+                                                if !bytes.is_empty() {
+                                                    #{SmithyHttpServer}::protocol::content_type_header_classifier_smithy(
+                                                        &headers,
+                                                        Some("$expectedRequestContentType"),
+                                                    )?;
+                                                }
+                                                """,
                                                 *codegenScope,
                                             )
                                         }

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 name = "aws-smithy-checksums"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-http 0.60.13",
+ "aws-smithy-http 0.60.14",
  "aws-smithy-types 1.2.13",
  "bytes",
  "bytes-utils",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.13"
+version = "0.60.14"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.7",
@@ -512,7 +512,7 @@ name = "aws-smithy-http-server"
 version = "0.63.3"
 dependencies = [
  "aws-smithy-cbor",
- "aws-smithy-http 0.60.13",
+ "aws-smithy-http 0.60.14",
  "aws-smithy-json 0.61.2",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.13",
@@ -542,7 +542,7 @@ dependencies = [
 name = "aws-smithy-http-server-python"
 version = "0.63.2"
 dependencies = [
- "aws-smithy-http 0.60.13",
+ "aws-smithy-http 0.60.14",
  "aws-smithy-http-server",
  "aws-smithy-json 0.61.2",
  "aws-smithy-types 1.2.13",
@@ -659,7 +659,7 @@ version = "1.7.8"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.4",
- "aws-smithy-http 0.60.13",
+ "aws-smithy-http 0.60.14",
  "aws-smithy-protocol-test 0.63.0",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.13",
@@ -828,7 +828,7 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
- "aws-smithy-http 0.60.13",
+ "aws-smithy-http 0.60.14",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.13",
  "bytes",
@@ -2242,7 +2242,7 @@ version = "0.1.0"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-compression",
- "aws-smithy-http 0.60.13",
+ "aws-smithy-http 0.60.14",
  "aws-smithy-json 0.61.2",
  "aws-smithy-runtime 1.7.8",
  "aws-smithy-runtime-api 1.7.3",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 name = "aws-smithy-checksums"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-http 0.60.14",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-types 1.2.13",
  "bytes",
  "bytes-utils",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.14"
+version = "0.61.1"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream 0.60.7",
@@ -512,7 +512,7 @@ name = "aws-smithy-http-server"
 version = "0.63.3"
 dependencies = [
  "aws-smithy-cbor",
- "aws-smithy-http 0.60.14",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json 0.61.2",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.13",
@@ -542,7 +542,7 @@ dependencies = [
 name = "aws-smithy-http-server-python"
 version = "0.63.2"
 dependencies = [
- "aws-smithy-http 0.60.14",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-http-server",
  "aws-smithy-json 0.61.2",
  "aws-smithy-types 1.2.13",
@@ -659,7 +659,7 @@ version = "1.7.8"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.4",
- "aws-smithy-http 0.60.14",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-protocol-test 0.63.0",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.13",
@@ -828,7 +828,7 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.3"
 dependencies = [
- "aws-smithy-http 0.60.14",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-runtime-api 1.7.3",
  "aws-smithy-types 1.2.13",
  "bytes",
@@ -2242,7 +2242,7 @@ version = "0.1.0"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-compression",
- "aws-smithy-http 0.60.14",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json 0.61.2",
  "aws-smithy-runtime 1.7.8",
  "aws-smithy-runtime-api 1.7.3",

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.60.14"
+version = "0.61.1"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.60.13"
+version = "0.60.14"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-http/src/event_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream.rs
@@ -17,4 +17,4 @@ pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 pub use sender::{EventStreamSender, MessageStreamAdapter, MessageStreamError};
 
 #[doc(inline)]
-pub use receiver::{Receiver, ReceiverError};
+pub use receiver::{InitialMessageType, Receiver, ReceiverError};

--- a/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
@@ -123,6 +123,23 @@ pub struct Receiver<T, E> {
     _phantom: PhantomData<E>,
 }
 
+// Used by `Receiver::try_recv_initial`, hence this enum is also doc hidden
+#[doc(hidden)]
+#[non_exhaustive]
+pub enum InitialMessageType {
+    Request,
+    Response,
+}
+
+impl InitialMessageType {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            InitialMessageType::Request => "initial-request",
+            InitialMessageType::Response => "initial-response",
+        }
+    }
+}
+
 impl<T, E> Receiver<T, E> {
     /// Creates a new `Receiver` with the given message unmarshaller and SDK body.
     pub fn new(
@@ -205,10 +222,13 @@ impl<T, E> Receiver<T, E> {
         Ok(None)
     }
 
-    /// Tries to receive the initial response message that has `:event-type` of `initial-response`.
+    /// Tries to receive the initial response message that has `:event-type` of a given `message_type`.
     /// If a different event type is received, then it is buffered and `Ok(None)` is returned.
     #[doc(hidden)]
-    pub async fn try_recv_initial(&mut self) -> Result<Option<Message>, SdkError<E, RawMessage>> {
+    pub async fn try_recv_initial(
+        &mut self,
+        message_type: InitialMessageType,
+    ) -> Result<Option<Message>, SdkError<E, RawMessage>> {
         if let Some(message) = self.next_message().await? {
             if let Some(event_type) = message
                 .headers()
@@ -218,7 +238,7 @@ impl<T, E> Receiver<T, E> {
                 if event_type
                     .value()
                     .as_string()
-                    .map(|s| s.as_str() == "initial-response")
+                    .map(|s| s.as_str() == message_type.as_str())
                     .unwrap_or(false)
                 {
                     return Ok(Some(message));
@@ -260,7 +280,7 @@ impl<T, E> Receiver<T, E> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Receiver, UnmarshallMessage};
+    use super::{InitialMessageType, Receiver, UnmarshallMessage};
     use aws_smithy_eventstream::error::Error as EventStreamError;
     use aws_smithy_eventstream::frame::{write_message_to, UnmarshalledMessage};
     use aws_smithy_runtime_api::client::result::SdkError;
@@ -507,7 +527,11 @@ mod tests {
         let chunk_stream = futures_util::stream::iter(chunks);
         let body = SdkBody::from_body_0_4(Body::wrap_stream(chunk_stream));
         let mut receiver = Receiver::<TestMessage, EventStreamError>::new(Unmarshaller, body);
-        assert!(receiver.try_recv_initial().await.unwrap().is_some());
+        assert!(receiver
+            .try_recv_initial(InitialMessageType::Response)
+            .await
+            .unwrap()
+            .is_some());
         assert_eq!(
             TestMessage("one".into()),
             receiver.recv().await.unwrap().unwrap()
@@ -521,7 +545,11 @@ mod tests {
         let chunk_stream = futures_util::stream::iter(chunks);
         let body = SdkBody::from_body_0_4(Body::wrap_stream(chunk_stream));
         let mut receiver = Receiver::<TestMessage, EventStreamError>::new(Unmarshaller, body);
-        assert!(receiver.try_recv_initial().await.unwrap().is_none());
+        assert!(receiver
+            .try_recv_initial(InitialMessageType::Response)
+            .await
+            .unwrap()
+            .is_none());
         assert_eq!(
             TestMessage("one".into()),
             receiver.recv().await.unwrap().unwrap()

--- a/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
@@ -132,7 +132,7 @@ pub enum InitialMessageType {
 }
 
 impl InitialMessageType {
-    const fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
             InitialMessageType::Request => "initial-request",
             InitialMessageType::Response => "initial-response",

--- a/rust-runtime/inlineable/src/event_receiver.rs
+++ b/rust-runtime/inlineable/src/event_receiver.rs
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_smithy_http::event_stream::Receiver;
+use aws_smithy_http::event_stream::{InitialMessageType, Receiver};
 use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_types::event_stream::{Message, RawMessage};
 
@@ -19,10 +19,21 @@ impl<T, E> EventReceiver<T, E> {
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn try_recv_initial(
+    pub(crate) async fn try_recv_initial_request(
         &mut self,
     ) -> Result<Option<Message>, SdkError<E, RawMessage>> {
-        self.inner.try_recv_initial().await
+        self.inner
+            .try_recv_initial(InitialMessageType::Request)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn try_recv_initial_response(
+        &mut self,
+    ) -> Result<Option<Message>, SdkError<E, RawMessage>> {
+        self.inner
+            .try_recv_initial(InitialMessageType::Response)
+            .await
     }
 
     /// Asynchronously tries to receive an event from the stream. If the stream has ended, it


### PR DESCRIPTION
## Motivation and Context
Continuation of #4004, this PR is part 2 of the series. The PR focus on the request side, specifically handling the serialization of an initial request message for event stream operations using RPC-bound protocols.

## Description
Unlike `initial-response`, handling `initial-request` for event stream operations does _not_ require calling an async function, allowing serialization to be completed within a synchronous context.

Here’s an updated snippet from the input serializer, rendered from a newly added codegen test (since we currently don’t have AWS services with RPC protocols where the operation input contains event streams, this test represents such a service):
```
        let body = ::aws_smithy_types::body::SdkBody::from({
            let error_marshaller = crate::event_stream_serde::TestStreamErrorMarshaller::new();
            let marshaller = crate::event_stream_serde::TestStreamMarshaller::new();
            let (signer, signer_sender) = ::aws_smithy_eventstream::frame::DeferredSigner::new();
            _cfg.interceptor_state().store_put(signer_sender);
            ::aws_smithy_types::body::SdkBody::from_body_0_4(::hyper::Body::wrap_stream({
                use ::futures_util::StreamExt;
                let body = crate::protocol_serde::shape_test_stream_op::ser_test_stream_op_input(&input)?;
                let initial_message = crate::event_stream_serde::initial_message_from_body(body);
                let mut buffer = Vec::new();
                ::aws_smithy_eventstream::frame::write_message_to(&initial_message, &mut buffer)?;
                let initial_message_stream = futures_util::stream::iter(vec![Ok(buffer.into())]);
                let adapter = input.value.into_body_stream(marshaller, error_marshaller, signer);
                initial_message_stream.chain(adapter)
            }))
        });
```
whereas previously
```
        let body = ::aws_smithy_types::body::SdkBody::from({
            let error_marshaller = crate::event_stream_serde::TestStreamErrorMarshaller::new();
            let marshaller = crate::event_stream_serde::TestStreamMarshaller::new();
            let (signer, signer_sender) = ::aws_smithy_eventstream::frame::DeferredSigner::new();
            _cfg.interceptor_state().store_put(signer_sender);
            ::aws_smithy_types::body::SdkBody::from_body_0_4(::hyper::Body::wrap_stream(
                input
                    .value
                    .into_body_stream(marshaller, error_marshaller, signer),
            ))
        });
```
This "prepending initial-request message" only occurs when the operation input contains at least one non-event stream member, other than an event stream member.

The PR also refactors `ClientEventStreamUnmarshallerGeneratorTest.kt` (touched in the previous PR) while adding new tests in `ClientEventStreamMarshallerGeneratorTest`.

## Testing
- Existing CI
- Added client SDK codegen tests in `ClientEventStreamMarshallerGeneratorTest` to verify initial-request message handling

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
