### PR TITLE
Add CHANGELOG entries

### DIFF
--- a/.changelog/1740049466.md
+++ b/.changelog/1740049466.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- server
+authors:
+- drganjoo
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Previously, models would fail to generate when both the list and at least one of its members was directly constrained with documentation comments

--- a/.changelog/1740049621.md
+++ b/.changelog/1740049621.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- server
+authors:
+- drganjoo
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fixed code generation failure that occurred when using `Result` as a shape name in Smithy models with constrained members by properly handling naming conflicts with Rust's built-in Result type


### PR DESCRIPTION
This PR adds the CHANGELOG entries that were missed in these two earlier PRs:

https://github.com/smithy-lang/smithy-rs/pull/4010    
https://github.com/smithy-lang/smithy-rs/pull/4008