### PR TITLE
Incorporate account ID into service-specific endpoint params

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -137,6 +137,9 @@ fun Model.sdkConfigSetter(
  *  as it is not available when the `read_before_execution` method of the endpoint parameters interceptor is executed.
  */
 class DecoratorForAccountId(private val builtIn: Parameter) : DecoratorForBuiltIn(builtIn) {
+    // TODO(AccountIdBasedRouting): Override `configCustomizations` to avoid rendering `account_id` and `set_account_id`
+    //  on client config builder, and deprecate those that have already been exposed.
+
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return emptyList()
     }
@@ -147,9 +150,7 @@ class DecoratorForAccountId(private val builtIn: Parameter) : DecoratorForBuiltI
         if (rulesetContainsBuiltIn(codegenContext) && builtIn == AwsBuiltIns.ACCOUNT_ID) {
             listOf(
                 object : EndpointCustomization {
-                    override fun overrideResolveEndpointDefaultedTraitMethods(
-                        codegenContext: ClientCodegenContext,
-                    ): Writable? {
+                    override fun overrideFinalizeEndpointParams(codegenContext: ClientCodegenContext): Writable? {
                         val runtimeConfig = codegenContext.runtimeConfig
                         return writable {
                             rustTemplate(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -20,6 +20,8 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointRulesetIndex
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointTypesGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Types
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.symbol
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
@@ -36,6 +38,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.mapRustType
 import software.amazon.smithy.rust.codegen.core.util.PANIC
@@ -126,90 +129,163 @@ fun Model.sdkConfigSetter(
 }
 
 /**
- * Create a client codegen decorator that creates bindings for a builtIn parameter. Optionally, you can provide
- * [clientParam.Builder] which allows control over the config parameter that will be generated. You can also opt
- * to exclude including the extra sections that set the builtIn value on the SdkConfig. This is useful for builtIns
- * that are only minimally supported, like accountId and accountIdEndpointMode.
+ * A custom decorator that creates bindings for the `accountID` built-in parameter.
+ *
+ * The `accountID` parameter is special because:
+ * - It is not exposed in the `SdkConfig` setter.
+ * - It does not require customizations like `loadBuiltInFromServiceConfig`,
+ *  as it is not available when the `read_before_execution` method of the endpoint parameters interceptor is executed.
  */
-fun decoratorForBuiltIn(
-    builtIn: Parameter,
-    clientParamBuilder: ConfigParam.Builder? = null,
-    includeSdkConfigSetter: Boolean = true,
-): ClientCodegenDecorator {
-    val nameOverride = clientParamBuilder?.name
-    val name = nameOverride ?: builtIn.name.rustName()
-    return object : ClientCodegenDecorator {
-        override val name: String = "Auto${builtIn.builtIn.get()}"
-        override val order: Byte = 0
+class DecoratorForAccountId(private val builtIn: Parameter) : DecoratorForBuiltIn(builtIn) {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
+        return emptyList()
+    }
 
-        private fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
-            codegenContext.getBuiltIn(builtIn) != null
-
-        override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
-            if (includeSdkConfigSetter) {
-                return listOfNotNull(
-                    codegenContext.model.sdkConfigSetter(
-                        codegenContext.serviceShape.id,
-                        builtIn,
-                        clientParamBuilder?.name,
-                    ),
-                )
-            } else {
-                return listOf()
-            }
-        }
-
-        override fun configCustomizations(
-            codegenContext: ClientCodegenContext,
-            baseCustomizations: List<ConfigCustomization>,
-        ): List<ConfigCustomization> {
-            return baseCustomizations.extendIf(rulesetContainsBuiltIn(codegenContext)) {
-                standardConfigParam(
-                    clientParamBuilder?.toConfigParam(builtIn, codegenContext.runtimeConfig) ?: ConfigParam.Builder()
-                        .toConfigParam(builtIn, codegenContext.runtimeConfig),
-                )
-            }
-        }
-
-        override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
+    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
+        // TODO(AccountIdBasedRouting): Remove `builtIn == AwsBuiltIns.ACCOUNT_ID` once accountID becomes the only
+        //  usage of this class
+        if (rulesetContainsBuiltIn(codegenContext) && builtIn == AwsBuiltIns.ACCOUNT_ID) {
             listOf(
                 object : EndpointCustomization {
-                    override fun loadBuiltInFromServiceConfig(
-                        parameter: Parameter,
-                        configRef: String,
-                    ): Writable? =
-                        when (parameter.builtIn) {
-                            builtIn.builtIn ->
-                                writable {
-                                    val newtype = configParamNewtype(parameter, name, codegenContext.runtimeConfig)
-                                    val symbol = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
-                                    rustTemplate(
-                                        """$configRef.#{load_from_service_config_layer}""",
-                                        "load_from_service_config_layer" to loadFromConfigBag(symbol.name, newtype),
-                                    )
-                                }
-
-                            else -> null
-                        }
-
-                    override fun setBuiltInOnServiceConfig(
-                        name: String,
-                        value: Node,
-                        configBuilderRef: String,
+                    override fun overrideResolveEndpointDefaultedTraitMethods(
+                        codegenContext: ClientCodegenContext,
                     ): Writable? {
-                        if (name != builtIn.builtIn.get()) {
-                            return null
-                        }
+                        val runtimeConfig = codegenContext.runtimeConfig
                         return writable {
                             rustTemplate(
-                                "let $configBuilderRef = $configBuilderRef.${nameOverride ?: builtIn.name.rustName()}(#{value});",
-                                "value" to value.toWritable(),
+                                """
+                                fn finalize_params<'a>(&'a self, params: &'a mut #{EndpointResolverParams}) -> #{FinalizeParamsFuture}<'a> {
+                                    // This is required to satisfy the borrow checker. By obtaining an `Option<Identity>`,
+                                    // `params` is no longer mutably borrowed in the match expression below.
+                                    // Furthermore, by using `std::mem::replace` with an empty `Identity`, we avoid
+                                    // leaving the sensitive `Identity` inside `params` within `EndpointResolverParams`.
+                                    let identity = params
+                                        .get_property_mut::<#{Identity}>()
+                                        .map(|id| {
+                                            std::mem::replace(
+                                                id,
+                                                #{Identity}::new((), #{None}),
+                                            )
+                                        });
+                                    match (
+                                        params.get_mut::<#{Params}>(),
+                                        identity
+                                            .as_ref()
+                                            .and_then(|id| id.property::<#{AccountId}>()),
+                                    ) {
+                                        (#{Some}(concrete_params), #{Some}(account_id)) => {
+                                            concrete_params.account_id = #{Some}(account_id.as_str().to_string());
+                                        }
+                                        (#{Some}(_), #{None}) => {
+                                            // No account ID; nothing to do.
+                                        }
+                                        (#{None}, _) => {
+                                            return #{FinalizeParamsFuture}::ready(
+                                                #{Err}("service-specific endpoint params was not present".into()),
+                                            );
+                                        }
+                                    }
+                                    #{FinalizeParamsFuture}::ready(#{Ok}(()))
+                                }
+                                """,
+                                *preludeScope,
+                                *Types(runtimeConfig).toArray(),
+                                "AccountId" to
+                                    AwsRuntimeType.awsCredentialTypes(runtimeConfig)
+                                        .resolve("attributes::AccountId"),
+                                "FinalizeParamsFuture" to
+                                    RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                                        .resolve("client::endpoint::FinalizeParamsFuture"),
+                                "Identity" to
+                                    RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                                        .resolve("client::identity::Identity"),
+                                "Params" to EndpointTypesGenerator.fromContext(codegenContext).paramsStruct(),
                             )
                         }
                     }
                 },
             )
+        } else {
+            emptyList()
+        }
+}
+
+/**
+ * A common client codegen decorator that creates bindings for a builtIn parameter. Optionally,
+ * you can provide [clientParam.Builder] which allows control over the config parameter that will be generated.
+ */
+open class DecoratorForBuiltIn(
+    private val builtIn: Parameter,
+    private val clientParamBuilder: ConfigParam.Builder? = null,
+) : ClientCodegenDecorator {
+    override val name: String = "Auto${builtIn.builtIn.get()}"
+    override val order: Byte = 0
+
+    val builtinParamName = clientParamBuilder?.name ?: builtIn.name.rustName()
+
+    protected fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
+        codegenContext.getBuiltIn(builtIn) != null
+
+    override fun extraSections(codegenContext: ClientCodegenContext) =
+        listOfNotNull(
+            codegenContext.model.sdkConfigSetter(
+                codegenContext.serviceShape.id,
+                builtIn,
+                clientParamBuilder?.name,
+            ),
+        )
+
+    override fun configCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ConfigCustomization>,
+    ): List<ConfigCustomization> {
+        return baseCustomizations.extendIf(rulesetContainsBuiltIn(codegenContext)) {
+            standardConfigParam(
+                clientParamBuilder?.toConfigParam(builtIn, codegenContext.runtimeConfig) ?: ConfigParam.Builder()
+                    .toConfigParam(builtIn, codegenContext.runtimeConfig),
+            )
+        }
     }
+
+    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
+        listOf(
+            object : EndpointCustomization {
+                override fun loadBuiltInFromServiceConfig(
+                    parameter: Parameter,
+                    configRef: String,
+                ): Writable? =
+                    when (parameter.builtIn) {
+                        builtIn.builtIn ->
+                            writable {
+                                val newtype =
+                                    configParamNewtype(parameter, builtinParamName, codegenContext.runtimeConfig)
+                                val symbol = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
+                                rustTemplate(
+                                    """$configRef.#{load_from_service_config_layer}""",
+                                    "load_from_service_config_layer" to loadFromConfigBag(symbol.name, newtype),
+                                )
+                            }
+
+                        else -> null
+                    }
+
+                override fun setBuiltInOnServiceConfig(
+                    name: String,
+                    value: Node,
+                    configBuilderRef: String,
+                ): Writable? {
+                    if (name != builtIn.builtIn.get()) {
+                        return null
+                    }
+                    return writable {
+                        rustTemplate(
+                            "let $configBuilderRef = $configBuilderRef.$builtinParamName(#{value});",
+                            "value" to value.toWritable(),
+                        )
+                    }
+                }
+            },
+        )
 }
 
 private val endpointUrlDocs =
@@ -238,15 +314,17 @@ fun Node.toWritable(): Writable {
 
 val PromotedBuiltInsDecorators =
     listOf(
-        decoratorForBuiltIn(AwsBuiltIns.FIPS),
-        decoratorForBuiltIn(AwsBuiltIns.DUALSTACK),
-        decoratorForBuiltIn(
+        DecoratorForBuiltIn(AwsBuiltIns.FIPS),
+        DecoratorForBuiltIn(AwsBuiltIns.DUALSTACK),
+        DecoratorForBuiltIn(
             BuiltIns.SDK_ENDPOINT,
             ConfigParam.Builder()
                 .name("endpoint_url")
                 .type(RuntimeType.String.toSymbol())
                 .setterDocs(endpointUrlDocs),
         ),
-        decoratorForBuiltIn(AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE, null, false),
-        decoratorForBuiltIn(AwsBuiltIns.ACCOUNT_ID, null, false),
+        // TODO(AccountIdBasedRouting): Switch to DecoratorForBuiltIn once account_id_endpoint_mode is exposed
+        //  in SdkConfig
+        DecoratorForAccountId(AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE),
+        DecoratorForAccountId(AwsBuiltIns.ACCOUNT_ID),
     ).toTypedArray()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -81,12 +81,32 @@ interface EndpointCustomization {
     fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> = listOf()
 
     /**
-     * Allows overriding the `finalize_params` method  in the `ResolveEndpoint` trait.
+     * Allows overriding the `finalize_params` method  in the `ResolveEndpoint` trait within
+     * service-specific EndpointResolver, which is rendered in `serviceSpecificEndpointResolver`.
      *
      * `ResolveEndpoint::finalize_params` provides a default no-op implementation,
      * and this customization enables the implementor to provide an alternative implementation.
+     *
+     * Example:
+     * ```kotlin
+     * override fun serviceSpecificEndpointParamsFinalizer(codegenContext: ClientCodegenContext, params: String): Writable? {
+     *     return writable {
+     *         rustTemplate("""
+     *             let identity = $params
+     *                 .get_property_mut::<#{Identity}>();
+     *             // do more things on `params`
+     *         """,
+     *         "Identity" to RuntimeType.smithyRuntimeApiClient(codegenContext.runtimeConfig)
+     *             .resolve("client::identity::Identity"),
+     *         )
+     *     }
+     * }
+     * ```
      */
-    fun overrideFinalizeEndpointParams(codegenContext: ClientCodegenContext): Writable? = null
+    fun serviceSpecificEndpointParamsFinalizer(
+        codegenContext: ClientCodegenContext,
+        params: String,
+    ): Writable? = null
 }
 
 /**

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -81,12 +81,12 @@ interface EndpointCustomization {
     fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> = listOf()
 
     /**
-     * Allows overriding the default implementation of a method in the `ResolveEndpoint` trait.
+     * Allows overriding the `finalize_params` method  in the `ResolveEndpoint` trait.
      *
-     * For example, `ResolveEndpoint::finalize_params` provides a default no-op implementation,
+     * `ResolveEndpoint::finalize_params` provides a default no-op implementation,
      * and this customization enables the implementor to provide an alternative implementation.
      */
-    fun overrideResolveEndpointDefaultedTraitMethods(codegenContext: ClientCodegenContext): Writable? = null
+    fun overrideFinalizeEndpointParams(codegenContext: ClientCodegenContext): Writable? = null
 }
 
 /**

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -79,6 +79,14 @@ interface EndpointCustomization {
      * Provide a list of additional endpoints standard library functions that rules can use
      */
     fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> = listOf()
+
+    /**
+     * Allows overriding the default implementation of a method in the `ResolveEndpoint` trait.
+     *
+     * For example, `ResolveEndpoint::finalize_params` provides a default no-op implementation,
+     * and this customization enables the implementor to provide an alternative implementation.
+     */
+    fun overrideResolveEndpointDefaultedTraitMethods(codegenContext: ClientCodegenContext): Writable? = null
 }
 
 /**

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
@@ -440,7 +440,7 @@ fun ClientCodegenContext.serviceSpecificEndpointResolver(): RuntimeType {
             *codegenScope,
             "override_defaulted_methods" to (
                 endpointCustomizations.firstNotNullOfOrNull {
-                    it.overrideResolveEndpointDefaultedTraitMethods(ctx)
+                    it.overrideFinalizeEndpointParams(ctx)
                 } ?: writable {}
             ),
         )

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.65.0"
+version = "0.65.1"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-http",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -13,13 +13,20 @@ use aws_smithy_types::endpoint::Endpoint;
 use aws_smithy_types::type_erasure::TypeErasedBox;
 use error::InvalidEndpointError;
 use http_02x::uri::Authority;
+use std::any::TypeId;
+use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 
 new_type_future! {
-    #[doc = "Future for [`EndpointResolver::resolve_endpoint`]."]
+    #[doc = "Future for [`ResolveEndpoint::resolve_endpoint`]."]
     pub struct EndpointFuture<'a, Endpoint, BoxError>;
+}
+
+new_type_future! {
+    #[doc = "Future for [`ResolveEndpoint::finalize_params`]."]
+    pub struct FinalizeParamsFuture<'a, (), BoxError>;
 }
 
 /// Parameters originating from the Smithy endpoint ruleset required for endpoint resolution.
@@ -27,18 +34,53 @@ new_type_future! {
 /// The actual endpoint parameters are code generated from the Smithy model, and thus,
 /// are not known to the runtime crates. Hence, this struct is really a new-type around
 /// a [`TypeErasedBox`] that holds the actual concrete parameters in it.
+///
+/// This struct allows the caller to store and retrieve properties of arbitrary types.
+/// These arbitrary properties are intended to be incorporated into the concrete parameters
+/// by [`ResolveEndpoint::finalize_params`].
 #[derive(Debug)]
-pub struct EndpointResolverParams(TypeErasedBox);
+pub struct EndpointResolverParams {
+    inner: TypeErasedBox,
+    property: HashMap<TypeId, TypeErasedBox>,
+}
 
 impl EndpointResolverParams {
     /// Creates a new [`EndpointResolverParams`] from a concrete parameters instance.
     pub fn new<T: fmt::Debug + Send + Sync + 'static>(params: T) -> Self {
-        Self(TypeErasedBox::new(params))
+        Self {
+            inner: TypeErasedBox::new(params),
+            property: HashMap::new(),
+        }
     }
 
     /// Attempts to downcast the underlying concrete parameters to `T` and return it as a reference.
     pub fn get<T: fmt::Debug + Send + Sync + 'static>(&self) -> Option<&T> {
-        self.0.downcast_ref()
+        self.inner.downcast_ref()
+    }
+
+    /// Attempts to downcast the underlying concrete parameters to `T` and return it as a mutable reference.
+    pub fn get_mut<T: fmt::Debug + Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.inner.downcast_mut()
+    }
+
+    /// Sets property of an arbitrary type `T` for the endpoint resolver params.
+    pub fn set_property<T: fmt::Debug + Send + Sync + 'static>(&mut self, t: T) {
+        self.property
+            .insert(TypeId::of::<T>(), TypeErasedBox::new(t));
+    }
+
+    /// Attempts to retrieve a reference to property of a given type `T`.
+    pub fn get_property<T: fmt::Debug + Send + Sync + 'static>(&self) -> Option<&T> {
+        self.property
+            .get(&TypeId::of::<T>())
+            .and_then(|b| b.downcast_ref())
+    }
+
+    /// Attempts to retrieve a mutable reference to property of a given type `T`.
+    pub fn get_property_mut<T: fmt::Debug + Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.property
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|b| b.downcast_mut())
     }
 }
 
@@ -50,6 +92,22 @@ impl Storable for EndpointResolverParams {
 pub trait ResolveEndpoint: Send + Sync + fmt::Debug {
     /// Asynchronously resolves an endpoint to use from the given endpoint parameters.
     fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>;
+
+    /// Finalize the service-specific concrete parameters in `_params`.
+    ///
+    /// The `EndpointResolverParams` may need to include additional data at a later point,
+    /// after its creation in the `read_before_execution` method of an endpoint parameters interceptor.
+    /// Modifying it directly within the [`ResolveEndpoint::resolve_endpoint`] method is not feasible,
+    /// as `params` is passed by reference. This means that incorporating extra data would require
+    /// cloning `params` within the method. However, the return type `EndpointFuture` has a lifetime
+    /// tied to the input argument, making it impossible to return the cloned `params`, as its lifetime
+    /// is scoped to the method.
+    fn finalize_params<'a>(
+        &'a self,
+        _params: &'a mut EndpointResolverParams,
+    ) -> FinalizeParamsFuture<'a> {
+        FinalizeParamsFuture::ready(Ok(()))
+    }
 }
 
 /// Shared endpoint resolver.
@@ -68,6 +126,13 @@ impl SharedEndpointResolver {
 impl ResolveEndpoint for SharedEndpointResolver {
     fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a> {
         self.0.resolve_endpoint(params)
+    }
+
+    fn finalize_params<'a>(
+        &'a self,
+        params: &'a mut EndpointResolverParams,
+    ) -> FinalizeParamsFuture<'a> {
+        self.0.finalize_params(params)
     }
 }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -24,11 +24,6 @@ new_type_future! {
     pub struct EndpointFuture<'a, Endpoint, BoxError>;
 }
 
-new_type_future! {
-    #[doc = "Future for [`ResolveEndpoint::finalize_params`]."]
-    pub struct FinalizeParamsFuture<'a, (), BoxError>;
-}
-
 /// Parameters originating from the Smithy endpoint ruleset required for endpoint resolution.
 ///
 /// The actual endpoint parameters are code generated from the Smithy model, and thus,
@@ -105,8 +100,8 @@ pub trait ResolveEndpoint: Send + Sync + fmt::Debug {
     fn finalize_params<'a>(
         &'a self,
         _params: &'a mut EndpointResolverParams,
-    ) -> FinalizeParamsFuture<'a> {
-        FinalizeParamsFuture::ready(Ok(()))
+    ) -> Result<(), BoxError> {
+        Ok(())
     }
 }
 
@@ -131,7 +126,7 @@ impl ResolveEndpoint for SharedEndpointResolver {
     fn finalize_params<'a>(
         &'a self,
         params: &'a mut EndpointResolverParams,
-    ) -> FinalizeParamsFuture<'a> {
+    ) -> Result<(), BoxError> {
         self.0.finalize_params(params)
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -367,8 +367,7 @@ async fn try_attempt(
             cfg.interceptor_state().store_put(endpoint);
         }
         None => {
-            // TODO(AccountIdBasedRouting): Pass `identity` to `orchestrate_endpoint`.
-            halt_on_err!([ctx] => orchestrate_endpoint(ctx, runtime_components, cfg)
+            halt_on_err!([ctx] => orchestrate_endpoint(identity.clone(), ctx, runtime_components, cfg)
 				    .instrument(debug_span!("orchestrate_endpoint"))
 				    .await
 				    .map_err(OrchestratorError::other));

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -83,7 +83,7 @@ pub(super) async fn orchestrate_endpoint(
 
     let endpoint_resolver = runtime_components.endpoint_resolver();
 
-    endpoint_resolver.finalize_params(params).await?;
+    endpoint_resolver.finalize_params(params)?;
 
     tracing::debug!(endpoint_params = ?params, "resolving endpoint");
     let endpoint = endpoint_resolver.resolve_endpoint(params).await?;

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",


### PR DESCRIPTION
## Motivation and Context
This is part 4 in the series of supporting account ID-based routing (continuation of https://github.com/smithy-lang/smithy-rs/pull/4047, https://github.com/smithy-lang/smithy-rs/pull/4057, and https://github.com/smithy-lang/smithy-rs/pull/4087).
 
## Description
In this PR, we update the orchestrator to pass an Identity, resolved using the resolve_identity function, to service-specific endpoint parameters in the code-generated client SDKs. To support this, we've made changes to the following APIs:
- `EndpointResolverParams::get_mut` provides a mutable reference to the underlying data
- `EndpointResolverParams` can set and get arbitrary properties keyed on a type ID
- `ConfigBag::get_mut` is refactored to extract the portion of the method that doesn't require `Clone` into a separate, reusable method
- The `ResolveEndpoint` trait introduces `finalize_params` method (defaulted to no-op) to allow the caller to incorporate a property stored in `EndpointResolverParams` into its underlying service-specific endpoint params.
 
The following describes the interaction and flow between the above APIs:
1. The orchestrator resolves an `Identity` with the `resolve_identity` function.
2. The orchestrator passes the `Identity` to `orchestrate_endpoint`.
3. The orchestrator stores the resolved Identity in the `EndpointResolverParams` by setting it as a property using `set_property`.
4. The orchestrator calls `SharedEndpointResolver::finalize_params` so that the concrete endpoint resolver struct (i.e. `DowncastParams`) incorporates the `Identity` into service-specific endpoint params.
   - If a service uses the `AccountID` built-in endpoint parameter in endpoint rules, the generated client SDK overrides the `DowncastParams::finalize_params` method to retrieve the account ID from the property of `Identity` and to set it to the service-specific endpoint parameters.
5. The orchestrator calls `SharedEndpointResolver::resolve_endpoint`, with the account ID included in endpoint parameters.
 
## Questions
I made `ResolveEndpoint::finalize_params` be async to allow for future extensibility. To be honest, I _currently_ cannot think of use cases where one wants to do something in an async manner, but I was concerned that if I made the method sync, that would prevent customers from doing so completely, unless we deprecate the method and introduce an async counterpart.
 
## Testing
If we generate the dynamodb SDK using the changes in this PR and run the following experimental test, 

<details>
<summary>Experimental test</summary>

```
#[tokio::test]
async fn experiment() {
    let (http_client, request) = aws_smithy_http_client::test_util::capture_request(None);
    let client = aws_sdk_dynamodb::Client::from_conf(
        aws_sdk_dynamodb::config::Config::builder()
            .region(aws_config::Region::new("us-east-1"))
            .credentials_provider(
                aws_credential_types::Credentials::builder()
                    .account_id("333333333333")
                    .access_key_id("ANOTREAL")
                    .secret_access_key("notrealrnrELgWzOk3IfjzDKtFBhDby")
                    .provider_name("test")
                    .build(),
            )
            .http_client(http_client)
            .build(),
    );
    let mut attr_v = std::collections::HashMap::new();
    attr_v.insert(
        ":s".to_string(),
        aws_sdk_dynamodb::types::AttributeValue::S("value".into()),
    );

    let mut kv = std::collections::HashMap::new();
    kv.insert(
        ":pk".to_string(),
        aws_sdk_dynamodb::types::AttributeValue::M(attr_v),
    );
    let _ = client
        .batch_get_item()
        .request_items(
            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name",
            aws_sdk_dynamodb::types::KeysAndAttributes::builder()
                .keys(kv)
                .build()
                .unwrap(),
        )
        .send()
        .await;
    let _ = dbg!(request.expect_request());
}
``` 
</details>

`dbg!` above shows that the resulting request contains the endpoint URL with the account ID:
```
req = Request {
    ...
    uri: Uri {
        as_string: "https://333333333333.ddb.us-east-1.amazonaws.com/",
        parsed: H0(
            https://333333333333.ddb.us-east-1.amazonaws.com/,
        ),
    },
    ...
```
The DynamoDB endpoint tests include cases that validate behavior based on the account ID, like the one shown [here](https://github.com/awslabs/aws-sdk-rust/blob/d18b1585f06439909aede40fe206121379de0f20/sdk/dynamodb/tests/endpoint_tests.rs#L3027-L3058). Currently, we make these tests pass by explicitly setting the account ID on the client config builder. In the next PR, we plan to remove the `account_id` and `set_account_id` setters from the client config builder.

---
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._