### PR TITLE
Add `Clone` to `HickoryDnsResolver` and `TokioDnsResolver`

### DIFF
--- a/.changelog/dns-clone.md
+++ b/.changelog/dns-clone.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client"]
+authors: ["landonxjames"]
+references: ["smithy-rs#4274"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+The `HickoryDnsResolver` and `TokioDnsResolver` were not `Clone` making it impossible to use them in the http_client builder's `build_with_resolver` method.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-dns"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-smithy-runtime-api",
  "criterion",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "approx",
  "aws-smithy-async",

--- a/rust-runtime/aws-smithy-dns/Cargo.toml
+++ b/rust-runtime/aws-smithy-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-dns"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-dns/src/hickory.rs
+++ b/rust-runtime/aws-smithy-dns/src/hickory.rs
@@ -20,7 +20,7 @@ use hickory_resolver::{
 ///
 /// This resolver requires a [tokio] runtime to function and isn't available for WASM targets.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HickoryDnsResolver {
     resolver: Resolver<TokioConnectionProvider>,
 }

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.9.1"
+version = "1.9.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/dns.rs
@@ -15,7 +15,7 @@ mod tokio {
     ///
     /// This implementation isn't available for WASM targets.
     #[non_exhaustive]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, Clone)]
     pub struct TokioDnsResolver;
 
     impl TokioDnsResolver {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `HickoryDnsResolver` and `TokioDnsResolver` were not `Clone` making it impossible to use them in the http_client builder's `build_with_resolver` method.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
