### PR TITLE
Add fallback equality on `noAuth` scheme ID

### DIFF
--- a/.changelog/1753385864.md
+++ b/.changelog/1753385864.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- ysaito1001
+references:
+- smithy-rs#4232
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Add fallback equality on no auth `AuthSchemeId` for backward compatibility, treating `AuthSchemeId::from("no_auth")` (legacy) and `AuthSchemeId::from("noAuth")` (updated) as equivalent.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.8.4"
+version = "1.8.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
@@ -15,7 +15,6 @@ use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Storable, StoreReplac
 use aws_smithy_types::type_erasure::TypeErasedBox;
 use aws_smithy_types::Document;
 use std::borrow::Cow;
-use std::cmp::Ordering;
 use std::fmt;
 use std::sync::Arc;
 
@@ -140,7 +139,7 @@ impl std::error::Error for AuthSchemeOptionBuilderError {}
 /// Each auth scheme must have a unique string identifier associated with it,
 /// which is used to refer to auth schemes by the auth scheme option resolver, and
 /// also used to select an identity resolver to use.
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct AuthSchemeId {
     scheme_id: Cow<'static, str>,
 }
@@ -152,11 +151,22 @@ impl AsRef<AuthSchemeId> for AuthSchemeId {
     }
 }
 
+// Normalizes auth scheme IDs for comparison and hashing by treating "no_auth" and "noAuth" as equivalent
+// by converting "no_auth" to "noAuth".
+// This is for backward compatibility; "no_auth" was incorrectly used in earlier GA versions of the SDK and
+// could be used still in some places.
+const fn normalize_auth_scheme_id(s: &'static str) -> &'static str {
+    match s.as_bytes() {
+        b"no_auth" => "noAuth",
+        _ => s,
+    }
+}
+
 impl AuthSchemeId {
     /// Creates a new auth scheme ID.
     pub const fn new(scheme_id: &'static str) -> Self {
         Self {
-            scheme_id: Cow::Borrowed(scheme_id),
+            scheme_id: Cow::Borrowed(normalize_auth_scheme_id(scheme_id)),
         }
     }
 
@@ -189,48 +199,19 @@ impl From<&'static str> for AuthSchemeId {
 
 impl From<Cow<'static, str>> for AuthSchemeId {
     fn from(scheme_id: Cow<'static, str>) -> Self {
-        Self { scheme_id }
-    }
-}
-
-impl PartialEq for AuthSchemeId {
-    fn eq(&self, other: &Self) -> bool {
-        let self_normalized = normalize_auth_scheme_id(&self.scheme_id);
-        let other_normalized = normalize_auth_scheme_id(&other.scheme_id);
-        self_normalized == other_normalized
-    }
-}
-
-impl std::hash::Hash for AuthSchemeId {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // Hash the normalized scheme ID to ensure equal `AuthSchemeId`s have equal hashes
-        normalize_auth_scheme_id(&self.scheme_id).hash(state);
-    }
-}
-
-impl Ord for AuthSchemeId {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let self_normalized = normalize_auth_scheme_id(&self.scheme_id);
-        let other_normalized = normalize_auth_scheme_id(&other.scheme_id);
-        self_normalized.cmp(other_normalized)
-    }
-}
-
-impl PartialOrd for AuthSchemeId {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-// Normalizes auth scheme IDs for comparison and hashing by treating "no_auth" and "noAuth" as equivalent
-// by converting "no_auth" to "noAuth".
-// This is for backward compatibility; "no_auth" was incorrectly used in pre-GA versions of the SDK and
-// could be used still in some places.
-fn normalize_auth_scheme_id(scheme_id: &str) -> &str {
-    if scheme_id == "no_auth" {
-        "noAuth"
-    } else {
-        scheme_id
+        let normalized_scheme_id = match &scheme_id {
+            Cow::Borrowed(s) => Cow::Borrowed(normalize_auth_scheme_id(s)),
+            Cow::Owned(s) => {
+                if s == "no_auth" {
+                    Cow::Borrowed("noAuth")
+                } else {
+                    scheme_id
+                }
+            }
+        };
+        Self {
+            scheme_id: normalized_scheme_id,
+        }
     }
 }
 
@@ -502,249 +483,123 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_auth_scheme_id_equality_no_auth_variants() {
-        let no_auth_legacy = AuthSchemeId::new("no_auth");
+    fn test_auth_scheme_id_new_normalizes_no_auth() {
+        // Test that "no_auth" gets normalized to "noAuth"
+        let auth_scheme_id = AuthSchemeId::new("no_auth");
+        assert_eq!(auth_scheme_id.inner(), "noAuth");
+    }
+
+    #[test]
+    fn test_auth_scheme_id_new_preserves_no_auth_camel_case() {
+        // Test that "noAuth" remains unchanged
+        let auth_scheme_id = AuthSchemeId::new("noAuth");
+        assert_eq!(auth_scheme_id.inner(), "noAuth");
+    }
+
+    #[test]
+    fn test_auth_scheme_id_new_preserves_other_schemes() {
+        // Test that other auth scheme IDs are not modified
+        let test_cases = [
+            "sigv4",
+            "sigv4a",
+            "httpBearerAuth",
+            "httpBasicAuth",
+            "custom_auth",
+            "bearer",
+            "basic",
+        ];
+
+        for scheme in test_cases {
+            let auth_scheme_id = AuthSchemeId::new(scheme);
+            assert_eq!(auth_scheme_id.inner(), scheme);
+        }
+    }
+
+    #[test]
+    fn test_auth_scheme_id_equality_after_normalization() {
+        // Test that "no_auth" and "noAuth" are considered equal after normalization
+        let no_auth_underscore = AuthSchemeId::new("no_auth");
         let no_auth_camel = AuthSchemeId::new("noAuth");
 
-        // Test that "no_auth" and "noAuth" are considered equal
-        assert_eq!(no_auth_legacy, no_auth_camel);
-        assert_eq!(no_auth_camel, no_auth_legacy);
+        assert_eq!(no_auth_underscore, no_auth_camel);
+        assert_eq!(no_auth_underscore.inner(), no_auth_camel.inner());
     }
 
     #[test]
-    fn test_auth_scheme_id_equality_same_schemes() {
-        let sigv4_1 = AuthSchemeId::new("sigv4");
-        let sigv4_2 = AuthSchemeId::new("sigv4");
+    fn test_auth_scheme_id_hash_consistency_after_normalization() {
+        use std::collections::HashMap;
 
-        // Test that identical schemes are equal
-        assert_eq!(sigv4_1, sigv4_2);
-    }
-
-    #[test]
-    fn test_auth_scheme_id_inequality_different_schemes() {
-        let sigv4 = AuthSchemeId::new("sigv4");
-        let sigv4a = AuthSchemeId::new("sigv4a");
-        let bearer = AuthSchemeId::new("httpBearerAuth");
-
-        // Test that different schemes are not equal
-        assert_ne!(sigv4, sigv4a);
-        assert_ne!(sigv4, bearer);
-        assert_ne!(sigv4a, bearer);
-    }
-
-    #[test]
-    fn test_auth_scheme_id_no_auth_vs_other_schemes() {
-        let no_auth_legacy = AuthSchemeId::new("no_auth");
+        // Test that normalized IDs have consistent hashing behavior
+        let mut map = HashMap::new();
+        let no_auth_underscore = AuthSchemeId::new("no_auth");
         let no_auth_camel = AuthSchemeId::new("noAuth");
-        let sigv4 = AuthSchemeId::new("sigv4");
-        let bearer = AuthSchemeId::new("httpBearerAuth");
 
-        // Test that no_auth variants are not equal to other schemes
-        assert_ne!(no_auth_legacy, sigv4);
-        assert_ne!(no_auth_camel, sigv4);
-        assert_ne!(no_auth_legacy, bearer);
-        assert_ne!(no_auth_camel, bearer);
+        map.insert(no_auth_underscore.clone(), "value1");
+        map.insert(no_auth_camel.clone(), "value2");
 
-        // Test symmetry
-        assert_ne!(sigv4, no_auth_legacy);
-        assert_ne!(sigv4, no_auth_camel);
-        assert_ne!(bearer, no_auth_legacy);
-        assert_ne!(bearer, no_auth_camel);
+        // Should only have one entry since they normalize to the same value
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&no_auth_underscore), Some(&"value2"));
+        assert_eq!(map.get(&no_auth_camel), Some(&"value2"));
+    }
+
+    #[test]
+    fn test_auth_scheme_id_ordering_after_normalization() {
+        // Test that ordering works correctly with normalized values
+        let no_auth_underscore = AuthSchemeId::new("no_auth");
+        let no_auth_camel = AuthSchemeId::new("noAuth");
+        let other_scheme = AuthSchemeId::new("sigv4");
+
+        assert_eq!(
+            no_auth_underscore.cmp(&no_auth_camel),
+            std::cmp::Ordering::Equal
+        );
+        assert_eq!(no_auth_underscore.cmp(&other_scheme), "noAuth".cmp("sigv4"));
     }
 
     #[test]
     fn test_normalize_auth_scheme_id_function() {
-        // Test the helper function directly
-        assert_eq!("noAuth", normalize_auth_scheme_id("no_auth"));
-        assert_eq!("noAuth", normalize_auth_scheme_id("noAuth"));
-        assert_eq!("sigv4", normalize_auth_scheme_id("sigv4"));
-        assert_eq!("httpBearerAuth", normalize_auth_scheme_id("httpBearerAuth"));
-        assert_eq!("custom_scheme", normalize_auth_scheme_id("custom_scheme"));
+        // Test the normalize function directly
+        assert_eq!(normalize_auth_scheme_id("no_auth"), "noAuth");
+        assert_eq!(normalize_auth_scheme_id("noAuth"), "noAuth");
+        assert_eq!(normalize_auth_scheme_id("sigv4"), "sigv4");
+        assert_eq!(normalize_auth_scheme_id("custom"), "custom");
     }
 
     #[test]
-    fn test_auth_scheme_id_reflexivity() {
-        let no_auth_legacy = AuthSchemeId::new("no_auth");
-        let no_auth_camel = AuthSchemeId::new("noAuth");
-        let sigv4 = AuthSchemeId::new("sigv4");
-
-        // Test reflexivity: x == x
-        assert_eq!(no_auth_legacy, no_auth_legacy);
-        assert_eq!(no_auth_camel, no_auth_camel);
-        assert_eq!(sigv4, sigv4);
+    fn test_auth_scheme_id_from_cow_borrowed_normalizes_no_auth() {
+        // Test that Cow::Borrowed("no_auth") gets normalized to "noAuth"
+        let auth_scheme_id = AuthSchemeId::from(Cow::Borrowed("no_auth"));
+        assert_eq!(auth_scheme_id.inner(), "noAuth");
     }
 
     #[test]
-    fn test_auth_scheme_id_transitivity() {
-        let no_auth_1 = AuthSchemeId::new("no_auth");
-        let no_auth_2 = AuthSchemeId::new("noAuth");
-        let no_auth_3 = AuthSchemeId::new("no_auth");
-
-        // Test transitivity: if a == b and b == c, then a == c
-        assert_eq!(no_auth_1, no_auth_2);
-        assert_eq!(no_auth_2, no_auth_3);
-        assert_eq!(no_auth_1, no_auth_3);
+    fn test_auth_scheme_id_from_cow_borrowed_preserves_no_auth_camel_case() {
+        // Test that Cow::Borrowed("noAuth") remains unchanged
+        let auth_scheme_id = AuthSchemeId::from(Cow::Borrowed("noAuth"));
+        assert_eq!(auth_scheme_id.inner(), "noAuth");
     }
 
     #[test]
-    fn test_auth_scheme_id_hash_consistency() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        fn calculate_hash<T: Hash>(t: &T) -> u64 {
-            let mut s = DefaultHasher::new();
-            t.hash(&mut s);
-            s.finish()
-        }
-
-        // Test that equal AuthSchemeIds have the same hash
-        let no_auth_legacy = AuthSchemeId::new("no_auth");
-        let no_auth_camel = AuthSchemeId::new("noAuth");
-
-        // Since these are equal, they must have the same hash
-        assert_eq!(no_auth_legacy, no_auth_camel);
-        assert_eq!(
-            calculate_hash(&no_auth_legacy),
-            calculate_hash(&no_auth_camel)
-        );
-
-        // Test that identical schemes have the same hash
-        let sigv4_1 = AuthSchemeId::new("sigv4");
-        let sigv4_2 = AuthSchemeId::new("sigv4");
-        assert_eq!(calculate_hash(&sigv4_1), calculate_hash(&sigv4_2));
-
-        // Test that different schemes have different hashes (highly likely but not guaranteed)
-        let sigv4 = AuthSchemeId::new("sigv4");
-        let sigv4a = AuthSchemeId::new("sigv4a");
-        let bearer = AuthSchemeId::new("httpBearerAuth");
-
-        // These should be different (though hash collisions are theoretically possible)
-        assert_ne!(calculate_hash(&sigv4), calculate_hash(&sigv4a));
-        assert_ne!(calculate_hash(&sigv4), calculate_hash(&bearer));
-        assert_ne!(calculate_hash(&sigv4a), calculate_hash(&bearer));
+    fn test_auth_scheme_id_from_cow_owned_normalizes_no_auth() {
+        // Test that Cow::Owned(String::from("no_auth")) gets normalized to "noAuth"
+        let auth_scheme_id = AuthSchemeId::from(Cow::Owned(String::from("no_auth")));
+        assert_eq!(auth_scheme_id.inner(), "noAuth");
     }
 
     #[test]
-    fn test_auth_scheme_id_hash_in_collections() {
-        use std::collections::{HashMap, HashSet};
-
-        let no_auth_legacy = AuthSchemeId::new("no_auth");
-        let no_auth_camel = AuthSchemeId::new("noAuth");
-        let sigv4 = AuthSchemeId::new("sigv4");
-        let bearer = AuthSchemeId::new("httpBearerAuth");
-
-        // Test HashSet behavior - equal items should be treated as the same
-        let mut set = HashSet::new();
-        set.insert(no_auth_legacy.clone());
-        set.insert(no_auth_camel.clone());
-        set.insert(sigv4.clone());
-        set.insert(bearer.clone());
-
-        // Should only have 3 items since no_auth_legacy and no_auth_camel are equal
-        assert_eq!(set.len(), 3);
-        assert!(set.contains(&no_auth_legacy));
-        assert!(set.contains(&no_auth_camel));
-        assert!(set.contains(&sigv4));
-        assert!(set.contains(&bearer));
-
-        // Test HashMap behavior
-        let mut map = HashMap::new();
-        map.insert(no_auth_legacy.clone(), "legacy");
-        map.insert(no_auth_camel.clone(), "camel");
-        map.insert(sigv4.clone(), "v4");
-
-        // Should only have 2 entries since no_auth_legacy and no_auth_camel are equal
-        assert_eq!(map.len(), 2);
-        // The value should be "camel" since it was inserted last
-        assert_eq!(map.get(&no_auth_legacy), Some(&"camel"));
-        assert_eq!(map.get(&no_auth_camel), Some(&"camel"));
-        assert_eq!(map.get(&sigv4), Some(&"v4"));
+    fn test_auth_scheme_id_from_cow_owned_preserves_no_auth_camel_case() {
+        // Test that Cow::Owned(String::from("noAuth")) remains unchanged
+        let auth_scheme_id = AuthSchemeId::from(Cow::Owned(String::from("noAuth")));
+        assert_eq!(auth_scheme_id.inner(), "noAuth");
     }
 
     #[test]
-    fn test_auth_scheme_id_ord_consistency() {
-        let no_auth_legacy = AuthSchemeId::new("no_auth");
-        let no_auth_camel = AuthSchemeId::new("noAuth");
-        let sigv4 = AuthSchemeId::new("sigv4");
-        let sigv4a = AuthSchemeId::new("sigv4a");
-        let bearer = AuthSchemeId::new("httpBearerAuth");
+    fn test_auth_scheme_id_from_cow_between_borrowed_and_owned_mixing_updated_and_legacy() {
+        let borrowed_no_auth = AuthSchemeId::from(Cow::Borrowed("noAuth"));
+        let owned_no_auth = AuthSchemeId::from(Cow::Owned(String::from("no_auth")));
 
-        // Test that equal items compare as equal
-        assert_eq!(no_auth_legacy.cmp(&no_auth_camel), Ordering::Equal);
-        assert_eq!(no_auth_camel.cmp(&no_auth_legacy), Ordering::Equal);
-
-        // Test reflexivity: x.cmp(&x) == Equal
-        assert_eq!(sigv4.cmp(&sigv4), Ordering::Equal);
-        assert_eq!(bearer.cmp(&bearer), Ordering::Equal);
-
-        // Test that ordering is consistent with string ordering of normalized values
-        // "sigv4" < "sigv4a" lexicographically
-        assert_eq!(sigv4.cmp(&sigv4a), Ordering::Less);
-        assert_eq!(sigv4a.cmp(&sigv4), Ordering::Greater);
-
-        // Test transitivity with a chain of comparisons
-        let schemes = vec![
-            AuthSchemeId::new("a_scheme"),
-            AuthSchemeId::new("b_scheme"),
-            AuthSchemeId::new("c_scheme"),
-        ];
-
-        // a < b < c should hold
-        assert_eq!(schemes[0].cmp(&schemes[1]), Ordering::Less);
-        assert_eq!(schemes[1].cmp(&schemes[2]), Ordering::Less);
-        assert_eq!(schemes[0].cmp(&schemes[2]), Ordering::Less);
-    }
-
-    #[test]
-    fn test_auth_scheme_id_ord_sorting() {
-        let mut schemes = vec![
-            AuthSchemeId::new("z_last"),
-            AuthSchemeId::new("no_auth"), // Should be normalized to "noAuth"
-            AuthSchemeId::new("sigv4a"),
-            AuthSchemeId::new("noAuth"),
-            AuthSchemeId::new("sigv4"),
-            AuthSchemeId::new("a_first"),
-        ];
-
-        schemes.sort();
-        dbg!(&schemes);
-
-        // Expected order after sorting (considering normalization):
-        // "a_first", "sigv4", "sigv4a", "no_auth", "noAuth", "z_last"
-        // Note: "no_auth" gets normalized to "noAuth" for comparison
-        let expected_inner_values =
-            vec!["a_first", "no_auth", "noAuth", "sigv4", "sigv4a", "z_last"];
-
-        assert_eq!(schemes.len(), expected_inner_values.len());
-        for (scheme, expected) in schemes.iter().zip(expected_inner_values.iter()) {
-            assert_eq!(scheme.inner(), *expected);
-        }
-    }
-
-    #[test]
-    fn test_auth_scheme_id_ord_with_cow_variants() {
-        use std::borrow::Cow;
-
-        // Test ordering with different Cow variants
-        let borrowed = AuthSchemeId::new("test_scheme");
-        let owned = AuthSchemeId::from(Cow::Owned("test_scheme".to_string()));
-        let borrowed2 = AuthSchemeId::from(Cow::Borrowed("test_scheme"));
-
-        // All should be equal
-        assert_eq!(borrowed, owned);
-        assert_eq!(borrowed, borrowed2);
-        assert_eq!(owned, borrowed2);
-
-        // All should have the same ordering
-        assert_eq!(borrowed.cmp(&owned), Ordering::Equal);
-        assert_eq!(borrowed.cmp(&borrowed2), Ordering::Equal);
-        assert_eq!(owned.cmp(&borrowed2), Ordering::Equal);
-
-        // Test with different values
-        let borrowed_a = AuthSchemeId::new("a_scheme");
-        let owned_b = AuthSchemeId::from(Cow::Owned("b_scheme".to_string()));
-
-        assert_eq!(borrowed_a.cmp(&owned_b), Ordering::Less);
-        assert_eq!(owned_b.cmp(&borrowed_a), Ordering::Greater);
+        assert_eq!(borrowed_no_auth, owned_no_auth);
+        assert_eq!(borrowed_no_auth.inner(), owned_no_auth.inner());
     }
 }


### PR DESCRIPTION
## Motivation and Context
Implements fallback equality for no auth `AuthSchemeId` so that `AuthSchemeId::from("no_auth")` (legacy) and `AuthSchemeId::from("noAuth")` (updated) should be treated as equivalent.

## Description
In #4203, the internal raw strings of pre-defined `AuthSchemeId` were updated to better align with the Smithy spec ([discussion](https://github.com/smithy-lang/smithy-rs/pull/4203#discussion_r2198206822)). Acknowledging that this was a breaking change and that customers should not rely on these internal representations, we did receive reports of issues related to this update. After discussion, we proceeded with implementing fallback equality for no auth scheme ID to allow for a safer rollout.

## Testing
- ~Added unit tests for manually implemented traits for `AuthSchemeId`, `PartialEq`, `Hash`, and `Ord`~ (became unnecessary after 7922ef9)
- Added an auth scheme preference test to verify the legacy `no_auth` is supported

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
