### PR TITLE
Fix bug with enum customizations in TsServer codegen

### DIFF
--- a/codegen-server/typescript/src/main/kotlin/software/amazon/smithy/rust/codegen/server/typescript/smithy/TsServerCodegenVisitor.kt
+++ b/codegen-server/typescript/src/main/kotlin/software/amazon/smithy/rust/codegen/server/typescript/smithy/TsServerCodegenVisitor.kt
@@ -1,4 +1,3 @@
-
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -83,8 +82,15 @@ class TsServerCodegenVisitor(
             publicConstrainedTypes: Boolean,
             includeConstraintShapeProvider: Boolean,
             codegenDecorator: ServerCodegenDecorator,
-        ) =
-            RustServerCodegenTsPlugin.baseSymbolProvider(settings, model, serviceShape, rustSymbolProviderConfig, publicConstrainedTypes, includeConstraintShapeProvider, codegenDecorator)
+        ) = RustServerCodegenTsPlugin.baseSymbolProvider(
+            settings,
+            model,
+            serviceShape,
+            rustSymbolProviderConfig,
+            publicConstrainedTypes,
+            includeConstraintShapeProvider,
+            codegenDecorator,
+        )
 
         val serverSymbolProviders =
             ServerSymbolProviders.from(
@@ -171,7 +177,7 @@ class TsServerCodegenVisitor(
         fun tsServerEnumGeneratorFactory(
             codegenContext: ServerCodegenContext,
             shape: StringShape,
-        ) = TsServerEnumGenerator(codegenContext, shape, validationExceptionConversionGenerator)
+        ) = TsServerEnumGenerator(codegenContext, shape, validationExceptionConversionGenerator, emptyList())
         stringShape(shape, ::tsServerEnumGeneratorFactory)
     }
 

--- a/codegen-server/typescript/src/main/kotlin/software/amazon/smithy/rust/codegen/server/typescript/smithy/generators/TsServerEnumGenerator.kt
+++ b/codegen-server/typescript/src/main/kotlin/software/amazon/smithy/rust/codegen/server/typescript/smithy/generators/TsServerEnumGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGeneratorContext
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
@@ -41,6 +42,7 @@ class TsServerEnumGenerator(
     codegenContext: ServerCodegenContext,
     shape: StringShape,
     validationExceptionConversionGenerator: ValidationExceptionConversionGenerator,
+    customizations: List<EnumCustomization>,
 ) : EnumGenerator(
         codegenContext.model,
         codegenContext.symbolProvider,
@@ -50,4 +52,5 @@ class TsServerEnumGenerator(
             shape,
             validationExceptionConversionGenerator,
         ),
+        customizations,
     )


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixing bug from https://github.com/smithy-lang/smithy-rs/pull/4039. It is breaking the diff generation ([ex](https://github.com/smithy-lang/smithy-rs/actions/runs/16690158842/job/47246940590?pr=4243)) in other PRs. Can't seem to fix it in the other PR since the diff always picks up the older broken revision, so doing a small stand-alone PR to get this in. 


## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
