### PR TITLE
Fix redundant closure warnings in Rust 1.82

### DIFF
--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -291,7 +291,7 @@ fun Project.registerGenerateCargoConfigTomlTask(outputDir: File) {
                 .writeText(
                     """
                     [build]
-                    rustflags = ["--cfg", "aws_sdk_unstable"]
+                    rustflags = ["--deny", "warnings", "--cfg", "aws_sdk_unstable"]
                     """.trimIndent(),
                 )
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
@@ -351,9 +351,22 @@ class ServerBuilderGenerator(
                     if (!constrainedTypeHoldsFinalType(member)) varExpr = "($varExpr).into()"
 
                     if (wrapInMaybeConstrained) {
-                        conditionalBlock("input.map(##[allow(clippy::redundant_closure)] |v| ", ")", conditional = symbol.isOptional()) {
-                            conditionalBlock("Box::new(", ")", conditional = hasBox) {
-                                rust("$maybeConstrainedVariant($varExpr)")
+                        // Temporary fix for `#[allow(clippy::redundant_closure)]` not working in `rustc` version 1.82.
+                        // The issue occurs specifically when we generate code in the form:
+                        // ```rust
+                        // input.map(|v| MaybeConstrained(v))
+                        // ```
+                        // This pattern triggers a clippy warning about redundant closures, even with the allow attribute.
+                        // For this specific pattern, we directly use the constructor function reference.
+                        // Other cases like `Box::new(v)` or `v.into()` are valid closure usages and remain unchanged.
+                        if (symbol.isOptional() && varExpr == "v") {
+                            rust("input.map($maybeConstrainedVariant)")
+                        }
+                        else {
+                            conditionalBlock("input.map(##[allow(clippy::redundant_closure)] |v| ",")", conditional = symbol.isOptional()) {
+                                conditionalBlock("Box::new(", ")", conditional = hasBox) {
+                                    rust("$maybeConstrainedVariant($varExpr)")
+                                }
                             }
                         }
                     } else {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorCommon.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorCommon.kt
@@ -27,6 +27,7 @@ import software.amazon.smithy.model.shapes.LongShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.NumberShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShortShape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.TimestampShape
@@ -84,8 +85,18 @@ fun generateFallbackCodeToDefaultValue(
     symbolProvider: RustSymbolProvider,
     publicConstrainedTypes: Boolean,
 ) {
-    var defaultValue = defaultValue(model, runtimeConfig, symbolProvider, member)
     val targetShape = model.expectShape(member.target)
+    // Temporary fix for `#[allow(clippy::redundant_closure)]` not working in `rustc` version 1.82.
+    // The issue occurs specifically when we generate code in the form:
+    // ```rust
+    // .unwrap_or_else(HashMap::new())
+    // ```
+    if (isTargetListOrMap(targetShape, member)) {
+        writer.rustTemplate(".unwrap_or_default()")
+        return
+    }
+
+    var defaultValue = defaultValue(model, runtimeConfig, symbolProvider, member)
     val targetSymbol = symbolProvider.toSymbol(targetShape)
     // We need an .into() conversion to create defaults for the server types. A larger scale refactoring could store this information in the
     // symbol, however, retrieving it in this manner works for the moment.
@@ -123,6 +134,22 @@ fun generateFallbackCodeToDefaultValue(
             writer.rustTemplate(".unwrap_or_else(##[allow(clippy::redundant_closure)] || #{DefaultValue:W})", "DefaultValue" to defaultValue)
         }
     }
+}
+
+private fun isTargetListOrMap(
+    targetShape: Shape?,
+    member: MemberShape,
+): Boolean {
+    if (targetShape is ListShape) {
+        val node = member.expectTrait<DefaultTrait>().toNode()!!
+        check(node is ArrayNode && node.isEmpty)
+        return true
+    } else if (targetShape is MapShape) {
+        val node = member.expectTrait<DefaultTrait>().toNode()!!
+        check(node is ObjectNode && node.isEmpty)
+        return true
+    }
+    return false
 }
 
 /**


### PR DESCRIPTION
## Problem
In Rust 1.82, the `#[allow(clippy::redundant_closure)]` attribute is not functioning as intended, causing warnings that are elevated to errors in our build process. Specifically, when generating code in the form:

```rust
input.map(#[allow(clippy::redundant_closure)] |v| MaybeConstrained::Constrained(v))
```

Clippy still reports a redundant closure error despite the allow attribute.

## Solution
This PR implements a temporary workaround until the Clippy issue is fixed. Instead of relying on the allow attribute, we now generate code that follows Clippy's recommendation by using function references directly:

```rust
input.map(MaybeConstrained::Constrained)
```

For collection types like `Vec` and `HashMap`, we're using `.unwrap_or_default()` instead of closure-wrapped constructors.

## Implementation Details
- Added special handling for empty collections
- Modified code generation to produce different output based on context
- Preserved existing behavior for cases where we need to use closures (e.g., with `Box::new`, `.into()`)

## Testing
- Verified code generation produces the expected output
- Confirmed build succeeds without warnings when using the new code generator

The workaround will be revisited once the Clippy issue is resolved in a future Rust version.