### PR TITLE
Add `hints.mostly-unused = true` to `aws-sdk-lambda` and `aws-sdk-rds`

### DIFF
--- a/.changelog/hints-mostly-unused-lambda-rds.md
+++ b/.changelog/hints-mostly-unused-lambda-rds.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+  - aws-sdk-rust
+  - client
+authors:
+  - joshtriplett
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Enable `hints.mostly-unused = true` for `aws-sdk-lambda` (taking a release
+build from 57s to 40s) and `aws-sdk-rds` (taking a release build from 1m34s to
+49s).

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -117,6 +117,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
                 "com.amazonaws.cloudformation#CloudFormation",
                 "com.amazonaws.dynamodb#DynamoDB_20120810",
                 "com.amazonaws.ec2#AmazonEC2",
+                "com.amazonaws.lambda#AWSGirApiService",
                 "com.amazonaws.rds#AmazonRDSv19",
                 "com.amazonaws.s3#AmazonS3",
                 "com.amazonaws.sns#AmazonSimpleNotificationService",

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -117,6 +117,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
                 "com.amazonaws.cloudformation#CloudFormation",
                 "com.amazonaws.dynamodb#DynamoDB_20120810",
                 "com.amazonaws.ec2#AmazonEC2",
+                "com.amazonaws.rds#AmazonRDSv19",
                 "com.amazonaws.s3#AmazonS3",
                 "com.amazonaws.sns#AmazonSimpleNotificationService",
                 "com.amazonaws.sqs#AmazonSQS",


### PR DESCRIPTION
A release build of a crate with a dependency on only `aws-sdk-lambda` went from
57s to 40s with this hint.

A release build of a crate with a dependency on only `aws-sdk-rds` went from
1m34s to 49s with this hint.

## Testing

I did not rebuild the binding crates to test this; I tested using the profile
hint to confirm the performance improvement. I *think* I got the correct
binding name for these two bindings, but please confirm.

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
