### PR TITLE
aws-smithy-checksums: Cargo.toml, crc64fast-nvme 1.1.1 -> 1.2.0

### DIFF
--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -26,7 +26,7 @@ pin-project-lite = "0.2.9"
 sha1 = "0.10"
 sha2 = "0.10"
 tracing = "0.1"
-crc64fast-nvme = "1.1.1"
+crc64fast-nvme = "1.2.0"
 
 [dev-dependencies]
 bytes-utils = "0.1.2"


### PR DESCRIPTION
## Motivation and Context
crc64fast-nvme <= v1.1.1 breaks in sandoxed build environments like nix, see: https://github.com/awesomized/crc64fast-nvme/issues/5

v1.2.0 addressed this issue

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
