### PR TITLE
fix derive-arbitrary feature for aws-smithy-eventstreams

### DIFF
--- a/.changelog/1755263261.md
+++ b/.changelog/1755263261.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- aajtodd
+references: []
+breaking: false
+new_feature: false
+bug_fix: false
+---
+fix `aws-smithy-eventstream` feature `derive-arbitrary` on `arbitrary` >= 1.4.2

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -49,9 +49,12 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -182,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
@@ -237,9 +240,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -377,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.10"
+version = "0.60.11"
 dependencies = [
  "arbitrary",
  "aws-smithy-types",
@@ -1240,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2277,9 +2280,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "0.24.2"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8e213c36148d828083ae01948eed271d03f95f7e72571fa242d78184029af2"
+checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
 dependencies = [
  "half",
  "minicbor-derive",

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
 # <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.10"
+version = "0.60.11"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
 
 [features]
-derive-arbitrary = ["arbitrary", "derive_arbitrary"]
+derive-arbitrary = ["dep:arbitrary", "dep:derive_arbitrary", "arbitrary?/derive"]
 test-util = []
 __bench-jemalloc = []
 __bench-mimalloc = []


### PR DESCRIPTION
## Description
Latest CI run of the SDK failed https://github.com/awslabs/aws-sdk-rust/actions/runs/16974016317/job/48118142608


```
   Compiling aws-smithy-eventstream v0.60.10 (/home/runner/work/aws-sdk-rust/aws-sdk-rust/sdk/aws-smithy-eventstream)
error[E0433]: failed to resolve: could not find `details` in `arbitrary`
   --> sdk/aws-smithy-eventstream/src/arbitrary.rs:65:35
    |
65  | #[derive(Clone, Debug, PartialEq, derive_arbitrary::Arbitrary)]
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `details` in `arbitrary`
    |
note: found an item that was configured out
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arbitrary-1.4.2/src/lib.rs:558:9
    |
558 | pub mod details {
    |         ^^^^^^^
note: the item is gated behind the `derive` feature
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arbitrary-1.4.2/src/lib.rs:557:7
    |
557 | #[cfg(feature = "derive")]
    |       ^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `derive_arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0433`.
error: could not compile `aws-smithy-eventstream` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Traceback (most recent call last):
  File "/home/runner/work/aws-sdk-rust/aws-sdk-rust/./tools/ci/crate-range.py", line 286, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/work/aws-sdk-rust/aws-sdk-rust/./tools/ci/crate-range.py", line 204, in main
    return subcommand_run(repository_root, args.batches, args.start_inclusive, args.end_exclusive, args.folder, args.cmd)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/aws-sdk-rust/aws-sdk-rust/./tools/ci/crate-range.py", line 167, in subcommand_run
    subprocess.run(command, check=True)
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['cargo', 'test', '--all-features']' returned non-zero exit status 101.
Error: Process completed with exit code 1.
```



Looks like `arbitrary` crate released `1.4.2` yesterday and it's now triggering this for us. I looked at the changes but didn't see anything obvious on their end. Either way I don't think we ever had our `Cargo.toml` right though for enabling the required feature. 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
