### PR TITLE
Fix Rust 1.82 lint warnings in client runtime / SDK crates

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.6.2"
+version = "1.6.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -123,9 +123,8 @@ impl ProvideCredentials for CredentialsProviderChain {
 
     fn fallback_on_interrupt(&self) -> Option<Credentials> {
         for (_, provider) in &self.providers {
-            match provider.fallback_on_interrupt() {
-                creds @ Some(_) => return creds,
-                None => {}
+            if let creds @ Some(_) = provider.fallback_on_interrupt() {
+                return creds;
             }
         }
         None

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -101,6 +101,11 @@ impl<'a> SignatureValues<'a> {
         }
     }
 
+    #[allow(clippy::result_large_err)]
+    /*
+       QueryParams(QueryParamValues<'a>),
+       --------------------------------- the largest variant contains at least 192 bytes
+    */
     pub(crate) fn into_query_params(self) -> Result<QueryParamValues<'a>, Self> {
         match self {
             SignatureValues::QueryParams(values) => Ok(values),

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -105,6 +105,8 @@ impl<'a> SignatureValues<'a> {
     /*
        QueryParams(QueryParamValues<'a>),
        --------------------------------- the largest variant contains at least 192 bytes
+
+       Suppressing the Clippy warning, as the variant above is always returned wrapped in `Ok`.
     */
     pub(crate) fn into_query_params(self) -> Result<QueryParamValues<'a>, Self> {
         match self {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/AllowLintsCustomization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/AllowLintsCustomization.kt
@@ -57,6 +57,10 @@ private val allowedRustdocLints =
         // Rustdoc warns about redundant explicit links in doc comments. This is fine for handwritten
         // crates, but is impractical to manage for code generated crates. Thus, allow it.
         "redundant_explicit_links",
+        // The documentation directly from the model may contain invalid HTML tags. For instance,
+        // <p><code><bucketloggingstatus xmlns="http://doc.s3.amazonaws.com/2006-03-01" /></code></p>
+        // is considered an invalid self-closing HTML tag `bucketloggingstatus`
+        "invalid_html_tags",
     )
 
 class AllowLintsCustomization(


### PR DESCRIPTION
## Motivation and Context
Address warnings in client runtime / SDK crates as listed in #4122 

## Description
`TODO(MSRV1.82 follow-up)` are retained, since warnings coming from the server runtime crates need to be addressed as well.

## Testing
No lint warnings are generated with the changes.

```
aws-config git:(ysaito/fix-msrv-1-82-lint-warning) ✗ RUSTFLAGS="-Dwarnings" cargo clippy --all-features
    ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.80s
```
```
aws-sigv4 git:(ysaito/fix-msrv-1-82-lint-warning) ✗ RUSTFLAGS="-Dwarnings" cargo clippy --all-features
    ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 41.40s
```

```
s3 git:(ysaito/fix-msrv-1-82-lint-warning) ✗ RUSTDOCFLAGS='--cfg docsrs -Dwarnings' cargo +nightly-2025-05-04 doc --no-deps --document-private-items --all-features
    ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.16s
```
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
