### PR TITLE
Update the runner type for `check-client-codegen-unit-tests`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         - action: check-client-codegen-integration-tests
           runner: smithy_ubuntu-latest_8-core
         - action: check-client-codegen-unit-tests
-          runner: ubuntu-latest
+          runner: smithy_ubuntu-latest_8-core
         - action: check-core-codegen-unit-tests
           runner: smithy_ubuntu-latest_8-core
         - action: check-rust-runtimes


### PR DESCRIPTION
## Motivation and Context
To fix the [No space left on device](https://github.com/smithy-lang/smithy-rs/actions/runs/16148239040/job/45581865654#step:4:440) error encountered during the release.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
