### PR TITLE
Preserve custom content-encoding value when setting `aws-chunked`

### DIFF
--- a/.changelog/1745291346.md
+++ b/.changelog/1745291346.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- aws-sdk-rust#1281
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix an issue where a custom `Content-Encoding` header was incorrectly overwritten by the `aws-chunked` header value.

--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -377,7 +377,9 @@ fn wrap_streaming_request_body_in_checksum_calculating_body(
         http::header::HeaderName::from_static("x-amz-decoded-content-length"),
         HeaderValue::from(original_body_size),
     );
-    headers.insert(
+    // The target service does not depend on where `aws-chunked` appears in the `Content-Encoding` header,
+    // as it will ultimately be stripped.
+    headers.append(
         http::header::CONTENT_ENCODING,
         HeaderValue::from_str(AWS_CHUNKED)
             .map_err(BuildError::other)

--- a/aws/sdk/integration-tests/s3/tests/checksums.rs
+++ b/aws/sdk/integration-tests/s3/tests/checksums.rs
@@ -193,6 +193,7 @@ async fn test_checksum_on_streaming_request<'a>(
         .put_object()
         .bucket("test-bucket")
         .key("test.txt")
+        .content_encoding("custom")
         .body(body)
         .checksum_algorithm(checksum_algorithm)
         .send()
@@ -214,9 +215,7 @@ async fn test_checksum_on_streaming_request<'a>(
     let content_length = headers
         .get("Content-Length")
         .expect("Content-Length header exists");
-    let content_encoding = headers
-        .get("Content-Encoding")
-        .expect("Content-Encoding header exists");
+    let content_encoding = headers.get_all("Content-Encoding").collect::<Vec<_>>();
 
     assert_eq!(
         HeaderValue::from_static("STREAMING-UNSIGNED-PAYLOAD-TRAILER"),
@@ -228,11 +227,9 @@ async fn test_checksum_on_streaming_request<'a>(
         x_amz_trailer,
         "x-amz-trailer is incorrect"
     );
-    assert_eq!(
-        HeaderValue::from_static(aws_runtime::content_encoding::header_value::AWS_CHUNKED),
-        content_encoding,
-        "content-encoding wasn't set to aws-chunked"
-    );
+    // The position for `aws-chunked` in `content_encoding` doesn't matter for the target service.
+    // The expected here just reflects the current behavior of appending `aws-chunked` to the header.
+    assert_eq!(vec!["custom", "aws-chunked"], content_encoding);
 
     // The length of the string "Hello world"
     assert_eq!(


### PR DESCRIPTION
## Motivation and Context
aws-sdk-rust#1281

## Description
When setting `aws-chunked` to the `Content-Encoding` header for streaming APIs, we overwrite an existing custom value, if any provided by the customer. The expected behavior is to support multiple values as described in [the documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html).

## Testing
Updated existing unit test to account for a custom `Content-Encoding` header value.

## Checklist
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
