### PR TITLE
Make Rpc V2 CBOR `awsQuery` compatible

### DIFF
--- a/codegen-client/build.gradle.kts
+++ b/codegen-client/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":codegen-core"))
     implementation(kotlin("stdlib-jdk8"))
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/ClientProtocolLoader.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/ClientProtocolLoader.kt
@@ -16,13 +16,17 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationGenerator
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.AwsJson
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.AwsJsonVersion
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.AwsQueryCompatible
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.AwsQueryProtocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Ec2QueryProtocol
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.ParseErrorMetadataParams
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolGeneratorFactory
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolLoader
@@ -67,7 +71,23 @@ private class ClientAwsJsonFactory(private val version: AwsJsonVersion) :
     ProtocolGeneratorFactory<OperationGenerator, ClientCodegenContext> {
     override fun protocol(codegenContext: ClientCodegenContext): Protocol =
         if (compatibleWithAwsQuery(codegenContext.serviceShape, version)) {
-            AwsQueryCompatible(codegenContext, AwsJson(codegenContext, version))
+            AwsQueryCompatible(
+                codegenContext, AwsJson(codegenContext, version),
+                ParseErrorMetadataParams(
+                    RuntimeType.smithyJson(codegenContext.runtimeConfig)
+                        .resolve("deserialize::error::DeserializeError"),
+                    writable {
+                        rustTemplate(
+                            """
+                            #{parse_error_metadata}(response_body, response_headers)?
+                            """,
+                            "parse_error_metadata" to
+                                RuntimeType.jsonErrors(codegenContext.runtimeConfig)
+                                    .resolve("parse_error_metadata"),
+                        )
+                    },
+                ),
+            )
         } else {
             AwsJson(codegenContext, version)
         }
@@ -122,10 +142,33 @@ class ClientRestXmlFactory(
 }
 
 class ClientRpcV2CborFactory : ProtocolGeneratorFactory<OperationGenerator, ClientCodegenContext> {
-    override fun protocol(codegenContext: ClientCodegenContext): Protocol = RpcV2Cbor(codegenContext)
+    override fun protocol(codegenContext: ClientCodegenContext): Protocol =
+        if (compatibleWithAwsQuery(codegenContext.serviceShape)) {
+            AwsQueryCompatible(
+                codegenContext, RpcV2Cbor(codegenContext),
+                ParseErrorMetadataParams(
+                    RuntimeType.smithyCbor(codegenContext.runtimeConfig)
+                        .resolve("decode::DeserializeError"),
+                    writable {
+                        rustTemplate(
+                            """
+                            #{parse_error_metadata}(_response_status, response_headers, response_body)?
+                            """,
+                            "parse_error_metadata" to
+                                RuntimeType.cborErrors(codegenContext.runtimeConfig)
+                                    .resolve("parse_error_metadata"),
+                        )
+                    },
+                ),
+            )
+        } else {
+            RpcV2Cbor(codegenContext)
+        }
 
     override fun buildProtocolGenerator(codegenContext: ClientCodegenContext): OperationGenerator =
         OperationGenerator(codegenContext, protocol(codegenContext))
 
     override fun support(): ProtocolSupport = CLIENT_PROTOCOL_SUPPORT
+
+    private fun compatibleWithAwsQuery(serviceShape: ServiceShape) = serviceShape.hasTrait<AwsQueryCompatibleTrait>()
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
