### PR TITLE
Revise account-based endpoints integ tests for DDB

### DIFF
--- a/aws/sdk/aws-models/dynamodb.json
+++ b/aws/sdk/aws-models/dynamodb.json
@@ -788,7 +788,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>This operation allows you to perform batch reads or writes on data stored in DynamoDB,\n            using PartiQL. Each read statement in a <code>BatchExecuteStatement</code> must specify\n            an equality condition on all key attributes. This enforces that each <code>SELECT</code>\n            statement in a batch returns at most a single item. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html\">Running batch operations with PartiQL for DynamoDB\n            </a>.</p>\n         <note>\n            <p>The entire batch must consist of either read statements or write statements, you\n                cannot mix both in one batch.</p>\n         </note>\n         <important>\n            <p>A HTTP 200 response does not mean that all statements in the BatchExecuteStatement\n                succeeded. Error details for individual statements can be found under the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchStatementResponse.html#DDB-Type-BatchStatementResponse-Error\">Error</a> field of the <code>BatchStatementResponse</code> for each\n                statement.</p>\n         </important>"
+                "smithy.api#documentation": "<p>This operation allows you to perform batch reads or writes on data stored in DynamoDB,\n            using PartiQL. Each read statement in a <code>BatchExecuteStatement</code> must specify\n            an equality condition on all key attributes. This enforces that each <code>SELECT</code>\n            statement in a batch returns at most a single item. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html\">Running batch operations with PartiQL for DynamoDB </a>.</p>\n         <note>\n            <p>The entire batch must consist of either read statements or write statements, you\n                cannot mix both in one batch.</p>\n         </note>\n         <important>\n            <p>A HTTP 200 response does not mean that all statements in the BatchExecuteStatement\n                succeeded. Error details for individual statements can be found under the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchStatementResponse.html#DDB-Type-BatchStatementResponse-Error\">Error</a> field of the <code>BatchStatementResponse</code> for each\n                statement.</p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#BatchExecuteStatementInput": {
@@ -858,7 +858,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>BatchGetItem</code> operation returns the attributes of one or more items\n            from one or more tables. You identify requested items by primary key.</p>\n         <p>A single operation can retrieve up to 16 MB of data, which can contain as many as 100\n            items. <code>BatchGetItem</code> returns a partial result if the response size limit is\n            exceeded, the table's provisioned throughput is exceeded, more than 1MB per partition is\n            requested, or an internal processing failure occurs. If a partial result is returned,\n            the operation returns a value for <code>UnprocessedKeys</code>. You can use this value\n            to retry the operation starting with the next item to get.</p>\n         <important>\n            <p>If you request more than 100 items, <code>BatchGetItem</code> returns a\n                    <code>ValidationException</code> with the message \"Too many items requested for\n                the BatchGetItem call.\"</p>\n         </important>\n         <p>For example, if you ask to retrieve 100 items, but each individual item is 300 KB in\n            size, the system returns 52 items (so as not to exceed the 16 MB limit). It also returns\n            an appropriate <code>UnprocessedKeys</code> value so you can get the next page of\n            results. If desired, your application can include its own logic to assemble the pages of\n            results into one dataset.</p>\n         <p>If <i>none</i> of the items can be processed due to insufficient\n            provisioned throughput on all of the tables in the request, then\n                <code>BatchGetItem</code> returns a\n                <code>ProvisionedThroughputExceededException</code>. If <i>at least\n                one</i> of the items is successfully processed, then\n                <code>BatchGetItem</code> completes successfully, while returning the keys of the\n            unread items in <code>UnprocessedKeys</code>.</p>\n         <important>\n            <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on\n                those items. However, <i>we strongly recommend that you use an exponential\n                    backoff algorithm</i>. If you retry the batch operation immediately, the\n                underlying read or write requests can still fail due to throttling on the individual\n                tables. If you delay the batch operation using exponential backoff, the individual\n                requests in the batch are much more likely to succeed.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#BatchOperations\">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB\n                    Developer Guide</i>.</p>\n         </important>\n         <p>By default, <code>BatchGetItem</code> performs eventually consistent reads on every\n            table in the request. If you want strongly consistent reads instead, you can set\n                <code>ConsistentRead</code> to <code>true</code> for any or all tables.</p>\n         <p>In order to minimize response latency, <code>BatchGetItem</code> may retrieve items in\n            parallel.</p>\n         <p>When designing your application, keep in mind that DynamoDB does not return items in\n            any particular order. To help parse the response by item, include the primary key values\n            for the items in your request in the <code>ProjectionExpression</code> parameter.</p>\n         <p>If a requested item does not exist, it is not returned in the result. Requests for\n            nonexistent items consume the minimum read capacity units according to the type of read.\n            For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations\">Working with Tables</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
+                "smithy.api#documentation": "<p>The <code>BatchGetItem</code> operation returns the attributes of one or more items\n            from one or more tables. You identify requested items by primary key.</p>\n         <p>A single operation can retrieve up to 16 MB of data, which can contain as many as 100\n            items. <code>BatchGetItem</code> returns a partial result if the response size limit is\n            exceeded, the table's provisioned throughput is exceeded, more than 1MB per partition is\n            requested, or an internal processing failure occurs. If a partial result is returned,\n            the operation returns a value for <code>UnprocessedKeys</code>. You can use this value\n            to retry the operation starting with the next item to get.</p>\n         <important>\n            <p>If you request more than 100 items, <code>BatchGetItem</code> returns a\n                    <code>ValidationException</code> with the message \"Too many items requested for\n                the BatchGetItem call.\"</p>\n         </important>\n         <p>For example, if you ask to retrieve 100 items, but each individual item is 300 KB in\n            size, the system returns 52 items (so as not to exceed the 16 MB limit). It also returns\n            an appropriate <code>UnprocessedKeys</code> value so you can get the next page of\n            results. If desired, your application can include its own logic to assemble the pages of\n            results into one dataset.</p>\n         <p>If <i>none</i> of the items can be processed due to insufficient\n            provisioned throughput on all of the tables in the request, then\n                <code>BatchGetItem</code> returns a\n                <code>ProvisionedThroughputExceededException</code>. If <i>at least\n                one</i> of the items is successfully processed, then\n                <code>BatchGetItem</code> completes successfully, while returning the keys of the\n            unread items in <code>UnprocessedKeys</code>.</p>\n         <important>\n            <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on\n                those items. However, <i>we strongly recommend that you use an exponential\n                    backoff algorithm</i>. If you retry the batch operation immediately, the\n                underlying read or write requests can still fail due to throttling on the individual\n                tables. If you delay the batch operation using exponential backoff, the individual\n                requests in the batch are much more likely to succeed.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#BatchOperations\">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB\n                    Developer Guide</i>.</p>\n         </important>\n         <p>By default, <code>BatchGetItem</code> performs eventually consistent reads on every\n            table in the request. If you want strongly consistent reads instead, you can set\n                <code>ConsistentRead</code> to <code>true</code> for any or all tables.</p>\n         <p>In order to minimize response latency, <code>BatchGetItem</code> may retrieve items in\n            parallel.</p>\n         <p>When designing your application, keep in mind that DynamoDB does not return items in\n            any particular order. To help parse the response by item, include the primary key values\n            for the items in your request in the <code>ProjectionExpression</code> parameter.</p>\n         <p>If a requested item does not exist, it is not returned in the result. Requests for\n            nonexistent items consume the minimum read capacity units according to the type of read.\n            For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations\">Working with Tables</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>\n         <note>\n            <p>\n               <code>BatchGetItem</code> will result in a <code>ValidationException</code> if the\n                same key is specified multiple times.</p>\n         </note>",
                 "smithy.api#examples": [
                     {
                         "title": "To retrieve multiple items from a table",
@@ -918,7 +918,12 @@
                             }
                         }
                     }
-                ]
+                ],
+                "smithy.rules#operationContextParams": {
+                    "ResourceArnList": {
+                        "path": "keys(RequestItems)"
+                    }
+                }
             }
         },
         "com.amazonaws.dynamodb#BatchGetItemInput": {
@@ -1237,7 +1242,12 @@
                         },
                         "output": {}
                     }
-                ]
+                ],
+                "smithy.rules#operationContextParams": {
+                    "ResourceArnList": {
+                        "path": "keys(RequestItems)"
+                    }
+                }
             }
         },
         "com.amazonaws.dynamodb#BatchWriteItemInput": {
@@ -1629,7 +1639,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>A condition specified in the operation could not be evaluated.</p>",
+                "smithy.api#documentation": "<p>A condition specified in the operation failed to be evaluated.</p>",
                 "smithy.api#error": "client"
             }
         },
@@ -1909,7 +1919,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table. You can also provide the Amazon Resource Name (ARN) of the table in this\n            parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "BackupName": {
@@ -1971,7 +1984,7 @@
                 "OnDemandThroughput": {
                     "target": "com.amazonaws.dynamodb#OnDemandThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>The maximum number of read and write units for the global secondary index being\n            created. If you use this parameter, you must specify <code>MaxReadRequestUnits</code>,\n                <code>MaxWriteRequestUnits</code>, or both.</p>"
+                        "smithy.api#documentation": "<p>The maximum number of read and write units for the global secondary index being\n            created. If you use this parameter, you must specify <code>MaxReadRequestUnits</code>,\n                <code>MaxWriteRequestUnits</code>, or both. You must use either\n            <code>OnDemand Throughput</code> or <code>ProvisionedThroughput</code> based on your table's\n        capacity mode.</p>"
                     }
                 },
                 "WarmThroughput": {
@@ -2024,7 +2037,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The global table name.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "ReplicationGroup": {
@@ -2156,7 +2172,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to create. You can also provide the Amazon Resource Name (ARN) of the table in\n            this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "KeySchema": {
@@ -2169,19 +2188,19 @@
                 "LocalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#LocalSecondaryIndexList",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more local secondary indexes (the maximum is 5) to be created on the table.\n            Each index is scoped to a given partition key value. There is a 10 GB size limit per\n            partition key value; otherwise, the size of a local secondary index is\n            unconstrained.</p>\n         <p>Each local secondary index in the array includes the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index. Must be unique\n                    only for this table.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the key schema for the local secondary index.\n                    The key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>One or more local secondary indexes (the maximum is 5) to be created on the table.\n            Each index is scoped to a given partition key value. There is a 10 GB size limit per\n            partition key value; otherwise, the size of a local secondary index is\n            unconstrained.</p>\n         <p>Each local secondary index in the array includes the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index. Must be unique\n                    only for this table.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the key schema for the local secondary index.\n                    The key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total. This limit only applies when you\n                            specify the ProjectionType of <code>INCLUDE</code>. You still can specify the\n                            ProjectionType of <code>ALL</code> to project all attributes from the\n                            source table, even if the table has more than 100 attributes.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
                     }
                 },
                 "GlobalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#GlobalSecondaryIndexList",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more global secondary indexes (the maximum is 20) to be created on the table.\n            Each global secondary index in the array includes the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index. Must be unique\n                    only for this table.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the key schema for the global secondary\n                    index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>One or more global secondary indexes (the maximum is 20) to be created on the table.\n            Each global secondary index in the array includes the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index. Must be unique\n                    only for this table.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the key schema for the global secondary\n                    index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total. This limit only applies when you\n                            specify the ProjectionType of <code>INCLUDE</code>. You still can\n                            specify the ProjectionType of <code>ALL</code> to project all attributes\n                            from the source table, even if the table has more than 100 attributes.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "BillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html\">Provisioned capacity mode</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html\">On-demand capacity mode</a>. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for most DynamoDB workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html\">On-demand capacity mode</a>. </p>\n            </li>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    steady workloads with predictable growth where capacity requirements can be\n                    reliably forecasted. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html\">Provisioned capacity mode</a>.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ProvisionedThroughput": {
@@ -2223,7 +2242,7 @@
                 "WarmThroughput": {
                     "target": "com.amazonaws.dynamodb#WarmThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the warm throughput (in read units per second and write units per second) for creating a table.</p>"
+                        "smithy.api#documentation": "<p>Represents the warm throughput (in read units per second and write units per second)\n            for creating a table.</p>"
                     }
                 },
                 "ResourcePolicy": {
@@ -2399,7 +2418,10 @@
                     "target": "com.amazonaws.dynamodb#BackupArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The ARN associated with the backup.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -2510,7 +2532,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table from which to delete the item. You can also provide the\n            Amazon Resource Name (ARN) of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Key": {
@@ -2691,7 +2716,10 @@
                     "target": "com.amazonaws.dynamodb#ResourceArnString",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the DynamoDB resource from which the policy will be\n            removed. The resources you can specify include tables and streams. If you remove the\n            policy of a table, it will also remove the permissions for the table's indexes defined\n            in that policy document. This is because index permissions are defined in the table's\n            policy.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "ExpectedRevisionId": {
@@ -2780,7 +2808,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to delete. You can also provide the Amazon Resource Name (ARN) of the table in\n            this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -2840,7 +2871,10 @@
                     "target": "com.amazonaws.dynamodb#BackupArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) associated with the backup.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -2885,7 +2919,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Checks the status of continuous backups and point in time recovery on the specified\n            table. Continuous backups are <code>ENABLED</code> on all tables at table creation. If\n            point in time recovery is enabled, <code>PointInTimeRecoveryStatus</code> will be set to\n            ENABLED.</p>\n         <p> After continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n         <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time in the last 35 days. You can set the recovery period to any value between 1 and 35 days. </p>\n         <p>You can call <code>DescribeContinuousBackups</code> at a maximum rate of 10 times per\n            second.</p>"
+                "smithy.api#documentation": "<p>Checks the status of continuous backups and point in time recovery on the specified\n            table. Continuous backups are <code>ENABLED</code> on all tables at table creation. If\n            point in time recovery is enabled, <code>PointInTimeRecoveryStatus</code> will be set to\n            ENABLED.</p>\n         <p> After continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n         <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time in the last 35 days. You can set the\n            recovery period to any value between 1 and 35 days. </p>\n         <p>You can call <code>DescribeContinuousBackups</code> at a maximum rate of 10 times per\n            second.</p>"
             }
         },
         "com.amazonaws.dynamodb#DescribeContinuousBackupsInput": {
@@ -2895,7 +2929,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>Name of the table for which the customer wants to check the continuous backups and\n            point in time recovery settings.</p>\n         <p>You can also provide the Amazon Resource Name (ARN) of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -2944,7 +2981,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to describe. You can also provide the Amazon Resource Name (ARN) of the table in\n            this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "IndexName": {
@@ -3066,7 +3106,10 @@
                     "target": "com.amazonaws.dynamodb#ExportArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) associated with the export.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3121,7 +3164,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the global table.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3176,7 +3222,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the global table to describe.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3228,7 +3277,10 @@
                     "target": "com.amazonaws.dynamodb#ImportArn",
                     "traits": {
                         "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) associated with the table you're importing to. </p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3284,7 +3336,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table being described. You can also provide the Amazon Resource Name (ARN) of the table\n            in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3455,7 +3510,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to describe. You can also provide the Amazon Resource Name (ARN) of the table in\n            this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3506,7 +3564,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table. You can also provide the Amazon Resource Name (ARN) of the table in this\n            parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3561,7 +3622,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to be described. You can also provide the Amazon Resource Name (ARN) of the table\n            in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -3911,6 +3975,16 @@
                             "required": false,
                             "documentation": "The AccountId Endpoint Mode.",
                             "type": "String"
+                        },
+                        "ResourceArn": {
+                            "required": false,
+                            "documentation": "ResourceArn containing arn of resource",
+                            "type": "String"
+                        },
+                        "ResourceArnList": {
+                            "required": false,
+                            "documentation": "ResourceArnList containing list of resource arns",
+                            "type": "stringArray"
                         }
                     },
                     "rules": [
@@ -4059,113 +4133,6 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "isSet",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "AccountIdEndpointMode"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "AccountIdEndpointMode"
-                                                        },
-                                                        "required"
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "not",
-                                                    "argv": [
-                                                        {
-                                                            "fn": "isSet",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "AccountId"
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded.",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "isSet",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "AccountId"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "name"
-                                                            ]
-                                                        },
-                                                        "aws"
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "not",
-                                                    "argv": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "UseFIPS"
-                                                                },
-                                                                true
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "not",
-                                                    "argv": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "UseDualStack"
-                                                                },
-                                                                true
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "not",
-                                                    "argv": [
-                                                        {
-                                                            "fn": "isValidHostLabel",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "AccountId"
-                                                                },
-                                                                false
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "error": "Credentials-sourced account ID parameter is invalid",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
                                                     "fn": "booleanEquals",
                                                     "argv": [
                                                         {
@@ -4235,16 +4202,18 @@
                                                                         {
                                                                             "ref": "AccountIdEndpointMode"
                                                                         },
-                                                                        "disabled"
+                                                                        "required"
                                                                     ]
                                                                 }
                                                             ],
-                                                            "endpoint": {
-                                                                "url": "https://dynamodb-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported",
+                                                                    "type": "error"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
                                                         },
                                                         {
                                                             "conditions": [],
@@ -4333,16 +4302,18 @@
                                                                                 {
                                                                                     "ref": "AccountIdEndpointMode"
                                                                                 },
-                                                                                "disabled"
+                                                                                "required"
                                                                             ]
                                                                         }
                                                                     ],
-                                                                    "endpoint": {
-                                                                        "url": "https://dynamodb.{Region}.{PartitionResult#dnsSuffix}",
-                                                                        "properties": {},
-                                                                        "headers": {}
-                                                                    },
-                                                                    "type": "endpoint"
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported",
+                                                                            "type": "error"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
                                                                 },
                                                                 {
                                                                     "conditions": [],
@@ -4372,16 +4343,18 @@
                                                                         {
                                                                             "ref": "AccountIdEndpointMode"
                                                                         },
-                                                                        "disabled"
+                                                                        "required"
                                                                     ]
                                                                 }
                                                             ],
-                                                            "endpoint": {
-                                                                "url": "https://dynamodb-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported",
+                                                                    "type": "error"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
                                                         },
                                                         {
                                                             "conditions": [],
@@ -4451,16 +4424,44 @@
                                                                         {
                                                                             "ref": "AccountIdEndpointMode"
                                                                         },
-                                                                        "disabled"
+                                                                        "required"
                                                                     ]
                                                                 }
                                                             ],
-                                                            "endpoint": {
-                                                                "url": "https://dynamodb.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "not",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported",
+                                                                            "type": "error"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported",
+                                                                    "type": "error"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
                                                         },
                                                         {
                                                             "conditions": [],
@@ -4493,29 +4494,16 @@
                                                     ]
                                                 },
                                                 {
-                                                    "fn": "stringEquals",
+                                                    "fn": "not",
                                                     "argv": [
                                                         {
-                                                            "ref": "AccountIdEndpointMode"
-                                                        },
-                                                        "disabled"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://dynamodb.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "isSet",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "AccountId"
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "AccountIdEndpointMode"
+                                                                },
+                                                                "disabled"
+                                                            ]
                                                         }
                                                     ]
                                                 },
@@ -4561,14 +4549,471 @@
                                                             ]
                                                         }
                                                     ]
+                                                },
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "ResourceArn"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "aws.parseArn",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "ResourceArn"
+                                                        }
+                                                    ],
+                                                    "assign": "ParsedArn"
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "service"
+                                                            ]
+                                                        },
+                                                        "dynamodb"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "isValidHostLabel",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "region"
+                                                            ]
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "region"
+                                                            ]
+                                                        },
+                                                        "{Region}"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "isValidHostLabel",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "accountId"
+                                                            ]
+                                                        },
+                                                        false
+                                                    ]
                                                 }
                                             ],
                                             "endpoint": {
-                                                "url": "https://{AccountId}.ddb.{Region}.{PartitionResult#dnsSuffix}",
+                                                "url": "https://{ParsedArn#accountId}.ddb.{Region}.{PartitionResult#dnsSuffix}",
                                                 "properties": {},
                                                 "headers": {}
                                             },
                                             "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "AccountIdEndpointMode"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "not",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "AccountIdEndpointMode"
+                                                                },
+                                                                "disabled"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "not",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "not",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "ResourceArnList"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "getAttr",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "ResourceArnList"
+                                                        },
+                                                        "[0]"
+                                                    ],
+                                                    "assign": "FirstArn"
+                                                },
+                                                {
+                                                    "fn": "aws.parseArn",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "FirstArn"
+                                                        }
+                                                    ],
+                                                    "assign": "ParsedArn"
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "service"
+                                                            ]
+                                                        },
+                                                        "dynamodb"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "isValidHostLabel",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "region"
+                                                            ]
+                                                        },
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "region"
+                                                            ]
+                                                        },
+                                                        "{Region}"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "isValidHostLabel",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "ParsedArn"
+                                                                },
+                                                                "accountId"
+                                                            ]
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "endpoint": {
+                                                "url": "https://{ParsedArn#accountId}.ddb.{Region}.{PartitionResult#dnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "AccountIdEndpointMode"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "not",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "AccountIdEndpointMode"
+                                                                },
+                                                                "disabled"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "getAttr",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "PartitionResult"
+                                                                },
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "aws"
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "not",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "not",
+                                                    "argv": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "AccountId"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "isValidHostLabel",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "AccountId"
+                                                                },
+                                                                false
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://{AccountId}.ddb.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "Credentials-sourced account ID parameter is invalid",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "AccountIdEndpointMode"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "stringEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "AccountIdEndpointMode"
+                                                        },
+                                                        "required"
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "not",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "not",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "name"
+                                                                                    ]
+                                                                                },
+                                                                                "aws"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded",
+                                                                            "type": "error"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition",
+                                                                    "type": "error"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
                                         },
                                         {
                                             "conditions": [],
@@ -5303,43 +5748,88 @@
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with account ID available, FIPS enabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
                             "expect": {
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
                             "params": {
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
                                 "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with account ID available, FIPS enabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
                             "expect": {
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
                             "params": {
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
                                 "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with account ID available, FIPS disabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
                             "expect": {
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
                             "params": {
-                                "AccountId": "012345678901",
                                 "UseFIPS": false,
                                 "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with account ID available, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
@@ -5349,162 +5839,3831 @@
                                 {
                                     "builtInParams": {
                                         "SDK::Endpoint": "https://example.com",
-                                        "AWS::Auth::AccountId": "012345678901"
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Endpoint": "https://example.com"
-                            }
-                        },
-                        {
-                            "documentation": "For custom endpoint with empty account ID available, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://example.com"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "SDK::Endpoint": "https://example.com",
-                                        "AWS::Auth::AccountId": ""
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "AccountId": "",
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Endpoint": "https://example.com"
-                            }
-                        },
-                        {
-                            "documentation": "For region local with account ID available, FIPS enabled, and DualStack enabled",
-                            "expect": {
-                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
-                            },
-                            "params": {
-                                "Region": "local",
-                                "AccountId": "012345678901",
-                                "UseFIPS": true,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region local with account ID available, FIPS enabled, and DualStack disabled",
-                            "expect": {
-                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
-                            },
-                            "params": {
-                                "Region": "local",
-                                "AccountId": "012345678901",
-                                "UseFIPS": true,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region local with account ID available, FIPS disabled, and DualStack enabled",
-                            "expect": {
-                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
-                            },
-                            "params": {
-                                "Region": "local",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region local with account ID available, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "name": "sigv4",
-                                                "signingName": "dynamodb",
-                                                "signingRegion": "us-east-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "http://localhost:8000"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "local",
-                                        "AWS::Auth::AccountId": "012345678901"
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "local",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region local with empty account ID available, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "name": "sigv4",
-                                                "signingName": "dynamodb",
-                                                "signingRegion": "us-east-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "http://localhost:8000"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "local",
-                                        "AWS::Auth::AccountId": ""
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "local",
-                                "AccountId": "",
-                                "UseFIPS": false,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For AccountIdEndpointMode required and no AccountId set",
-                            "expect": {
-                                "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded."
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
                                         "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=preferred, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=disabled, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
                                         "AWS::Auth::AccountIdEndpointMode": "required"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
                                 "Region": "us-east-1",
-                                "AccountIdEndpointMode": "required"
+                                "Endpoint": "https://example.com"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with account ID available, FIPS enabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "SDK::Endpoint": "https://example.com",
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=required, Region=us-east-1, Endpoint=https://example.com}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=preferred, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=disabled, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and local endpoint are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "local",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=required, Region=local}",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "signingRegion": "us-east-1",
+                                                "signingName": "dynamodb",
+                                                "name": "sigv4"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "required",
+                                "Region": "local"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb-fips.us-east-1.api.aws"
@@ -5514,241 +9673,384 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
                                         "AWS::UseFIPS": true,
-                                        "AWS::UseDualStack": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": true,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, FIPS enabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseFIPS": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": true,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode preferred, FIPS enabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::Auth::AccountIdEndpointMode": "preferred",
-                                        "AWS::UseFIPS": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "preferred",
-                                "UseFIPS": true,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode required, FIPS enabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::Auth::AccountIdEndpointMode": "required",
-                                        "AWS::UseFIPS": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "required",
-                                "UseFIPS": true,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, FIPS disabled, and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-east-1.api.aws"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseDualStack": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, FIPS disabled, and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-east-1.api.aws"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseDualStack": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode preferred, FIPS disabled, and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "preferred",
-                                "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode disabled, FIPS disabled, and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "disabled",
-                                "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode required, FIPS disabled, and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "required",
-                                "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode preferred, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://012345678901.ddb.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
                                         "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "AccountIdEndpointMode": "preferred"
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode required, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1}",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://012345678901.ddb.us-east-1.amazonaws.com"
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
                                 }
                             },
                             "operationInputs": [
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
+                                "UseFIPS": true,
                                 "UseDualStack": false,
-                                "AccountIdEndpointMode": "required"
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with account ID available, AccountIdEndpointMode disabled, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://111111111111.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://222222222222.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://111111111111.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://111111111111.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "error": "Credentials-sourced account ID parameter is invalid"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://222222222222.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-east-1.amazonaws.com"
@@ -5758,22 +10060,506 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://222222222222.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=preferred, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "AccountIdEndpointMode": "disabled"
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with empty account ID, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://111111111111.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://222222222222.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://111111111111.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://111111111111.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=required, Region=us-east-1}",
                             "expect": {
                                 "error": "Credentials-sourced account ID parameter is invalid"
                             },
@@ -5781,161 +10567,1552 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-east-1",
-                                        "AWS::Auth::AccountId": " "
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-east-1",
-                                "AccountId": "",
                                 "UseFIPS": false,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with account ID available, FIPS enabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://222222222222.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://333333333333.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://222222222222.ddb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=required, Region=us-east-1}",
+                            "expect": {
+                                "error": "AccountIdEndpointMode is required but no AccountID was provided or able to be loaded"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "required",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and FIPS is enabled, but FIPS account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required and DualStack is enabled, but DualStack account endpoints are not supported"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "required"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=required, Region=cn-north-1}",
+                            "expect": {
+                                "error": "Invalid Configuration: AccountIdEndpointMode is required but account endpoints are not supported in this partition"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "required",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.api.aws"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": true,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "disabled"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=disabled, Region=us-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "disabled",
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=cn-north-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb-fips.cn-north-1.api.amazonwebservices.com.cn"
                                 }
                             },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "cn-north-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseFIPS": true,
-                                        "AWS::UseDualStack": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
                             "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
-                                "UseDualStack": true
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with account ID available, FIPS enabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=cn-north-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb-fips.cn-north-1.amazonaws.com.cn"
                                 }
                             },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "cn-north-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseFIPS": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
                             "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with account ID available, FIPS disabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=cn-north-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.cn-north-1.api.amazonwebservices.com.cn"
                                 }
                             },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "cn-north-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseDualStack": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
                             "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": false,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-north-1 with account ID available, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
-                                }
-                            },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "cn-north-1",
-                                        "AWS::Auth::AccountId": "012345678901"
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
-                            "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
-                                "UseFIPS": false,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-north-1 with account ID available, AccountIdEndpointMode preferred, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
                                 "AccountIdEndpointMode": "preferred",
-                                "UseFIPS": false,
-                                "UseDualStack": false
+                                "Region": "cn-north-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with account ID available, AccountIdEndpointMode disabled, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "disabled",
-                                "UseFIPS": false,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-north-1 with account ID available, AccountIdEndpointMode required, FIPS disabled, and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "012345678901",
-                                "AccountIdEndpointMode": "required",
-                                "UseFIPS": false,
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-north-1 with empty account ID available, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=cn-north-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
@@ -5945,68 +12122,501 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "cn-north-1",
-                                        "AWS::Auth::AccountId": ""
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "cn-north-1",
-                                "AccountId": "",
                                 "UseFIPS": false,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with account ID available, FIPS enabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "ListTables"
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=preferred, Region=cn-north-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
                             "expect": {
                                 "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
                             },
                             "params": {
-                                "Region": "us-iso-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
-                                "UseDualStack": true
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with account ID available, FIPS enabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb-fips.us-iso-east-1.c2s.ic.gov"
                                 }
                             },
-                            "operationInputs": [
-                                {
-                                    "builtInParams": {
-                                        "AWS::Region": "us-iso-east-1",
-                                        "AWS::Auth::AccountId": "012345678901",
-                                        "AWS::UseFIPS": true
-                                    },
-                                    "operationName": "ListTables"
-                                }
-                            ],
                             "params": {
-                                "Region": "us-iso-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with account ID available, FIPS disabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
                             "expect": {
                                 "error": "DualStack is enabled but this partition does not support DualStack"
                             },
                             "params": {
-                                "Region": "us-iso-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": false,
-                                "UseDualStack": true
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with account ID available, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
@@ -6016,20 +12626,24 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-iso-east-1",
-                                        "AWS::Auth::AccountId": "012345678901"
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-iso-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": false,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with empty account ID available, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
@@ -6039,62 +12653,470 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-iso-east-1",
-                                        "AWS::Auth::AccountId": "012345678901"
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-iso-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
                                 "AccountId": "",
-                                "UseFIPS": false,
-                                "UseDualStack": false
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-east-1 with account ID available, FIPS enabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-iso-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-iso-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-iso-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-iso-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=preferred, Region=us-iso-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb-fips.us-gov-east-1.api.aws"
                                 }
                             },
                             "params": {
-                                "Region": "us-gov-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
-                                "UseDualStack": true
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-east-1 with account ID available, FIPS enabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=true, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "Region": "us-gov-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": true,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-east-1 with account ID available, FIPS disabled, and DualStack enabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=true, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-gov-east-1.api.aws"
                                 }
                             },
                             "params": {
-                                "Region": "us-gov-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": false,
-                                "UseDualStack": true
+                                "UseDualStack": true,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-east-1 with account ID available, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
@@ -6104,20 +13126,24 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-gov-east-1",
-                                        "AWS::Auth::AccountId": "012345678901"
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-gov-east-1",
-                                "AccountId": "012345678901",
                                 "UseFIPS": false,
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-east-1 with empty account ID available, FIPS disabled, and DualStack disabled",
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
@@ -6127,16 +13153,429 @@
                                 {
                                     "builtInParams": {
                                         "AWS::Region": "us-gov-east-1",
-                                        "AWS::Auth::AccountId": ""
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "111111111111",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-west-2:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-west-2:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=111111111111, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, ResourceArnList=[arn:aws:s3:us-east-1:333333333333:stream/testStream], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountId": "111111111111",
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "ResourceArnList": [
+                                    "arn:aws:s3:us-east-1:333333333333:stream/testStream"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountId=, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-gov-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountId": "",
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
                                     },
                                     "operationName": "ListTables"
                                 }
                             ],
                             "params": {
-                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
                                 "AccountId": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
                                 "UseFIPS": false,
-                                "UseDualStack": false
+                                "UseDualStack": true,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-gov-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-west-2:222222222222:table/table_name, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-gov-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-west-2:222222222222:table/table_name",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:s3:us-west-2:222222222222:stream/testStream, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-gov-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "DescribeTable",
+                                    "operationParams": {
+                                        "TableName": "arn:aws:s3:us-west-2:222222222222:stream/testStream"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:s3:us-west-2:222222222222:stream/testStream",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "",
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=true, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=true, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-gov-east-1",
+                                        "AWS::UseFIPS": false,
+                                        "AWS::UseDualStack": false,
+                                        "AWS::Auth::AccountIdEndpointMode": "preferred"
+                                    },
+                                    "operationName": "BatchGetItem",
+                                    "operationParams": {
+                                        "RequestItems": {
+                                            "arn:aws:dynamodb:us-east-1:333333333333:table/table_name": {
+                                                "Keys": [
+                                                    {
+                                                        "pk": {
+                                                            "S": "value"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, ResourceArn=arn:aws:dynamodb:us-east-1:222222222222:table/table_name, ResourceArnList=[arn:aws:dynamodb:us-east-1:333333333333:table/table_name], AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "ResourceArn": "arn:aws:dynamodb:us-east-1:222222222222:table/table_name",
+                                "ResourceArnList": [
+                                    "arn:aws:dynamodb:us-east-1:333333333333:table/table_name"
+                                ],
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "{UseFIPS=false, UseDualStack=false, AccountIdEndpointMode=preferred, Region=us-gov-east-1}",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "AccountIdEndpointMode": "preferred",
+                                "Region": "us-gov-east-1"
                             }
                         }
                     ],
@@ -6769,7 +14208,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) associated with the table to export.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "ExportTime": {
@@ -7055,7 +14497,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table containing the requested item. You can also provide the\n            Amazon Resource Name (ARN) of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Key": {
@@ -7155,7 +14600,10 @@
                     "target": "com.amazonaws.dynamodb#ResourceArnString",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the DynamoDB resource to which the policy is attached. The\n            resources you can specify include tables and streams.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 }
             },
@@ -7780,7 +15228,12 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p> Imports table data from an S3 bucket. </p>"
+                "smithy.api#documentation": "<p> Imports table data from an S3 bucket. </p>",
+                "smithy.rules#operationContextParams": {
+                    "ResourceArn": {
+                        "path": "TableCreationParameters.TableName"
+                    }
+                }
             }
         },
         "com.amazonaws.dynamodb#ImportTableDescription": {
@@ -8468,7 +15921,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the DynamoDB table. You can also provide the Amazon Resource Name (ARN) of the\n            table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "StreamArn": {
@@ -8568,7 +16024,10 @@
                 "TableName": {
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>Lists the backups from the table specified in <code>TableName</code>. You can also\n            provide the Amazon Resource Name (ARN) of the table in this parameter.</p>"
+                        "smithy.api#documentation": "<p>Lists the backups from the table specified in <code>TableName</code>. You can also\n            provide the Amazon Resource Name (ARN) of the table in this parameter.</p>",
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Limit": {
@@ -8657,7 +16116,10 @@
                 "TableName": {
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the table. You can also provide the Amazon Resource Name (ARN) of the table in this\n            parameter.</p>"
+                        "smithy.api#documentation": "<p>The name of the table. You can also provide the Amazon Resource Name (ARN) of the table in this\n            parameter.</p>",
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "NextToken": {
@@ -8738,7 +16200,10 @@
                 "TableArn": {
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) associated with the exported table.</p>"
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) associated with the exported table.</p>",
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "MaxResults": {
@@ -8884,7 +16349,10 @@
                 "TableArn": {
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
-                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) associated with the table that was imported to.\n        </p>"
+                        "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) associated with the table that was imported to.\n        </p>",
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "PageSize": {
@@ -9075,7 +16543,10 @@
                     "target": "com.amazonaws.dynamodb#ResourceArnString",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon DynamoDB resource with tags to be listed. This value is an Amazon Resource\n            Name (ARN).</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "NextToken": {
@@ -9426,7 +16897,7 @@
                 "RecoveryPeriodInDays": {
                     "target": "com.amazonaws.dynamodb#RecoveryPeriodInDays",
                     "traits": {
-                        "smithy.api#documentation": "<p>The number of preceding days for which continuous backups are taken and maintained.\n            Your table data is only recoverable to any point-in-time from within the configured\n            recovery period. This parameter is optional. If no value is provided, the value will\n            default to 35.</p>"
+                        "smithy.api#documentation": "<p>The number of preceding days for which continuous backups are taken and maintained.\n            Your table data is only recoverable to any point-in-time from within the configured\n            recovery period. This parameter is optional.</p>"
                     }
                 },
                 "EarliestRestorableDateTime": {
@@ -9565,7 +17036,7 @@
                 "NonKeyAttributes": {
                     "target": "com.amazonaws.dynamodb#NonKeyAttributeNameList",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the non-key attribute names which will be projected into the index.</p>\n         <p>For local secondary indexes, the total count of <code>NonKeyAttributes</code> summed\n            across all of the local secondary indexes, must not exceed 100. If you project the same\n            attribute into two different indexes, this counts as two distinct attributes when\n            determining the total.</p>"
+                        "smithy.api#documentation": "<p>Represents the non-key attribute names which will be projected into the index.</p>\n         <p>For global and local secondary indexes, the total count of <code>NonKeyAttributes</code> summed\n            across all of the secondary indexes, must not exceed 100. If you project the same\n            attribute into two different indexes, this counts as two distinct attributes when\n            determining the total. This limit only applies when you specify the ProjectionType of\n            <code>INCLUDE</code>. You still can specify the ProjectionType of <code>ALL</code> to\n            project all attributes from the source table, even if the table has more than 100\n            attributes.</p>"
                     }
                 }
             },
@@ -9618,7 +17089,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the provisioned throughput settings for a specified table or index. The\n            settings can be modified using the <code>UpdateTable</code> operation.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index. You must use <code>ProvisionedThroughput</code> or\n                <code>OnDemandThroughput</code> based on your table’s capacity mode.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#ProvisionedThroughputDescription": {
@@ -9812,7 +17283,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to contain the item. You can also provide the Amazon Resource Name (ARN) of the\n            table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Item": {
@@ -9972,7 +17446,10 @@
                     "target": "com.amazonaws.dynamodb#ResourceArnString",
                     "traits": {
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the DynamoDB resource to which the policy will be attached.\n            The resources you can specify include tables and streams.</p>\n         <p>You can control index permissions using the base table's policy. To specify the same permission level for your table and its indexes, you can provide both the table and index Amazon Resource Name (ARN)s in the <code>Resource</code> field of a given <code>Statement</code> in your policy document. Alternatively, to specify different permissions for your table, indexes, or both, you can define multiple <code>Statement</code> fields in your policy document.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Policy": {
@@ -10091,7 +17568,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table containing the requested items. You can also provide the\n            Amazon Resource Name (ARN) of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "IndexName": {
@@ -10213,7 +17693,7 @@
                     "target": "com.amazonaws.dynamodb#Integer",
                     "traits": {
                         "smithy.api#default": 0,
-                        "smithy.api#documentation": "<p>The number of items evaluated, before any <code>QueryFilter</code> is applied. A high\n                <code>ScannedCount</code> value with few, or no, <code>Count</code> results\n            indicates an inefficient <code>Query</code> operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Count\">Count and\n                ScannedCount</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n         <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same\n            as <code>Count</code>.</p>"
+                        "smithy.api#documentation": "<p>The number of items evaluated, before any <code>QueryFilter</code> is applied. A high\n                <code>ScannedCount</code> value with few, or no, <code>Count</code> results\n            indicates an inefficient <code>Query</code> operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Count\">Count and ScannedCount</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>\n         <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same\n            as <code>Count</code>.</p>"
                     }
                 },
                 "LastEvaluatedKey": {
@@ -10914,7 +18394,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Throughput exceeds the current throughput quota for your account. Please contact\n                <a href=\"https://aws.amazon.com/support\">Amazon Web Services Support</a> to request a\n            quota increase.</p>",
+                "smithy.api#documentation": "<p>Throughput exceeds the current throughput quota for your account. Please contact\n                <a href=\"https://aws.amazon.com/support\">Amazon Web ServicesSupport</a> to request a\n            quota increase.</p>",
                 "smithy.api#error": "client"
             }
         },
@@ -11042,7 +18522,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the new table to which the backup must be restored.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "BackupArn": {
@@ -11142,7 +18625,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Restores the specified table to the specified point in time within\n                <code>EarliestRestorableDateTime</code> and <code>LatestRestorableDateTime</code>.\n            You can restore your table to any point in time in the last 35 days. You can set the recovery period to any value between 1 and 35 days. Any number of\n            users can execute up to 50 concurrent restores (any type of restore) in a given account. </p>\n         <p>When you restore using point in time recovery, DynamoDB restores your table data to\n            the state based on the selected date and time (day:hour:minute:second) to a new table. </p>\n         <p>Along with data, the following are also included on the new restored table using point\n            in time recovery: </p>\n         <ul>\n            <li>\n               <p>Global secondary indexes (GSIs)</p>\n            </li>\n            <li>\n               <p>Local secondary indexes (LSIs)</p>\n            </li>\n            <li>\n               <p>Provisioned read and write capacity</p>\n            </li>\n            <li>\n               <p>Encryption settings</p>\n               <important>\n                  <p> All these settings come from the current settings of the source table at\n                        the time of restore. </p>\n               </important>\n            </li>\n         </ul>\n         <p>You must manually set up the following on the restored table:</p>\n         <ul>\n            <li>\n               <p>Auto scaling policies</p>\n            </li>\n            <li>\n               <p>IAM policies</p>\n            </li>\n            <li>\n               <p>Amazon CloudWatch metrics and alarms</p>\n            </li>\n            <li>\n               <p>Tags</p>\n            </li>\n            <li>\n               <p>Stream settings</p>\n            </li>\n            <li>\n               <p>Time to Live (TTL) settings</p>\n            </li>\n            <li>\n               <p>Point in time recovery settings</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Restores the specified table to the specified point in time within\n                <code>EarliestRestorableDateTime</code> and <code>LatestRestorableDateTime</code>.\n            You can restore your table to any point in time in the last 35 days. You can set the\n            recovery period to any value between 1 and 35 days. Any number of users can execute up\n            to 50 concurrent restores (any type of restore) in a given account. </p>\n         <p>When you restore using point in time recovery, DynamoDB restores your table data to\n            the state based on the selected date and time (day:hour:minute:second) to a new table. </p>\n         <p>Along with data, the following are also included on the new restored table using point\n            in time recovery: </p>\n         <ul>\n            <li>\n               <p>Global secondary indexes (GSIs)</p>\n            </li>\n            <li>\n               <p>Local secondary indexes (LSIs)</p>\n            </li>\n            <li>\n               <p>Provisioned read and write capacity</p>\n            </li>\n            <li>\n               <p>Encryption settings</p>\n               <important>\n                  <p> All these settings come from the current settings of the source table at\n                        the time of restore. </p>\n               </important>\n            </li>\n         </ul>\n         <p>You must manually set up the following on the restored table:</p>\n         <ul>\n            <li>\n               <p>Auto scaling policies</p>\n            </li>\n            <li>\n               <p>IAM policies</p>\n            </li>\n            <li>\n               <p>Amazon CloudWatch metrics and alarms</p>\n            </li>\n            <li>\n               <p>Tags</p>\n            </li>\n            <li>\n               <p>Stream settings</p>\n            </li>\n            <li>\n               <p>Time to Live (TTL) settings</p>\n            </li>\n            <li>\n               <p>Point in time recovery settings</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#RestoreTableToPointInTimeInput": {
@@ -11164,7 +18647,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the new table to which it must be restored to.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "UseLatestRestorableTime": {
@@ -11631,7 +19117,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table containing the requested items or if you provide\n                <code>IndexName</code>, the name of the table to which that index belongs.</p>\n         <p>You can also provide the Amazon Resource Name (ARN) of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "IndexName": {
@@ -12215,13 +19704,13 @@
                 "LocalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#LocalSecondaryIndexDescriptionList",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents one or more local secondary indexes on the table. Each index is scoped to a\n            given partition key value. Tables with one or more local secondary indexes are subject\n            to an item collection size limit, where the amount of data within a given item\n            collection cannot exceed 10 GB. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - Represents the total size of the index, in bytes.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - Represents the number of items in the index. DynamoDB\n                    updates this value approximately every six hours. Recent changes might not be\n                    reflected in this value.</p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
+                        "smithy.api#documentation": "<p>Represents one or more local secondary indexes on the table. Each index is scoped to a\n            given partition key value. Tables with one or more local secondary indexes are subject\n            to an item collection size limit, where the amount of data within a given item\n            collection cannot exceed 10 GB. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total. This limit only applies when you\n                            specify the ProjectionType of <code>INCLUDE</code>. You still can\n                            specify the ProjectionType of <code>ALL</code> to project all attributes\n                            from the source table, even if the table has more than 100 attributes.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - Represents the total size of the index, in bytes.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - Represents the number of items in the index. DynamoDB\n                    updates this value approximately every six hours. Recent changes might not be\n                    reflected in this value.</p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
                     }
                 },
                 "GlobalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#GlobalSecondaryIndexDescriptionList",
                     "traits": {
-                        "smithy.api#documentation": "<p>The global secondary indexes, if any, on the table. Each index is scoped to a given\n            partition key value. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Backfilling</code> - If true, then the index is currently in the\n                    backfilling phase. Backfilling occurs only when a new global secondary index is\n                    added to the table. It is the process by which DynamoDB populates the new index\n                    with data from the table. (This attribute does not appear for indexes that were\n                    created during a <code>CreateTable</code> operation.) </p>\n               <p> You can delete an index that is being created during the\n                        <code>Backfilling</code> phase when <code>IndexStatus</code> is set to\n                    CREATING and <code>Backfilling</code> is true. You can't delete the index that\n                    is being created when <code>IndexStatus</code> is set to CREATING and\n                        <code>Backfilling</code> is false. (This attribute does not appear for\n                    indexes that were created during a <code>CreateTable</code> operation.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - The total size of the global secondary index, in\n                    bytes. DynamoDB updates this value approximately every six hours. Recent changes\n                    might not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexStatus</code> - The current status of the global secondary\n                    index:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>CREATING</code> - The index is being created.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>UPDATING</code> - The index is being updated.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>DELETING</code> - The index is being deleted.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ACTIVE</code> - The index is ready for use.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - The number of items in the global secondary index.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - In addition to the attributes described\n                                    in <code>KEYS_ONLY</code>, the secondary index will include\n                                    other non-key attributes that you specify.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units, along with\n                    data about increases and decreases. </p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
+                        "smithy.api#documentation": "<p>The global secondary indexes, if any, on the table. Each index is scoped to a given\n            partition key value. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Backfilling</code> - If true, then the index is currently in the\n                    backfilling phase. Backfilling occurs only when a new global secondary index is\n                    added to the table. It is the process by which DynamoDB populates the new index\n                    with data from the table. (This attribute does not appear for indexes that were\n                    created during a <code>CreateTable</code> operation.) </p>\n               <p> You can delete an index that is being created during the\n                        <code>Backfilling</code> phase when <code>IndexStatus</code> is set to\n                    CREATING and <code>Backfilling</code> is true. You can't delete the index that\n                    is being created when <code>IndexStatus</code> is set to CREATING and\n                        <code>Backfilling</code> is false. (This attribute does not appear for\n                    indexes that were created during a <code>CreateTable</code> operation.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - The total size of the global secondary index, in\n                    bytes. DynamoDB updates this value approximately every six hours. Recent changes\n                    might not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexStatus</code> - The current status of the global secondary\n                    index:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>CREATING</code> - The index is being created.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>UPDATING</code> - The index is being updated.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>DELETING</code> - The index is being deleted.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ACTIVE</code> - The index is ready for use.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - The number of items in the global secondary index.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - In addition to the attributes described\n                                    in <code>KEYS_ONLY</code>, the secondary index will include\n                                    other non-key attributes that you specify.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total. This limit only applies when you\n                            specify the ProjectionType of <code>INCLUDE</code>. You still can\n                            specify the ProjectionType of <code>ALL</code> to project all attributes\n                            from the source table, even if the table has more than 100 attributes.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units, along with\n                    data about increases and decreases. </p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
                     }
                 },
                 "StreamSpecification": {
@@ -12418,12 +19907,12 @@
                 "Status": {
                     "target": "com.amazonaws.dynamodb#TableStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents warm throughput value of the base table..</p>"
+                        "smithy.api#documentation": "<p>Represents warm throughput value of the base table.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the warm throughput value (in read units per second and write units per\n            second) of the base table.</p>"
+                "smithy.api#documentation": "<p>Represents the warm throughput value (in read units per second and write units per second)\n            of the table. Warm throughput is applicable for DynamoDB Standard-IA tables and specifies\n            the minimum provisioned capacity maintained for immediate data access.</p>"
             }
         },
         "com.amazonaws.dynamodb#Tag": {
@@ -12498,7 +19987,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Associate a set of tags with an Amazon DynamoDB resource. You can then activate these\n            user-defined tags so that they appear on the Billing and Cost Management console for\n            cost allocation tracking. You can call TagResource up to five times per second, per\n            account. </p>\n         <ul>\n            <li>\n               <p>\n                  <code>TagResource</code> is an asynchronous operation. If you issue a <a>ListTagsOfResource</a> request immediately after a <code>TagResource</code> request, DynamoDB might return your previous tag set, if there was one, or an empty tag set. This is because <code>ListTagsOfResource</code> uses an eventually consistent query, and the metadata for your tags or table might not be available at that moment. Wait for a few seconds, and then try the <code>ListTagsOfResource</code> request again.</p>\n            </li>\n            <li>\n               <p>The application or removal of tags using <code>TagResource</code> and <code>UntagResource</code> APIs is eventually consistent. <code>ListTagsOfResource</code> API will only reflect the changes after a few seconds.</p>\n            </li>\n         </ul>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Associate a set of tags with an Amazon DynamoDB resource. You can then activate these\n            user-defined tags so that they appear on the Billing and Cost Management console for\n            cost allocation tracking. You can call TagResource up to five times per second, per\n            account. </p>\n         <ul>\n            <li>\n               <p>\n                  <code>TagResource</code> is an asynchronous operation. If you issue a <a>ListTagsOfResource</a> request immediately after a\n                        <code>TagResource</code> request, DynamoDB might return your\n                    previous tag set, if there was one, or an empty tag set. This is because\n                        <code>ListTagsOfResource</code> uses an eventually consistent query, and the\n                    metadata for your tags or table might not be available at that moment. Wait for\n                    a few seconds, and then try the <code>ListTagsOfResource</code> request\n                    again.</p>\n            </li>\n            <li>\n               <p>The application or removal of tags using <code>TagResource</code> and\n                        <code>UntagResource</code> APIs is eventually consistent.\n                        <code>ListTagsOfResource</code> API will only reflect the changes after a\n                    few seconds.</p>\n            </li>\n         </ul>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#TagResourceInput": {
@@ -12508,7 +19997,10 @@
                     "target": "com.amazonaws.dynamodb#ResourceArnString",
                     "traits": {
                         "smithy.api#documentation": "<p>Identifies the Amazon DynamoDB resource to which tags should be added. This value is\n            an Amazon Resource Name (ARN).</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Tags": {
@@ -12680,7 +20172,12 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>\n            <code>TransactGetItems</code> is a synchronous operation that atomically retrieves\n            multiple items from one or more tables (but not from indexes) in a single account and\n            Region. A <code>TransactGetItems</code> call can contain up to 100\n                <code>TransactGetItem</code> objects, each of which contains a <code>Get</code>\n            structure that specifies an item to retrieve from a table in the account and Region. A\n            call to <code>TransactGetItems</code> cannot retrieve items from tables in more than one\n                Amazon Web Services account or Region. The aggregate size of the items in the\n            transaction cannot exceed 4 MB.</p>\n         <p>DynamoDB rejects the entire <code>TransactGetItems</code> request if any of\n            the following is true:</p>\n         <ul>\n            <li>\n               <p>A conflicting operation is in the process of updating an item to be\n                    read.</p>\n            </li>\n            <li>\n               <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n               <p>There is a user error, such as an invalid data format.</p>\n            </li>\n            <li>\n               <p>The aggregate size of the items in the transaction exceeded 4 MB.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>\n            <code>TransactGetItems</code> is a synchronous operation that atomically retrieves\n            multiple items from one or more tables (but not from indexes) in a single account and\n            Region. A <code>TransactGetItems</code> call can contain up to 100\n                <code>TransactGetItem</code> objects, each of which contains a <code>Get</code>\n            structure that specifies an item to retrieve from a table in the account and Region. A\n            call to <code>TransactGetItems</code> cannot retrieve items from tables in more than one\n                Amazon Web Services account or Region. The aggregate size of the items in the\n            transaction cannot exceed 4 MB.</p>\n         <p>DynamoDB rejects the entire <code>TransactGetItems</code> request if any of\n            the following is true:</p>\n         <ul>\n            <li>\n               <p>A conflicting operation is in the process of updating an item to be\n                    read.</p>\n            </li>\n            <li>\n               <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n               <p>There is a user error, such as an invalid data format.</p>\n            </li>\n            <li>\n               <p>The aggregate size of the items in the transaction exceeded 4 MB.</p>\n            </li>\n         </ul>",
+                "smithy.rules#operationContextParams": {
+                    "ResourceArnList": {
+                        "path": "TransactItems[*].Get.TableName"
+                    }
+                }
             }
         },
         "com.amazonaws.dynamodb#TransactGetItemsInput": {
@@ -12931,7 +20428,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Removes the association of tags from an Amazon DynamoDB resource. You can call\n                <code>UntagResource</code> up to five times per second, per account. </p>\n         <ul>\n            <li>\n               <p>\n                  <code>UntagResource</code> is an asynchronous operation. If you issue a <a>ListTagsOfResource</a> request immediately after an <code>UntagResource</code> request, DynamoDB might return your previous tag set, if there was one, or an empty tag set. This is because <code>ListTagsOfResource</code> uses an eventually consistent query, and the metadata for your tags or table might not be available at that moment. Wait for a few seconds, and then try the <code>ListTagsOfResource</code> request again.</p>\n            </li>\n            <li>\n               <p>The application or removal of tags using <code>TagResource</code> and <code>UntagResource</code> APIs is eventually consistent. <code>ListTagsOfResource</code> API will only reflect the changes after a few seconds.</p>\n            </li>\n         </ul>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Removes the association of tags from an Amazon DynamoDB resource. You can call\n                <code>UntagResource</code> up to five times per second, per account. </p>\n         <ul>\n            <li>\n               <p>\n                  <code>UntagResource</code> is an asynchronous operation. If you issue a <a>ListTagsOfResource</a> request immediately after an\n                        <code>UntagResource</code> request, DynamoDB might return your\n                    previous tag set, if there was one, or an empty tag set. This is because\n                        <code>ListTagsOfResource</code> uses an eventually consistent query, and the\n                    metadata for your tags or table might not be available at that moment. Wait for\n                    a few seconds, and then try the <code>ListTagsOfResource</code> request\n                    again.</p>\n            </li>\n            <li>\n               <p>The application or removal of tags using <code>TagResource</code> and\n                        <code>UntagResource</code> APIs is eventually consistent.\n                        <code>ListTagsOfResource</code> API will only reflect the changes after a\n                    few seconds.</p>\n            </li>\n         </ul>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#UntagResourceInput": {
@@ -12941,7 +20438,10 @@
                     "target": "com.amazonaws.dynamodb#ResourceArnString",
                     "traits": {
                         "smithy.api#documentation": "<p>The DynamoDB resource that the tags will be removed from. This value is an Amazon\n            Resource Name (ARN).</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "TagKeys": {
@@ -13035,7 +20535,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>\n            <code>UpdateContinuousBackups</code> enables or disables point in time recovery for\n            the specified table. A successful <code>UpdateContinuousBackups</code> call returns the\n            current <code>ContinuousBackupsDescription</code>. Continuous backups are\n                <code>ENABLED</code> on all tables at table creation. If point in time recovery is\n            enabled, <code>PointInTimeRecoveryStatus</code> will be set to ENABLED.</p>\n         <p> Once continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n         <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time in the last 35 days. You can set the recovery period to any value between 1 and 35 days.</p>"
+                "smithy.api#documentation": "<p>\n            <code>UpdateContinuousBackups</code> enables or disables point in time recovery for\n            the specified table. A successful <code>UpdateContinuousBackups</code> call returns the\n            current <code>ContinuousBackupsDescription</code>. Continuous backups are\n                <code>ENABLED</code> on all tables at table creation. If point in time recovery is\n            enabled, <code>PointInTimeRecoveryStatus</code> will be set to ENABLED.</p>\n         <p> Once continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n         <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time in the last 35 days. You can set the\n            <code>RecoveryPeriodInDays</code> to any value between 1 and 35 days.</p>"
             }
         },
         "com.amazonaws.dynamodb#UpdateContinuousBackupsInput": {
@@ -13045,7 +20545,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table. You can also provide the Amazon Resource Name (ARN) of the table in this\n            parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "PointInTimeRecoverySpecification": {
@@ -13101,7 +20604,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table. You can also provide the Amazon Resource Name (ARN) of the table in this\n            parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "IndexName": {
@@ -13226,7 +20732,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The global table name.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "ReplicaUpdates": {
@@ -13300,7 +20809,10 @@
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the global table</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "GlobalTableBillingMode": {
@@ -13456,7 +20968,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table containing the item to update. You can also provide the\n            Amazon Resource Name (ARN) of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "Key": {
@@ -13615,7 +21130,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The table name for the Kinesis streaming destination input. You can also provide the\n            ARN of the table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "StreamArn": {
@@ -13758,13 +21276,16 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to be updated. You can also provide the Amazon Resource Name (ARN) of the table\n            in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "BillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. When switching from pay-per-request to provisioned capacity, initial\n            provisioned capacity values must be set. The initial provisioned capacity values are\n            estimated based on the consumed read and write capacity of your table and global\n            secondary indexes over the past 30 minutes.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html\">Provisioned capacity mode</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html\">On-demand capacity mode</a>. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. When switching from pay-per-request to provisioned capacity, initial\n            provisioned capacity values must be set. The initial provisioned capacity values are\n            estimated based on the consumed read and write capacity of your table and global\n            secondary indexes over the past 30 minutes.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for most DynamoDB workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html\">On-demand capacity mode</a>. </p>\n            </li>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    steady workloads with predictable growth where capacity requirements can be\n                    reliably forecasted. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html\">Provisioned capacity mode</a>.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ProvisionedThroughput": {
@@ -13812,7 +21333,7 @@
                 "MultiRegionConsistency": {
                     "target": "com.amazonaws.dynamodb#MultiRegionConsistency",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the consistency mode for a new global table. This parameter is only valid when you create a global table by specifying one or more <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ReplicationGroupUpdate.html#DDB-Type-ReplicationGroupUpdate-Create\">Create</a> actions in the <a href=\"https://docs.aws.amazon.com/https:/docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html#DDB-UpdateTable-request-ReplicaUpdates\">ReplicaUpdates</a> action list.</p>\n         <p>You can specify one of the following consistency modes:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>EVENTUAL</code>: Configures a new global table for multi-Region eventual consistency. This is the default consistency mode for global tables.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STRONG</code>: Configures a new global table for multi-Region strong consistency (preview).</p>\n               <note>\n                  <p>Multi-Region strong consistency (MRSC) is a new DynamoDB global tables capability currently available in preview mode. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PreviewFeatures.html#multi-region-strong-consistency-gt\">Global tables multi-Region strong consistency</a>.</p>\n               </note>\n            </li>\n         </ul>\n         <p>If you don't specify this parameter, the global table consistency mode defaults to <code>EVENTUAL</code>.</p>"
+                        "smithy.api#documentation": "<p>Specifies the consistency mode for a new global table. This parameter is only valid\n            when you create a global table by specifying one or more <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ReplicationGroupUpdate.html#DDB-Type-ReplicationGroupUpdate-Create\">Create</a> actions in the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html#DDB-UpdateTable-request-ReplicaUpdates\">ReplicaUpdates</a> action list.</p>\n         <p>You can specify one of the following consistency modes:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>EVENTUAL</code>: Configures a new global table for multi-Region eventual\n                    consistency. This is the default consistency mode for global tables.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STRONG</code>: Configures a new global table for multi-Region strong\n                    consistency (preview).</p>\n               <note>\n                  <p>Multi-Region strong consistency (MRSC) is a new DynamoDB global\n                        tables capability currently available in preview mode. For more information,\n                        see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PreviewFeatures.html#multi-region-strong-consistency-gt\">Global tables multi-Region strong consistency</a>.</p>\n               </note>\n            </li>\n         </ul>\n         <p>If you don't specify this parameter, the global table consistency mode defaults to\n                <code>EVENTUAL</code>.</p>"
                     }
                 },
                 "OnDemandThroughput": {
@@ -13824,7 +21345,7 @@
                 "WarmThroughput": {
                     "target": "com.amazonaws.dynamodb#WarmThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the warm throughput (in read units per second and write units per second) for updating a table.</p>"
+                        "smithy.api#documentation": "<p>Represents the warm throughput (in read units per second and write units per second)\n            for updating a table.</p>"
                     }
                 }
             },
@@ -13887,7 +21408,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the global table to be updated. You can also provide the Amazon Resource Name (ARN) of the\n            table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "ProvisionedWriteCapacityAutoScalingUpdate": {
@@ -13957,7 +21481,10 @@
                     "target": "com.amazonaws.dynamodb#TableArn",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the table to be configured. You can also provide the Amazon Resource Name (ARN) of the\n            table in this parameter.</p>",
-                        "smithy.api#required": {}
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "ResourceArn"
+                        }
                     }
                 },
                 "TimeToLiveSpecification": {


### PR DESCRIPTION
## Motivation and Context
Previous #4097 used a stale dynamodb model for account-based endpoints tests. This PR makes use of the latest model, and revises the integration tests based on the test cases prescribed in the spec.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
