### PR TITLE
Fix `TSApplicationGenerator` to use `Result<>` instead of `#{Result}`

### DIFF
--- a/codegen-server/typescript/src/main/kotlin/software/amazon/smithy/rust/codegen/server/typescript/smithy/generators/TsApplicationGenerator.kt
+++ b/codegen-server/typescript/src/main/kotlin/software/amazon/smithy/rust/codegen/server/typescript/smithy/generators/TsApplicationGenerator.kt
@@ -212,7 +212,7 @@ class TsApplicationGenerator(
                 )
             }
             writer.rustBlockTemplate(
-                """pub fn new_socket(address: String, port: i32, backlog: Option<i32>) -> #{Result}<#{socket2}::Socket, Box<dyn std::error::Error>> """.trimIndent(),
+                """pub fn new_socket(address: String, port: i32, backlog: Option<i32>) -> Result<#{socket2}::Socket, Box<dyn std::error::Error>> """.trimIndent(),
                 *codegenScope,
             ) {
                 writer.rustTemplate(


### PR DESCRIPTION
The [earlier PR](https://github.com/smithy-lang/smithy-rs/pull/4010), which ensured that a Smithy shape named `Result` does not conflict with the Rust type `Result`, had a bug in `TSApplicationGenerator`. The `rustTemplateBlock` was using `#{Result}` but `preludeScope` was not passed in as a parameter.

This bug can be addressed in two ways:

1. Pass `*RuntimeType.preludeScope` to the `rustBlockTemplate` call
2. Remove `#{Result}` from `rustBlockTemplate` and continue using `Result<>`

This PR implements the second approach because:

1. `TSApplicationGenerator` is slated for deprecation
2. The CI step `CI / PR Bot / Generate diff and upload to S3 (pull_request)` currently fails when comparing codegen between HEAD and this version. Removing `#{Result}` is the most reliable way to avoid parameter-passing issues with `rustBlockTemplate`