### PR TITLE
Bump aws-smithy-http-server version

### DIFF
--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.63.5"
+version = "0.65.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
When updating `aws-smithy-http-server (v0.63.4)` to depend on `aws-smithy-json v0.61`,  we should have bumped its minor version to `0.64.0` instead of just increasing the patch version.

Current dependency tree:
```
aws-smithy-json v0.61.x
└── aws-smithy-http-server v0.63.4
```

This affects SDKs that have been generated by an older version of `smithy-rs`:

```
aws-smithy-json v0.60.7
└── service-sdk v0.1.0 
aws-smithy-json v0.61.2
└── aws-smithy-http-server v0.63.4
    ├── service-sdk v0.1.0
```

This PR bumps `aws-smithy-http-server` to version `0.64.1`.
```