### PR TITLE
Fix recursive definition in SupportStructures.k

### DIFF
--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
@@ -556,6 +556,7 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
             }
             """,
             "Shape" to shape, "body" to block, *SupportStructures.codegenScope,
+            *RuntimeType.preludeScope,
         )
     }
 
@@ -578,6 +579,7 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
                 }
                 """,
                 "Shape" to shape, "body" to block, *SupportStructures.codegenScope,
+                *RuntimeType.preludeScope,
             )
         }
     }

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SupportStructures.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SupportStructures.kt
@@ -23,7 +23,6 @@ object SupportStructures {
 
     val codegenScope =
         arrayOf(
-            *RuntimeType.preludeScope,
             "ConfigurableSerde" to configurableSerde(),
             "SerializeConfigured" to serializeConfigured(),
             "ConfigurableSerdeRef" to configurableSerdeRef(),
@@ -54,7 +53,7 @@ object SupportStructures {
                 "serde" to serde,
                 "SerializeConfigured" to serializeConfigured(),
                 "SerializationSettings" to serializationSettings(),
-                *codegenScope,
+                *RuntimeType.preludeScope,
             )
         }
 
@@ -78,7 +77,7 @@ object SupportStructures {
                 "serde" to serde,
                 "SerializeConfigured" to serializeConfigured(),
                 "SerializationSettings" to serializationSettings(),
-                *codegenScope,
+                *RuntimeType.preludeScope,
             )
         }
 
@@ -150,7 +149,7 @@ object SupportStructures {
                 }
                 """,
                 "serde" to CargoDependency.Serde.toType(),
-                *codegenScope,
+                *RuntimeType.preludeScope,
             )
         }
 
@@ -196,7 +195,7 @@ object SupportStructures {
                 "ConfigurableSerdeRef" to configurableSerdeRef(),
                 "SerializeConfigured" to serializeConfigured(),
                 "serde" to CargoDependency.Serde.toType(),
-                *codegenScope,
+                *RuntimeType.preludeScope,
             )
         }
 


### PR DESCRIPTION
This PR fixes a recursive definition issue in the `SupportStructures.kt` file where `codegenScope` was being used within its own dependent functions, creating a circular dependency. The issue specifically occurred in the `serializeRedacted()`, `sensitive()`, `configurableSerde()` and `serializeUnredacted()` functions where `codegenScope` was being included in the template parameters.

The fix:
- Removed the recursive usage of `codegenScope`
- Instead, directly used `RuntimeType.preludeScope` where needed
- This change maintains the same functionality while avoiding the circular dependency

Before:
```kotlin
*codegenScope  // This created a recursive definition as codegenScope depends on these functions
```

After:
```kotlin
*RuntimeType.preludeScope  // Direct usage of prelude scope without recursion
```