### PR TITLE
Log actual recorded events on panic in `match_events!`

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -426,7 +426,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.0.0"
+version = "1.0.1"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/src/test_util/wire.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/wire.rs
@@ -80,7 +80,12 @@ pub fn check_matches(events: &[RecordedEvent], matchers: &[Matcher]) {
     let mut idx = -1;
     loop {
         idx += 1;
-        let bail = |err: Box<dyn Error>| panic!("failed on event {}:\n  {}", idx, err);
+        let bail = |err: Box<dyn Error>| {
+            panic!(
+                "failed on event {}:\n  {}\n  actual recorded events: {:?}",
+                idx, err, events
+            )
+        };
         match (events_iter.next(), matcher_iter.next()) {
             (Some(event), Some((matcher, _msg))) => matcher(event).unwrap_or_else(bail),
             (None, None) => return,


### PR DESCRIPTION
## Motivation and Context
We've had flaky tests in our release pipeline. The pain points are that reproducing these failures is difficult and that when a test does fail, `panic` from the `match_events!` macro does not provide visibility into the actual recorded events.

This PR does not address the underlying test failures but aims to improve visibility into the actual recorded events when a test fails. This will help us better diagnose and troubleshoot flaky tests.

Here is the new diagnostic message looks like (deliberately made a test fail just to show what the message looks like):
```
  expected `ev!(connect)` but got Response(HttpResponse { status: 429, body: b"{\"__type\":\"com.amazonaws.dynamodb.v20120810#ThrottlingException\",\n\"message\":\"enhance your calm\"}" })
  actual recorded events: [DnsLookup("this-url-is-converted-to-localhost.com"), NewConnection, Response(HttpResponse { status: 429, body: b"{\"__type\":\"com.amazonaws.dynamodb.v20120810#ThrottlingException\",\n\"message\":\"enhance your calm\"}" }), Response(HttpResponse { status: 200, body: b"{\"Count\":0,\"Items\":[],\"ScannedCount\":2}" })]
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
