### PR TITLE
Removing the optimize_crc32_auto feature flag from the crc-fast

### DIFF
--- a/.changelog/crc-fast-feature.md
+++ b/.changelog/crc-fast-feature.md
@@ -1,0 +1,10 @@
+---
+applies_to: ["client", "aws-sdk-rust"]
+authors: ["landonxjames"]
+references: ["aws-sdk-rust#1291"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Removing the `optimize_crc32_auto` feature flag from the `crc-fast` dependency of the `aws-smithy-checksums` crate since it was causing build issues for some customers.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.2"
+version = "0.63.3"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.63.2"
+version = "0.63.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1.10.0"
-crc-fast = { version = "1.2.1", features = ["optimize_crc32_auto"] }
+crc-fast = { version = "1.2.1" }
 hex = "0.4.3"
 http = "0.2.9"
 http-body = "0.4.5"


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Removing the `optimize_crc32_auto` feature flag from the `crc-fast` dependency of the `aws-smithy-checksums` crate since it was causing build issues for some customers.

https://github.com/awslabs/aws-sdk-rust/issues/1291


## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in an [Amazon Linux 2023 Docker Container](https://docs.aws.amazon.com/linux/al2023/ug/base-container.html) on an M1 Mac. Both `cargo lambda build --arm64` and `cargo lambda build --x86-64` succeeded with this change


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
