### PR TITLE
Consolidating some layers in Dockerfile

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -134,17 +134,17 @@ cargo_mdbook_version=0.4.37 \
 cargo_mdbook_mermaid_version=0.13.0
 
 RUN cargo install cargo-deny --locked --version ${cargo_deny_version} \
-cargo +${rust_nightly_version} install cargo-udeps --locked --version ${cargo_udeps_version} \
-cargo install cargo-hack --locked --version ${cargo_hack_version} \
-cargo install cargo-minimal-versions --locked --version ${cargo_minimal_versions_version} \
-cargo install cargo-check-external-types --locked --version ${cargo_check_external_types_version} \
-cargo install maturin --locked --version ${maturin_version} \
-cargo install wasm-pack --locked --version ${wasm_pack_version} \
-cargo install wasmtime-cli --features="component-model" --locked --version ${cargo_wasmtime_version} \
-cargo +${rust_nightly_version} install cargo-component --locked --version ${cargo_component_version} \
-cargo install cargo-semver-checks --locked --version ${cargo_semver_checks_version} \
-cargo install mdbook --locked --version ${cargo_mdbook_version} \
-cargo install mdbook-mermaid --locked --version ${cargo_mdbook_mermaid_version}
+&& cargo +${rust_nightly_version} install cargo-udeps --locked --version ${cargo_udeps_version} \
+&& cargo install cargo-hack --locked --version ${cargo_hack_version} \
+&& cargo install cargo-minimal-versions --locked --version ${cargo_minimal_versions_version} \
+&& cargo install cargo-check-external-types --locked --version ${cargo_check_external_types_version} \
+&& cargo install maturin --locked --version ${maturin_version} \
+&& cargo install wasm-pack --locked --version ${wasm_pack_version} \
+&& cargo install wasmtime-cli --features="component-model" --locked --version ${cargo_wasmtime_version} \
+&& cargo +${rust_nightly_version} install cargo-component --locked --version ${cargo_component_version} \
+&& cargo install cargo-semver-checks --locked --version ${cargo_semver_checks_version} \
+&& cargo install mdbook --locked --version ${cargo_mdbook_version} \
+&& cargo install mdbook-mermaid --locked --version ${cargo_mdbook_mermaid_version}
 
 # nodejs needed by internal release process
 FROM install_rust AS nodejs


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We recently started seeing errors with the Acquire Base Image actions ([ex](https://github.com/smithy-lang/smithy-rs/actions/runs/16784733761/job/47532356543)). These were all caused by:
```
------STDERR---------
failed to register layer: max depth exceeded
-------------------
```

We are not quite sure why these started showing up in the past two days. The last change to our Dockerfile was about two weeks ago in https://github.com/smithy-lang/smithy-rs/pull/4217. The issue might be related to the clone of smithy-rs introduced in that change, but that didn't cause any issues at the time.

To get around this and unblock CI until we root cause it this PR reduces the number of layers in the image by grouping the ARGs and the RUNs for the local tool installation into a single statement each. 


## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
