### PR TITLE
Backport `aws-smithy-http-server` crate version bump

### DIFF
--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.63.2"
+version = "0.64.1"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.63.4"
+version = "0.64.1"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
`aws-smithy-http-server`'s minor version should have been updated as part of `release-2025-02-20`. This update will allow consumers to use earlier versions of the generator.

Without this fix, the cargo dependency tree shows incompatible version conflicts:
```
aws-smithy-json v0.60.7
└── service-sdk v0.1.0
aws-smithy-json v0.61.2
└── aws-smithy-http-server v0.63.4
    ├── amzn-serpentine-service-sdk v0.1.0
    └── amzn-smithy-http-server-internal v0.1.13193
        └── service-sdk v0.1.0
```

This PR backports the version alignment fix to the release branch.