### PR TITLE
Preallocate correct-sized buffer for event stream

### DIFF
--- a/.changelog/1752602322.md
+++ b/.changelog/1752602322.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- server
+- client
+- aws-sdk-rust
+authors:
+- rcoh
+references: ["smithy-rs#4212"]
+breaking: false
+new_feature: false
+bug_fix: false
+---
+Event streams now allocate a right-sized buffer avoiding repeated reallocations during serialization

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -228,7 +228,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -253,6 +253,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -368,14 +379,17 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.9"
+version = "0.60.10"
 dependencies = [
  "arbitrary",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "crc32fast",
+ "criterion",
  "derive_arbitrary",
+ "jemallocator",
+ "mimalloc",
 ]
 
 [[package]]
@@ -384,7 +398,7 @@ version = "0.2.0"
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
@@ -431,7 +445,7 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.7",
  "hyper-util",
- "indexmap",
+ "indexmap 2.9.0",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.27",
@@ -476,6 +490,45 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-smithy-http-server-python"
+version = "0.66.1"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-http-server",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "bytes",
+ "futures",
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "lambda_http",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "pretty_assertions",
+ "pyo3",
+ "pyo3-asyncio",
+ "rcgen",
+ "rustls-pemfile 1.0.4",
+ "signal-hook",
+ "socket2",
+ "thiserror 2.0.12",
+ "tls-listener",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "tokio-test",
+ "tower 0.4.13",
+ "tower-test",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -751,7 +804,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.102",
  "which",
 ]
 
@@ -938,6 +991,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
@@ -952,7 +1020,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.5",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1060,7 +1137,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap",
+ "clap 4.5.40",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1087,6 +1164,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1153,7 +1239,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1180,7 +1266,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1353,7 +1439,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1455,7 +1541,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1474,7 +1560,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1493,9 +1579,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1810,14 +1917,30 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
  "serde",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inlineable"
@@ -1847,12 +1970,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.1",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -1880,6 +2012,26 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -1999,6 +2151,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2223,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,7 +2264,7 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2179,6 +2359,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.1",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,6 +2479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2510,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2367,12 +2572,18 @@ checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.1",
  "pin-project-lite",
  "rustix 1.0.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -2415,7 +2626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2445,6 +2656,97 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-asyncio"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea6b68e93db3622f3bb3bf363246cf948ed5375afe7abff98ccbdd50b184995"
+dependencies = [
+ "async-channel 1.9.0",
+ "clap 3.2.25",
+ "futures",
+ "inventory",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "pyo3-asyncio-macros",
+ "tokio",
+]
+
+[[package]]
+name = "pyo3-asyncio-macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c467178e1da6252c95c29ecf898b133f742e9181dca5def15dc24e19d45a39"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2568,6 +2870,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring 0.16.20",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2939,21 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "ring"
@@ -2694,7 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.14",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -2708,7 +3037,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.103.3",
  "subtle",
@@ -2772,7 +3101,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -2783,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -2902,7 +3231,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -2971,7 +3300,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2980,7 +3309,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3031,7 +3360,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3072,6 +3401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "cc",
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,6 +3446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,10 +3464,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3142,8 +3505,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -3157,6 +3526,21 @@ dependencies = [
  "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -3184,7 +3568,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3195,7 +3579,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3215,6 +3599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3274,6 +3659,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls-listener"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81294c017957a1a69794f506723519255879e15a870507faf45dfed288b763dd"
+dependencies = [
+ "futures-util",
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
 name = "tokio"
 version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,7 +3698,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3416,6 +3815,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tower-test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
+dependencies = [
+ "futures-util",
+ "pin-project",
+ "tokio",
+ "tokio-test",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3841,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,7 +3860,7 @@ checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3508,7 +3933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3534,6 +3959,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"
@@ -3680,7 +4111,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -3715,7 +4146,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3965,6 +4396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,7 +4424,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -4005,7 +4445,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4025,7 +4465,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -4065,5 +4505,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.102",
 ]

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
 # <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.9"
+version = "0.60.10"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."
@@ -12,6 +12,8 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 [features]
 derive-arbitrary = ["arbitrary", "derive_arbitrary"]
 test-util = []
+__bench-jemalloc = []
+__bench-mimalloc = []
 
 [dependencies]
 arbitrary = { version = "1.3", optional = true }
@@ -22,6 +24,16 @@ derive_arbitrary = { version = "1.3", optional = true }
 
 [dev-dependencies]
 bytes-utils = "0.1"
+criterion = { version = "0.5", features = ["html_reports"] }
+mimalloc = { version = "0.1.43" }
+
+# jemalloc doesn't work on windows, this breaks windows CI
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+jemallocator = { version = "0.5" }
+
+[[bench]]
+name = "write_message_performance"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/aws-smithy-eventstream/benches/write_message_performance.rs
+++ b/rust-runtime/aws-smithy-eventstream/benches/write_message_performance.rs
@@ -1,0 +1,484 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_eventstream::frame::write_message_to;
+use aws_smithy_eventstream::message_size_hint::MessageSizeHint;
+use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
+use bytes::{BufMut, Bytes};
+use crc32fast::Hasher;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::mem::size_of;
+
+/// Configuration for buffer allocation strategies in benchmarks
+#[derive(Debug, Clone)]
+pub enum BufferConfig {
+    /// Start with an empty buffer (Vec::new() - zero capacity)
+    Empty,
+    /// Pre-allocate buffer with exact message size
+    ExactSize(usize),
+    /// Pre-allocate buffer smaller than message size (factor < 1.0)
+    Undersized(f32),
+    /// Pre-allocate buffer larger than message size (factor > 1.0)
+    Oversized(f32),
+}
+
+impl BufferConfig {
+    /// Get a description of the buffer configuration for benchmark naming
+    pub fn description(&self) -> &'static str {
+        match self {
+            BufferConfig::Empty => "empty",
+            BufferConfig::ExactSize(_) => "exact",
+            BufferConfig::Undersized(_) => "undersized",
+            BufferConfig::Oversized(_) => "oversized",
+        }
+    }
+}
+
+/// Get the actual serialized size of a message by running serialization once
+pub fn get_message_size(message: &Message) -> usize {
+    let mut buffer = Vec::new();
+    write_message_to(message, &mut buffer).expect("Failed to serialize message");
+    buffer.len()
+}
+
+/// Create a buffer based on the configuration and actual message size
+pub fn create_buffer(config: &BufferConfig, message_size: usize) -> Vec<u8> {
+    match config {
+        BufferConfig::Empty => Vec::new(),
+        BufferConfig::ExactSize(_) => Vec::with_capacity(message_size),
+        BufferConfig::Undersized(factor) => {
+            let capacity = ((message_size as f32) * factor) as usize;
+            Vec::with_capacity(capacity.max(1)) // Ensure at least 1 byte capacity
+        }
+        BufferConfig::Oversized(factor) => {
+            let capacity = ((message_size as f32) * factor) as usize;
+            Vec::with_capacity(capacity)
+        }
+    }
+}
+
+// Global allocator configuration for different allocators
+#[cfg(all(feature = "__bench-jemalloc", not(feature = "__bench-mimalloc")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(all(feature = "__bench-mimalloc", not(feature = "__bench-jemalloc")))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+// Constants from the frame module
+const PRELUDE_LENGTH_BYTES: u32 = 3 * size_of::<u32>() as u32;
+const MESSAGE_CRC_LENGTH_BYTES: u32 = size_of::<u32>() as u32;
+const MAX_HEADER_NAME_LEN: usize = 255;
+
+const TYPE_TRUE: u8 = 0;
+const TYPE_FALSE: u8 = 1;
+const TYPE_BYTE: u8 = 2;
+const TYPE_INT16: u8 = 3;
+const TYPE_INT32: u8 = 4;
+const TYPE_INT64: u8 = 5;
+const TYPE_BYTE_ARRAY: u8 = 6;
+const TYPE_STRING: u8 = 7;
+const TYPE_TIMESTAMP: u8 = 8;
+const TYPE_UUID: u8 = 9;
+
+/// Optimized version of write_message to remove inline buffer. Stashing this here—this implemenetation
+/// is about 10% faster but needs more testing.
+pub fn write_message_to_optimized_v1(
+    message: &Message,
+    buffer: &mut Vec<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Pre-calculate header size without allocating
+    let mut headers_len = 0u32;
+    for header in message.headers() {
+        headers_len += calculate_header_size(header)?;
+    }
+
+    let payload_len = message.payload().len() as u32;
+    let message_len = PRELUDE_LENGTH_BYTES + headers_len + payload_len + MESSAGE_CRC_LENGTH_BYTES;
+
+    // Reserve space upfront
+    buffer.reserve(message_len as usize);
+
+    // Write prelude with CRC
+    let mut crc = Hasher::new();
+
+    // Write message length
+    buffer.put_u32(message_len);
+    crc.update(&message_len.to_be_bytes());
+
+    // Write headers length
+    buffer.put_u32(headers_len);
+    crc.update(&headers_len.to_be_bytes());
+
+    // Write prelude CRC and include it in the ongoing CRC calculation
+    let prelude_crc = crc.clone().finalize();
+    buffer.put_u32(prelude_crc);
+    crc.update(&prelude_crc.to_be_bytes());
+
+    // Write headers directly to buffer
+    for header in message.headers() {
+        write_header_to_optimized(header, buffer, &mut crc)?;
+    }
+
+    // Write payload
+    buffer.put_slice(message.payload());
+    crc.update(message.payload());
+
+    // Write message CRC
+    buffer.put_u32(crc.finalize());
+
+    Ok(())
+}
+
+/// Calculate the size a header will take when serialized
+fn calculate_header_size(header: &Header) -> Result<u32, Box<dyn std::error::Error>> {
+    let name_len = header.name().as_bytes().len();
+    if name_len > MAX_HEADER_NAME_LEN {
+        return Err("Header name too long".into());
+    }
+
+    let mut size = 1 + name_len; // name length byte + name bytes
+
+    use HeaderValue::*;
+    match header.value() {
+        Bool(_) => size += 1,                            // type byte only
+        Byte(_) => size += 2,                            // type + value
+        Int16(_) => size += 3,                           // type + value
+        Int32(_) => size += 5,                           // type + value
+        Int64(_) => size += 9,                           // type + value
+        ByteArray(val) => size += 3 + val.len(),         // type + length + data
+        String(val) => size += 3 + val.as_bytes().len(), // type + length + data
+        Timestamp(_) => size += 9,                       // type + value
+        Uuid(_) => size += 17,                           // type + value
+        _ => return Err("Unsupported header value type".into()),
+    }
+
+    Ok(size as u32)
+}
+
+/// Write header directly to buffer with CRC update
+fn write_header_to_optimized(
+    header: &Header,
+    buffer: &mut Vec<u8>,
+    crc: &mut Hasher,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let name_bytes = header.name().as_bytes();
+    if name_bytes.len() > MAX_HEADER_NAME_LEN {
+        return Err("Header name too long".into());
+    }
+
+    // Write name length
+    let name_len = name_bytes.len() as u8;
+    buffer.put_u8(name_len);
+    crc.update(&[name_len]);
+
+    // Write name
+    buffer.put_slice(name_bytes);
+    crc.update(name_bytes);
+
+    // Write value
+    write_header_value_to_optimized(header.value(), buffer, crc)?;
+
+    Ok(())
+}
+
+/// Get the name of the current allocator for benchmark naming
+fn get_allocator_name() -> &'static str {
+    #[cfg(all(feature = "__bench-jemalloc", not(feature = "__bench-mimalloc")))]
+    return "jemalloc";
+
+    #[cfg(all(feature = "__bench-mimalloc", not(feature = "__bench-jemalloc")))]
+    return "mimalloc";
+
+    #[cfg(not(any(feature = "__bench-jemalloc", feature = "__bench-mimalloc")))]
+    return "system";
+
+    #[cfg(all(feature = "__bench-jemalloc", feature = "__bench-mimalloc"))]
+    return "system"; // When both features are enabled, default to system allocator
+}
+
+/// Write header value directly to buffer with CRC update
+fn write_header_value_to_optimized(
+    value: &HeaderValue,
+    buffer: &mut Vec<u8>,
+    crc: &mut Hasher,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use HeaderValue::*;
+    match value {
+        Bool(val) => {
+            let type_byte = if *val { TYPE_TRUE } else { TYPE_FALSE };
+            buffer.put_u8(type_byte);
+            crc.update(&[type_byte]);
+        }
+        Byte(val) => {
+            buffer.put_u8(TYPE_BYTE);
+            buffer.put_i8(*val);
+            crc.update(&[TYPE_BYTE]);
+            crc.update(&val.to_be_bytes());
+        }
+        Int16(val) => {
+            buffer.put_u8(TYPE_INT16);
+            buffer.put_i16(*val);
+            crc.update(&[TYPE_INT16]);
+            crc.update(&val.to_be_bytes());
+        }
+        Int32(val) => {
+            buffer.put_u8(TYPE_INT32);
+            buffer.put_i32(*val);
+            crc.update(&[TYPE_INT32]);
+            crc.update(&val.to_be_bytes());
+        }
+        Int64(val) => {
+            buffer.put_u8(TYPE_INT64);
+            buffer.put_i64(*val);
+            crc.update(&[TYPE_INT64]);
+            crc.update(&val.to_be_bytes());
+        }
+        ByteArray(val) => {
+            if val.len() > u16::MAX as usize {
+                return Err("Byte array too long".into());
+            }
+            buffer.put_u8(TYPE_BYTE_ARRAY);
+            buffer.put_u16(val.len() as u16);
+            buffer.put_slice(val);
+            crc.update(&[TYPE_BYTE_ARRAY]);
+            crc.update(&(val.len() as u16).to_be_bytes());
+            crc.update(val);
+        }
+        String(val) => {
+            let bytes = val.as_bytes();
+            if bytes.len() > u16::MAX as usize {
+                return Err("String too long".into());
+            }
+            buffer.put_u8(TYPE_STRING);
+            buffer.put_u16(bytes.len() as u16);
+            buffer.put_slice(bytes);
+            crc.update(&[TYPE_STRING]);
+            crc.update(&(bytes.len() as u16).to_be_bytes());
+            crc.update(bytes);
+        }
+        Timestamp(time) => {
+            let millis = time.to_millis().map_err(|_| "Timestamp too large")?;
+            buffer.put_u8(TYPE_TIMESTAMP);
+            buffer.put_i64(millis);
+            crc.update(&[TYPE_TIMESTAMP]);
+            crc.update(&millis.to_be_bytes());
+        }
+        Uuid(val) => {
+            buffer.put_u8(TYPE_UUID);
+            buffer.put_u128(*val);
+            crc.update(&[TYPE_UUID]);
+            crc.update(&val.to_be_bytes());
+        }
+        _ => return Err("Unsupported header value type".into()),
+    }
+    Ok(())
+}
+
+/// Optimized version 2: Just pre-allocate buffer size, keep everything else simple
+pub fn write_message_preallocate(
+    message: &Message,
+    buffer: &mut Vec<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Simple size estimation: headers are typically small, so just estimate
+    let estimated_size = message.size_hint(); // rough estimate for headers + overhead
+    buffer.reserve(estimated_size);
+
+    // Use the original implementation but with Vec<u8> instead of dyn BufMut
+    write_message_to(message, buffer).map_err(|e| e.into())
+}
+
+fn benchmark_write_message_to(c: &mut Criterion) {
+    let allocator = get_allocator_name();
+    // Create a simple test message with 1KB payload
+    let payload = Bytes::from(vec![0u8; 1024]);
+    let message = Message::new(payload).add_header(Header::new(
+        "content-type",
+        HeaderValue::String("application/json".into()),
+    ));
+
+    // Test different buffer configurations
+    let buffer_configs = vec![
+        BufferConfig::Empty,
+        BufferConfig::Undersized(0.5),
+        BufferConfig::ExactSize(0), // Will be calculated
+        BufferConfig::Oversized(2.0),
+    ];
+
+    let actual_size = message.size_hint();
+
+    // Original implementation benchmarks
+    for buffer_config in &buffer_configs {
+        let bench_name = format!(
+            "original_write_message_to_1kb_{}_buffer_{allocator}",
+            buffer_config.description()
+        );
+
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                let mut buffer = create_buffer(buffer_config, actual_size);
+                write_message_to(&message, &mut buffer).unwrap();
+                black_box(buffer);
+            });
+        });
+    }
+
+    // Optimized v1 implementation benchmarks (complex but fastest)
+    for buffer_config in &buffer_configs {
+        let bench_name = format!(
+            "optimized_v1_write_message_to_1kb_{}_buffer_{allocator}",
+            buffer_config.description()
+        );
+
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                let mut buffer = create_buffer(buffer_config, actual_size);
+                write_message_to_optimized_v1(&message, &mut buffer).unwrap();
+                black_box(buffer);
+            });
+        });
+    }
+
+    // Optimized v2 implementation benchmarks (simple pre-allocation)
+    for buffer_config in &buffer_configs {
+        let bench_name = format!(
+            "optimized_v2_write_message_to_1kb_{}_buffer_{allocator}",
+            buffer_config.description()
+        );
+
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                let mut buffer = create_buffer(buffer_config, actual_size);
+                write_message_preallocate(&message, &mut buffer).unwrap();
+                black_box(buffer);
+            });
+        });
+    }
+}
+
+/// Verification test to ensure both implementations produce identical output
+#[cfg(test)]
+fn verify_implementations_match() {
+    use bytes::Bytes;
+
+    // Test cases with different message configurations
+    let test_cases = vec![
+        // Simple message with 1KB payload
+        Message::new(Bytes::from(vec![0u8; 1024])).add_header(Header::new(
+            "content-type",
+            HeaderValue::String("application/json".into()),
+        )),
+        // Empty payload
+        Message::new(Bytes::new()),
+        // Message with multiple headers and different value types
+        Message::new(Bytes::from(b"test payload".to_vec()))
+            .add_header(Header::new("bool-true", HeaderValue::Bool(true)))
+            .add_header(Header::new("bool-false", HeaderValue::Bool(false)))
+            .add_header(Header::new("byte-val", HeaderValue::Byte(42)))
+            .add_header(Header::new("int16-val", HeaderValue::Int16(12345)))
+            .add_header(Header::new("int32-val", HeaderValue::Int32(987654321)))
+            .add_header(Header::new(
+                "int64-val",
+                HeaderValue::Int64(1234567890123456789),
+            ))
+            .add_header(Header::new(
+                "string-val",
+                HeaderValue::String("hello world".into()),
+            ))
+            .add_header(Header::new(
+                "bytes-val",
+                HeaderValue::ByteArray(Bytes::from(b"binary data".to_vec())),
+            )),
+        // Large payload
+        Message::new(Bytes::from(vec![0xAB; 4096])).add_header(Header::new(
+            "large-content",
+            HeaderValue::String("large payload test".into()),
+        )),
+        // Message with long header name (near limit)
+        Message::new(Bytes::from(b"payload".to_vec())).add_header(Header::new(
+            "x".repeat(200), // Long but valid header name
+            HeaderValue::String("long header name test".into()),
+        )),
+    ];
+
+    for (i, message) in test_cases.iter().enumerate() {
+        println!("Testing case {}: {:?}", i, message.headers().len());
+
+        // Test original implementation
+        let mut original_buffer = Vec::new();
+        write_message_to(message, &mut original_buffer).expect(&format!(
+            "Original implementation failed for test case {}",
+            i
+        ));
+
+        // Test all optimized implementations
+        let mut optimized_v1_buffer = Vec::new();
+        write_message_to_optimized_v1(message, &mut optimized_v1_buffer).expect(&format!(
+            "Optimized v1 implementation failed for test case {}",
+            i
+        ));
+
+        let mut optimized_v2_buffer = Vec::new();
+        write_message_preallocate(message, &mut optimized_v2_buffer).expect(&format!(
+            "Optimized v2 implementation failed for test case {}",
+            i
+        ));
+
+        // Compare results
+        assert_eq!(
+            original_buffer, optimized_v1_buffer,
+            "V1 implementation produces different output for test case {}\nOriginal length: {}, V1 length: {}",
+            i, original_buffer.len(), optimized_v1_buffer.len()
+        );
+
+        assert_eq!(
+            original_buffer, optimized_v2_buffer,
+            "V2 implementation produces different output for test case {}\nOriginal length: {}, V2 length: {}",
+            i, original_buffer.len(), optimized_v2_buffer.len()
+        );
+
+        // Verify the output can be read back correctly
+        let parsed_message = aws_smithy_eventstream::frame::read_message_from(&mut Bytes::from(
+            original_buffer.clone(),
+        ))
+        .expect(&format!(
+            "Failed to parse original output for test case {}",
+            i
+        ));
+
+        // Verify headers match
+        assert_eq!(
+            message.headers(),
+            parsed_message.headers(),
+            "Headers don't match after round-trip for test case {}",
+            i
+        );
+
+        // Verify payload matches
+        assert_eq!(
+            message.payload().as_ref(),
+            parsed_message.payload().as_ref(),
+            "Payload doesn't match after round-trip for test case {}",
+            i
+        );
+
+        println!("✓ Test case {} passed - {} bytes", i, original_buffer.len());
+    }
+
+    println!("All verification tests passed!");
+}
+
+/// Run verification during benchmarks
+fn benchmark_write_message_to_with_verification(c: &mut Criterion) {
+    // First run verification
+    verify_implementations_match();
+
+    // Then run the actual benchmarks
+    benchmark_write_message_to(c);
+}
+
+criterion_group!(benches, benchmark_write_message_to_with_verification);
+criterion_main!(benches);

--- a/rust-runtime/aws-smithy-eventstream/src/lib.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/lib.rs
@@ -21,6 +21,7 @@ pub mod arbitrary;
 mod buf;
 pub mod error;
 pub mod frame;
+pub mod message_size_hint;
 pub mod smithy;
 #[cfg(feature = "test-util")]
 pub mod test_util;

--- a/rust-runtime/aws-smithy-eventstream/src/message_size_hint.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/message_size_hint.rs
@@ -1,0 +1,187 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Provides size hint functionality for Event Stream messages to optimize buffer allocation.
+
+use aws_smithy_types::event_stream::{HeaderValue, Message};
+use std::mem::size_of;
+
+/// Extension trait that provides size hint functionality for Event Stream messages.
+///
+/// This trait allows callers to get an accurate estimate of the serialized size
+/// of a message before serialization, enabling optimal buffer pre-allocation.
+pub trait MessageSizeHint {
+    /// Returns an estimate of the serialized size of this message in bytes.
+    ///
+    /// This provides a hint for buffer allocation to improve performance when
+    /// serializing the message. The estimate includes the message prelude,
+    /// headers, payload, and CRC checksums.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
+    /// use aws_smithy_eventstream::message_size_hint::MessageSizeHint;
+    /// use bytes::Bytes;
+    ///
+    /// let message = Message::new(Bytes::from(b"hello world".to_vec()))
+    ///     .add_header(Header::new("content-type", HeaderValue::String("text/plain".into())));
+    ///
+    /// let size_hint = message.size_hint();
+    /// // Use the size hint to pre-allocate a buffer
+    /// let mut buffer: Vec<u8> = Vec::with_capacity(size_hint);
+    /// ```
+    fn size_hint(&self) -> usize;
+}
+
+impl MessageSizeHint for Message {
+    fn size_hint(&self) -> usize {
+        // Constants from the frame format
+        const PRELUDE_LENGTH_BYTES: usize = 3 * size_of::<u32>();
+        const MESSAGE_CRC_LENGTH_BYTES: usize = size_of::<u32>();
+        const MAX_HEADER_NAME_LEN: usize = 255;
+
+        // Calculate headers size
+        let mut headers_len = 0;
+        for header in self.headers() {
+            let name_len = header.name().as_bytes().len().min(MAX_HEADER_NAME_LEN);
+            headers_len += 1 + name_len; // name length byte + name bytes
+
+            // Add header value size based on type
+            headers_len += match header.value() {
+                HeaderValue::Bool(_) => 1,                            // type byte only
+                HeaderValue::Byte(_) => 2,                            // type + value
+                HeaderValue::Int16(_) => 3,                           // type + value
+                HeaderValue::Int32(_) => 5,                           // type + value
+                HeaderValue::Int64(_) => 9,                           // type + value
+                HeaderValue::ByteArray(val) => 3 + val.len(),         // type + length + data
+                HeaderValue::String(val) => 3 + val.as_bytes().len(), // type + length + data
+                HeaderValue::Timestamp(_) => 9,                       // type + value
+                HeaderValue::Uuid(_) => 17,                           // type + value
+                _ => 0, // Handle any future header value types conservatively
+            };
+        }
+
+        let payload_len = self.payload().len();
+
+        // Total message size: prelude + headers + payload + message CRC
+        PRELUDE_LENGTH_BYTES + headers_len + payload_len + MESSAGE_CRC_LENGTH_BYTES
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::write_message_to;
+    use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
+    use bytes::Bytes;
+
+    #[test]
+    fn test_size_hint_accuracy() {
+        // Test cases with different message configurations
+        let test_cases = vec![
+            // Simple message with small payload
+            Message::new(Bytes::from(b"hello world".to_vec())),
+            // Message with headers
+            Message::new(Bytes::from(b"test payload".to_vec())).add_header(Header::new(
+                "content-type",
+                HeaderValue::String("application/json".into()),
+            )),
+            // Message with multiple headers and different value types
+            Message::new(Bytes::from(b"complex test".to_vec()))
+                .add_header(Header::new("bool-true", HeaderValue::Bool(true)))
+                .add_header(Header::new("bool-false", HeaderValue::Bool(false)))
+                .add_header(Header::new("byte-val", HeaderValue::Byte(42)))
+                .add_header(Header::new("int16-val", HeaderValue::Int16(12345)))
+                .add_header(Header::new("int32-val", HeaderValue::Int32(987654321)))
+                .add_header(Header::new(
+                    "int64-val",
+                    HeaderValue::Int64(1234567890123456789),
+                ))
+                .add_header(Header::new(
+                    "string-val",
+                    HeaderValue::String("hello world".into()),
+                ))
+                .add_header(Header::new(
+                    "bytes-val",
+                    HeaderValue::ByteArray(Bytes::from(b"binary data".to_vec())),
+                )),
+            // Empty payload
+            Message::new(Bytes::new()),
+            // Large payload (1KB)
+            Message::new(Bytes::from(vec![0u8; 1024])).add_header(Header::new(
+                "large-content",
+                HeaderValue::String("large payload test".into()),
+            )),
+        ];
+
+        for (i, message) in test_cases.iter().enumerate() {
+            let size_hint = message.size_hint();
+
+            // Get actual serialized size
+            let mut buffer = Vec::new();
+            write_message_to(message, &mut buffer)
+                .expect(&format!("Failed to serialize test case {}", i));
+            let actual_size = buffer.len();
+
+            // The size hint should exactly match the actual serialized size
+            assert_eq!(
+                size_hint, actual_size,
+                "Size hint mismatch for test case {}: hint={}, actual={}",
+                i, size_hint, actual_size
+            );
+        }
+    }
+
+    #[test]
+    fn test_size_hint_with_long_header_name() {
+        // Test with a header name that's near the maximum length
+        let long_name = "x".repeat(200); // Long but valid header name
+        let message = Message::new(Bytes::from(b"payload".to_vec())).add_header(Header::new(
+            long_name,
+            HeaderValue::String("long header name test".into()),
+        ));
+
+        let size_hint = message.size_hint();
+
+        let mut buffer = Vec::new();
+        write_message_to(&message, &mut buffer)
+            .expect("Failed to serialize message with long header name");
+        let actual_size = buffer.len();
+
+        assert_eq!(
+            size_hint, actual_size,
+            "Size hint should match actual size for long header names"
+        );
+    }
+
+    #[test]
+    fn test_size_hint_performance_benefit() {
+        // Create a message with 1KB payload
+        let message = Message::new(Bytes::from(vec![0u8; 1024])).add_header(Header::new(
+            "content-type",
+            HeaderValue::String("application/json".into()),
+        ));
+
+        let size_hint = message.size_hint();
+
+        // Verify that using size hint for pre-allocation works
+        let mut buffer = Vec::with_capacity(size_hint);
+        write_message_to(&message, &mut buffer).expect("Failed to serialize message");
+
+        // The buffer should not have needed to reallocate
+        assert!(
+            buffer.capacity() >= buffer.len(),
+            "Buffer should have sufficient capacity"
+        );
+
+        // The size hint should be reasonably close to actual size
+        assert_eq!(
+            size_hint,
+            buffer.len(),
+            "Size hint should exactly match serialized size"
+        );
+    }
+}

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 authors = [
-  "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
-  "Russell Cohen <rcoh@amazon.com>",
+    "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
+    "Russell Cohen <rcoh@amazon.com>",
 ]
 description = "Smithy HTTP logic for smithy-rs."
 edition = "2021"
@@ -38,9 +38,9 @@ futures-util = { version = "0.3.29", default-features = false }
 hyper = { version = "0.14.26", features = ["stream"] }
 proptest = "1"
 tokio = { version = "1.23.1", features = [
-  "macros",
-  "rt",
-  "rt-multi-thread",
+    "macros",
+    "rt",
+    "rt-multi-thread",
 ] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Motivation and Context

Currently when serializing event streams, an empty buffer is used. This results in repeated reallocations as the buffer grows. However, we can actually precalculate the exact size that is required.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

This PR does two things:
1. Add a MessageSizeHint that aws-smithy-http can use to determine the in-memory serialized size of the message
2. Add a benchmark of write_message. The benchmark includes an prototype optimized implementation that we can switch to at a later date.

## Testing
- Benchmark
- Test of correctness for size calculation

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
