### PR TITLE
Avoid treating `addedDefault` as `default` when serializing numbers and bools

### DIFF
--- a/.changelog/1746737221.md
+++ b/.changelog/1746737221.md
@@ -1,0 +1,14 @@
+---
+applies_to:
+- client
+- server
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#4117
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix a bug where fields that were initially annotated with the `required` trait and later updated to use the `addedDefault` trait were not serialized when their values matched the default, even when the values were explicitly set. With this fix, fields with `addedDefault` are now always serialized.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/SerializerUtil.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/SerializerUtil.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.AddedDefaultTrait
 import software.amazon.smithy.model.traits.ClientOptionalTrait
 import software.amazon.smithy.model.traits.InputTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
@@ -30,6 +31,10 @@ class SerializerUtil(private val model: Model, private val symbolProvider: Symbo
         if (
             shape.isRequired ||
             shape.hasTrait<ClientOptionalTrait>() ||
+            // Treating `addedDefault` as `default` could break existing serializers.
+            // Fields that were previously marked as `required` but later replaced with `addedDefault`
+            // may no longer be serialized. This could occur when an explicitly set value matches the default.
+            shape.hasTrait<AddedDefaultTrait>() ||
             // Zero values are always serialized in lists and collections, this only applies to structures
             container !is StructureShape ||
             container.hasTrait<InputTrait>()


### PR DESCRIPTION
## Description
This PR fixes a regression in input serializers. Previously, fields of numbers/bool annotated with the `required` trait were always serialized. With the introduction of the [addedDefault](https://smithy.io/2.0/spec/type-refinement-traits.html#addeddefault-trait) trait, they stopped being serialized when an input values match the default even if explicitly set by the user.

An example is `LoggingConfig` in CloudFront ([change](https://github.com/awslabs/aws-sdk-rust/commit/3465444a0f6b66816febdeb6441110ec283c1317#diff-8ff83311bcd0649ac0bee175e8a1f3d1fce9c8863c64b896c58f41ac17051bf0R8)). The previously required fields `enabled` and `include_cookies` were annotated with the `addedDefault` trait and the `LoggingConfig`'s serializer made serialization of those fields conditional:
```
pub fn ser_logging_config(...) -> ... {
    #[allow(unused_mut)]
    let mut scope = writer.finish();
    if input.enabled {
        let mut inner_writer = scope.start_el("Enabled").finish();
        inner_writer.data(::aws_smithy_types::primitive::Encoder::from(input.enabled).encode());
    }
    if input.include_cookies {
        let mut inner_writer = scope.start_el("IncludeCookies").finish();
        inner_writer.data(::aws_smithy_types::primitive::Encoder::from(input.include_cookies).encode());
    }
   ...
``` 
When their values were `false`, they did not get serialized, regardless of whether they were explicitly set; when they were `required` fields previously, they had always been serialized.

This has caused CloudFront SDK users to encounter an error response from the service, e.g,
```
You must specify IncludeCookies when Enabled is missing or set to true within a Logging object
``` 

This PR treats the `addedDefault` trait as non `default`, making the fields always be serialized.

## Testing
- CI and release pipeline
- Confirmed that `LoggingConfig`'s serializer always serializes the fields in question

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
