### PR TITLE
Bump version of Python server

### DIFF
--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.63.3"
+version = "0.64.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
The Python server version must be semver compatible with the Rust server version it's binding to. The version mismatch between these servers causes dependency conflicts, as shown by the multiple versions being pulled in:
```
aws-smithy-http-server v0.63.3
└── aws-smithy-http-server-python v0.63.2
    └── amzn-pokemon-service-python-server-sdk v0.1.0

aws-smithy-http-server v0.64.0
└── amzn-pokemon-service-python-server-sdk v0.1.0
```

This leads to type incompatibility errors in the server bindings.