### PR TITLE
Fix up the order of auth scheme and endpoint resolution

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.7"
+version = "0.60.8"
 dependencies = [
  "arbitrary",
  "aws-smithy-types",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "approx",
  "aws-smithy-async",

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.8.0"
+version = "1.8.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -36,7 +36,7 @@ use std::mem;
 use tracing::{debug, debug_span, instrument, trace, Instrument};
 
 mod auth;
-pub use auth::AuthSchemeOptionResolverHandlesEndpointResolution;
+pub use auth::AuthSchemeAndEndpointOrchestrationV2;
 
 /// Defines types that implement a trait for endpoint resolution
 pub mod endpoints;
@@ -356,7 +356,7 @@ async fn try_attempt(
 
     match endpoint {
         Some(endpoint) => {
-            // This branch is for backward compatibility when `AuthSchemeOptionResolverHandlesEndpointResolution` is not present in the config bag.
+            // This branch is for backward compatibility when `AuthSchemeAndEndpointOrchestrationV2` is not present in the config bag.
             // `resolve_identity` internally resolved an endpoint to determine the most suitable scheme ID, and returned that endpoint.
             halt_on_err!([ctx] => apply_endpoint(&endpoint, ctx, cfg).map_err(OrchestratorError::other));
             // Make the endpoint config available to interceptors

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use self::auth::orchestrate_auth;
 use crate::client::interceptors::Interceptors;
 use crate::client::orchestrator::http::{log_response_body, read_body};
 use crate::client::timeout::{MaybeTimeout, MaybeTimeoutConfig, TimeoutKind};
@@ -11,6 +10,7 @@ use crate::client::{
     http::body::minimum_throughput::MaybeUploadThroughputCheckFuture,
     orchestrator::endpoints::orchestrate_endpoint,
 };
+use auth::{resolve_identity, sign_request};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::http::{HttpClient, HttpConnector, HttpConnectorSettings};
@@ -31,10 +31,12 @@ use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::timeout::{MergeTimeoutConfig, TimeoutConfig};
+use endpoints::apply_endpoint;
 use std::mem;
 use tracing::{debug, debug_span, instrument, trace, Instrument};
 
 mod auth;
+pub use auth::AuthSchemeOptionResolverHandlesEndpointResolution;
 
 /// Defines types that implement a trait for endpoint resolution
 pub mod endpoints;
@@ -350,14 +352,28 @@ async fn try_attempt(
 ) {
     run_interceptors!(halt_on_err: read_before_attempt(ctx, runtime_components, cfg));
 
-    halt_on_err!([ctx] => orchestrate_endpoint(ctx, runtime_components, cfg).await.map_err(OrchestratorError::other));
+    let (scheme_id, identity, endpoint) = halt_on_err!([ctx] => resolve_identity(runtime_components, cfg).await.map_err(OrchestratorError::other));
+
+    match endpoint {
+        Some(endpoint) => {
+            // This branch is for backward compatibility when `AuthSchemeOptionResolverHandlesEndpointResolution` is not present in the config bag.
+            // `resolve_identity` internally resolved an endpoint to determine the most suitable scheme ID, and returned that endpoint.
+            halt_on_err!([ctx] => apply_endpoint(&endpoint, ctx, cfg).map_err(OrchestratorError::other));
+            // Make the endpoint config available to interceptors
+            cfg.interceptor_state().store_put(endpoint);
+        }
+        None => {
+            // TODO(AccountIdBasedRouting): Pass `identity` to `orchestrate_endpoint`.
+            halt_on_err!([ctx] => orchestrate_endpoint(ctx, runtime_components, cfg).await.map_err(OrchestratorError::other));
+        }
+    }
 
     run_interceptors!(halt_on_err: {
         modify_before_signing(ctx, runtime_components, cfg);
         read_before_signing(ctx, runtime_components, cfg);
     });
 
-    halt_on_err!([ctx] => orchestrate_auth(ctx, runtime_components, cfg).await.map_err(OrchestratorError::other));
+    halt_on_err!([ctx] => sign_request(scheme_id, &identity, ctx, runtime_components, cfg).map_err(OrchestratorError::other));
 
     run_interceptors!(halt_on_err: {
         read_after_signing(ctx, runtime_components, cfg);

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -265,6 +265,12 @@ async fn endpoint_auth_scheme_matches_configured_scheme_id(
         .await
         .map_err(AuthOrchestrationError::FailedToResolveEndpoint)?;
 
+    // This line repurposes `extract_endpoint_auth_scheme_config` to check whether
+    // the function returns `Ok` for the given `endpoint`.
+    // Essentially, we want verify if the `authSchemes` property of `endpoint` contains `scheme_id`,
+    // which is done by `schemes.iter().find(...).ok_or(...)` within the function.
+    // However, this execution path is only exercised for legacy auth scheme and endpoint orchestration,
+    // so we don't bother refactoring the predicate out of the function.
     let _ = extract_endpoint_auth_scheme_config(&endpoint, scheme_id)?;
 
     Ok(Some(endpoint))

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -255,7 +255,7 @@ async fn legacy_try_resolve_endpoint(
         .load::<EndpointResolverParams>()
         .expect("endpoint resolver params must be set");
 
-    tracing::debug!(endpoint_params = ?params, "resolving endpoint");
+    tracing::debug!(scheme_id = ?scheme_id, endpoint_params = ?params, "using legacy auth and endpoint orchestration, resolving endpoint for auth scheme selection");
 
     let endpoint = runtime_components
         .endpoint_resolver()
@@ -265,7 +265,7 @@ async fn legacy_try_resolve_endpoint(
 
     // This line repurposes `extract_endpoint_auth_scheme_config` to check whether
     // the function returns `Ok` for the given `endpoint`.
-    // Essentially, we want verify if the `authSchemes` property of `endpoint` contains `scheme_id`,
+    // Essentially, we verify if the `authSchemes` property of `endpoint` contains `scheme_id`,
     // which is done by `schemes.iter().find(...).ok_or(...)` within the function.
     // However, this execution path is only exercised for legacy auth scheme and endpoint orchestration,
     // so we don't bother refactoring the predicate out of the function.

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -255,6 +255,8 @@ async fn legacy_try_resolve_endpoint(
         .load::<EndpointResolverParams>()
         .expect("endpoint resolver params must be set");
 
+    tracing::debug!(endpoint_params = ?params, "resolving endpoint");
+
     let endpoint = runtime_components
         .endpoint_resolver()
         .resolve_endpoint(params)

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -77,23 +77,32 @@ pub(super) async fn orchestrate_endpoint(
     let params = cfg
         .load::<EndpointResolverParams>()
         .expect("endpoint resolver params must be set");
-    let endpoint_prefix = cfg.load::<EndpointPrefix>();
-    tracing::debug!(endpoint_params = ?params, endpoint_prefix = ?endpoint_prefix, "resolving endpoint");
-    let request = ctx.request_mut().expect("set during serialization");
-
     let endpoint = runtime_components
         .endpoint_resolver()
         .resolve_endpoint(params)
         .await?;
-    tracing::debug!("will use endpoint {:?}", endpoint);
-    apply_endpoint(request, &endpoint, endpoint_prefix)?;
+    tracing::debug!(endpoint_params = ?params, "will use endpoint {:?}", endpoint);
+
+    apply_endpoint(&endpoint, ctx, cfg)?;
 
     // Make the endpoint config available to interceptors
     cfg.interceptor_state().store_put(endpoint);
     Ok(())
 }
 
-fn apply_endpoint(
+pub(super) fn apply_endpoint(
+    endpoint: &Endpoint,
+    ctx: &mut InterceptorContext,
+    cfg: &ConfigBag,
+) -> Result<(), BoxError> {
+    let endpoint_prefix = cfg.load::<EndpointPrefix>();
+    tracing::debug!(endpoint_prefix = ?endpoint_prefix, "resolving endpoint");
+    let request = ctx.request_mut().expect("set during serialization");
+
+    apply_endpoint_to_request(request, endpoint, endpoint_prefix)
+}
+
+fn apply_endpoint_to_request(
     request: &mut HttpRequest,
     endpoint: &Endpoint,
     endpoint_prefix: Option<&EndpointPrefix>,
@@ -157,7 +166,8 @@ mod test {
         req.set_uri("/foo?bar=1").unwrap();
         let endpoint = Endpoint::builder().url("https://s3.amazon.com").build();
         let prefix = EndpointPrefix::new("prefix.subdomain.").unwrap();
-        super::apply_endpoint(&mut req, &endpoint, Some(&prefix)).expect("should succeed");
+        super::apply_endpoint_to_request(&mut req, &endpoint, Some(&prefix))
+            .expect("should succeed");
         assert_eq!(
             req.uri(),
             "https://prefix.subdomain.s3.amazon.com/foo?bar=1"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -77,11 +77,11 @@ pub(super) async fn orchestrate_endpoint(
     let params = cfg
         .load::<EndpointResolverParams>()
         .expect("endpoint resolver params must be set");
+    tracing::debug!(endpoint_params = ?params, "resolving endpoint");
     let endpoint = runtime_components
         .endpoint_resolver()
         .resolve_endpoint(params)
         .await?;
-    tracing::debug!(endpoint_params = ?params, "will use endpoint {:?}", endpoint);
 
     apply_endpoint(&endpoint, ctx, cfg)?;
 
@@ -96,7 +96,7 @@ pub(super) fn apply_endpoint(
     cfg: &ConfigBag,
 ) -> Result<(), BoxError> {
     let endpoint_prefix = cfg.load::<EndpointPrefix>();
-    tracing::debug!(endpoint_prefix = ?endpoint_prefix, "resolving endpoint");
+    tracing::debug!(endpoint_prefix = ?endpoint_prefix, "will apply endpoint {:?}", endpoint);
     let request = ctx.request_mut().expect("set during serialization");
 
     apply_endpoint_to_request(request, endpoint, endpoint_prefix)


### PR DESCRIPTION
## Motivation and Context
This PR updates the order of auth scheme resolution, identity resolution, endpoint resolution from
- endpoint -> auth scheme -> identity

to

- auth scheme -> identity -> endpoint

within the orchestrator. The scope of this PR only fixes up the resolution order above, and everything else will be handles by subsequent PRs. Furthermore, this PR introduces a special runtime marker but it won't be placed in the config bag by anyone yet, and that'll be done in the next PR.

## Description
This is the first in the series towards adding support for the [account-based endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html) in the Rust SDK. To enable the functionality, the information of account ID needs to be incorporated into endpoint resolution. However, the way the orchestrator works today is
- [endpoint -> auth scheme -> identity](https://github.com/smithy-lang/smithy-rs/blob/94dbe3b0f658fe2c69bdfbefba06cd3ecde2a668/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs#L353-L360)

So we need to fix up this order to become

- auth scheme -> identity -> endpoint

The key aspect of the code changes is to correct the resolution order while maintaining backward compatibility. When older GA-ed SDKs (ex. `aws-sdk-s3 1.76.0`) update their dependencies to a newer `aws-smithy-runtime` crate that includes these changes, they must not be broken. This is crucial because some SDKs, such as S3, have already been relying on the incorrect resolution order: endpoint → auth scheme → identity.

We introduce a special runtime marker `AuthSchemeAndEndpointOrchestrationV2` to support both resolution orders within the [`try_attempt`](https://github.com/smithy-lang/smithy-rs/blob/94dbe3b0f658fe2c69bdfbefba06cd3ecde2a668/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs#L345) function. This approach allows us to avoid introducing `aws-smithy-runtime` version 2.x, which would enforce only the correct resolution order and require customers to upgrade to 2.x to access the functionality of account-based endpoints.

Moving forward, all SDKs generated with the `aws-smithy-runtime` crate from this PR will, by default, place the marker in the config bag. When this marker is present, the execution flow in the `try_attempt` function will follow the correct resolution order: auth scheme → identity → endpoint. Older GA-ed SDKs, generated prior to this PR, will not have the marker in the config bag, causing the `try_attempt` function to continue using the incorrect resolution order: endpoint → auth scheme → identity.

## Testing
- Existing tests in CI (specifically, passing `Check for semver hazards` is crucial)
 
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
