### PR TITLE
Fix bug with enum code generation

### DIFF
--- a/.changelog/unknown-debug.md
+++ b/.changelog/unknown-debug.md
@@ -1,0 +1,18 @@
+---
+applies_to: ["client"]
+authors: ["landonxjames"]
+references: ["smithy-rs#4137"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Fix bug with enum codegen
+
+When the first enum generated has the `@sensitive` trait the opaque type
+underlying the `UnknownVariant` inherits that sensitivity. This means that
+it does not derive `Debug`. Since the module is only generated once this
+causes a problem for non-sensitive enums that rely on the type deriving
+`Debug` so that they can also derive `Debug`. We manually add `Debug` to
+the module so it will always be there since the `UnknownVariant` is not
+modeled and cannot be `@sensitive`.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
@@ -194,7 +194,12 @@ data class InfallibleEnumType(
                 This is not intended to be used directly.
                 """.trimIndent(),
             )
-            context.enumMeta.render(this)
+
+            // The UnknownVariant's underlying opaque type should always derive `Debug`. If this isn't explicitly
+            // added and the first enum to render this module has the `@sensitive` trait then the UnknownVariant
+            // inherits that sensitivity and does not derive `Debug`. This leads to issues deriving `Debug` for
+            // all enum variants that are not marked `@sensitive`.
+            context.enumMeta.withDerives(RuntimeType.Debug).render(this)
             rustTemplate("struct $UNKNOWN_VARIANT_VALUE(pub(crate) #{String});", *preludeScope)
             rustBlock("impl $UNKNOWN_VARIANT_VALUE") {
                 // The generated as_str is not pub as we need to prevent users from calling it on this opaque struct.


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
A customer's model was impacted by this bug. 

## Description
<!--- Describe your changes in detail -->

When the first enum generated has the `@sensitive` trait the opaque type underlying the `UnknownVariant` inherits that sensitivity. This means that it does not derive `Debug`. Since the module is only generated once this causes a problem for non-sensitive enums that rely on the type deriving `Debug` so that they can also derive `Debug`. We manually add `Debug` to the module so it will always be there since the `UnknownVariant` is not modeled and cannot be `@sensitive`.

The Smithy library iterates shapes in alphabetical order, in practice that means this bug will only be hit when the alphabetically first enum is `@sensitive`. With the current behavior the following model will fail to codegen:
```smithy
@sensitive
@enum([
    { name: "Foo", value: "Foo" },
    { name: "Bar", value: "Bar" },
])
string FooA

@enum([
    { name: "Baz", value: "Baz" },
    { name: "Ahh", value: "Ahh" },
])
string FooB
```

But this model will succeed (note that we only changed the name and thus the alphabetical order of the `@sensitive` shape).
```smithy
@sensitive
@enum([
    { name: "Foo", value: "Foo" },
    { name: "Bar", value: "Bar" },
])
string FooZ

@enum([
    { name: "Baz", value: "Baz" },
    { name: "Ahh", value: "Ahh" },
])
string FooB
```


**Note:** The general behavior underlying this issue, the idempotency of RustModule generation could cause more bugs and this is really just a bandaid fix for this particular case. TODO: create issue to investigate the idempotency of Rust Modules.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test that fails on the current behavior and succeeds with the bug fix. It creates a project and first generates an `@sensitive` enum and then generates a non-sensitive enum. Before the fix this failed to compile, but is now successful.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
