### PR TITLE
Remove `#[test]` attributes from doc tests

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.configReexport
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
@@ -21,6 +22,8 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
         arrayOf(
             "Intercept" to configReexport(RuntimeType.intercept(runtimeConfig)),
             "SharedInterceptor" to configReexport(RuntimeType.sharedInterceptor(runtimeConfig)),
+            // TODO(Http1x): Update this dependency to Http1x
+            "Http" to CargoDependency.Http.toType(),
         )
 
     override fun section(section: ServiceConfig) =
@@ -55,7 +58,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         /// use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
                         /// use aws_smithy_types::config_bag::ConfigBag;
                         /// use $moduleUseName::config::Config;
-                        /// use http::uri::Uri;
+                        /// use #{Http}::uri::Uri;
                         ///
                         /// fn base_url() -> String {
                         ///     // ...

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
@@ -48,14 +48,14 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         ///
                         /// ## Examples
                         /// ```no_run
-                        /// ## ##[cfg(test)]
-                        /// ## mod tests {
-                        /// ## ##[test]
                         /// ## fn example() {
-                        /// use aws_smithy_runtime_api::client::interceptors::context::phase::BeforeTransmit;
-                        /// use aws_smithy_runtime_api::client::interceptors::{Interceptor, InterceptorContext};
+                        /// use aws_smithy_runtime_api::box_error::BoxError;
+                        /// use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
+                        /// use aws_smithy_runtime_api::client::interceptors::Intercept;
+                        /// use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
                         /// use aws_smithy_types::config_bag::ConfigBag;
                         /// use $moduleUseName::config::Config;
+                        /// use http::uri::Uri;
                         ///
                         /// fn base_url() -> String {
                         ///     // ...
@@ -65,14 +65,18 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         /// ##[derive(Debug)]
                         /// pub struct UriModifierInterceptor;
                         /// impl Intercept for UriModifierInterceptor {
+                        ///     fn name(&self) -> &'static str {
+                        ///         "UriModifierInterceptor"
+                        ///     }
                         ///     fn modify_before_signing(
                         ///         &self,
-                        ///         context: &mut InterceptorContext<BeforeTransmit>,
+                        ///         context: &mut BeforeTransmitInterceptorContextMut<'_>,
+                        ///         _runtime_components: &RuntimeComponents,
                         ///         _cfg: &mut ConfigBag,
-                        ///     ) -> Result<(), aws_smithy_runtime_api::client::interceptors::BoxError> {
+                        ///     ) -> Result<(), BoxError> {
                         ///         let request = context.request_mut();
-                        ///         let uri = format!("{}{}", base_url(), request.uri().path());
-                        ///         *request.uri_mut() = uri.parse()?;
+                        ///         let uri = format!("{}{}", base_url(), request.uri());
+                        ///         *request.uri_mut() = uri.parse::<Uri>()?.into();
                         ///
                         ///         Ok(())
                         ///     }
@@ -82,60 +86,13 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         ///     .interceptor(UriModifierInterceptor)
                         ///     .build();
                         /// ## }
-                        /// ## }
                         /// ```
                         pub fn interceptor(mut self, interceptor: impl #{Intercept} + 'static) -> Self {
                             self.push_interceptor(#{SharedInterceptor}::new(interceptor));
                             self
                         }
 
-                        /// Add a [`SharedInterceptor`](#{SharedInterceptor}) that runs at specific stages of the request execution pipeline.
-                        ///
-                        /// Interceptors targeted at a certain stage are executed according to the pre-defined priority.
-                        /// The SDK provides a default set of interceptors. An interceptor configured by this method
-                        /// will run after those default interceptors.
-                        ///
-                        /// ## Examples
-                        /// ```no_run
-                        /// ## ##[cfg(test)]
-                        /// ## mod tests {
-                        /// ## ##[test]
-                        /// ## fn example() {
-                        /// use aws_smithy_runtime_api::client::interceptors::context::phase::BeforeTransmit;
-                        /// use aws_smithy_runtime_api::client::interceptors::{Interceptor, InterceptorContext, SharedInterceptor};
-                        /// use aws_smithy_types::config_bag::ConfigBag;
-                        /// use $moduleUseName::config::{Builder, Config};
-                        ///
-                        /// fn base_url() -> String {
-                        ///     // ...
-                        ///     ## String::new()
-                        /// }
-                        ///
-                        /// fn modify_request_uri(builder: &mut Builder) {
-                        ///     ##[derive(Debug)]
-                        ///     pub struct UriModifierInterceptor;
-                        ///     impl Intercept for UriModifierInterceptor {
-                        ///         fn modify_before_signing(
-                        ///             &self,
-                        ///             context: &mut InterceptorContext<BeforeTransmit>,
-                        ///             _cfg: &mut ConfigBag,
-                        ///         ) -> Result<(), aws_smithy_runtime_api::client::interceptors::BoxError> {
-                        ///             let request = context.request_mut();
-                        ///             let uri = format!("{}{}", base_url(), request.uri().path());
-                        ///             *request.uri_mut() = uri.parse()?;
-                        ///
-                        ///             Ok(())
-                        ///         }
-                        ///     }
-                        ///     builder.push_interceptor(SharedInterceptor::new(UriModifierInterceptor));
-                        /// }
-                        ///
-                        /// let mut builder = Config::builder();
-                        /// modify_request_uri(&mut builder);
-                        /// let config = builder.build();
-                        /// ## }
-                        /// ## }
-                        /// ```
+                        /// Like [`Self::interceptor`], but takes a [`SharedInterceptor`](#{SharedInterceptor}).
                         pub fn push_interceptor(&mut self, interceptor: #{SharedInterceptor}) -> &mut Self {
                             self.runtime_components.push_interceptor(interceptor);
                             self

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/RetryClassifierConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/RetryClassifierConfigCustomization.kt
@@ -56,9 +56,6 @@ class RetryClassifierConfigCustomization(codegenContext: ClientCodegenContext) :
                         ///
                         /// ## Examples
                         /// ```no_run
-                        /// ## ##[cfg(test)]
-                        /// ## mod tests {
-                        /// ## ##[test]
                         /// ## fn example() {
                         /// use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
                         /// use aws_smithy_runtime_api::client::orchestrator::OrchestratorError;
@@ -69,17 +66,26 @@ class RetryClassifierConfigCustomization(codegenContext: ClientCodegenContext) :
                         /// use aws_smithy_types::retry::ErrorKind;
                         /// use std::error::Error as StdError;
                         /// use std::marker::PhantomData;
+                        /// use std::fmt;
                         /// use $moduleUseName::config::Config;
+                        /// ## ##[derive(Debug)]
                         /// ## struct SomeOperationError {}
+                        /// ## impl StdError for SomeOperationError {}
+                        /// ## impl fmt::Display for SomeOperationError {
+                        /// ##    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { todo!() }
+                        /// ## }
+                        /// ## impl ProvideErrorMetadata for SomeOperationError {
+                        /// ##    fn meta(&self) -> &$moduleUseName::error::ErrorMetadata { todo!() }
+                        /// ## }
                         ///
-                        /// const RETRYABLE_ERROR_CODES: &[&str] = [
+                        /// const RETRYABLE_ERROR_CODES: &[&str] = &[
                         ///     // List error codes to be retried here...
                         /// ];
                         ///
                         /// // When classifying at an operation's error type, classifiers require a generic parameter.
                         /// // When classifying the HTTP response alone, no generic is needed.
                         /// ##[derive(Debug, Default)]
-                        /// pub struct ErrorCodeClassifier<E> {
+                        /// pub struct ExampleErrorCodeClassifier<E> {
                         ///     _inner: PhantomData<E>,
                         /// }
                         ///
@@ -129,98 +135,13 @@ class RetryClassifierConfigCustomization(codegenContext: ClientCodegenContext) :
                         ///     .retry_classifier(ExampleErrorCodeClassifier::<SomeOperationError>::new())
                         ///     .build();
                         /// ## }
-                        /// ## }
                         /// ```
                         pub fn retry_classifier(mut self, retry_classifier: impl #{ClassifyRetry} + 'static) -> Self {
                             self.push_retry_classifier(#{SharedRetryClassifier}::new(retry_classifier));
                             self
                         }
 
-                        /// Add a [`SharedRetryClassifier`](#{SharedRetryClassifier}) that will be used by the
-                        /// [`RetryStrategy`](#{RetryStrategy}) to determine what responses should be retried.
-                        ///
-                        /// A retry classifier configured by this method will run according to its priority.
-                        ///
-                        /// ## Examples
-                        /// ```no_run
-                        /// ## ##[cfg(test)]
-                        /// ## mod tests {
-                        /// ## ##[test]
-                        /// ## fn example() {
-                        /// use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
-                        /// use aws_smithy_runtime_api::client::orchestrator::OrchestratorError;
-                        /// use aws_smithy_runtime_api::client::retries::classifiers::{
-                        ///     ClassifyRetry, RetryAction, RetryClassifierPriority,
-                        /// };
-                        /// use aws_smithy_types::error::metadata::ProvideErrorMetadata;
-                        /// use aws_smithy_types::retry::ErrorKind;
-                        /// use std::error::Error as StdError;
-                        /// use std::marker::PhantomData;
-                        /// use $moduleUseName::config::{Builder, Config};
-                        /// ## struct SomeOperationError {}
-                        ///
-                        /// const RETRYABLE_ERROR_CODES: &[&str] = [
-                        ///     // List error codes to be retried here...
-                        /// ];
-                        /// fn set_example_error_code_classifier(builder: &mut Builder) {
-                        ///     // When classifying at an operation's error type, classifiers require a generic parameter.
-                        ///     // When classifying the HTTP response alone, no generic is needed.
-                        ///     ##[derive(Debug, Default)]
-                        ///     pub struct ExampleErrorCodeClassifier<E> {
-                        ///         _inner: PhantomData<E>,
-                        ///     }
-                        ///
-                        ///     impl<E> ExampleErrorCodeClassifier<E> {
-                        ///         pub fn new() -> Self {
-                        ///             Self {
-                        ///                 _inner: PhantomData,
-                        ///             }
-                        ///         }
-                        ///     }
-                        ///
-                        ///     impl<E> ClassifyRetry for ExampleErrorCodeClassifier<E>
-                        ///     where
-                        ///         // Adding a trait bound for ProvideErrorMetadata allows us to inspect the error code.
-                        ///         E: StdError + ProvideErrorMetadata + Send + Sync + 'static,
-                        ///     {
-                        ///         fn classify_retry(&self, ctx: &InterceptorContext) -> RetryAction {
-                        ///             // Check for a result
-                        ///             let output_or_error = ctx.output_or_error();
-                        ///             // Check for an error
-                        ///             let error = match output_or_error {
-                        ///                 Some(Ok(_)) | None => return RetryAction::NoActionIndicated,
-                        ///                   Some(Err(err)) => err,
-                        ///             };
-                        ///
-                        ///             // Downcast the generic error and extract the code
-                        ///             let error_code = OrchestratorError::as_operation_error(error)
-                        ///                 .and_then(|err| err.downcast_ref::<E>())
-                        ///                 .and_then(|err| err.code());
-                        ///
-                        ///             // If this error's code is in our list, return an action that tells the RetryStrategy to retry this request.
-                        ///             if let Some(error_code) = error_code {
-                        ///                 if RETRYABLE_ERROR_CODES.contains(&error_code) {
-                        ///                     return RetryAction::transient_error();
-                        ///                 }
-                        ///             }
-                        ///
-                        ///             // Otherwise, return that no action is indicated i.e. that this classifier doesn't require a retry.
-                        ///             // Another classifier may still classify this response as retryable.
-                        ///             RetryAction::NoActionIndicated
-                        ///         }
-                        ///
-                        ///         fn name(&self) -> &'static str { "Example Error Code Classifier" }
-                        ///     }
-                        ///
-                        ///     builder.push_retry_classifier(ExampleErrorCodeClassifier::<SomeOperationError>::new())
-                        /// }
-                        ///
-                        /// let mut builder = Config::builder();
-                        /// set_example_error_code_classifier(&mut builder);
-                        /// let config = builder.build();
-                        /// ## }
-                        /// ## }
-                        /// ```
+                        /// Like [`Self::retry_classifier`], but takes a [`SharedRetryClassifier`](#{SharedRetryClassifier}).
                         pub fn push_retry_classifier(&mut self, retry_classifier: #{SharedRetryClassifier}) -> &mut Self {
                             self.runtime_components.push_retry_classifier(retry_classifier);
                             self


### PR DESCRIPTION
## Motivation and Context
This PR cleans up doc tests by removing `#[test]` attributes from code snippets to prevent them from being executed. We've observed logs indicating that some doc snippets have been running for over 60 seconds, even though they are annotated with `no_run`.

In addition, this PR also removes duplicated example snippets that previously took up a lot of space.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
