### PR TITLE
Update UnionGenerator to handle members named Unknown

### DIFF
--- a/.changelog/unknown-variants.md
+++ b/.changelog/unknown-variants.md
@@ -1,0 +1,10 @@
+---
+applies_to: ["client", "server"]
+authors: ["rcoh"]
+references: ["smithy-rs#4132"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Smithy unions that contain members named "unknown" will now codegen correctly

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
@@ -110,7 +110,8 @@ open class UnionGenerator(
     private fun renderImplBlock(unionSymbol: Symbol) {
         writer.rustBlock("impl ${unionSymbol.name}") {
             sortedMembers.forEach { member ->
-                val funcNamePart = member.memberName.toSnakeCase()
+                // We need to get the symbol first because the member can be renamed
+                val funcNamePart = symbolProvider.toSymbol(member).name.toSnakeCase()
                 val variantName = symbolProvider.toMemberName(member)
 
                 if (sortedMembers.size == 1) {
@@ -219,7 +220,10 @@ private fun RustWriter.renderAsVariant(
             targetSymbol,
         )
         rust("/// Returns `Err(&Self)` if it can't be converted.")
-        rustBlockTemplate("pub fn as_$funcNamePart(&self) -> #{Result}<&${memberSymbol.rustType().render()}, &Self>", *preludeScope) {
+        rustBlockTemplate(
+            "pub fn as_$funcNamePart(&self) -> #{Result}<&${memberSymbol.rustType().render()}, &Self>",
+            *preludeScope,
+        ) {
             rustTemplate(
                 "if let ${unionSymbol.name}::$variantName(val) = &self { #{Ok}(val) } else { #{Err}(self) }",
                 *preludeScope,


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently when a Smithy `union` type contains a member named `unknown` it causes a codegen error because we generate two functions named `is_unknown` in the `impl` block for the enum. One to indicate if the type is the `Unknown` variant we add to all enums and the other to indicate if it is the variant for the 'unknown' member in the model (which in codegen is already renamed to `UnknownValue` in the enum). 

This change mirrors the renaming of the enum variant by changing the function for it to `is_unknown_value`.  This is achieved by first passing the member through the `SymbolProvider` to get the properly renamed symbol. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added codegen test for a `union` with a member named `unknown`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
