### PR TITLE
Ignore region provider spans test

### DIFF
--- a/aws/sdk/integration-tests/telemetry/tests/spans.rs
+++ b/aws/sdk/integration-tests/telemetry/tests/spans.rs
@@ -224,7 +224,11 @@ async fn config_spans_emitted() {
     build_profile_token_provider.assert();
 }
 
+// NOTE: this test is being temporarily ignored since, although it succeeds both locally and in the
+// GitHub CI, it fails in our CodeBuild CI, likely because CodeBuild runs on EC2 so IMDS is present
+// and causes different behavior.
 #[tokio::test]
+#[ignore]
 async fn region_spans_emitted() {
     let assertion_registry = AssertionRegistry::default();
     let base_subscriber = tracing_subscriber::Registry::default();


### PR DESCRIPTION
It was behaving differently in GitHub CI vs CodeBuild CI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
