### PR TITLE
Externalize `-Dwarnings` outside Dockerfile

### DIFF
--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -286,7 +286,6 @@ fun Project.registerGenerateCargoConfigTomlTask(outputDir: File) {
         // is completed, warnings can be prohibited in rustdoc by setting `rustdocflags` to `-D warnings`.
         doFirst {
             outputDir.resolve(".cargo").mkdirs()
-            // TODO(MSRV1.82 follow-up): Restore `"--deny", "warnings"` once lints are fixed in the server runtime crates
             outputDir.resolve(".cargo/config.toml")
                 .writeText(
                     """

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -239,9 +239,6 @@ ENV PATH=/opt/nodejs/bin:/opt/cargo/bin:$PATH:/usr/local/musl/bin/ \
     RUST_STABLE_VERSION=${rust_stable_version} \
     RUST_NIGHTLY_VERSION=${rust_nightly_version} \
     CARGO_INCREMENTAL=0 \
-    RUSTDOCFLAGS="-D warnings" \
-    # TODO(MSRV1.85 follow-up): Remove the allowed lints once fixed
-    RUSTFLAGS="-D warnings -A clippy::redundant_closure -A non_local_definitions" \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 # SMITHY_RS_DOCKER_BUILD_IMAGE indicates to build scripts that they are being built inside of the Docker build image.

--- a/tools/ci-build/build.docker-compose.yml
+++ b/tools/ci-build/build.docker-compose.yml
@@ -6,6 +6,10 @@ version: '3.9'
 services:
   smithy-rs-build:
     image: smithy-rs-build-image:latest
+    environment:
+      RUSTDOCFLAGS: -D warnings
+      # TODO(https://github.com/smithy-lang/smithy-rs/issues/4122): Remove the allowed lints once fixed in the server runtime crates
+      RUSTFLAGS: -D warnings -A clippy::redundant_closure -A non_local_definitions
     user: ${USER_ID}:build
     volumes:
     - type: bind

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -31,8 +31,6 @@ do
 
     echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
 
-    # TODO(MSRV1.82 follow-up): Restore `-Dwarnings` once lints are fixed in aws-smithy-http-server-python:
-    # "error: unexpected `cfg` condition name: `addr_of`"
     RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
     echo -e "## ${C_YELLOW}Running 'cargo minimal-versions check' on ${runtime_path}...${C_RESET}"


### PR DESCRIPTION
## Motivation and Context
Previously, our Docker image configurations had different warning handling for internal and external use:
- External images (used in smithy-rs CI): Treated warnings as errors
- Internal images: Ignored warnings

Now that we've unified our Docker image for both internal and external use, internal tests have inherited the stricter warning handling. This has caused unwanted test failures within our release pipeline.

This PR moves `-Dwarnings` (warning as error) outside of the Docker image, allowing the environment executing a Docker container to control whether warnings should be treated as errors. With this change, warnings won't be treated as errors in Docker containers themselves. The smithy-rs CI can set those flags to treat warnings as errors, and the release pipeline does not set the flags to continue ignoring warnings.

## Testing
After having externalized `-Dwarnings` outside the Docker image, confirmed that the smithy-r CI replicates the same set of errors with a fake change that introduced an intentional `unused` clippy warning ([main branch with a fake change](https://github.com/smithy-lang/smithy-rs/actions/runs/16282439691), [PR branch with a fake change](https://github.com/smithy-lang/smithy-rs/actions/runs/16283665358))

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
