### PR TITLE
Make the behavior of account ID based routing configurable in SDK

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -155,6 +155,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
+ "once_cell",
  "regex-lite",
  "tracing",
 ]
@@ -175,6 +176,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
+ "once_cell",
  "regex-lite",
  "tracing",
 ]
@@ -196,13 +198,14 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
+ "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -214,7 +217,6 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
- "once_cell",
  "percent-encoding",
  "sha2",
  "time",
@@ -232,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -242,7 +244,6 @@ dependencies = [
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -288,10 +289,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aws-smithy-runtime-api",
- "once_cell",
 ]
 
 [[package]]
@@ -335,7 +335,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "once_cell",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -360,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -388,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -66,3 +66,6 @@ pub mod request_min_compression_size_bytes;
 
 /// Default provider chains for request/response checksum configuration
 pub mod checksums;
+
+/// Default provider chain for account-based endpoint mode
+pub mod account_id_endpoint_mode;

--- a/aws/rust-runtime/aws-config/src/default_provider/account_id_endpoint_mode.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/account_id_endpoint_mode.rs
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::provider_config::ProviderConfig;
+use aws_runtime::env_config::EnvConfigValue;
+use aws_smithy_types::error::display::DisplayErrorContext;
+use aws_types::endpoint_config::AccountIdEndpointMode;
+use std::str::FromStr;
+
+mod env {
+    pub(super) const ACCOUNT_ID_ENDPOINT_MODE: &str = "AWS_ACCOUNT_ID_ENDPOINT_MODE";
+}
+
+mod profile_key {
+    pub(super) const ACCOUNT_ID_ENDPOINT_MODE: &str = "account_id_endpoint_mode";
+}
+
+/// Load the value for the Account-based endpoint mode
+///
+/// This checks the following sources:
+/// 1. The environment variable `AWS_ACCOUNT_ID_ENDPOINT_MODE=preferred/disabled/required`
+/// 2. The profile key `account_id_endpoint_mode=preferred/disabled/required`
+///
+/// If invalid values are found, the provider will return `None` and an error will be logged.
+pub(crate) async fn account_id_endpoint_mode_provider(
+    provider_config: &ProviderConfig,
+) -> Option<AccountIdEndpointMode> {
+    let env = provider_config.env();
+    let profiles = provider_config.profile().await;
+
+    EnvConfigValue::new()
+        .env(env::ACCOUNT_ID_ENDPOINT_MODE)
+        .profile(profile_key::ACCOUNT_ID_ENDPOINT_MODE)
+        .validate(&env, profiles, AccountIdEndpointMode::from_str)
+        .map_err(|err| tracing::warn!(err = %DisplayErrorContext(&err), "invalid value for `AccountIdEndpointMode`"))
+        .unwrap_or(None)
+}
+
+#[cfg(test)]
+mod test {
+    use super::account_id_endpoint_mode_provider;
+    use super::env;
+    #[allow(deprecated)]
+    use crate::profile::profile_file::{ProfileFileKind, ProfileFiles};
+    use crate::provider_config::ProviderConfig;
+    use aws_types::os_shim_internal::{Env, Fs};
+    use tracing_test::traced_test;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn log_error_on_invalid_value() {
+        let conf = ProviderConfig::empty().with_env(Env::from_slice(&[(
+            env::ACCOUNT_ID_ENDPOINT_MODE,
+            "invalid",
+        )]));
+        assert_eq!(None, account_id_endpoint_mode_provider(&conf).await);
+        assert!(logs_contain("invalid value for `AccountIdEndpointMode`"));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn environment_priority() {
+        let conf = ProviderConfig::empty()
+            .with_env(Env::from_slice(&[(
+                env::ACCOUNT_ID_ENDPOINT_MODE,
+                "disabled",
+            )]))
+            .with_profile_config(
+                Some(
+                    #[allow(deprecated)]
+                    ProfileFiles::builder()
+                        .with_file(
+                            #[allow(deprecated)]
+                            ProfileFileKind::Config,
+                            "conf",
+                        )
+                        .build(),
+                ),
+                None,
+            )
+            .with_fs(Fs::from_slice(&[(
+                "conf",
+                "[default]\naccount_id_endpoint_mode = required",
+            )]));
+        assert_eq!(
+            "disabled".to_owned(),
+            account_id_endpoint_mode_provider(&conf)
+                .await
+                .unwrap()
+                .to_string(),
+        );
+    }
+}

--- a/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
+++ b/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
@@ -301,6 +301,18 @@ impl Credentials {
     }
 }
 
+#[cfg(feature = "test-util")]
+impl CredentialsBuilder {
+    /// Creates a test `CredentialsBuilder` with the required fields:
+    /// `access_key_id`, `secret_access_key`, and `provider_name`.
+    pub fn for_tests() -> Self {
+        CredentialsBuilder::default()
+            .access_key_id("ANOTREAL")
+            .secret_access_key("notrealrnrELgWzOk3IfjzDKtFBhDby")
+            .provider_name("test")
+    }
+}
+
 impl From<Credentials> for Identity {
     fn from(val: Credentials) -> Self {
         let expiry = val.expiry();

--- a/aws/rust-runtime/aws-inlineable/src/endpoint_auth_plugin.rs
+++ b/aws/rust-runtime/aws-inlineable/src/endpoint_auth_plugin.rs
@@ -102,8 +102,6 @@ impl aws_smithy_runtime_api::client::auth::ResolveAuthSchemeOptions
             let result =
                 merge_auth_scheme_ids(&self.modeled_auth_scheme_ids, endpoint_auth_scheme_ids);
 
-            // TODO(AccountIdBasedRouting): Before merging the final PR to main, experiment pupulating the `properties`
-            // field of `AuthSchemeOption` to avoid the orchestrator relying upon `AuthSchemeEndpointConfig`.
             Ok(result
                 .into_iter()
                 .map(|auth_scheme_id| {

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Cross-service types for the AWS SDK."
 edition = "2021"

--- a/aws/rust-runtime/aws-types/src/endpoint_config.rs
+++ b/aws/rust-runtime/aws-types/src/endpoint_config.rs
@@ -7,6 +7,9 @@
 //!
 //! Parameters require newtypes so they have distinct types when stored in layers in config bag.
 
+use std::fmt;
+use std::str::FromStr;
+
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 
 /// Newtype for `use_fips`
@@ -28,4 +31,124 @@ impl Storable for UseDualStack {
 pub struct EndpointUrl(pub String);
 impl Storable for EndpointUrl {
     type Storer = StoreReplace<EndpointUrl>;
+}
+
+const PREFERRED: &str = "preferred";
+const DISABLED: &str = "disabled";
+const REQUIRED: &str = "required";
+
+/// Setting to control the account ID-based routing behavior.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AccountIdEndpointMode {
+    /// The endpoint should include account ID if available.
+    #[default]
+    Preferred,
+    /// A resolved endpoint does not include account ID.
+    Disabled,
+    /// The endpoint must include account ID. If the account ID isn't available, the SDK throws an error.
+    Required,
+}
+
+impl AccountIdEndpointMode {
+    fn all_variants() -> [AccountIdEndpointMode; 3] {
+        use AccountIdEndpointMode::*;
+        [Preferred, Disabled, Required]
+    }
+}
+
+impl Storable for AccountIdEndpointMode {
+    type Storer = StoreReplace<Self>;
+}
+
+impl fmt::Display for AccountIdEndpointMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        use AccountIdEndpointMode::*;
+        write!(
+            f,
+            "{}",
+            match self {
+                Preferred => "preferred",
+                Disabled => "disabled",
+                Required => "required",
+            }
+        )
+    }
+}
+
+impl FromStr for AccountIdEndpointMode {
+    type Err = AccountIdEndpointModeParseError;
+
+    fn from_str(mode_str: &str) -> Result<Self, Self::Err> {
+        if mode_str.eq_ignore_ascii_case(PREFERRED) {
+            Ok(Self::Preferred)
+        } else if mode_str.eq_ignore_ascii_case(DISABLED) {
+            Ok(Self::Disabled)
+        } else if mode_str.eq_ignore_ascii_case(REQUIRED) {
+            Ok(Self::Required)
+        } else {
+            Err(AccountIdEndpointModeParseError::new(mode_str))
+        }
+    }
+}
+
+/// Error encountered when failing to parse a string into [`AccountIdEndpointMode`].
+#[derive(Debug)]
+pub struct AccountIdEndpointModeParseError {
+    mode_string: String,
+}
+
+impl AccountIdEndpointModeParseError {
+    fn new(mode_string: impl Into<String>) -> Self {
+        Self {
+            mode_string: mode_string.into(),
+        }
+    }
+}
+
+impl fmt::Display for AccountIdEndpointModeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "error parsing string `{}` as `AccountIdEndpointMode`, valid options are: {:#?}",
+            self.mode_string,
+            AccountIdEndpointMode::all_variants().map(|mode| mode.to_string())
+        )
+    }
+}
+
+impl std::error::Error for AccountIdEndpointModeParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ok_account_id_endpoint_mode() {
+        assert_eq!(
+            AccountIdEndpointMode::Preferred,
+            AccountIdEndpointMode::from_str("preferred").unwrap()
+        );
+        assert_eq!(
+            AccountIdEndpointMode::Disabled,
+            AccountIdEndpointMode::from_str("disabled").unwrap()
+        );
+        assert_eq!(
+            AccountIdEndpointMode::Required,
+            AccountIdEndpointMode::from_str("required").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_err_account_id_endpoint_mode() {
+        let err = AccountIdEndpointMode::from_str("invalid").err().unwrap();
+        assert_eq!(
+            r#"error parsing string `invalid` as `AccountIdEndpointMode`, valid options are: [
+    "preferred",
+    "disabled",
+    "required",
+]"#,
+            format!("{err}")
+        );
+    }
 }

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -11,6 +11,7 @@
 
 use crate::app_name::AppName;
 use crate::docs_for;
+use crate::endpoint_config::AccountIdEndpointMode;
 use crate::origin::Origin;
 use crate::region::Region;
 use crate::service_config::LoadServiceConfig;
@@ -70,6 +71,17 @@ This is useful for request bodies because, for small request bodies, compression
 **Only some services support request compression.** For services
 that don't support request compression, this setting does nothing.
 " };
+        (account_id_endpoint_mode) => {
+"Controls the account ID-based routing behavior.
+
+By default, the routing behavior is set to `preferred`.
+Customers can adjust this setting to other values to switch between different routing patterns or temporarily disable the feature.
+
+See the developer guide on [account-based endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html)
+for more information.
+
+For services that do not use the account-based endpoints, this setting does nothing.
+" };
     }
 }
 
@@ -81,6 +93,7 @@ pub struct SdkConfig {
     credentials_provider: Option<SharedCredentialsProvider>,
     token_provider: Option<SharedTokenProvider>,
     region: Option<Region>,
+    account_id_endpoint_mode: Option<AccountIdEndpointMode>,
     endpoint_url: Option<String>,
     retry_config: Option<RetryConfig>,
     sleep_impl: Option<SharedAsyncSleep>,
@@ -111,6 +124,7 @@ pub struct Builder {
     credentials_provider: Option<SharedCredentialsProvider>,
     token_provider: Option<SharedTokenProvider>,
     region: Option<Region>,
+    account_id_endpoint_mode: Option<AccountIdEndpointMode>,
     endpoint_url: Option<String>,
     retry_config: Option<RetryConfig>,
     sleep_impl: Option<SharedAsyncSleep>,
@@ -161,6 +175,24 @@ impl Builder {
     /// ```
     pub fn set_region(&mut self, region: impl Into<Option<Region>>) -> &mut Self {
         self.region = region.into();
+        self
+    }
+
+    #[doc = docs_for!(account_id_endpoint_mode)]
+    pub fn account_id_endpoint_mode(
+        mut self,
+        account_id_endpoint_mode: AccountIdEndpointMode,
+    ) -> Self {
+        self.set_account_id_endpoint_mode(Some(account_id_endpoint_mode));
+        self
+    }
+
+    #[doc = docs_for!(account_id_endpoint_mode)]
+    pub fn set_account_id_endpoint_mode(
+        &mut self,
+        account_id_endpoint_mode: Option<AccountIdEndpointMode>,
+    ) -> &mut Self {
+        self.account_id_endpoint_mode = account_id_endpoint_mode;
         self
     }
 
@@ -761,6 +793,7 @@ impl Builder {
             credentials_provider: self.credentials_provider,
             token_provider: self.token_provider,
             region: self.region,
+            account_id_endpoint_mode: self.account_id_endpoint_mode,
             endpoint_url: self.endpoint_url,
             retry_config: self.retry_config,
             sleep_impl: self.sleep_impl,
@@ -856,6 +889,11 @@ impl SdkConfig {
     /// Configured region
     pub fn region(&self) -> Option<&Region> {
         self.region.as_ref()
+    }
+
+    /// Configured account ID endpoint mode
+    pub fn account_id_endpoint_mode(&self) -> Option<&AccountIdEndpointMode> {
+        self.account_id_endpoint_mode.as_ref()
     }
 
     /// Configured endpoint URL
@@ -986,6 +1024,7 @@ impl SdkConfig {
             credentials_provider: self.credentials_provider,
             token_provider: self.token_provider,
             region: self.region,
+            account_id_endpoint_mode: self.account_id_endpoint_mode,
             endpoint_url: self.endpoint_url,
             retry_config: self.retry_config,
             sleep_impl: self.sleep_impl,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AccountIdEndpointParamsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AccountIdEndpointParamsDecorator.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.rulesengine.aws.language.functions.AwsBuiltIns
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ConditionalDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointTypesGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.docsOrFallback
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.orNull
+
+/**
+ * Client codegen decorator for the `AWS::Auth::AccountId` endpoint built-in parameter.
+ *
+ * The `AccountID` parameter is special because:
+ * - The setters are neither exposed in `SdkConfig` nor in config builder.
+ * - It does not require customizations like `loadBuiltInFromServiceConfig`,
+ *  as it is not available when the `read_before_execution` method of the endpoint parameters interceptor is executed
+ *  (the identity from which an account ID is retrieved has not been resolved yet).
+ */
+class AccountIdBuiltInParamDecorator : ConditionalDecorator(
+    predicate =
+        { codegenContext, _ ->
+            codegenContext?.let {
+                codegenContext.getBuiltIn(AwsBuiltIns.ACCOUNT_ID) != null
+            } ?: false
+        },
+    delegateTo =
+        object : ClientCodegenDecorator {
+            override val name: String get() = "AccountIdBuiltInParamDecorator"
+            override val order: Byte = 0
+
+            override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
+                listOf(
+                    object : EndpointCustomization {
+                        override fun serviceSpecificEndpointParamsFinalizer(
+                            codegenContext: ClientCodegenContext,
+                            params: String,
+                        ): Writable? {
+                            val runtimeConfig = codegenContext.runtimeConfig
+                            return writable {
+                                rustTemplate(
+                                    """
+                                    // This is required to satisfy the borrow checker. By obtaining an `Option<Identity>`,
+                                    // `params` is no longer mutably borrowed in the match expression below.
+                                    // Furthermore, by using `std::mem::replace` with an empty `Identity`, we avoid
+                                    // leaving the sensitive `Identity` inside `params` within `EndpointResolverParams`.
+                                    let identity = $params
+                                        .get_property_mut::<#{Identity}>()
+                                        .map(|id| {
+                                            std::mem::replace(
+                                                id,
+                                                #{Identity}::new((), #{None}),
+                                            )
+                                        });
+                                    match (
+                                        $params.get_mut::<#{Params}>(),
+                                        identity
+                                            .as_ref()
+                                            .and_then(|id| id.property::<#{AccountId}>()),
+                                    ) {
+                                        (#{Some}(concrete_params), #{Some}(account_id)) => {
+                                            concrete_params.account_id = #{Some}(account_id.as_str().to_string());
+                                        }
+                                        (#{Some}(_), #{None}) => {
+                                            // No account ID; nothing to do.
+                                        }
+                                        (#{None}, _) => {
+                                            return #{Err}("service-specific endpoint params was not present".into());
+                                        }
+                                    }
+                                    """,
+                                    *preludeScope,
+                                    "AccountId" to
+                                        AwsRuntimeType.awsCredentialTypes(runtimeConfig)
+                                            .resolve("attributes::AccountId"),
+                                    "Identity" to
+                                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                                            .resolve("client::identity::Identity"),
+                                    "Params" to EndpointTypesGenerator.fromContext(codegenContext).paramsStruct(),
+                                )
+                            }
+                        }
+                    },
+                )
+        },
+)
+
+/**
+ * Client codegen decorator for the `AWS::Auth::AccountIdEndpointMode` endpoint built-in parameter.
+ *
+ * The `AccountIdEndpointMode` parameter is special because:
+ * - The corresponding Rust type is an enum containing valid values
+ */
+class AccountIdEndpointModeBuiltInParamDecorator : ConditionalDecorator(
+    predicate =
+        { codegenContext, _ ->
+            codegenContext?.let {
+                codegenContext.getBuiltIn(AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE) != null
+            } ?: false
+        },
+    delegateTo =
+        object : ClientCodegenDecorator {
+            override val name: String get() = "AccountIdEndpointModeBuiltInParamDecorator"
+            override val order: Byte = 0
+            private val paramName = AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE.name.rustName()
+
+            override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
+                listOf(
+                    adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+                        rust("${section.serviceConfigBuilder}.set_$paramName(${section.sdkConfig}.$paramName().cloned());")
+                    },
+                )
+
+            override fun configCustomizations(
+                codegenContext: ClientCodegenContext,
+                baseCustomizations: List<ConfigCustomization>,
+            ): List<ConfigCustomization> {
+                return baseCustomizations +
+                    object : ConfigCustomization() {
+                        private val codegenScope =
+                            arrayOf(
+                                *preludeScope,
+                                "AccountIdEndpointMode" to
+                                    AwsRuntimeType.awsTypes(codegenContext.runtimeConfig)
+                                        .resolve("endpoint_config::AccountIdEndpointMode"),
+                            )
+
+                        override fun section(section: ServiceConfig): Writable {
+                            return when (section) {
+                                ServiceConfig.BuilderImpl ->
+                                    writable {
+                                        val docs = AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE.documentation.orNull()
+                                        docsOrFallback(docs)
+                                        rustTemplate(
+                                            """
+                                            pub fn $paramName(mut self, $paramName: #{AccountIdEndpointMode}) -> Self {
+                                                self.set_$paramName(#{Some}($paramName));
+                                                self
+                                            }""",
+                                            *codegenScope,
+                                        )
+
+                                        docsOrFallback(docs)
+                                        rustTemplate(
+                                            """
+                                            pub fn set_$paramName(&mut self, $paramName: #{Option}<#{AccountIdEndpointMode}>) -> &mut Self {
+                                                self.config.store_or_unset($paramName);
+                                                self
+                                            }
+                                            """,
+                                            *codegenScope,
+                                        )
+                                    }
+
+                                is ServiceConfig.BuilderFromConfigBag ->
+                                    writable {
+                                        rustTemplate(
+                                            """
+                                            ${section.builder}.set_$paramName(${section.configBag}.load::<#{AccountIdEndpointMode}>().cloned());
+                                            """,
+                                            "AccountIdEndpointMode" to
+                                                AwsRuntimeType.awsTypes(codegenContext.runtimeConfig)
+                                                    .resolve("endpoint_config::AccountIdEndpointMode"),
+                                        )
+                                    }
+
+                                else -> emptySection
+                            }
+                        }
+                    }
+            }
+
+            override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
+                listOf(
+                    object : EndpointCustomization {
+                        private val codegenScope =
+                            arrayOf(
+                                *preludeScope,
+                                "AccountIdEndpointMode" to
+                                    AwsRuntimeType.awsTypes(codegenContext.runtimeConfig)
+                                        .resolve("endpoint_config::AccountIdEndpointMode"),
+                            )
+
+                        override fun loadBuiltInFromServiceConfig(
+                            parameter: Parameter,
+                            configRef: String,
+                        ): Writable? =
+                            when (parameter) {
+                                AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE -> {
+                                    writable {
+                                        rustTemplate(
+                                            "#{Some}($configRef.load::<#{AccountIdEndpointMode}>().cloned().unwrap_or_default().to_string())",
+                                            *codegenScope,
+                                        )
+                                    }
+                                }
+
+                                else -> null
+                            }
+
+                        // This override is for endpoint_tests.
+                        override fun setBuiltInOnServiceConfig(
+                            name: String,
+                            value: Node,
+                            configBuilderRef: String,
+                        ): Writable? {
+                            if (name != AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE.builtIn.get()) {
+                                return null
+                            }
+                            return writable {
+                                rustTemplate(
+                                    """let $configBuilderRef = $configBuilderRef.account_id_endpoint_mode(<#{AccountIdEndpointMode} as std::str::FromStr>::from_str(${value.expectStringNode().value.dq()}).expect("should parse"));""",
+                                    *codegenScope,
+                                )
+                            }
+                        }
+                    },
+                )
+        },
+)

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -20,7 +20,6 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointRulesetIndex
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointTypesGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.symbol
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
@@ -37,7 +36,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.mapRustType
 import software.amazon.smithy.rust.codegen.core.util.PANIC
@@ -128,158 +126,82 @@ fun Model.sdkConfigSetter(
 }
 
 /**
- * A custom decorator that creates bindings for the `accountID` built-in parameter.
- *
- * The `accountID` parameter is special because:
- * - It is not exposed in the `SdkConfig` setter.
- * - It does not require customizations like `loadBuiltInFromServiceConfig`,
- *  as it is not available when the `read_before_execution` method of the endpoint parameters interceptor is executed.
+ * Create a client codegen decorator that creates bindings for a builtIn parameter. Optionally, you can provide
+ * [clientParam.Builder] which allows control over the config parameter that will be generated.
  */
-class DecoratorForAccountId(private val builtIn: Parameter) : DecoratorForBuiltIn(builtIn) {
-    // TODO(AccountIdBasedRouting): Override `configCustomizations` to avoid rendering `account_id` and `set_account_id`
-    //  on client config builder, and deprecate those that have already been exposed.
+fun decoratorForBuiltIn(
+    builtIn: Parameter,
+    clientParamBuilder: ConfigParam.Builder? = null,
+): ClientCodegenDecorator {
+    val nameOverride = clientParamBuilder?.name
+    val name = nameOverride ?: builtIn.name.rustName()
+    return object : ClientCodegenDecorator {
+        override val name: String = "Auto${builtIn.builtIn.get()}"
+        override val order: Byte = 0
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
-        return emptyList()
-    }
+        private fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
+            codegenContext.getBuiltIn(builtIn) != null
 
-    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
-        // TODO(AccountIdBasedRouting): Remove `builtIn == AwsBuiltIns.ACCOUNT_ID` once accountID becomes the only
-        //  usage of this class
-        if (rulesetContainsBuiltIn(codegenContext) && builtIn == AwsBuiltIns.ACCOUNT_ID) {
+        override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
+            listOfNotNull(
+                codegenContext.model.sdkConfigSetter(
+                    codegenContext.serviceShape.id,
+                    builtIn,
+                    clientParamBuilder?.name,
+                ),
+            )
+
+        override fun configCustomizations(
+            codegenContext: ClientCodegenContext,
+            baseCustomizations: List<ConfigCustomization>,
+        ): List<ConfigCustomization> {
+            return baseCustomizations.extendIf(rulesetContainsBuiltIn(codegenContext)) {
+                standardConfigParam(
+                    clientParamBuilder?.toConfigParam(builtIn, codegenContext.runtimeConfig) ?: ConfigParam.Builder()
+                        .toConfigParam(builtIn, codegenContext.runtimeConfig),
+                )
+            }
+        }
+
+        override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
             listOf(
                 object : EndpointCustomization {
-                    override fun serviceSpecificEndpointParamsFinalizer(
-                        codegenContext: ClientCodegenContext,
-                        params: String,
+                    override fun loadBuiltInFromServiceConfig(
+                        parameter: Parameter,
+                        configRef: String,
+                    ): Writable? =
+                        when (parameter.builtIn) {
+                            builtIn.builtIn ->
+                                writable {
+                                    val newtype = configParamNewtype(parameter, name, codegenContext.runtimeConfig)
+                                    val symbol = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
+                                    rustTemplate(
+                                        """$configRef.#{load_from_service_config_layer}""",
+                                        "load_from_service_config_layer" to loadFromConfigBag(symbol.name, newtype),
+                                    )
+                                }
+
+                            else -> null
+                        }
+
+                    override fun setBuiltInOnServiceConfig(
+                        name: String,
+                        value: Node,
+                        configBuilderRef: String,
                     ): Writable? {
-                        val runtimeConfig = codegenContext.runtimeConfig
+                        if (name != builtIn.builtIn.get()) {
+                            return null
+                        }
                         return writable {
                             rustTemplate(
-                                """
-                                // This is required to satisfy the borrow checker. By obtaining an `Option<Identity>`,
-                                // `params` is no longer mutably borrowed in the match expression below.
-                                // Furthermore, by using `std::mem::replace` with an empty `Identity`, we avoid
-                                // leaving the sensitive `Identity` inside `params` within `EndpointResolverParams`.
-                                let identity = $params
-                                    .get_property_mut::<#{Identity}>()
-                                    .map(|id| {
-                                        std::mem::replace(
-                                            id,
-                                            #{Identity}::new((), #{None}),
-                                        )
-                                    });
-                                match (
-                                    $params.get_mut::<#{Params}>(),
-                                    identity
-                                        .as_ref()
-                                        .and_then(|id| id.property::<#{AccountId}>()),
-                                ) {
-                                    (#{Some}(concrete_params), #{Some}(account_id)) => {
-                                        concrete_params.account_id = #{Some}(account_id.as_str().to_string());
-                                    }
-                                    (#{Some}(_), #{None}) => {
-                                        // No account ID; nothing to do.
-                                    }
-                                    (#{None}, _) => {
-                                        return #{Err}("service-specific endpoint params was not present".into());
-                                    }
-                                }
-                                """,
-                                *preludeScope,
-                                "AccountId" to
-                                    AwsRuntimeType.awsCredentialTypes(runtimeConfig)
-                                        .resolve("attributes::AccountId"),
-                                "Identity" to
-                                    RuntimeType.smithyRuntimeApiClient(runtimeConfig)
-                                        .resolve("client::identity::Identity"),
-                                "Params" to EndpointTypesGenerator.fromContext(codegenContext).paramsStruct(),
+                                "let $configBuilderRef = $configBuilderRef.${nameOverride ?: builtIn.name.rustName()}(#{value});",
+                                "value" to value.toWritable(),
                             )
                         }
                     }
                 },
             )
-        } else {
-            emptyList()
-        }
-}
-
-/**
- * A common client codegen decorator that creates bindings for a builtIn parameter. Optionally,
- * you can provide [clientParam.Builder] which allows control over the config parameter that will be generated.
- */
-open class DecoratorForBuiltIn(
-    private val builtIn: Parameter,
-    private val clientParamBuilder: ConfigParam.Builder? = null,
-) : ClientCodegenDecorator {
-    override val name: String = "Auto${builtIn.builtIn.get()}"
-    override val order: Byte = 0
-
-    val builtinParamName = clientParamBuilder?.name ?: builtIn.name.rustName()
-
-    protected fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
-        codegenContext.getBuiltIn(builtIn) != null
-
-    override fun extraSections(codegenContext: ClientCodegenContext) =
-        listOfNotNull(
-            codegenContext.model.sdkConfigSetter(
-                codegenContext.serviceShape.id,
-                builtIn,
-                clientParamBuilder?.name,
-            ),
-        )
-
-    override fun configCustomizations(
-        codegenContext: ClientCodegenContext,
-        baseCustomizations: List<ConfigCustomization>,
-    ): List<ConfigCustomization> {
-        return baseCustomizations.extendIf(rulesetContainsBuiltIn(codegenContext)) {
-            standardConfigParam(
-                clientParamBuilder?.toConfigParam(builtIn, codegenContext.runtimeConfig) ?: ConfigParam.Builder()
-                    .toConfigParam(builtIn, codegenContext.runtimeConfig),
-            )
-        }
     }
-
-    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> =
-        listOf(
-            object : EndpointCustomization {
-                override fun loadBuiltInFromServiceConfig(
-                    parameter: Parameter,
-                    configRef: String,
-                ): Writable? =
-                    when (parameter.builtIn) {
-                        builtIn.builtIn ->
-                            writable {
-                                val newtype =
-                                    configParamNewtype(parameter, builtinParamName, codegenContext.runtimeConfig)
-                                val symbol = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
-                                rustTemplate(
-                                    """$configRef.#{load_from_service_config_layer}""",
-                                    "load_from_service_config_layer" to loadFromConfigBag(symbol.name, newtype),
-                                )
-                            }
-
-                        else -> null
-                    }
-
-                override fun setBuiltInOnServiceConfig(
-                    name: String,
-                    value: Node,
-                    configBuilderRef: String,
-                ): Writable? {
-                    if (name != builtIn.builtIn.get()) {
-                        return null
-                    }
-                    return writable {
-                        rustTemplate(
-                            "let $configBuilderRef = $configBuilderRef.$builtinParamName(#{value});",
-                            "value" to value.toWritable(),
-                        )
-                    }
-                }
-            },
-        )
 }
 
 private val endpointUrlDocs =
@@ -308,17 +230,15 @@ fun Node.toWritable(): Writable {
 
 val PromotedBuiltInsDecorators =
     listOf(
-        DecoratorForBuiltIn(AwsBuiltIns.FIPS),
-        DecoratorForBuiltIn(AwsBuiltIns.DUALSTACK),
-        DecoratorForBuiltIn(
+        decoratorForBuiltIn(AwsBuiltIns.FIPS),
+        decoratorForBuiltIn(AwsBuiltIns.DUALSTACK),
+        decoratorForBuiltIn(
             BuiltIns.SDK_ENDPOINT,
             ConfigParam.Builder()
                 .name("endpoint_url")
                 .type(RuntimeType.String.toSymbol())
                 .setterDocs(endpointUrlDocs),
         ),
-        // TODO(AccountIdBasedRouting): Switch to DecoratorForBuiltIn once account_id_endpoint_mode is exposed
-        //  in SdkConfig
-        DecoratorForAccountId(AwsBuiltIns.ACCOUNT_ID_ENDPOINT_MODE),
-        DecoratorForAccountId(AwsBuiltIns.ACCOUNT_ID),
+        AccountIdEndpointModeBuiltInParamDecorator(),
+        AccountIdBuiltInParamDecorator(),
     ).toTypedArray()

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecoratorTest.kt
@@ -7,98 +7,83 @@ package software.amazon.smithy.rustsdk
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+import software.amazon.smithy.rust.codegen.core.testutil.tokioTest
+import software.amazon.smithy.rust.codegen.core.util.dq
 
 class EndpointBuiltInsDecoratorTest {
-    private val endpointUrlModel =
-        """
-        namespace test
-
-        use aws.api#service
-        use aws.auth#sigv4
-        use aws.protocols#restJson1
-        use smithy.rules#endpointRuleSet
-        use smithy.rules#staticContextParams
-
-        @service(sdkId: "dontcare")
-        @restJson1
-        @sigv4(name: "dontcare")
-        @auth([sigv4])
-        @suppress(["RuleSetAwsBuiltIn.AWS::Auth::AccountId", "RuleSetAwsBuiltIn.AWS::Auth::AccountIdEndpointMode"])
-        @endpointRuleSet({
-            "version": "1.0"
-            "parameters": {
-                "endpoint": { "required": false, "type": "string", "builtIn": "SDK::Endpoint" },
-                "region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
-                "accountId": { "required": false, "type": "String", "builtIn": "AWS::Auth::AccountId" },
-                "accountIdEndpointMode": { "required": false, "type": "String", "builtIn": "AWS::Auth::AccountIdEndpointMode" },
-            }
-            "rules": [
-                {
-                    "type": "endpoint"
-                    "conditions": [
-                        {"fn": "isSet", "argv": [{"ref": "endpoint"}]},
-                        {"fn": "isSet", "argv": [{"ref": "region"}]},
-                        {
-                            "fn": "not",
-                            "argv": [
-                                {
-                                    "fn": "isSet",
-                                    "argv": [
-                                        {"ref": "accountId"}
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "endpoint": {
-                        "url": "{endpoint}"
-                        "properties": {
-                            "authSchemes": [{"name": "sigv4","signingRegion": "{region}", "signingName": "dontcare"}]
-                        }
-                    }
-                },
-                {
-                    "type": "endpoint"
-                    "conditions": [
-                        {"fn": "isSet", "argv": [{"ref": "region"}]},
-                    ],
-                    "endpoint": {
-                        "url": "https://WRONG/"
-                        "properties": {
-                            "authSchemes": [{"name": "sigv4", "signingRegion": "{region}", "signingName": "dontcare"}]
-                        }
-                    }
-                }
-            ]
-        })
-        service TestService {
-            version: "2023-01-01",
-            operations: [SomeOperation]
-        }
-
-        structure SomeOutput {
-            someAttribute: Long,
-            someVal: String
-        }
-
-        @http(uri: "/SomeOperation", method: "GET")
-        @optionalAuth
-        @staticContextParams(
-            accountIdEndpointMode: {
-                value: "some value"
-            }
-        )
-        operation SomeOperation {
-            output: SomeOutput
-        }
-        """.asSmithyModel()
-
     @Test
     fun endpointUrlBuiltInWorksEndToEnd() {
+        val endpointUrlModel =
+            """
+            namespace test
+
+            use aws.api#service
+            use aws.auth#sigv4
+            use aws.protocols#restJson1
+            use smithy.rules#endpointRuleSet
+
+            @service(sdkId: "dontcare")
+            @restJson1
+            @sigv4(name: "dontcare")
+            @auth([sigv4])
+            @endpointRuleSet({
+                "version": "1.0"
+                "parameters": {
+                    "endpoint": { "required": false, "type": "string", "builtIn": "SDK::Endpoint" },
+                    "region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+                }
+                "rules": [
+                    {
+                        "type": "endpoint"
+                        "conditions": [
+                            {"fn": "isSet", "argv": [{"ref": "endpoint"}]},
+                            {"fn": "isSet", "argv": [{"ref": "region"}]},
+                        ],
+                        "endpoint": {
+                            "url": "{endpoint}"
+                            "properties": {
+                                "authSchemes": [{"name": "sigv4","signingRegion": "{region}", "signingName": "dontcare"}]
+                            }
+                        }
+                    },
+                    {
+                        "type": "endpoint"
+                        "conditions": [
+                            {"fn": "isSet", "argv": [{"ref": "region"}]},
+                        ],
+                        "endpoint": {
+                            "url": "https://WRONG/"
+                            "properties": {
+                                "authSchemes": [{"name": "sigv4", "signingRegion": "{region}", "signingName": "dontcare"}]
+                            }
+                        }
+                    }
+                ]
+            })
+            service TestService {
+                version: "2023-01-01",
+                operations: [SomeOperation]
+            }
+
+            structure SomeOutput {
+                someAttribute: Long,
+                someVal: String
+            }
+
+            @http(uri: "/SomeOperation", method: "GET")
+            @optionalAuth
+            operation SomeOperation {
+                output: SomeOutput
+            }
+            """.asSmithyModel(smithyVersion = "2.0")
+
         awsSdkIntegrationTest(endpointUrlModel) { codegenContext, rustCrate ->
             rustCrate.integrationTest("endpoint_url_built_in_works") {
                 val module = codegenContext.moduleUseName()
@@ -138,5 +123,149 @@ class EndpointBuiltInsDecoratorTest {
                 )
             }
         }
+    }
+
+    private fun modelWithAccountId(authAnnotation: String? = null) =
+        """
+        namespace test
+
+        use aws.api#service
+        use aws.protocols#restJson1
+        use smithy.rules#endpointRuleSet
+
+        @service(sdkId: "dontcare")
+        @restJson1
+        """ + (authAnnotation.orEmpty()) +
+            """
+            @suppress(["RuleSetAwsBuiltIn.AWS::Auth::AccountId", "RuleSetAwsBuiltIn.AWS::Auth::AccountIdEndpointMode"])
+            @endpointRuleSet({
+                "version": "1.0"
+                "parameters": {
+                    "endpoint": { "required": false, "type": "string", "builtIn": "SDK::Endpoint" },
+                    "region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+                    "accountId": { "required": false, "type": "String", "builtIn": "AWS::Auth::AccountId" },
+                    "accountIdEndpointMode": { "required": false, "type": "String", "builtIn": "AWS::Auth::AccountIdEndpointMode" },
+                }
+                "rules": [
+                    {
+                        "type": "endpoint"
+                        "conditions": [
+                            {"fn": "isSet", "argv": [{"ref": "region"}]},
+                            {
+                                "fn": "not",
+                                "argv": [
+                                    {
+                                        "fn": "isSet",
+                                        "argv": [
+                                            {"ref": "accountId"}
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "endpoint": {
+                            "url": "https://ACCOUNT-ID-NOT-SET/"
+                        }
+                    },
+                    {
+                        "type": "endpoint"
+                        "conditions": [
+                            {"fn": "isSet", "argv": [{"ref": "region"}]},
+                            {
+                                "fn": "isSet",
+                                "argv": [
+                                    {"ref": "accountId"}
+                                ]
+                            }
+                        ],
+                        "endpoint": {
+                            "url": "https://ACCOUNT-ID-SET/"
+                        }
+                    }
+                ]
+            })
+            service TestService {
+                version: "2023-01-01",
+                operations: [SomeOperation]
+            }
+
+            structure SomeOutput {
+                someAttribute: Long,
+                someVal: String
+            }
+
+            @http(uri: "/SomeOperation", method: "GET")
+            operation SomeOperation {
+                output: SomeOutput
+            }
+            """
+
+    @Test
+    fun accountIdBuiltInParam() {
+        fun runTest(
+            expectedUrl: String,
+            credentialsProvider: (CodegenContext) -> Writable,
+            authAnnotation: String? = null,
+        ) {
+            awsSdkIntegrationTest(modelWithAccountId(authAnnotation).asSmithyModel(smithyVersion = "2.0")) { ctx, rustCrate ->
+                rustCrate.integrationTest("account_id_built_in_param") {
+                    tokioTest("should_work") {
+                        val module = ctx.moduleUseName()
+                        rustTemplate(
+                            """
+                            use $module::{Config, Client, config::Region};
+
+                            let (conn, req) = #{capture_request}(None);
+                            let config = Config::builder()
+                                #{creds_provider}
+                                .http_client(conn)
+                                .region(Region::new("us-east-1"))
+                                .build();
+                            let client = Client::from_conf(config);
+                            let _ = dbg!(client.some_operation().send().await);
+                            let req = req.expect_request();
+                            assert_eq!(${expectedUrl.dq()}, req.uri());
+                            """,
+                            "capture_request" to RuntimeType.captureRequest(ctx.runtimeConfig),
+                            "creds_provider" to credentialsProvider(ctx),
+                        )
+                    }
+                }
+            }
+        }
+
+        // The model uses no authentication (`NoAuthScheme`), causing  `NoAuthIdentityResolver` to resolve a
+        // `NoAuthIdentity`. Since `NoAuthIdentity` lacks an account ID, this test is intended
+        // to exercise an endpoint rule whose condition expects the account ID to be unset.
+        runTest("https://ACCOUNT-ID-NOT-SET/SomeOperation", { _ -> writable {} })
+
+        // The model uses SigV4 authentication, with the credentials provider returning credentials
+        // containing an account ID. This should exercise an endpoint rule whose condition expects the account ID to
+        // be set.
+        runTest(
+            "https://ACCOUNT-ID-SET/SomeOperation",
+            { ctx ->
+                writable {
+                    rustTemplate(
+                        """
+                        .credentials_provider(
+                            #{SharedCredentialsProvider}::new(
+                                #{CredentialsBuilder}::for_tests()
+                                    .account_id("123456789012")
+                                    .build()
+                            )
+                        )
+                        """,
+                        "SharedCredentialsProvider" to
+                            AwsRuntimeType.awsCredentialTypes(ctx.runtimeConfig)
+                                .resolve("provider::SharedCredentialsProvider"),
+                        "CredentialsBuilder" to
+                            AwsRuntimeType.awsCredentialTypesTestUtil(ctx.runtimeConfig)
+                                .resolve("CredentialsBuilder"),
+                    )
+                }
+            },
+            "@aws.auth#sigv4(name: \"donotcare\")\n",
+        )
     }
 }


### PR DESCRIPTION
## Motivation and Context
This is part 5, and the last, in the series of supporting account ID-based routing (continuation of https://github.com/smithy-lang/smithy-rs/pull/4047, https://github.com/smithy-lang/smithy-rs/pull/4057, https://github.com/smithy-lang/smithy-rs/pull/4087, and https://github.com/smithy-lang/smithy-rs/pull/4091).

## Description
This PR makes the feature of account ID-based routing configurable across the SDK. The `AccountIdEndpointMode` configuration takes one of three values: `preferred`, `disabled`, or `required`, with `preferred` being the default value (see [the reference guide](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html) for more information).

This PR makes the `AccountIdEndpointMode` configurable by:
- Exposing the setter(s) for `account_id_endpoint_mode` on both [`ConfigLoader`](https://github.com/smithy-lang/smithy-rs/blob/a008dc282e6e9615064302616a81c36d43c6eb5b/aws/rust-runtime/aws-config/src/lib.rs#L631-L638) and [`SdkConfig`](https://github.com/smithy-lang/smithy-rs/blob/a008dc282e6e9615064302616a81c36d43c6eb5b/aws/rust-runtime/aws-types/src/sdk_config.rs#L181-L197).
- Passing the configured value through the existing configuration chain: `ConfigLoader` → `SdkConfig` → service config's `Builder` → `read_before_execution` method of the endpoint params' interceptors.

In addition, this PR includes the following supporting changes:
- Defines an enum `AccountIdEndpointMode` in the `aws-types` crate.
- Breaks APIs in the `dynamodb` to set [`account_id`](https://docs.rs/aws-sdk-dynamodb/1.71.2/aws_sdk_dynamodb/config/struct.Builder.html#method.account_id) and  [`account_id_endpoint_mode`](https://docs.rs/aws-sdk-dynamodb/1.71.2/aws_sdk_dynamodb/config/struct.Builder.html#method.account_id_endpoint_mode) (introduced in smithy-rs#3792). This involves removing the setters for `account_id` and updating the setters for `account_id_endpoint_mode` to accept the `AccountIdEndpointMode` enum instead of a `String`.

## Testing
- Added tests for sourcing `AccountIdEndpointMode` from env config
- Passed `dynamodb`'s `endpoint_tests`, which cover the account ID mode test cases in the design spec, with code changes in the PR
- Added codegen test to verify the account ID based routing with/without auth

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
