### PR TITLE
Fix broken workflows since the introduction of private ecr repository

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -58,7 +58,7 @@ jobs:
       run: ./.github/scripts/acquire-build-image
     - name: Tag and upload image
       run: |
-        IMAGE_TAG="ci-$(./.github/scripts/docker-image-hash)"
+        IMAGE_TAG="ci-$(./smithy-rs/.github/scripts/docker-image-hash)"
         ./smithy-rs/.github/scripts/upload-build-image.sh $IMAGE_TAG
 
   # Run the shared CI after a Docker build image has been uploaded to ECR

--- a/.github/workflows/dry-run-release-scheduled.yml
+++ b/.github/workflows/dry-run-release-scheduled.yml
@@ -25,9 +25,11 @@ jobs:
     with:
       commit_sha: main
       dry_run: true
-      skip_ci: true
+      # If the automation runs this workflow in the background, we might as well run the full CI to catch any potential issues.
+      skip_ci: false
     secrets:
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
       RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
       CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
       CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}
+      SMITHY_RS_ECR_PUSH_ROLE_ARN: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}

--- a/.github/workflows/manual-update-lockfiles.yml
+++ b/.github/workflows/manual-update-lockfiles.yml
@@ -34,5 +34,5 @@ jobs:
       force_update_on_broken_dependencies: ${{ inputs.force_update_on_broken_dependencies }}
     secrets:
       DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
-      SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
+      SMITHY_RS_ECR_PUSH_ROLE_ARN: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}

--- a/.github/workflows/pull-request-updating-lockfiles.yml
+++ b/.github/workflows/pull-request-updating-lockfiles.yml
@@ -18,13 +18,10 @@ on:
     secrets:
       DOCKER_LOGIN_TOKEN_PASSPHRASE:
         required: true
-      SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN:
+      SMITHY_RS_ECR_PUSH_ROLE_ARN:
         required: true
       RELEASE_AUTOMATION_BOT_PAT:
         required: true
-
-env:
-  ecr_repository: public.ecr.aws/w0m4q9l7/github-awslabs-smithy-rs-ci
 
 jobs:
   save-docker-login-token:
@@ -42,14 +39,14 @@ jobs:
     - name: Attempt to load a docker login password
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
+        role-to-assume: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions
         aws-region: us-west-2
     - name: Save the docker login password to the output
       id: set-token
       run: |
         ENCRYPTED_PAYLOAD=$(
-          gpg --symmetric --batch --passphrase "${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}" --output - <(aws ecr-public get-login-password --region us-east-1) | base64 -w0
+          gpg --symmetric --batch --passphrase "${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}" --output - <(aws ecr get-login-password --region us-west-2) | base64 -w0
         )
         echo "docker-login-password=$ENCRYPTED_PAYLOAD" >> $GITHUB_OUTPUT
 
@@ -77,19 +74,18 @@ jobs:
     - name: Acquire credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
+        role-to-assume: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions
         aws-region: us-west-2
     - name: Upload image
       run: |
-        IMAGE_TAG="$(./smithy-rs/.github/scripts/docker-image-hash)"
-        docker tag "smithy-rs-base-image:${IMAGE_TAG}" "${{ env.ecr_repository }}:${IMAGE_TAG}"
-        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-        docker push "${{ env.ecr_repository }}:${IMAGE_TAG}"
+        IMAGE_TAG="ci-$(./smithy-rs/.github/scripts/docker-image-hash)"
+        ./smithy-rs/.github/scripts/upload-build-image.sh $IMAGE_TAG
 
   create-pull-request-for-updating-lockfiles:
     name: Create a Pull Request for updating lockfiles
     needs:
+    - save-docker-login-token
     - acquire-base-image
     runs-on: ubuntu-latest
     steps:
@@ -106,6 +102,9 @@ jobs:
         branch_name="update-all-lockfiles-$(date +%s)"
         echo "branch_name=${branch_name}" > $GITHUB_OUTPUT
     - name: Cargo update all lockfiles
+      env:
+        ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
+        DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: cargo-update-lockfiles

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -23,5 +23,5 @@ jobs:
       force_update_on_broken_dependencies: false
     secrets:
       DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
-      SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
+      SMITHY_RS_ECR_PUSH_ROLE_ARN: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}
       RELEASE_AUTOMATION_BOT_PAT: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}


### PR DESCRIPTION
## Motivation and Context
Minor cleanup following #4153

## Description
The following workflows have been broken due to minor issues—such as missing secrets, not using the latest upload scripts, and so on:
- `pull-request-updating-lockfiles.yml`
  - `update-lockfiles.yml` and `manual-update-lockfiles.yml` are callers of the given workflow
- `ci-main.yml`
- `dry-run-release-scheduled.yml`

## Testing
The changes to `ci-main.yml` and `dry-run-release-scheduled.yml` haven't been verified, as these workflows only run in live environments (if they are still broken after this PR, will look into them further).

For the changes to `pull-request-updating-lockfiles.yml`, manually triggered `manual-update-lockfiles.yml` and confirmed that #4219 has been created.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
