### PR TITLE
Bump server crate versions

### DIFF
--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.64.0"
+version = "0.65.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.64.0"
+version = "0.65.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
The `aws-smithy-http` crate, which is part of our publicly exposed API, has undergone a semver-incompatible version bump. This PR updates the version numbers of all dependent server crates to maintain compatibility with this change.