### PR TITLE
Update manual CI workflows to take commit SHA

### DIFF
--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -8,6 +8,10 @@ on:
         description: The PR number to invoke the canary for.
         required: true
         type: string
+      commit_sha:
+        description: The the full SHA for the HEAD commit of the PR
+        required: true
+        type: string
 run-name: ${{ github.workflow }} for Pull Request ${{ inputs.pull_request_number }}
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
@@ -34,6 +38,9 @@ jobs:
             commit_sha: response.data.head.sha,
           };
           console.log("data:", data);
+          if(data.commit_sha !== ${{ inputs.commit_sha }}){
+            throw new Error("Input SHA does not match retrieved SHA")
+          }
           return data;
     outputs:
       pull_data: ${{ steps.get-pr-info.outputs.result }}
@@ -48,8 +55,8 @@ jobs:
       with:
         path: smithy-rs
             # The ref used needs to match the HEAD revision of the PR being diffed, or else
-          # the `docker-build` action won't find the built Docker image.
-        ref: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).commit_sha }}
+            # the `docker-build` action won't find the built Docker image.
+        ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
     - name: Acquire base image
       id: acquire
@@ -71,7 +78,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
-        ref: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).commit_sha }}
+        ref: ${{ inputs.commit_sha }}
     - name: Generate a subset of SDKs for the canary
       uses: ./smithy-rs/.github/actions/docker-build
       with:
@@ -90,7 +97,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
-        ref: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).commit_sha }}
+        ref: ${{ inputs.commit_sha }}
     - name: Configure credentials
       id: creds
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -38,7 +38,7 @@ jobs:
             commit_sha: response.data.head.sha,
           };
           console.log("data:", data);
-          if(data.commit_sha !== "${{ inputs.commit_sha }}""){
+          if(data.commit_sha !== "${{ inputs.commit_sha }}"){
             throw new Error("Input SHA does not match retrieved SHA")
           }
           return data;

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -38,7 +38,7 @@ jobs:
             commit_sha: response.data.head.sha,
           };
           console.log("data:", data);
-          if(data.commit_sha !== ${{ inputs.commit_sha }}){
+          if(data.commit_sha !== "${{ inputs.commit_sha }}""){
             throw new Error("Input SHA does not match retrieved SHA")
           }
           return data;

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -33,7 +33,7 @@ jobs:
             head_revision: response.data.head.sha,
           };
           console.log("data:", data);
-          if(data.head_revision !== ${{ inputs.commit_sha }}){
+          if(data.head_revision !== "${{ inputs.commit_sha }}""){
             throw new Error("Input SHA does not match retrieved SHA")
           }
           return data;
@@ -52,10 +52,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
-          # The ref used needs to match the HEAD revision of the PR being diffed, or else
-          # the `docker-build` action won't find the built Docker image. This has the unfortunate
-          # side effect that the codegen diff tool used is the one in the PR rather than in
-          # the branch this workflow was launched from.
+            # The ref used needs to match the HEAD revision of the PR being diffed, or else
+            # the `docker-build` action won't find the built Docker image. This has the unfortunate
+            # side effect that the codegen diff tool used is the one in the PR rather than in
+            # the branch this workflow was launched from.
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
     - name: Acquire base image

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -33,7 +33,7 @@ jobs:
             head_revision: response.data.head.sha,
           };
           console.log("data:", data);
-          if(data.head_revision !== "${{ inputs.commit_sha }}""){
+          if(data.head_revision !== "${{ inputs.commit_sha }}"){
             throw new Error("Input SHA does not match retrieved SHA")
           }
           return data;

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -8,6 +8,10 @@ on:
         description: The PR number to invoke the PR bot on.
         required: true
         type: string
+      commit_sha:
+        description: The the full SHA for the HEAD commit of the PR
+        required: true
+        type: string
 
 jobs:
   get-pr-info:
@@ -29,6 +33,9 @@ jobs:
             head_revision: response.data.head.sha,
           };
           console.log("data:", data);
+          if(data.head_revision !== ${{ inputs.commit_sha }}){
+            throw new Error("Input SHA does not match retrieved SHA")
+          }
           return data;
     outputs:
       pull_data: ${{ steps.get-pr-info.outputs.result }}
@@ -45,11 +52,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
-        # The ref used needs to match the HEAD revision of the PR being diffed, or else
-        # the `docker-build` action won't find the built Docker image. This has the unfortunate
-        # side effect that the codegen diff tool used is the one in the PR rather than in
-        # the branch this workflow was launched from.
-        ref: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).head_revision }}
+          # The ref used needs to match the HEAD revision of the PR being diffed, or else
+          # the `docker-build` action won't find the built Docker image. This has the unfortunate
+          # side effect that the codegen diff tool used is the one in the PR rather than in
+          # the branch this workflow was launched from.
+        ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
     - name: Acquire base image
       id: acquire
@@ -70,7 +77,7 @@ jobs:
     with:
       issue_number: ${{ inputs.pull_number }}
       base_revision: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).base_revision }}
-      head_revision: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).head_revision }}
+      head_revision: ${{ inputs.commit_sha  }}
     secrets:
       SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME }}
       SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->



## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Canary fails with appropriate error message if provided SHA and retrieved SHA (from the PR number) don't match: https://github.com/smithy-lang/smithy-rs/actions/runs/14210739747

Canary works if the provided SHA and the retrieved SHA do match: https://github.com/smithy-lang/smithy-rs/actions/runs/14210752482

Manual PR bot fails with appropriate error message if provided SHA and retrieved SHA do not match: https://github.com/smithy-lang/smithy-rs/actions/runs/14210797894

Manual PR bot works if the provided SHA and retrieved SHA do match: https://github.com/smithy-lang/smithy-rs/actions/runs/14210813156

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
