### PR TITLE
Centralize the default checksum algorithm in a single place

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -105,7 +105,7 @@ private fun HttpChecksumTrait.requestAlgorithmMember(
 // This is the single place where the default algorithm is set. It must be all uppercased.
 // There is some special logic in HttpChecksumTest and in the http_request_checksum inlineable
 // for testing the default case, if you change this value you will have to update that logic as well.
-const val defaultAlgorithm = "CRC32"
+const val DEFAULT_ALGORITHM = "CRC32"
 
 /**
  * Extract the name of the operation's input member that indicates which checksum algorithm to use
@@ -121,7 +121,7 @@ private fun HttpChecksumTrait.checksumAlgorithmToStr(
     return {
         if (requestAlgorithmMember == null && isRequestChecksumRequired) {
             // Checksums are required but a user can't set one, so we set the default for them
-            rust("""let checksum_algorithm = Some("${defaultAlgorithm.lowercase()}");""")
+            rust("""let checksum_algorithm = Some("${DEFAULT_ALGORITHM.lowercase()}");""")
         } else {
             // Use checksum algo set by user
             rust("""let checksum_algorithm = checksum_algorithm.map(|algorithm| algorithm.as_str());""")
@@ -225,7 +225,7 @@ class HttpRequestChecksumCustomization(
                                         (_, _, _, _, true) => {}
                                         (#{RequestChecksumCalculation}::WhenSupported, _, false, false, _)
                                         | (#{RequestChecksumCalculation}::WhenRequired, true, false, false, _) => {
-                                            request.headers_mut().insert(${requestAlgoHeader.dq()}, "$defaultAlgorithm");
+                                            request.headers_mut().insert(${requestAlgoHeader.dq()}, "$DEFAULT_ALGORITHM");
                                         }
                                         _ => {},
                                     }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When I initially did the checksum work I meant to have the default checksum algorithm set in a single place to make it easy to update in the future. But it seems I missed actually getting that done, so I am doing it now. 


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
