### PR TITLE
Scope `GITHUB_TOKEN` permissions

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -19,6 +19,7 @@ jobs:
   create-backport-pull-request:
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,6 +18,12 @@ concurrency:
 env:
   ecr_repository: public.ecr.aws/w0m4q9l7/github-awslabs-smithy-rs-ci
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   # Build and upload the Docker build image if necessary
   acquire-base-image:
@@ -30,6 +36,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout
       uses: actions/checkout@v4
     - name: Acquire credentials

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -16,6 +16,12 @@ concurrency:
 env:
   ecr_repository: public.ecr.aws/w0m4q9l7/github-awslabs-smithy-rs-ci
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   # This job will, if possible, save a docker login password to the job outputs. The token will
   # be encrypted with the passphrase stored as a GitHub secret. The login password expires after 12h.
@@ -31,6 +37,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Attempt to load a docker login password
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -60,6 +67,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/ci-pr-forks.yml
+++ b/.github/workflows/ci-pr-forks.yml
@@ -12,6 +12,12 @@ concurrency:
   group: ci-forks-yaml-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   # This job detects if the PR made changes to build tools. If it did, then it builds a new
   # build Docker image. Otherwise, it downloads a build image from Public ECR. In both cases,
@@ -19,9 +25,13 @@ jobs:
   acquire-base-image:
     name: Acquire Base Image
     if: ${{ github.event.pull_request.head.repo.full_name != 'smithy-lang/smithy-rs' }}
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,6 +15,12 @@ concurrency:
 env:
   ecr_repository: public.ecr.aws/w0m4q9l7/github-awslabs-smithy-rs-ci
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: write
+
 jobs:
   # This job will, if possible, save a docker login password to the job outputs. The token will
   # be encrypted with the passphrase stored as a GitHub secret. The login password expires after 12h.
@@ -31,6 +37,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Attempt to load a docker login password
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -44,7 +51,6 @@ jobs:
           gpg --symmetric --batch --passphrase "${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}" --output - <(aws ecr-public get-login-password --region us-east-1) | base64 -w0
         )
         echo "docker-login-password=$ENCRYPTED_PAYLOAD" >> $GITHUB_OUTPUT
-
 
   # This job detects if the PR made changes to build tools. If it did, then it builds a new
   # build Docker image. Otherwise, it downloads a build image from Public ECR. In both cases,
@@ -62,6 +68,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -112,6 +119,8 @@ jobs:
 
   semver-checks:
     name: Check PR semver compliance
+    permissions:
+      pull-requests: read
     runs-on: smithy_ubuntu-latest_8-core
     timeout-minutes: 20
     needs:
@@ -124,6 +133,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         - action: generate-aws-sdk-smoketest
         - action: generate-smithy-rs-release
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -127,6 +128,7 @@ jobs:
         - action: check-deterministic-codegen
           runner: smithy_ubuntu-latest_8-core
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -144,6 +146,7 @@ jobs:
     runs-on: smithy_ubuntu-latest_8-core
     timeout-minutes: 30
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -188,6 +191,7 @@ jobs:
         - action: check-aws-sdk-standalone-integration-tests
           runner: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -266,6 +270,7 @@ jobs:
           test_aws_exclude: --exclude aws-inlineable
           test_smithy_rs_exclude: --exclude aws-smithy-http-server-python --exclude aws-smithy-http-server-typescript --exclude aws-smithy-experimental --exclude aws-smithy-http-client
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -343,7 +348,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
+      pull-requests: read
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -368,6 +376,7 @@ jobs:
     if: ${{ !inputs.run_canary }}
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - run: |
         echo "PR bot and canary cannot be invoked from a forked repository. Ask a maintainer to manually invoke them using your PR."
         exit 1
@@ -387,6 +396,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Matrix Success
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Verify jobs succeeded
       # Pinned to commit hash of v1.2.2
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -25,6 +25,7 @@ jobs:
     name: Check that workflow is running in main
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Main branch check
       if: ${{ github.ref_name != 'main' }}
       uses: actions/github-script@v7
@@ -35,10 +36,14 @@ jobs:
   # This job will be a no-op if an image was already built on main by another workflow.
   acquire-base-image:
     name: Acquire Base Image
+    permissions:
+      id-token: write
+      contents: read
     needs:
     - main-branch-check
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -60,6 +65,7 @@ jobs:
     - acquire-base-image
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/credentials-verification.yml
+++ b/.github/workflows/credentials-verification.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository == 'smithy-lang/smithy-rs'
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout smithy-rs
       uses: actions/checkout@v4
     - name: Verify Crates.io Token
@@ -38,6 +39,7 @@ jobs:
     if: github.repository == 'smithy-lang/smithy-rs'
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout smithy-rs
         # To test the validity of the personal access token, we only need to perform checkout with the specified token.
       uses: actions/checkout@v4

--- a/.github/workflows/dry-run-release-scheduled.yml
+++ b/.github/workflows/dry-run-release-scheduled.yml
@@ -11,6 +11,12 @@ on:
     # Runs 00:00 UTC every day
   - cron: 0 0 * * *
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   smithy-rs-scheduled-dry-run-release:
     name: Scheduled dry-run release

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -22,6 +22,12 @@ on:
         type: boolean
         default: true
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   smithy-rs-manual-dry-run-release:
     name: Manual dry run release

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,6 +20,7 @@ jobs:
     if: github.repository == 'smithy-lang/smithy-rs'
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -24,6 +24,7 @@ jobs:
     name: Get PR info
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Get PR info
       id: get-pr-info
       uses: actions/github-script@v7
@@ -47,10 +48,14 @@ jobs:
 
   acquire-base-image:
     name: Acquire Base Image
+    permissions:
+      id-token: write
+      contents: read
     needs:
     - get-pr-info
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -75,6 +80,7 @@ jobs:
     - get-pr-info
     runs-on: smithy_ubuntu-latest_8-core
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -94,6 +100,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -13,11 +13,17 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: read
+
 jobs:
   get-pr-info:
     name: Get PR info
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Get PR info
       id: get-pr-info
       uses: actions/github-script@v7
@@ -45,10 +51,14 @@ jobs:
   # it uploads the image as a build artifact for other jobs to download and use.
   acquire-base-image:
     name: Acquire Base Image
+    permissions:
+      id-token: write
+      contents: read
     needs:
     - get-pr-info
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/manual-update-lockfiles.yml
+++ b/.github/workflows/manual-update-lockfiles.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.base_branch }}
   cancel-in-progress: true

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -17,6 +17,12 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   smithy-rs-prod-release:
     name: Prod release

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -46,6 +46,7 @@ jobs:
     outputs:
       bot-message: ${{ steps.generate-diff.outputs.bot-message }}
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -147,6 +148,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/pull-request-updating-lockfiles.yml
+++ b/.github/workflows/pull-request-updating-lockfiles.yml
@@ -38,6 +38,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Attempt to load a docker login password
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -64,6 +65,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -91,6 +93,7 @@ jobs:
     - acquire-base-image
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout smithy-rs
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
     env:
       ACTOR: ${{ github.actor }}
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Check actor for prod run
       run: |
         set -e
@@ -63,6 +64,9 @@ jobs:
   # This job will be a no-op if an image had already been built.
   acquire-base-image:
     name: Acquire Base Image
+    permissions:
+      id-token: write
+      contents: read
     needs:
     - check-actor-for-prod-run
     # We need `always` here otherwise this job won't run if the previous job has been skipped
@@ -72,6 +76,7 @@ jobs:
       (needs.check-actor-for-prod-run.result == 'success' || needs.check-actor-for-prod-run.result == 'skipped')
     runs-on: smithy_ubuntu-latest_16-core
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -110,6 +115,7 @@ jobs:
     if: always()
     runs-on: smithy_ubuntu-latest_8-core
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
@@ -143,6 +149,7 @@ jobs:
       release_branch: ${{ steps.branch-push.outputs.release_branch }}
       new_release_series: ${{ steps.branch-push.outputs.new_release_series }}
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
@@ -171,6 +178,7 @@ jobs:
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -8,6 +8,10 @@ on:
     # Runs 22:00 UTC every Tuesday
   - cron: 0 22 * * 2
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   cargo-update-runtime-lockfiles-and-sdk-lockfile:
     name: Run cargo update on the runtime lockfiles and the SDK lockfile

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -22,6 +22,7 @@ jobs:
     name: Update `next`
     runs-on: ubuntu-latest
     steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Check out `smithy-rs`
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Description
This PR does a few things related to scoping our tokens:
* Add a `- uses: GitHubSecurityLab/actions-permissions/monitor@v1` to most of our actions so we can get ongoing summaries of the permissions each action is using. Some actions, like Windows tests and the TLS tests, are excluded because they are not supported or the proxy it uses breaks the test.
* Add explicit `permissions` scoping to various jobs that need it.
* Although not part of the PR I have changed our Workflow Permissions (in Settings > Actions > General > Workflow Permissions) from defaulting to Read/Write to Read Only.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* The CI for this PR ran successfully (except the Canary, but that appears to be an issue unrelated to this PR)
* A dry-run release using the workflows from this branch succeeded https://github.com/smithy-lang/smithy-rs/actions/runs/14275005243
* Various other manually runnable actions tested against this branch:
  * Daily credentials verification: https://github.com/smithy-lang/smithy-rs/actions/runs/14288824835
  * Update lockfiles: https://github.com/smithy-lang/smithy-rs/actions/runs/14288809742
  * Invoke canary (failed but not for permissions reasons): https://github.com/smithy-lang/smithy-rs/actions/runs/14288631692

**Note:** I did not test the prod release workflow for obvious reasons. It might need permissions added next time it is invoked. I will cut a release as a follow up to this PR to see if anything needs updating

## Checklist

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
