### PR TITLE
Fix #4082: Remove name() method generation for unnamed Smithy enums

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
@@ -59,20 +59,27 @@ class PythonConstrainedEnum(
         }
 
     private fun pyEnumName(context: EnumGeneratorContext): Writable =
-        writable {
-            rustBlock(
-                """
-                ##[getter]
-                pub fn name(&self) -> &str
-                """,
-            ) {
-                rustBlock("match self") {
-                    context.sortedMembers.forEach { member ->
-                        val memberName = member.name()?.name
-                        rust("""${context.enumName}::$memberName => ${memberName?.dq()},""")
+        // Only named enums have a `name` property. Do not generate `fn name` for
+        // unnamed enums.
+        if (context.enumTrait.hasNames()) {
+            writable {
+                rustBlock(
+                    """
+                    ##[getter]
+                    pub fn name(&self) -> &str
+                    """,
+                ) {
+                    rustBlock("match self") {
+                        context.sortedMembers.forEach { member ->
+                            val memberName = member.name()?.name
+                            check(memberName != null) { "${context.enumTrait} cannot have null members" }
+                            rust("""${context.enumName}::$memberName => ${memberName?.dq()},""")
+                        }
                     }
                 }
             }
+        } else {
+            writable {}
         }
 }
 

--- a/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerTypesTest.kt
+++ b/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerTypesTest.kt
@@ -17,13 +17,14 @@ import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.generat
 import kotlin.io.path.appendText
 
 internal class PythonServerTypesTest {
-    @Test
-    fun `document type`() {
-        val model =
-            """
+    private fun getModel(
+        structures: String,
+        vararg errors: String = emptyArray(),
+    ) = """
             namespace test
 
             use aws.protocols#restJson1
+            use smithy.framework#ValidationException
 
             @restJson1
             service Service {
@@ -36,16 +37,25 @@ internal class PythonServerTypesTest {
             operation Echo {
                 input: EchoInput,
                 output: EchoOutput,
+                ${if (errors.isNotEmpty()) "errors: [${errors.joinToString(", ")}]," else ""}
             }
 
+            $structures
+            """.asSmithyModel()
+
+    @Test
+    fun `document type`() {
+        val model =
+            getModel(
+                """
             structure EchoInput {
                 value: Document,
             }
-
             structure EchoOutput {
                 value: Document,
             }
-            """.asSmithyModel()
+            """,
+            )
 
         val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
         executePythonServerCodegenVisitor(pluginCtx)
@@ -151,26 +161,8 @@ internal class PythonServerTypesTest {
     @Test
     fun `timestamp type`() {
         val model =
-            """
-            namespace test
-
-            use aws.protocols#restJson1
-            use smithy.framework#ValidationException
-
-            @restJson1
-            service Service {
-                operations: [
-                    Echo,
-                ],
-            }
-
-            @http(method: "POST", uri: "/echo")
-            operation Echo {
-                input: EchoInput,
-                output: EchoOutput,
-                errors: [ValidationException],
-            }
-
+            getModel(
+                """
             structure EchoInput {
                 @required
                 value: Timestamp,
@@ -182,7 +174,9 @@ internal class PythonServerTypesTest {
                 value: Timestamp,
                 opt_value: Timestamp,
             }
-            """.asSmithyModel()
+            """,
+                "ValidationException",
+            )
 
         val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
         executePythonServerCodegenVisitor(pluginCtx)
@@ -237,6 +231,52 @@ internal class PythonServerTypesTest {
         }
 
         testDir.resolve("src/service.rs").appendText(writer.toString())
+
+        cargoTest(testDir)
+    }
+
+    @Test
+    fun `unnamed enum type`() {
+        val model =
+            getModel(
+                """
+            structure EchoInput {
+                @required
+                unnamedValue: Choice,
+                unnamedOptValue: Choice,
+                @required
+                namedValue: Choice,
+                namedOptValue: Choice,
+            }
+
+            structure EchoOutput {
+                @required
+                unnamedValue: Choice,
+                unnamedOptValue: Choice,
+                @required
+                namedValue: Choice,
+                namedOptValue: Choice,
+            }
+
+            @enum([
+                {
+                    value: "t2.nano",
+                },
+                {
+                    value: "t2.micro",
+                },
+                {
+                    value: "m256.mega",
+                    deprecated: true
+                }
+            ])
+            string Choice
+            """,
+                "ValidationException",
+            )
+
+        val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
+        executePythonServerCodegenVisitor(pluginCtx)
 
         cargoTest(testDir)
     }


### PR DESCRIPTION
This PR addresses issue #4082 by removing the generation of the `name()` method for unnamed Smithy enums in Python code output.

### Changes

- Modified the enum code generator to check if an enum is unnamed (string enum)
- Skip generating the `name()` method for unnamed enums, as they don't have separate name identifiers
- Retained the `name()` method generation for properly named enums

### Testing

Verified that code generation for unnamed enums no longer includes the problematic `name()` method that was previously trying to reference undefined `null` values.

Closes: $4082