### PR TITLE
Implement Display for nested shapes referenced in error messages

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
@@ -42,6 +42,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerat
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolGeneratorFactory
+import software.amazon.smithy.rust.codegen.core.smithy.transformers.AddSyntheticTraitForImplDisplay
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.EventStreamNormalizer
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.RecursiveShapeBoxer
@@ -146,6 +147,9 @@ class ClientCodegenVisitor(
             .let(EventStreamNormalizer::transform)
             // Mark operations incompatible with stalled stream protection as such
             .let(DisableStalledStreamProtection::transformModel)
+            // Add synthetic trait to shapes referenced by error types to ensure they implement `Display`.
+            // This ensures error formatting works correctly for nested structures.
+            .let(AddSyntheticTraitForImplDisplay::transform)
 
     /**
      * Execute code generation

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCus
 import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationSection
 import software.amazon.smithy.rust.codegen.client.smithy.generators.http.ResponseBindingGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.assignment
@@ -33,6 +34,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctions
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.StructuredDataParserGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.operationErrors
 import software.amazon.smithy.rust.codegen.core.util.UNREACHABLE
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -163,10 +165,11 @@ class ProtocolParserGenerator(
                                     }
                                 }
                                 val errorMessageMember = errorShape.errorMessageMember()
-                                // If the message member is optional and wasn't set, we set a generic error message.
+                                // If the message member is optional, is of `String` Rust type and wasn't set, we set a generic error message.
                                 if (errorMessageMember != null) {
                                     val symbol = symbolProvider.toSymbol(errorMessageMember)
-                                    if (symbol.isOptional()) {
+                                    val currentRustType = symbol.rustType()
+                                    if (symbol.isOptional() && currentRustType == RustType.String) {
                                         rust(
                                             """
                                             if tmp.message.is_none() {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientErrorReachableShapesDisplayTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientErrorReachableShapesDisplayTest.kt
@@ -1,0 +1,16 @@
+package software.amazon.smithy.rust.codegen.client.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import java.io.File
+
+class ClientErrorReachableShapesDisplayTest {
+    @Test
+    fun correctMissingFields() {
+        var sampleModel = File("../codegen-core/common-test-models/nested-error.smithy").readText().asSmithyModel()
+        clientIntegrationTest(sampleModel) { _, _ ->
+            // It should compile.
+        }
+    }
+}

--- a/codegen-core/common-test-models/nested-error.smithy
+++ b/codegen-core/common-test-models/nested-error.smithy
@@ -1,0 +1,70 @@
+$version: "2"
+
+namespace sample
+
+use smithy.framework#ValidationException
+use aws.protocols#restJson1
+
+@restJson1
+service SampleService {
+    operations: [SampleOperation]
+}
+
+@http(uri: "/anOperation", method: "POST")
+operation SampleOperation {
+    output:= {}
+    input:= {}
+    errors: [
+        SimpleError,
+        ErrorWithCompositeShape,
+        ErrorWithDeepCompositeShape,
+        ComposedSensitiveError
+    ]
+}
+
+@error("client")
+structure ErrorWithCompositeShape {
+    message: ErrorMessage
+}
+
+@error("client")
+structure SimpleError {
+    message: String
+}
+
+structure ErrorMessage {
+    @required
+    statusCode: String
+    @required
+    errorMessage: String
+    requestId: String
+    @required
+    toolName: String
+}
+
+structure WrappedErrorMessage {
+    someValue: Integer
+    contained: ErrorMessage
+}
+
+@error("client")
+structure ErrorWithDeepCompositeShape {
+    message: WrappedErrorMessage
+}
+
+@sensitive
+structure SensitiveMessage {
+    nothing: String
+    should: String
+    bePrinted: String
+}
+
+@error("server")
+structure ComposedSensitiveError {
+    message: SensitiveMessage
+}
+
+@error("server")
+structure ErrorWithNestedError {
+    message: ErrorWithDeepCompositeShape
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/traits/SyntheticImplDisplayTrait.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/traits/SyntheticImplDisplayTrait.kt
@@ -1,0 +1,11 @@
+package software.amazon.smithy.rust.codegen.core.smithy.traits
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.AnnotationTrait
+
+class SyntheticImplDisplayTrait : AnnotationTrait(ID, Node.objectNode()) {
+    companion object {
+        val ID: ShapeId = ShapeId.from("software.amazon.smithy.rust.codegen.core.smithy.traits#syntheticImplDisplayTrait")
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/AddSyntheticTraitForImplDisplay.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/transformers/AddSyntheticTraitForImplDisplay.kt
@@ -1,0 +1,73 @@
+package software.amazon.smithy.rust.codegen.core.smithy.transformers
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.AbstractShapeBuilder
+import software.amazon.smithy.model.shapes.EnumShape
+import software.amazon.smithy.model.shapes.ListShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.ErrorTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.core.smithy.DirectedWalker
+import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticImplDisplayTrait
+import software.amazon.smithy.rust.codegen.core.util.UNREACHABLE
+import software.amazon.smithy.rust.codegen.core.util.getTrait
+import software.amazon.smithy.utils.ToSmithyBuilder
+
+/**
+ * Adds a synthetic trait to shapes that are reachable from error shapes to ensure they
+ * implement the `Display` trait in generated code.
+ *
+ * When a shape is annotated with `@error`, it needs to implement Rust's `Display` trait.
+ * If the error shape contains references to other structures, those structures also
+ * need to implement `Display` for proper error formatting.
+ */
+object AddSyntheticTraitForImplDisplay {
+    /**
+     * Transforms the model by adding [SyntheticImplDisplayTrait] to all shapes that are:
+     * 1. Reachable from an error shape
+     * 2. Not already marked with `@error`
+     * 3. Of a type that can implement `Display` (structure, list, union, or map)
+     *
+     * @param model The input model to transform
+     * @return The transformed model with synthetic traits added
+     */
+    fun transform(model: Model): Model {
+        val walker = DirectedWalker(model)
+
+        // Find all error shapes from operations.
+        val errorShapes =
+            model.operationShapes
+                .flatMap { it.errors }
+                .mapNotNull { model.expectShape(it).asStructureShape().orElse(null) }
+
+        // Get shapes reachable from error shapes that need Display impl.
+        val shapesNeedingDisplay =
+            errorShapes
+                .flatMap { walker.walkShapes(it) }
+                .filter {
+                    (it is StructureShape || it is ListShape || it is UnionShape || it is MapShape || it is EnumShape) &&
+                        it.getTrait<ErrorTrait>() == null
+                }
+
+        // Add synthetic trait to identified shapes.
+        val transformedShapes =
+            shapesNeedingDisplay.mapNotNull { shape ->
+                if (shape !is ToSmithyBuilder<*>) {
+                    UNREACHABLE("Shapes reachable from error shapes should be buildable")
+                    return@mapNotNull null
+                }
+
+                val builder = shape.toBuilder()
+                if (builder is AbstractShapeBuilder<*, *>) {
+                    builder.addTrait(SyntheticImplDisplayTrait()).build()
+                } else {
+                    UNREACHABLE("`impl Display` cannot be generated for ${shape.id}")
+                    null
+                }
+            }
+
+        return ModelTransformer.create().replaceShapes(model, transformedShapes)
+    }
+}

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/NestedErrorStructureTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/NestedErrorStructureTest.kt
@@ -1,0 +1,168 @@
+package software.amazon.smithy.rust.codegen.core.smithy.generators.error
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.ErrorTrait
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.core.rustlang.RustReservedWordConfig
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.generators.StructSettings
+import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.transformers.AddSyntheticTraitForImplDisplay
+import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+import software.amazon.smithy.rust.codegen.core.util.REDACTION
+import software.amazon.smithy.rust.codegen.core.util.getTrait
+import software.amazon.smithy.rust.codegen.core.util.lookup
+import java.io.File
+
+class NestedErrorStructureTest {
+    private var sampleModel = File("../codegen-core/common-test-models/nested-error.smithy").readText().asSmithyModel()
+    private val model = sampleModel.let(AddSyntheticTraitForImplDisplay::transform)
+
+    private val errorWithCompositeShape = model.lookup<StructureShape>("sample#ErrorWithCompositeShape")
+    private val simpleError = model.lookup<StructureShape>("sample#SimpleError")
+    private val errorWithDeepCompositeShape = model.lookup<StructureShape>("sample#ErrorWithDeepCompositeShape")
+    private val composedSensitiveError = model.lookup<StructureShape>("sample#ComposedSensitiveError")
+    private val errorWithNestedError = model.lookup<StructureShape>("sample#ErrorWithNestedError")
+    private val errorMessage = model.lookup<StructureShape>("sample#ErrorMessage")
+    private val wrappedErrorMessage = model.lookup<StructureShape>("sample#WrappedErrorMessage")
+    private val sensitiveMessage = model.lookup<StructureShape>("sample#SensitiveMessage")
+
+    private val allStructures =
+        arrayOf(
+            errorWithCompositeShape,
+            simpleError,
+            errorWithDeepCompositeShape,
+            composedSensitiveError,
+            errorWithNestedError,
+            errorMessage,
+            wrappedErrorMessage,
+            sensitiveMessage,
+        )
+    private val errorShapes =
+        arrayOf(
+            errorWithCompositeShape,
+            simpleError,
+            errorWithDeepCompositeShape,
+            errorWithNestedError,
+            composedSensitiveError,
+        )
+
+    private val rustReservedWordConfig: RustReservedWordConfig =
+        RustReservedWordConfig(
+            structureMemberMap = StructureGenerator.structureMemberNameMap,
+            enumMemberMap = emptyMap(),
+            unionMemberMap = emptyMap(),
+        )
+
+    private val provider = testSymbolProvider(model, rustReservedWordConfig = rustReservedWordConfig)
+
+    private fun structureGenerator(
+        writer: RustWriter,
+        shape: StructureShape,
+    ) = StructureGenerator(model, provider, writer, shape, emptyList(), StructSettings(flattenVecAccessors = true))
+
+    private fun errorImplGenerator(
+        writer: RustWriter,
+        shape: StructureShape,
+    ) = ErrorImplGenerator(model, provider, writer, shape, shape.getTrait<ErrorTrait>()!!, emptyList())
+
+    @Test
+    fun `generate nested error structure`() {
+        val project = TestWorkspace.testProject(provider)
+        // Generate code for each structure.
+        for (shape in allStructures) {
+            project.useShapeWriter(shape) {
+                structureGenerator(this, shape).render()
+            }
+        }
+        // Generate code for each structure marked with an error trait.
+        for (shape in errorShapes) {
+            project.useShapeWriter(shape) {
+                errorImplGenerator(this, shape).render()
+            }
+        }
+
+        project.withModule(
+            RustModule.public("tests"),
+        ) {
+            unitTest("optional_field_prints_none") {
+                rustTemplate(
+                    """
+                        let message = crate::test_model::ErrorMessage {
+                            status_code: "200".to_owned(),
+                            error_message: "this is an error".to_owned(),
+                            request_id: None,
+                            tool_name : "vscode".to_owned()
+                        };
+                        let formatted = format!("{message}");
+                        assert_eq!(formatted, "ErrorMessage {status_code=200, error_message=this is an error, request_id=None, tool_name=vscode}");
+                        """,
+                )
+            }
+            unitTest("optional_field_prints_value") {
+                rustTemplate(
+                    """
+                        let message = crate::test_model::ErrorMessage {
+                            status_code: "200".to_owned(),
+                            error_message: "this is an error".to_owned(),
+                            request_id: Some("1234".to_owned()),
+                            tool_name : "vscode".to_owned()
+                        };
+                        let formatted = format!("{message}");
+                        assert_eq!(formatted, "ErrorMessage {status_code=200, error_message=this is an error, request_id=Some(1234), tool_name=vscode}");
+                        """,
+                )
+            }
+            unitTest("sensitive_is_redacted") {
+                val redacted = REDACTION.removeSurrounding("\"")
+                rustTemplate(
+                    """
+                        let message = crate::test_model::SensitiveMessage {
+                            nothing: Some("some value".to_owned()),
+                            should: Some("some other value".to_owned()),
+                            be_printed: Some("another value".to_owned()),
+                        };
+                        let formatted = format!("{message}");
+                        assert_eq!(formatted, "SensitiveMessage {nothing=$redacted, should=$redacted, be_printed=$redacted}");
+                        """,
+                )
+            }
+            unitTest("nested_error_structure_do_not_implement_display_twice") {
+                val redacted = REDACTION.removeSurrounding("\"")
+                rustTemplate(
+                    """
+                    let message = crate::test_error::ErrorWithNestedError {
+                        message: Some(crate::test_error::ErrorWithDeepCompositeShape {
+                            message: Some(crate::test_model::WrappedErrorMessage {
+                                some_value: Some(123),
+                                contained: Some(crate::test_model::ErrorMessage {
+                                    status_code: "200".to_owned(),
+                                    error_message: "this is an error".to_owned(),
+                                    request_id: Some("1234".to_owned()),
+                                    tool_name: "vscode".to_owned(),
+                                }),
+                            }),
+                        }),
+                    };
+                    let formatted = format!("{message}");
+                    const EXPECTED: &str = "ErrorWithNestedError: ErrorWithDeepCompositeShape: \
+                        WrappedErrorMessage {some_value=Some(123), \
+                        contained=Some(ErrorMessage {status_code=200, \
+                        error_message=this is an error, \
+                        request_id=Some(1234), \
+                        tool_name=vscode})}";
+                    assert_eq!(formatted, EXPECTED);
+                    """,
+                )
+            }
+        }
+
+        project.compileAndTest()
+    }
+}

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
@@ -59,20 +59,27 @@ class PythonConstrainedEnum(
         }
 
     private fun pyEnumName(context: EnumGeneratorContext): Writable =
-        writable {
-            rustBlock(
-                """
-                ##[getter]
-                pub fn name(&self) -> &str
-                """,
-            ) {
-                rustBlock("match self") {
-                    context.sortedMembers.forEach { member ->
-                        val memberName = member.name()?.name
-                        rust("""${context.enumName}::$memberName => ${memberName?.dq()},""")
+        // Only named enums have a `name` property. Do not generate `fn name` for
+        // unnamed enums.
+        if (context.enumTrait.hasNames()) {
+            writable {
+                rustBlock(
+                    """
+                    ##[getter]
+                    pub fn name(&self) -> &str
+                    """,
+                ) {
+                    rustBlock("match self") {
+                        context.sortedMembers.forEach { member ->
+                            val memberName = member.name()?.name
+                            check(memberName != null) { "${context.enumTrait} cannot have null members" }
+                            rust("""${context.enumName}::$memberName => ${memberName?.dq()},""")
+                        }
                     }
                 }
             }
+        } else {
+            writable {}
         }
 }
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -44,6 +44,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.error.ErrorImplGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.lifetimeDeclaration
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolGeneratorFactory
+import software.amazon.smithy.rust.codegen.core.smithy.transformers.AddSyntheticTraitForImplDisplay
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.EventStreamNormalizer
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.RecursiveShapeBoxer
@@ -213,6 +214,9 @@ open class ServerCodegenVisitor(
             .let { ServerProtocolBasedTransformationFactory.transform(it, settings) }
             // Normalize event stream operations
             .let(EventStreamNormalizer::transform)
+            // Add synthetic trait to shapes referenced by error types to ensure they implement Display.
+            // This ensures error formatting works correctly for nested structures.
+            .let(AddSyntheticTraitForImplDisplay::transform)
 
     /**
      * Exposure purely for unit test purposes.

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerErrorReachableShapesDisplayTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerErrorReachableShapesDisplayTest.kt
@@ -1,0 +1,16 @@
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
+import java.io.File
+
+class ServerErrorReachableShapesDisplayTest {
+    @Test
+    fun `composite error shapes are compilable`() {
+        var sampleModel = File("../codegen-core/common-test-models/nested-error.smithy").readText().asSmithyModel()
+        serverIntegrationTest(sampleModel) { _, _ ->
+            // It should compile.
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses the issue where shapes annotated with `@error` can reference other complex shapes in their `message` fields, which previously lacked `Display` implementations.

### Changes

- Added a model transformation (`AddSyntheticTraitForImplDisplay`) to identify all shapes reachable from error shapes
- Added a synthetic trait to mark shapes that need `Display` implementations
- Modified code generation to implement `Display` for all shapes reachable from error shapes
- Ensured consistent formatting for both optional and non-optional fields
- Added tests to verify correct `Display` implementation for nested error structures

### Implementation Details

- The transformation uses a directed graph walker to find all shapes reachable from error shapes
- Only adds implementations to shapes that don't already have the `@error` trait
- Formats all fields consistently, including handling of `Option<T>` values
- Maintains the standard "StructName { field=value }" format across all generated Display implementations

### Testing
- Added test cases for various error structures with different levels of nesting
- Verified that both simple and complex error shapes correctly implement Display
- Confirmed proper handling of optional fields

Fixes #4080 