### PR TITLE
fix hyper 1.x connection refused errors not marked as retryable

### DIFF
--- a/.changelog/1750957379.md
+++ b/.changelog/1750957379.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- aajtodd
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix hyper 1.x connection refused errors not marked as retryable

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.4"
+version = "1.8.1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -423,7 +423,7 @@ version = "0.60.3"
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.0.5"
+version = "1.0.6"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -1002,7 +1002,7 @@ mod test {
             .adapter;
 
         let resp = hyper
-            .call(HttpRequest::get("http://static-uri:20227.com").unwrap())
+            .call(HttpRequest::get("http://static-uri:50227.com").unwrap())
             .await
             .unwrap_err();
         assert!(

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -762,7 +762,6 @@ fn new_conn_builder(
 #[cfg(test)]
 mod test {
     use std::io::{Error, ErrorKind};
-    use std::net::{IpAddr, Ipv4Addr};
     use std::pin::Pin;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
@@ -772,7 +771,6 @@ mod test {
     use aws_smithy_async::assert_elapsed;
     use aws_smithy_async::rt::sleep::TokioSleep;
     use aws_smithy_async::time::SystemTimeSource;
-    use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use http_1x::Uri;
     use hyper::rt::ReadBufCursor;
@@ -978,6 +976,8 @@ mod test {
     #[tokio::test]
     async fn connection_refused_works() {
         use crate::client::dns::HyperUtilResolver;
+        use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns};
+        use std::net::{IpAddr, Ipv4Addr};
 
         #[derive(Debug, Clone, Default)]
         struct TestResolver;

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+mod dns;
 mod timeout;
 /// TLS connector(s)
 pub mod tls;
@@ -400,7 +401,17 @@ fn downcast_error(err: BoxError) -> ConnectorError {
     // error classifications
     let err = match find_source::<hyper::Error>(err.as_ref()) {
         Some(hyper_error) => return to_connector_error(hyper_error)(err),
-        None => err,
+        None => match find_source::<hyper_util::client::legacy::Error>(err.as_ref()) {
+            Some(hyper_util_err) => {
+                if hyper_util_err.is_connect()
+                    || find_source::<std::io::Error>(hyper_util_err).is_some()
+                {
+                    return ConnectorError::io(err);
+                }
+                err
+            }
+            None => err,
+        },
     };
 
     // otherwise, we have no idea!
@@ -559,7 +570,6 @@ pub struct Builder<Tls = TlsUnset> {
 }
 
 cfg_tls! {
-    mod dns;
     use aws_smithy_runtime_api::client::dns::ResolveDns;
 
     impl ConnectorBuilder<TlsProviderSelected> {
@@ -752,20 +762,22 @@ fn new_conn_builder(
 #[cfg(test)]
 mod test {
     use std::io::{Error, ErrorKind};
+    use std::net::{IpAddr, Ipv4Addr};
     use std::pin::Pin;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::task::{Context, Poll};
 
+    use crate::client::dns::HyperUtilResolver;
+    use crate::client::timeout::test::NeverConnects;
     use aws_smithy_async::assert_elapsed;
     use aws_smithy_async::rt::sleep::TokioSleep;
     use aws_smithy_async::time::SystemTimeSource;
+    use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use http_1x::Uri;
     use hyper::rt::ReadBufCursor;
     use hyper_util::client::legacy::connect::Connected;
-
-    use crate::client::timeout::test::NeverConnects;
 
     use super::*;
 
@@ -961,6 +973,49 @@ mod test {
             "expected '{message}' to contain '{expected}'"
         );
         assert_elapsed!(now, Duration::from_secs(2));
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct TestResolver;
+    impl ResolveDns for TestResolver {
+        fn resolve_dns<'a>(&'a self, _name: &'a str) -> DnsFuture<'a> {
+            let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+            DnsFuture::ready(Ok(vec![localhost_v4]))
+        }
+    }
+
+    #[tokio::test]
+    async fn connection_refused_works() {
+        let connector_settings = HttpConnectorSettings::builder()
+            .connect_timeout(Duration::from_secs(20))
+            .build();
+
+        let resolver = HyperUtilResolver {
+            resolver: TestResolver::default(),
+        };
+        let connector = Connector::builder().base_connector_with_resolver(resolver);
+
+        let hyper = Connector::builder()
+            .connector_settings(connector_settings)
+            .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+            .wrap_connector(connector)
+            .adapter;
+
+        let resp = hyper
+            .call(HttpRequest::get("http://static-uri:20227.com").unwrap())
+            .await
+            .unwrap_err();
+        assert!(
+            resp.is_io(),
+            "expected resp.is_io() to be true but it was false, resp == {:?}",
+            resp
+        );
+        let message = DisplayErrorContext(&resp).to_string();
+        let expected = "Connection refused";
+        assert!(
+            message.contains(expected),
+            "expected '{message}' to contain '{expected}'"
+        );
     }
 
     #[cfg(feature = "s2n-tls")]

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -984,6 +984,7 @@ mod test {
         }
     }
 
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn connection_refused_works() {
         let connector_settings = HttpConnectorSettings::builder()


### PR DESCRIPTION
## Description
internal ref: `V1820425457`

Fixes a regression in the way connection issues are classified which was causing them to not be retried when using the hyper 1.x client.

The issue is the logic for [classifying the error](https://github.com/smithy-lang/smithy-rs/blob/release-2025-06-11/rust-runtime/aws-smithy-http-client/src/client.rs#L401) was never being hit because connection errors are no longer `hyper::Error` they are `hyper_util::client::legacy::Error`. 

* [hyper-util::Error](https://docs.rs/hyper-util/0.1.14/hyper_util/client/legacy/struct.Error.html)
* [hyper@1.x::Error](https://docs.rs/hyper/1.6.0/hyper/struct.Error.html)
* [hyper@0.14.x::Error](https://docs.rs/hyper/0.14.32/hyper/struct.Error.html#method.is_connect) 

## Testing
New unit test plus verification against internal package that opened the issue.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
