### PR TITLE
Further fixes to ci-main

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -58,8 +58,9 @@ jobs:
       run: ./.github/scripts/acquire-build-image
     - name: Tag and upload image
       run: |
-        IMAGE_TAG="ci-$(./smithy-rs/.github/scripts/docker-image-hash)"
-        ./smithy-rs/.github/scripts/upload-build-image.sh $IMAGE_TAG
+        pwd
+        IMAGE_TAG="ci-$(./.github/scripts/docker-image-hash)"
+        ./.github/scripts/upload-build-image.sh $IMAGE_TAG
 
   # Run the shared CI after a Docker build image has been uploaded to ECR
   ci:


### PR DESCRIPTION
## Motivation and Context
Noticed `ci-main.yml` is [still broken](https://github.com/smithy-lang/smithy-rs/actions/runs/16329860467/job/46129467122) (CI won't run when a PR is merged to main)

## Description
Noticed from [the commit history on main](https://github.com/smithy-lang/smithy-rs/commits/main/) that the path `./.github/scripts/...` works, while `./smithy-rs/.github/scripts/...` doesn't ([example](https://github.com/smithy-lang/smithy-rs/actions/runs/16308735604/job/46059996940)).

[The previous PR](https://github.com/smithy-lang/smithy-rs/pull/4220/files#diff-a1a3cb9bdeb5541d148091d973cf266aa3b317e6415a86630e816cbe27cf8b9cR61) used the latter path in `Tag and upload image` within `ci-main.yml`, but it failed after being merged into main. This PR switches to `./.github/scripts/...` to see if it works.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
