### PR TITLE
Add allow http and cert verifier configs to http client

### DIFF
--- a/.changelog/change.md
+++ b/.changelog/change.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- client
+authors:
+- kevinzwang
+references: []
+breaking: false
+new_feature: false
+bug_fix: false
+---
+Added allow http and cert verifier configs to http client

--- a/rust-runtime/aws-smithy-http-client/examples/client-aws-lc.rs
+++ b/rust-runtime/aws-smithy-http-client/examples/client-aws-lc.rs
@@ -12,12 +12,12 @@ use aws_smithy_http_client::{
 async fn main() {
     // feature = rustls-aws-lc
     let _client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(CryptoMode::AwsLc))
+        .tls_provider(tls::Provider::rustls(CryptoMode::AwsLc))
         .build_https();
 
     // feature = rustls-aws-lc-fips
     // A FIPS client can also be created. Note that this has a more complex build environment required.
     let _client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(CryptoMode::AwsLcFips))
+        .tls_provider(tls::Provider::rustls(CryptoMode::AwsLcFips))
         .build_https();
 }

--- a/rust-runtime/aws-smithy-http-client/examples/client-ring.rs
+++ b/rust-runtime/aws-smithy-http-client/examples/client-ring.rs
@@ -10,6 +10,6 @@ use aws_smithy_http_client::{
 
 fn main() {
     let _client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
+        .tls_provider(tls::Provider::rustls(CryptoMode::Ring))
         .build_https();
 }

--- a/rust-runtime/aws-smithy-http-client/examples/custom-dns.rs
+++ b/rust-runtime/aws-smithy-http-client/examples/custom-dns.rs
@@ -21,6 +21,6 @@ impl ResolveDns for StaticResolver {
 
 fn main() {
     let _client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
+        .tls_provider(tls::Provider::rustls(CryptoMode::Ring))
         .build_with_resolver(StaticResolver);
 }

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -61,7 +61,7 @@ pub fn default_connector(
         }
 
         let conn = conn_builder
-            .tls_provider(tls::Provider::Rustls(
+            .tls_provider(tls::Provider::rustls(
                 tls::rustls_provider::CryptoMode::AwsLc,
             ))
             .build();
@@ -603,11 +603,13 @@ cfg_tls! {
                     feature = "rustls-aws-lc-fips",
                     feature = "rustls-ring"
                 ))]
-                tls::Provider::Rustls(crypto_mode) => {
+                tls::Provider::Rustls { crypto_mode, cert_verifier } => {
                     let https_connector = tls::rustls_provider::build_connector::wrap_connector(
                         http_connector,
                         crypto_mode.clone(),
+                        cert_verifier.clone(),
                         &self.tls.context,
+
                     );
                     self.wrap_connector(https_connector)
                 },

--- a/rust-runtime/aws-smithy-http-client/tests/smoke_test_clients.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/smoke_test_clients.rs
@@ -26,7 +26,7 @@ use tower::Service;
 #[tokio::test]
 async fn ring_client() {
     let client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::Ring,
         ))
         .build_https();
@@ -37,7 +37,7 @@ async fn ring_client() {
 #[tokio::test]
 async fn aws_lc_fips_client() {
     let client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::AwsLcFips,
         ))
         .build_https();
@@ -48,7 +48,7 @@ async fn aws_lc_fips_client() {
 #[tokio::test]
 async fn aws_lc_client() {
     let client = Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::AwsLc,
         ))
         .build_https();
@@ -88,7 +88,7 @@ async fn custom_dns_client() {
 
     let providers = [
         #[cfg(feature = "rustls-ring")]
-        tls::Provider::Rustls(tls::rustls_provider::CryptoMode::Ring),
+        tls::Provider::rustls(tls::rustls_provider::CryptoMode::Ring),
         #[cfg(feature = "s2n-tls")]
         tls::Provider::S2nTls,
     ];

--- a/rust-runtime/aws-smithy-http-client/tests/tls.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/tls.rs
@@ -154,7 +154,7 @@ fn tls_context_from_pem(filename: &str) -> TlsContext {
 #[tokio::test]
 async fn test_rustls_aws_lc_native_ca() {
     let client = aws_smithy_http_client::Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::AwsLc,
         ))
         .build_https();
@@ -166,7 +166,7 @@ async fn test_rustls_aws_lc_native_ca() {
 #[tokio::test]
 async fn test_rustls_aws_lc_custom_ca() {
     let client = aws_smithy_http_client::Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::AwsLc,
         ))
         .tls_context(tls_context_from_pem("tests/server.pem"))
@@ -180,7 +180,7 @@ async fn test_rustls_aws_lc_custom_ca() {
 #[tokio::test]
 async fn test_rustls_aws_lc_fips_native_ca() {
     let client = aws_smithy_http_client::Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::AwsLcFips,
         ))
         .build_https();
@@ -192,7 +192,7 @@ async fn test_rustls_aws_lc_fips_native_ca() {
 #[tokio::test]
 async fn test_rustls_aws_lc_fips_custom_ca() {
     let client = aws_smithy_http_client::Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::AwsLcFips,
         ))
         .tls_context(tls_context_from_pem("tests/server.pem"))
@@ -206,7 +206,7 @@ async fn test_rustls_aws_lc_fips_custom_ca() {
 #[tokio::test]
 async fn test_rustls_ring_native_ca() {
     let client = aws_smithy_http_client::Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::Ring,
         ))
         .build_https();
@@ -218,7 +218,7 @@ async fn test_rustls_ring_native_ca() {
 #[tokio::test]
 async fn test_rustls_ring_custom_ca() {
     let client = aws_smithy_http_client::Builder::new()
-        .tls_provider(tls::Provider::Rustls(
+        .tls_provider(tls::Provider::rustls(
             tls::rustls_provider::CryptoMode::Ring,
         ))
         .tls_context(tls_context_from_pem("tests/server.pem"))


### PR DESCRIPTION
## Motivation and Context
I work on [Daft](https://github.com/Eventual-Inc/Daft), which uses the AWS SDK and Smithy to read data from S3. We expose certain S3 configurations to allow them to enforce HTTPS or disable SSL verification.

Using the legacy HTTP client in `aws-smithy-http-client`, these were possible to implement because we could pass in [our own `hyper-tls` connector](https://github.com/Eventual-Inc/Daft/blob/71790a235c99c62ddbd01fa0c320d65487b02031/src/daft-io/src/s3_like.rs#L438-L439). However, the new HTTP client builder does not expose ways to do this.

## Description
These new configurations are added to the `aws-smithy-http-client` crate:
- An optional custom cert verifier to `crate::tls::rustls_provider::Provider::Rustls`
- A default-true `allow_http` parameter to `crate::tls::rustls_provider::TlsContext`

## Testing
none (let me know if there are tests that I could write, to my knowledge this is a pretty small change that should not modify existing behavior)

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
