### PR TITLE
Add missing setters to `ConfigLoader`

### DIFF
--- a/.changelog/config_loader_setters.md
+++ b/.changelog/config_loader_setters.md
@@ -1,0 +1,10 @@
+---
+applies_to: ["aws-sdk-rust"]
+authors: ["landonxjames"]
+references: ["smithy-rs#920"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Add missing `request_checksum_calculation` and `response_checksum_validation` setters to the `ConfigLoader`

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.17"
+version = "1.5.18"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.9"
+version = "1.2.8"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.5.17"
+version = "1.5.18"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -732,6 +732,36 @@ mod loader {
             self
         }
 
+        /// Set the checksum calculation strategy to use when making requests.
+        /// # Examples
+        /// ```
+        /// use aws_types::SdkConfig;
+        /// use aws_smithy_types::checksum_config::RequestChecksumCalculation;
+        /// let config = SdkConfig::builder().request_checksum_calculation(RequestChecksumCalculation::WhenSupported).build();
+        /// ```
+        pub fn request_checksum_calculation(
+            mut self,
+            request_checksum_calculation: RequestChecksumCalculation,
+        ) -> Self {
+            self.request_checksum_calculation = Some(request_checksum_calculation);
+            self
+        }
+
+        /// Set the checksum calculation strategy to use for responses.
+        /// # Examples
+        /// ```
+        /// use aws_types::SdkConfig;
+        /// use aws_smithy_types::checksum_config::ResponseChecksumValidation;
+        /// let config = SdkConfig::builder().response_checksum_validation(ResponseChecksumValidation::WhenSupported).build();
+        /// ```
+        pub fn response_checksum_validation(
+            mut self,
+            response_checksum_validation: ResponseChecksumValidation,
+        ) -> Self {
+            self.response_checksum_validation = Some(response_checksum_validation);
+            self
+        }
+
         /// Load the default configuration chain
         ///
         /// If fields have been overridden during builder construction, the override values will be used.

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -1010,6 +1010,7 @@ mod loader {
         use aws_types::app_name::AppName;
         use aws_types::origin::Origin;
         use aws_types::os_shim_internal::{Env, Fs};
+        use aws_types::sdk_config::{RequestChecksumCalculation, ResponseChecksumValidation};
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
 
@@ -1188,6 +1189,30 @@ mod loader {
             let app_name = AppName::new("my-app-name").unwrap();
             let conf = base_conf().app_name(app_name.clone()).load().await;
             assert_eq!(Some(&app_name), conf.app_name());
+        }
+
+        #[tokio::test]
+        async fn request_checksum_calculation() {
+            let conf = base_conf()
+                .request_checksum_calculation(RequestChecksumCalculation::WhenRequired)
+                .load()
+                .await;
+            assert_eq!(
+                Some(RequestChecksumCalculation::WhenRequired),
+                conf.request_checksum_calculation()
+            );
+        }
+
+        #[tokio::test]
+        async fn response_checksum_validation() {
+            let conf = base_conf()
+                .response_checksum_validation(ResponseChecksumValidation::WhenRequired)
+                .load()
+                .await;
+            assert_eq!(
+                Some(ResponseChecksumValidation::WhenRequired),
+                conf.response_checksum_validation()
+            );
         }
 
         #[cfg(feature = "rustls")]

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -488,7 +488,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.63.3"
+version = "0.63.4"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-http",


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Customer reported that the `request_checksum_calculation` and `response_checksum_validation` setters were missing from the `ConfigLoader`, but were present on the `SdkConfig` builder. This PR adds those setters.

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
