### PR TITLE
Expose setter for `client_builder` in `aws_smithy_http_client::client::Builder`

### DIFF
--- a/.changelog/1748945737.md
+++ b/.changelog/1748945737.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- client
+authors:
+- kevinzwang
+references: []
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Expose setter for `client_builder` in `aws_smithy_http_client::client::Builder`

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -661,6 +661,14 @@ cfg_tls! {
     }
 }
 
+impl<Tls> Builder<Tls> {
+    /// Configure the Hyper client builder
+    pub fn client_builder(mut self, builder: Option<hyper_util::client::legacy::Builder>) -> Self {
+        self.client_builder = builder;
+        self
+    }
+}
+
 impl Builder<TlsUnset> {
     /// Creates a new builder.
     pub fn new() -> Self {


### PR DESCRIPTION
## Motivation and Context

Right now [`Builder::client_builder`](https://github.com/smithy-lang/smithy-rs/blob/main/rust-runtime/aws-smithy-http-client/src/client.rs#L556) cannot actually be set, which means that users will only be able to use the default Hyper client builder.

The legacy [`HyperClientBuilder`](https://github.com/smithy-lang/smithy-rs/blob/main/rust-runtime/aws-smithy-http-client/src/hyper_legacy.rs#L553) allowed setting both the client builder and the TCP connector, so this functionality is lost when porting code over to the new, Hyper v1-based HTTP client.

## Description
Adds a method on `Builder` to set `client_builder`, similar to existing builder methods. It's implemented over a generic `Builder<Tcp>` so that it can be used when a builder has its TCP provider both set or unset.

## Testing
none

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
