### PR TITLE
add secondary 'tls-rustls-webpki' and 'rustls-webpki' features that don't implicitly enable rustls-native-certs

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -17,9 +17,13 @@ client-hyper = ["aws-smithy-runtime/connector-hyper-0-14-x"]
 credentials-process = ["tokio/process"]
 default = ["client-hyper", "rustls", "rt-tokio", "credentials-process", "sso"]
 rt-tokio = ["aws-smithy-async/rt-tokio", "aws-smithy-runtime/rt-tokio", "tokio/rt"]
-rustls = ["aws-smithy-runtime/tls-rustls", "client-hyper"]
+rustls = ["aws-smithy-runtime/tls-rustls", "__rustls"]
+rustls-webpki = ["aws-smithy-runtime/tls-rustls-webpki", "__rustls"]
 sso = ["dep:aws-sdk-sso", "dep:aws-sdk-ssooidc", "dep:ring", "dep:hex", "dep:zeroize", "aws-smithy-runtime-api/http-auth"]
 test-util = ["aws-runtime/test-util"]
+
+# Enables common types used for rustls. Useless on its own.
+__rustls = ["aws-smithy-runtime/__rustls", "client-hyper"]
 
 # deprecated: this feature does nothing
 allow-compilation = []

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -14,7 +14,7 @@ use crate::meta::credentials::CredentialsProviderChain;
 use crate::meta::region::ProvideRegion;
 use crate::provider_config::ProviderConfig;
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 /// Default Credentials Provider chain
 ///
 /// The region from the default region provider will be used

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -1104,7 +1104,7 @@ pub(crate) mod test {
     #[cfg_attr(windows, ignore)]
     /// Verify that the end-to-end real client has a 1-second connect timeout
     #[tokio::test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "__rustls")]
     async fn one_second_connect_timeout() {
         use crate::imds::client::ImdsError;
         let client = Client::builder()

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -417,7 +417,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "__rustls")]
     async fn read_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials() {
         let client = crate::imds::Client::builder()
             // 240.* can never be resolved
@@ -435,7 +435,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "__rustls")]
     async fn read_timeout_during_credentials_refresh_should_error_without_last_retrieved_credentials(
     ) {
         let client = crate::imds::Client::builder()
@@ -457,7 +457,7 @@ mod test {
     // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "__rustls")]
     async fn external_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials() {
         use aws_smithy_async::rt::sleep::AsyncSleep;
         let client = crate::imds::Client::builder()

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -1160,7 +1160,7 @@ mod loader {
             assert_eq!(Some(&app_name), conf.app_name());
         }
 
-        #[cfg(feature = "rustls")]
+        #[cfg(feature = "__rustls")]
         #[tokio::test]
         async fn disable_default_credentials() {
             let config = defaults(BehaviorVersion::latest())
@@ -1170,7 +1170,7 @@ mod loader {
             assert!(config.credentials_provider().is_none());
         }
 
-        #[cfg(feature = "rustls")]
+        #[cfg(feature = "__rustls")]
         #[tokio::test]
         async fn identity_cache_defaulted() {
             let config = defaults(BehaviorVersion::latest()).load().await;
@@ -1178,7 +1178,7 @@ mod loader {
             assert!(config.identity_cache().is_some());
         }
 
-        #[cfg(feature = "rustls")]
+        #[cfg(feature = "__rustls")]
         #[allow(deprecated)]
         #[tokio::test]
         async fn identity_cache_old_behavior_version() {

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -73,7 +73,7 @@ impl CredentialsProviderChain {
     }
 
     /// Add a fallback to the default provider chain
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "__rustls")]
     pub async fn or_default_provider(self) -> Self {
         self.or_else(
             "DefaultProviderChain",
@@ -82,7 +82,7 @@ impl CredentialsProviderChain {
     }
 
     /// Creates a credential provider chain that starts with the default provider
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "__rustls")]
     pub async fn default_provider() -> Self {
         Self::first_try(
             "DefaultProviderChain",

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -91,7 +91,7 @@ pub(crate) mod repr;
 ///         future::ProvideCredentials::new(self.load_credentials())
 ///     }
 /// }
-/// # if cfg!(feature = "rustls") {
+/// # if cfg!(feature = "__rustls") {
 /// let provider = ProfileFileCredentialsProvider::builder()
 ///     .with_custom_provider("Custom", MyCustomProvider)
 ///     .build();
@@ -421,7 +421,7 @@ impl Builder {
     ///     }
     /// }
     ///
-    /// # if cfg!(feature = "rustls") {
+    /// # if cfg!(feature = "__rustls") {
     /// let provider = ProfileFileCredentialsProvider::builder()
     ///     .with_custom_provider("Custom", MyCustomProvider)
     ///     .build();

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -128,7 +128,7 @@ impl ProviderConfig {
     ///
     /// # Examples
     /// ```no_run
-    /// # #[cfg(feature = "rustls")]
+    /// # #[cfg(feature = "__rustls")]
     /// # fn example() {
     /// use aws_config::provider_config::ProviderConfig;
     /// use aws_sdk_sts::config::Region;

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -321,7 +321,7 @@ where
     E: Error,
 {
     #[allow(unused)]
-    #[cfg(all(feature = "client-hyper", feature = "rustls"))]
+    #[cfg(all(feature = "client-hyper", feature = "__rustls"))]
     /// Record a test case from live (remote) HTTPS traffic
     ///
     /// The `default_connector()` from the crate will be used

--- a/design/src/rfcs/rfc0002_http_versions.md
+++ b/design/src/rfcs/rfc0002_http_versions.md
@@ -98,7 +98,7 @@ The `https()` method on the Builder constructs the actual Hyper client, and is d
 select the correct TLS implementation. For example:
 
 ```rust
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 pub fn https() -> Https {
     let https = hyper_rustls::HttpsConnector::with_native_roots();
     let client = hyper::Client::builder().build::<_, SdkBody>(https);
@@ -134,7 +134,7 @@ A default `make_connector` implementation would be provided that creates a Hyper
 Cargo feature flags. This might look something like this:
 
 ```rust
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 pub fn default_connector(reqs: &HttpRequirements) -> HyperAdapter {
     let https = hyper_rustls::HttpsConnector::with_native_roots();
     let mut builder = hyper::Client::builder();

--- a/design/src/rfcs/rfc0015_using_features_responsibly.md
+++ b/design/src/rfcs/rfc0015_using_features_responsibly.md
@@ -35,7 +35,7 @@ As noted earlier in an excerpt from the Cargo book:
 > enabling a feature should not disable functionality, and it should usually be safe to enable any combination of features. A feature should not introduce a [SemVer-incompatible change].
 
 ```rust
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 impl<M, R> ClientBuilder<(), M, R> {
     /// Connect to the service over HTTPS using Rustls.
     pub fn tls_adapter(self) -> ClientBuilder<Adapter<crate::conns::Https>, M, R> {
@@ -59,7 +59,7 @@ When the example code above is compiled with both features enabled, compilation 
 Here's an updated version of the example that fixes these issues:
 
 ```rust
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 impl<M, R> ClientBuilder<(), M, R> {
     /// Connect to the service over HTTPS using Rustls.
     pub fn rustls(self) -> ClientBuilder<Adapter<crate::conns::Https>, M, R> {

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -13,12 +13,17 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 client = ["aws-smithy-runtime-api/client", "aws-smithy-types/http-body-1-x"]
 http-auth = ["aws-smithy-runtime-api/http-auth"]
 connector-hyper-0-14-x = ["dep:hyper-0-14", "hyper-0-14?/client", "hyper-0-14?/http2", "hyper-0-14?/http1", "hyper-0-14?/tcp", "hyper-0-14?/stream", "dep:h2"]
-tls-rustls = ["dep:hyper-rustls", "dep:rustls", "connector-hyper-0-14-x"]
+tls-rustls = ["hyper-rustls/native-tokio", "__rustls"]
+tls-rustls-webpki = ["hyper-rustls/webpki-tokio", "__rustls"]
 rt-tokio = ["tokio/rt"]
 
 # Features for testing
 test-util = ["aws-smithy-runtime-api/test-util", "dep:aws-smithy-protocol-test", "dep:tracing-subscriber", "dep:serde", "dep:serde_json", "dep:indexmap"]
 wire-mock = ["test-util", "connector-hyper-0-14-x", "hyper-0-14?/server"]
+
+# Enables common types used for rustls. Useless on its own.
+__rustls = ["dep:hyper-rustls", "dep:rustls", "connector-hyper-0-14-x"]
+
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
@@ -37,7 +42,7 @@ http-body-1x = { package = "http-body", version = "1" }
 # This avoids bringing `httparse` 1.9.0 and 1.9.1 through `hyper-0-14` that break unit tests of runtime crates
 httparse = "1.8.0"
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, optional = true }
-hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
+hyper-rustls = { version = "0.24", features = ["http1", "tls12", "logging", "aws-lc-rs", "http2"], default-features = false, optional = true }
 once_cell = "1.18.0"
 pin-project-lite = "0.2.7"
 pin-utils = "0.1.0"

--- a/rust-runtime/aws-smithy-runtime/src/client/http/hyper_014.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/hyper_014.rs
@@ -34,7 +34,7 @@ use std::sync::RwLock;
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "__rustls")]
 mod default_connector {
     use aws_smithy_async::rt::sleep::SharedAsyncSleep;
     use aws_smithy_runtime_api::client::http::HttpConnectorSettings;
@@ -98,7 +98,7 @@ pub fn default_connector(
     settings: &HttpConnectorSettings,
     sleep: Option<SharedAsyncSleep>,
 ) -> Option<SharedHttpConnector> {
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "__rustls")]
     {
         tracing::trace!(settings = ?settings, sleep = ?sleep, "creating a new default connector");
         let hyper = default_connector::base(settings, sleep).build_https();
@@ -113,7 +113,7 @@ pub fn default_connector(
 
 /// Creates a hyper-backed HTTPS client from defaults depending on what cargo features are activated.
 pub fn default_client() -> Option<SharedHttpClient> {
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "__rustls")]
     {
         tracing::trace!("creating a new default hyper 0.14.x client");
         Some(HyperClientBuilder::new().build_https())
@@ -202,7 +202,7 @@ impl HyperConnectorBuilder {
     }
 
     /// Create a [`HyperConnector`] with the default rustls HTTPS implementation.
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "__rustls")]
     pub fn build_https(self) -> HyperConnector {
         self.build(default_connector::https())
     }
@@ -580,7 +580,7 @@ impl HyperClientBuilder {
     ///
     /// The trusted certificates will be loaded later when this becomes the selected
     /// HTTP client for a Smithy client.
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "__rustls")]
     pub fn build_https(self) -> SharedHttpClient {
         self.build_with_fn(default_connector::https)
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr/record.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/test_util/dvr/record.rs
@@ -74,7 +74,7 @@ pub struct RecordingClient {
     pub(crate) inner: SharedHttpConnector,
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "__rustls")]
 impl RecordingClient {
     /// Construct a recording connection wrapping a default HTTPS implementation without any timeouts.
     pub fn https() -> Self {


### PR DESCRIPTION
## Motivation and Context
I'm trying to remove `openssl` entirely from my package's dependency closure.

Currently `aws-smithy-runtime` and `aws-config` both implicitly bring in openssl, even under their respective `rustls` features, because they have default `hyper-rustls` features enabled. That in turn enables `rustls-native-certs`, which then brings in OpenSsl.

## Description
I've handled this in a non-breaking manner by adding a new feature to both packages, `tls-rustls-webpki`, and `rustls-webki`, respectively. I made sure to explicitly  enable all default features for `hyper-rustls` besides `rustls-native-certs` (which now is moved to the `tls-rustls` feature only). 

I also added a `__rustls` feature that both `rustls/rustls-webpki` and `tls-rustls/tls-rustls-webpki` resolve to, which all the conditional compilation inside application code now checks for. This is the convention I see in the hyper ecosystem.

## Testing
I'm publishing this as a draft for initial feedback, as I need to do more testing. Still sorting out my local build. It looks like I should check in `Cargo.lock` files as well?

Related - are there any CI/CD updates needed to test the new featureset?

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.


It's not clear if this merits a changelog entry... probably?

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
