### PR TITLE
fix gradle caching

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -90,6 +90,7 @@ RUN set -eux; \
 
 FROM install_rust AS local_tools
 ARG rust_nightly_version
+ENV GRADLE_USER_HOME=/home/build/.gradle
 COPY . tools/ci-build
 # when `checkout_smithy_rs_tools` is set to true, this commit will be checked out
 ARG smithy_rs_commit_hash=main
@@ -229,6 +230,7 @@ COPY --chown=build:build --from=local_tools /opt/cargo/bin/mdbook /opt/cargo/bin
 COPY --chown=build:build --from=local_tools /opt/cargo/bin/mdbook-mermaid /opt/cargo/bin/mdbook-mermaid
 COPY --chown=build:build --from=nodejs /opt/nodejs /opt/nodejs
 COPY --chown=build:build --from=musl_toolchain /usr/local/musl/ /usr/local/musl/
+COPY --chown=build:build --from=local_tools /home/build/.gradle /home/build/.gradle
 ENV PATH=/opt/nodejs/bin:/opt/cargo/bin:$PATH:/usr/local/musl/bin/ \
     NODE_HOME=/opt/nodejs \
     CARGO_HOME=/opt/cargo \
@@ -236,6 +238,7 @@ ENV PATH=/opt/nodejs/bin:/opt/cargo/bin:$PATH:/usr/local/musl/bin/ \
     RUST_STABLE_VERSION=${rust_stable_version} \
     RUST_NIGHTLY_VERSION=${rust_nightly_version} \
     CARGO_INCREMENTAL=0 \
+    GRADLE_USER_HOME=/home/build/.gradle \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 # SMITHY_RS_DOCKER_BUILD_IMAGE indicates to build scripts that they are being built inside of the Docker build image.


### PR DESCRIPTION
## Motivation and Context
Still seeing intermittent transient failures due to Gradle wrapper failing to download

## Description

https://github.com/smithy-lang/smithy-rs/pull/4217 was meant to fix this, I think we just missed that the installation and wrapper is being downloaded to an intermediate image rather than the final image. The final image did not have the gradle wrapper binary nor the env variable related to it set.

```
> env | sort
...
GRADLE_USER_HOME=/home/build/.gradle
...

> [localbuild@047e7e4b0e64 build]$ ls -lsa /home/build/.gradle
total 40
4 drwxr-xr-x. 10 build build 4096 Aug 15 14:39 .
4 drwxrwxr-x.  1 build build 4096 Aug 15 14:54 ..
4 drwxr-xr-x.  7 build build 4096 Aug 15 14:38 caches
4 drwxr-xr-x.  3 build build 4096 Aug 15 14:38 daemon
4 drwxr-xr-x.  2 build build 4096 Aug 15 14:38 jdks
4 drwxr-xr-x.  2 build build 4096 Aug 15 14:39 kotlin-profile
4 drwxr-xr-x.  5 build build 4096 Aug 15 14:38 native
4 drwxr-xr-x.  3 build build 4096 Aug 15 14:38 notifications
4 drwxr-xr-x.  3 build build 4096 Aug 15 14:39 .tmp
4 drwxr-xr-x.  3 build build 4096 Aug 15 14:38 wrapper
```

## Testing
Build image locally and see that gradle wrapper is present and GRADLE_USER_HOME is set.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
