### PR TITLE
Update docker-build action with use-cache input

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -47,7 +47,7 @@ runs:
       # it and tag it as the base image to use for this action. This will prevent acquire-build-image
       # from attempting to download an image from ECR since it will already exist,
       # which enables testing build image modifications as part of the pull request.
-      if [[ -d smithy-rs-base-image ]] && [[ ${{ inputs.use_cache }} ]]; then
+      if [[ -d smithy-rs-base-image ]] && [[ ${{ inputs.use-cache }} ]]; then
         IMAGE_TAG="$(./smithy-rs/.github/scripts/docker-image-hash)"
         docker load -i smithy-rs-base-image/smithy-rs-base-image
         docker tag "smithy-rs-base-image:${IMAGE_TAG}" "smithy-rs-base-image:local"

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -20,9 +20,9 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/cache@v4
+  - name: Gradle Cache
     if: ${{ inputs.use-cache }} == 'true'
-    name: Gradle Cache
+    uses: actions/cache@v4
     with:
       path: |
         gradle/caches

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
   - name: Gradle Cache
-    if: ${{ inputs.use_cache }}
+    if: ${{ github.event.inputs.use_cache == 'true' }}
     uses: actions/cache@v4
     with:
       path: |

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -29,7 +29,7 @@ runs:
       key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/caches/**/*', 'gradle/wrapper/**/*') }}
       restore-keys: |
         ${{ runner.os }}-gradle-
-      # Pinned to the commit hash of v2.7.3
+       # Pinned to the commit hash of v2.7.3
   - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:
       shared-key: ${{ runner.os }}-${{ github.job }}
@@ -47,7 +47,7 @@ runs:
       # it and tag it as the base image to use for this action. This will prevent acquire-build-image
       # from attempting to download an image from ECR since it will already exist,
       # which enables testing build image modifications as part of the pull request.
-      if [[ -d smithy-rs-base-image ]] && ${{ inputs.use_cache }}; then
+      if [[ -d smithy-rs-base-image ]] && [[ ${{ inputs.use_cache }} ]]; then
         IMAGE_TAG="$(./smithy-rs/.github/scripts/docker-image-hash)"
         docker load -i smithy-rs-base-image/smithy-rs-base-image
         docker tag "smithy-rs-base-image:${IMAGE_TAG}" "smithy-rs-base-image:local"

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -12,8 +12,8 @@ inputs:
   action-arguments:
     description: Arguments to pass to the action
     required: false
-  use-cache:
-    description: Whether to use the cache
+  use_cache:
+    description: Whether to use the gradle cache
     required: false
     default: true
 
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
   - name: Gradle Cache
-    if: ${{ inputs.use-cache }} == 'true'
+    if: ${{ inputs.use_cache }}
     uses: actions/cache@v4
     with:
       path: |

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -21,6 +21,7 @@ runs:
   using: composite
   steps:
   - uses: actions/cache@v4
+    if: ${{ inputs.use-cache }} == 'true'
     name: Gradle Cache
     with:
       path: |
@@ -47,7 +48,7 @@ runs:
       # it and tag it as the base image to use for this action. This will prevent acquire-build-image
       # from attempting to download an image from ECR since it will already exist,
       # which enables testing build image modifications as part of the pull request.
-      if [[ -d smithy-rs-base-image ]] && [[ ${{ inputs.use-cache }} ]]; then
+      if [[ -d smithy-rs-base-image ]]; then
         IMAGE_TAG="$(./smithy-rs/.github/scripts/docker-image-hash)"
         docker load -i smithy-rs-base-image/smithy-rs-base-image
         docker tag "smithy-rs-base-image:${IMAGE_TAG}" "smithy-rs-base-image:local"

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -12,6 +12,11 @@ inputs:
   action-arguments:
     description: Arguments to pass to the action
     required: false
+  use-cache:
+    description: Whether to use the cache
+    required: false
+    default: true
+
 runs:
   using: composite
   steps:
@@ -24,7 +29,7 @@ runs:
       key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/caches/**/*', 'gradle/wrapper/**/*') }}
       restore-keys: |
         ${{ runner.os }}-gradle-
-    # Pinned to the commit hash of v2.7.3
+      # Pinned to the commit hash of v2.7.3
   - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:
       shared-key: ${{ runner.os }}-${{ github.job }}
@@ -42,7 +47,7 @@ runs:
       # it and tag it as the base image to use for this action. This will prevent acquire-build-image
       # from attempting to download an image from ECR since it will already exist,
       # which enables testing build image modifications as part of the pull request.
-      if [[ -d smithy-rs-base-image ]]; then
+      if [[ -d smithy-rs-base-image ]] && ${{ inputs.use_cache }}; then
         IMAGE_TAG="$(./smithy-rs/.github/scripts/docker-image-hash)"
         docker load -i smithy-rs-base-image/smithy-rs-base-image
         docker tag "smithy-rs-base-image:${IMAGE_TAG}" "smithy-rs-base-image:local"
@@ -53,7 +58,7 @@ runs:
       # configuration won't cause each individual action to build its own image, which would
       # drastically increase the total CI time. Fail fast!
       ALLOW_LOCAL_BUILD=false ./smithy-rs/.github/scripts/acquire-build-image
-    # This runs the commands from the matrix strategy
+     # This runs the commands from the matrix strategy
   - name: Run ${{ inputs.action }}
     shell: bash
     run: |

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -14,6 +14,7 @@ inputs:
     required: false
   use_cache:
     description: Whether to use the gradle cache
+    type: boolean
     required: false
     default: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: check-semver-hazards
-        use-cache: false
+        use_cache: false
 
   get-or-create-release-branch:
     name: Get or create a release branch
@@ -186,14 +186,14 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: generate-smithy-rs-release
-        use-cache: false
+        use_cache: false
     - name: Download all artifacts
       uses: ./smithy-rs/.github/actions/download-all-artifacts
-      # This step is not idempotent, as it pushes release artifacts to the `smithy-rs-release-1.x.y` branch. However,
-      # if this step succeeds but a subsequent step fails, retrying the release workflow is "safe" in that it does not
-      # create any inconsistent states; this step would simply fail because the release branch would be ahead of `main`
-      # due to previously pushed artifacts.
-      # To successfully retry a release, revert the commits in the release branch that pushed the artifacts.
+        # This step is not idempotent, as it pushes release artifacts to the `smithy-rs-release-1.x.y` branch. However,
+        # if this step succeeds but a subsequent step fails, retrying the release workflow is "safe" in that it does not
+        # create any inconsistent states; this step would simply fail because the release branch would be ahead of `main`
+        # due to previously pushed artifacts.
+        # To successfully retry a release, revert the commits in the release branch that pushed the artifacts.
     - name: Push smithy-rs changes
       shell: bash
       working-directory: smithy-rs-release/smithy-rs
@@ -221,7 +221,7 @@ jobs:
           fi
         fi
         echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
-      # This step is idempotent; the `publisher` will not publish a crate if the version is already published on crates.io.
+       # This step is idempotent; the `publisher` will not publish a crate if the version is already published on crates.io.
     - name: Publish to crates.io
       shell: bash
       working-directory: smithy-rs-release/crates-to-publish
@@ -243,8 +243,8 @@ jobs:
         else
           publisher publish -y --location .
         fi
-      # This step is not idempotent and MUST be performed last, as it will generate a new release in the `smithy-rs`
-      # repository with the release tag that is always unique and has an increasing numerical suffix.
+       # This step is not idempotent and MUST be performed last, as it will generate a new release in the `smithy-rs`
+        # repository with the release tag that is always unique and has an increasing numerical suffix.
     - name: Tag release
       uses: actions/github-script@v7
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: check-semver-hazards
+        use-cache: false
 
   get-or-create-release-branch:
     name: Get or create a release branch
@@ -185,13 +186,14 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: generate-smithy-rs-release
+        use-cache: false
     - name: Download all artifacts
       uses: ./smithy-rs/.github/actions/download-all-artifacts
-    # This step is not idempotent, as it pushes release artifacts to the `smithy-rs-release-1.x.y` branch. However,
-    # if this step succeeds but a subsequent step fails, retrying the release workflow is "safe" in that it does not
-    # create any inconsistent states; this step would simply fail because the release branch would be ahead of `main`
-    # due to previously pushed artifacts.
-    # To successfully retry a release, revert the commits in the release branch that pushed the artifacts.
+      # This step is not idempotent, as it pushes release artifacts to the `smithy-rs-release-1.x.y` branch. However,
+      # if this step succeeds but a subsequent step fails, retrying the release workflow is "safe" in that it does not
+      # create any inconsistent states; this step would simply fail because the release branch would be ahead of `main`
+      # due to previously pushed artifacts.
+      # To successfully retry a release, revert the commits in the release branch that pushed the artifacts.
     - name: Push smithy-rs changes
       shell: bash
       working-directory: smithy-rs-release/smithy-rs
@@ -219,7 +221,7 @@ jobs:
           fi
         fi
         echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
-    # This step is idempotent; the `publisher` will not publish a crate if the version is already published on crates.io.
+      # This step is idempotent; the `publisher` will not publish a crate if the version is already published on crates.io.
     - name: Publish to crates.io
       shell: bash
       working-directory: smithy-rs-release/crates-to-publish
@@ -241,8 +243,8 @@ jobs:
         else
           publisher publish -y --location .
         fi
-    # This step is not idempotent and MUST be performed last, as it will generate a new release in the `smithy-rs`
-    # repository with the release tag that is always unique and has an increasing numerical suffix.
+      # This step is not idempotent and MUST be performed last, as it will generate a new release in the `smithy-rs`
+      # repository with the release tag that is always unique and has an increasing numerical suffix.
     - name: Tag release
       uses: actions/github-script@v7
       with:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Makes the gradle cache step in the composite `docker-build` action conditional and disables it for release builds. 

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
