### PR TITLE
Set enableStackTraceComments(true) on RustWriter

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -592,7 +592,7 @@ class RustWriter private constructor(
     private val commentCharacter: String = "//",
     private val printWarning: Boolean = true,
     /** Insert comments indicating where code was generated */
-    val debugMode: Boolean = false,
+    val debugMode: Boolean = true,
     /** When true, automatically change all dependencies to be in the test scope */
     val devDependenciesOnly: Boolean = false,
 ) :
@@ -665,7 +665,7 @@ class RustWriter private constructor(
                 location.first { it.isRelevant() }?.let { "/* ${it.fileName}:${it.lineNumber} */" }
                     ?.also { super.writeInline(it) }
             }
-            super.enableStackTraceComments(true)
+//            super.enableStackTraceComments(true)
             return super.write(content, *args)
         }
 


### PR DESCRIPTION
I just want to see the diff on the generated code and if it might be useful for helping LLMs figure out the connections between the generated Rust and the Kotlin that does the generation. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
