### PR TITLE
Adjust `no_auth` test expectation to address semver hazards failure

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/express.rs
+++ b/aws/sdk/integration-tests/s3/tests/express.rs
@@ -453,28 +453,3 @@ async fn s3_express_auth_flow_should_not_be_reached_with_no_auth_schemes() {
     // If s3 Express auth flow were exercised, no request would be received, most likely due to `TimeoutError`.
     let _ = request.expect_request();
 }
-
-#[tracing_test::traced_test]
-#[tokio::test]
-async fn no_auth_should_be_selected_when_no_credentials_is_configured() {
-    let (http_client, _) = capture_request(None);
-    let config = aws_config::from_env()
-        .http_client(http_client)
-        .region(Region::new("us-east-2"))
-        .no_credentials()
-        .load()
-        .await;
-
-    let client = Client::new(&config);
-    let _ = dbg!(
-        client
-            .list_objects_v2()
-            .bucket("doesnotmatter")
-            .send()
-            .await
-    );
-
-    assert!(logs_contain(
-        "resolving identity scheme_id=AuthSchemeId { scheme_id: \"no_auth\" }"
-    ));
-}

--- a/aws/sdk/integration-tests/s3/tests/no_auth.rs
+++ b/aws/sdk/integration-tests/s3/tests/no_auth.rs
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use aws_sdk_s3::config::Region;
 use aws_sdk_s3::{Client, Config};
+use aws_smithy_http_client::test_util::capture_request;
 use aws_smithy_http_client::test_util::dvr::ReplayingClient;
+use aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID;
 use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
 
 #[tokio::test]
@@ -130,4 +133,30 @@ async fn get_object() {
         .relaxed_validate("application/xml")
         .await
         .unwrap();
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn no_auth_should_be_selected_when_no_credentials_is_configured() {
+    let (http_client, _) = capture_request(None);
+    let config = aws_config::from_env()
+        .http_client(http_client)
+        .region(Region::new("us-east-2"))
+        .no_credentials()
+        .load()
+        .await;
+
+    let client = Client::new(&config);
+    let _ = dbg!(
+        client
+            .list_objects_v2()
+            .bucket("doesnotmatter")
+            .send()
+            .await
+    );
+
+    assert!(logs_contain(&format!(
+        "resolving identity scheme_id=AuthSchemeId {{ scheme_id: \"{auth_scheme_id_str}\" }}",
+        auth_scheme_id_str = NO_AUTH_SCHEME_ID.inner(),
+    )));
 }


### PR DESCRIPTION
## Motivation and Context
This PR is a prerequisite for #4203.

# Details
PR4203 has updated some of the `AuthSchemeId` string values, which causes the `no_auth` test to fail in the semver hazards check. This happens because the inner string value for `NO_AUTH_SCHEME_ID` has been modified from `no_auth` to `noAuth`.

To resolve this, this PR updates the test expectation so that it no longer depends on raw string values. Once this PR is merged and released from `aws-sdk-rust`, PR4203 should pass the semver hazards check successfully.

Also the test has been moved to `no_auth.rs` since it is not specific to S3 Express; it was originally placed in `express.rs` because the issue was first discovered while investigating S3 Express behavior.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
