### PR TITLE
Bump timeout when waiting for crates.io publish

### DIFF
--- a/tools/ci-build/publisher/src/subcommand/publish.rs
+++ b/tools/ci-build/publisher/src/subcommand/publish.rs
@@ -116,7 +116,7 @@ async fn is_published(index: Arc<CratesIndex>, handle: &PackageHandle) -> Result
 
 /// Waits for the given package to show up on crates.io
 async fn wait_for_eventual_consistency(index: Arc<CratesIndex>, package: &Package) -> Result<()> {
-    let max_wait_time = 10usize;
+    let max_wait_time = 60usize;
     for _ in 0..max_wait_time {
         if !is_published(index.clone(), &package.handle).await? {
             tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We have occasionally seen errors when crates.io takes longer than 10 seconds to show our crates as published. This change relaxes that timeout to 60 seconds. 

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
