### PR TITLE
Disable testing aws-sdk-rust tests/ dir

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-services
+++ b/tools/ci-scripts/check-aws-sdk-services
@@ -22,9 +22,10 @@ else
     cargo test --all-features
 fi
 
-for test_dir in tests/*; do
-    if [ -f "${test_dir}/Cargo.toml" ]; then
-        echo "#### Testing ${test_dir}..."
-        cargo test --all-features --manifest-path "${test_dir}/Cargo.toml"
-    fi
-done
+# TODO reenable these tests when they have lockfiles
+# for test_dir in tests/*; do
+#     if [ -f "${test_dir}/Cargo.toml" ]; then
+#         echo "#### Testing ${test_dir}..."
+#         cargo test --all-features --manifest-path "${test_dir}/Cargo.toml"
+#     fi
+# done


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
