### PR TITLE
fix h2 goaway error retry regression

### DIFF
--- a/.changelog/1747837382.md
+++ b/.changelog/1747837382.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- aajtodd
+references:
+- aws-sdk-rust#1272
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix h2 GoAway errors not being retried by hyper legacy client

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "h2 0.3.26",
  "h2 0.4.10",
  "http 0.2.12",
  "http-body 0.4.6",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
+ "h2 0.3.26",
  "h2 0.4.10",
  "http 0.2.12",
  "http 1.3.1",

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.0.2"
+version = "1.0.3"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"
@@ -14,6 +14,7 @@ hyper-014 = [
     "dep:http-02x",
     "dep:http-body-04x",
     "dep:hyper-0-14",
+    "dep:h2-0-3"
 ]
 
 default-client = [
@@ -100,6 +101,7 @@ http-body-04x = { package = "http-body", version = "0.4.5" , optional = true}
 hyper-0-14 = { package = "hyper", version = "0.14.26", default-features = false, features = ["client", "http1", "http2", "tcp", "stream"], optional = true }
 legacy-hyper-rustls = { package = "hyper-rustls", version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
 legacy-rustls = { package = "rustls", version = "0.21.8", optional = true }
+h2-0-3 = { package = "h2", version = "0.3.24", optional = true }
 # end legacy stack deps
 
 # test util stack

--- a/rust-runtime/aws-smithy-http-client/src/hyper_legacy.rs
+++ b/rust-runtime/aws-smithy-http-client/src/hyper_legacy.rs
@@ -24,7 +24,7 @@ use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_smithy_types::retry::ErrorKind;
-use h2::Reason;
+use h2_0_3::Reason;
 use hyper_0_14::client::connect::{capture_connection, CaptureConnection, Connection, HttpInfo};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -382,7 +382,7 @@ fn to_connector_error(err: hyper_0_14::Error) -> ConnectorError {
     if err.is_incomplete_message() {
         return ConnectorError::other(err.into(), Some(ErrorKind::TransientError));
     }
-    if let Some(h2_err) = find_source::<h2::Error>(&err) {
+    if let Some(h2_err) = find_source::<h2_0_3::Error>(&err) {
         if h2_err.is_go_away()
             || (h2_err.is_reset() && h2_err.reason() == Some(Reason::REFUSED_STREAM))
         {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
fixes https://github.com/awslabs/aws-sdk-rust/issues/1272

## Description
<!--- Describe your changes in detail -->

The hyper 1.x work introduced a regression to the hyper legacy 0.14 client's ability to retry h2::GoAway errors. This was due to the h2 version that each hyper version is pinned to as described in the reproduction in the issue. This is similar to the issue we've seen in the past with different major versions of a type being added to config bag. 

Also tested against hyper 1.x using the same mechanism supplied in the [reproduction](https://github.com/awslabs/aws-sdk-rust/issues/1272#issuecomment-2887562827) (see https://github.com/aajtodd/hyper/commit/7fe4ee6b091dc37ed5b6cd17d1da067a42e3b6a4) to verify it also works as intended.

## Testing
Tested repro locally with and without the fix. Without the fix I can see no retries attempted and the [warning message](https://github.com/smithy-lang/smithy-rs/blob/release-2025-05-19/rust-runtime/aws-smithy-http-client/src/hyper_legacy.rs#L393). With the fix retries are attempted and no warning message. 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
