### PR TITLE
Remove permissions monitor proxy form check semver hazards job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,6 @@ jobs:
     runs-on: smithy_ubuntu-latest_8-core
     timeout-minutes: 30
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
     if: always()
     runs-on: smithy_ubuntu-latest_8-core
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4
       with:
         path: smithy-rs


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The permissions proxy made the the checkout step for the aws-sdk-rust repo much slower. 

Run with proxy took ~1 hour: https://github.com/smithy-lang/smithy-rs/actions/runs/14340833647/job/40199555508
Run without took ~2 minutes: https://github.com/smithy-lang/smithy-rs/actions/runs/14343880973/job/40209574197



----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
