### PR TITLE
Support SigV4A auth trait

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.rustsdk.customize.AwsDisableStalledStreamProtectio
 import software.amazon.smithy.rustsdk.customize.DisabledAuthDecorator
 import software.amazon.smithy.rustsdk.customize.IsTruncatedPaginatorDecorator
 import software.amazon.smithy.rustsdk.customize.RemoveDefaultsDecorator
+import software.amazon.smithy.rustsdk.customize.Sigv4aAuthTraitBackfillDecorator
 import software.amazon.smithy.rustsdk.customize.apigateway.ApiGatewayDecorator
 import software.amazon.smithy.rustsdk.customize.applyDecorators
 import software.amazon.smithy.rustsdk.customize.applyExceptFor
@@ -67,6 +68,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
             HttpRequestCompressionDecorator(),
             DisablePayloadSigningDecorator(),
             AwsDisableStalledStreamProtection(),
+            Sigv4aAuthTraitBackfillDecorator(),
             EndpointBasedAuthSchemeDecorator(),
             SpanDecorator(),
             // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/Sigv4aAuthTraitBackfillDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/Sigv4aAuthTraitBackfillDecorator.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk.customize
+
+import software.amazon.smithy.aws.traits.ServiceTrait
+import software.amazon.smithy.aws.traits.auth.SigV4ATrait
+import software.amazon.smithy.aws.traits.auth.SigV4Trait
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.traits.AuthTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.core.util.getTrait
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+import software.amazon.smithy.rust.codegen.core.util.sdkId
+import software.amazon.smithy.rustsdk.SigV4AuthDecorator
+
+class Sigv4aAuthTraitBackfillDecorator : ClientCodegenDecorator {
+    private val needsSigv4aBackfill =
+        setOf(
+            "CloudFront KeyValueStore",
+            "EventBridge",
+            "S3",
+            "SESv2",
+        )
+
+    override val name: String get() = "Sigv4aAuthTraitBackfill"
+
+    // This decorator must decorate before SigV4AuthDecorator so the model transformer of this class runs first
+    override val order: Byte = (SigV4AuthDecorator.ORDER + 1).toByte()
+
+    override fun transformModel(
+        service: ServiceShape,
+        model: Model,
+        settings: ClientRustSettings,
+    ): Model {
+        if (!applies(service)) {
+            return model
+        }
+
+        return ModelTransformer.create().mapShapes(model) { shape ->
+            when (shape.isServiceShape) {
+                true -> {
+                    val builder = (shape as ServiceShape).toBuilder()
+
+                    if (!shape.hasTrait<SigV4ATrait>()) {
+                        builder.addTrait(
+                            SigV4ATrait.builder()
+                                .name(
+                                    shape.getTrait<SigV4Trait>()?.name
+                                        ?: shape.getTrait<ServiceTrait>()?.arnNamespace,
+                                )
+                                .build(),
+                        )
+                    }
+
+                    // SigV4A is appended at the end because these services implement SigV4A
+                    // through endpoint-specific rules rather than the service shape.
+                    // To ensure correct prioritization, it's safest to add it last,
+                    // letting the endpoint rules take precedence as needed.
+                    val authTrait =
+                        shape.getTrait<AuthTrait>()?.let {
+                            if (it.valueSet.contains(SigV4ATrait.ID)) {
+                                it
+                            } else {
+                                AuthTrait(it.valueSet + mutableSetOf(SigV4ATrait.ID))
+                            }
+                        } ?: AuthTrait(mutableSetOf(SigV4Trait.ID, SigV4ATrait.ID))
+                    builder.addTrait(authTrait)
+
+                    builder.build()
+                }
+
+                false -> {
+                    shape
+                }
+            }
+        }
+    }
+
+    private fun applies(service: ServiceShape) = needsSigv4aBackfill.contains(service.sdkId())
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpressDecorator.kt
@@ -33,13 +33,11 @@ import software.amazon.smithy.rustsdk.AwsCargoDependency
 import software.amazon.smithy.rustsdk.AwsRuntimeType
 import software.amazon.smithy.rustsdk.InlineAwsDependency
 import software.amazon.smithy.rustsdk.SdkConfigSection
-import software.amazon.smithy.rustsdk.SigV4AuthDecorator
 
 class S3ExpressDecorator : ClientCodegenDecorator {
     override val name: String = "S3ExpressDecorator"
 
-    // This decorator must decorate after SigV4AuthDecorator so that sigv4 appears before sigv4-s3express within auth_scheme_options
-    override val order: Byte = (SigV4AuthDecorator.ORDER - 1).toByte()
+    override val order: Byte = 0
 
     override fun serviceRuntimePluginCustomizations(
         codegenContext: ClientCodegenContext,


### PR DESCRIPTION
## Motivation and Context
#4076 

## Description
Prior to this PR, the SDK determined support for SigV4A authentication based on the presence of the `authSchemes` list property in endpoint rules. With the introduction of the `aws.auth#sigv4a` trait in the model, the code generator should instead rely on the presence of this trait to determine SigV4A support.

However, some services include sigv4a in their endpoint authSchemes list without actually modeling the `aws.auth#sigv4a` trait. Simply switching to trait-based detection would break these services. To maintain backward compatibility, this PR introduces a special-case decorator, `Sigv4aAuthTraitBackfillDecorator` (ported from [the Kotlin SDK](https://github.com/awslabs/aws-sdk-kotlin/blob/a9c1922f2da871148500edb40d13859109f27606/codegen/aws-sdk-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/SigV4AsymmetricTraitCustomization.kt)), which augments the model by injecting the sigv4a trait for affected services. 

## Testing
- CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
