### PR TITLE
Treat `aws_doc_sdk_examples_revision` as optional

### DIFF
--- a/aws/SDK_README.md.hb
+++ b/aws/SDK_README.md.hb
@@ -21,7 +21,7 @@ The code used to generate the SDK can be found in [smithy-rs](https://github.com
 
 ## Getting Started with the SDK
 
-> Examples are available for many services and operations, check out the [examples folder](./examples).
+> Examples are available for many services and operations, check out the [Rust examples](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/rustv1) in the `aws-doc-sdk-examples` repository.
 
 > For a step-by-step guide including several advanced use cases, check out the [Developer Guide](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/welcome.html).
 
@@ -74,7 +74,7 @@ Suggestions for additional sections or improvements for the guide are welcome. P
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](./examples)
+* [Usage examples](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/rustv1)
 
 ## Feedback and Contributing
 
@@ -101,7 +101,7 @@ version will be called out in the Release Notes for new releases of the SDK.
 
 - Design docs - Design documentation for the SDK lives in the [design folder of smithy-rs](https://github.com/smithy-lang/smithy-rs/tree/main/design).
 - Runtime / Handwritten code: The Rust Runtime code that underpins the SDK can be accessed [here](https://github.com/smithy-lang/smithy-rs/tree/main/rust-runtime) and [here](https://github.com/smithy-lang/smithy-rs/tree/main/aws/rust-runtime). This code is copied into this repo as part of code generation.
-- [Code Examples](./examples)
+- [Code Examples](https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/rustv1)
 - [API reference documentation (rustdoc)](https://awslabs.github.io/aws-sdk-rust/)
 
 ## Security

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -405,8 +405,6 @@ tasks.register<ExecRustBuildTool>("generateVersionManifest") {
         outputDir.asFile.absolutePath,
         "--smithy-build",
         layout.buildDirectory.file("smithy-build.json").get().asFile.normalize().absolutePath,
-        "--examples-revision",
-        properties.get("aws.sdk.examples.revision") ?: "missing",
     ).apply {
         getPreviousReleaseVersionManifestPath()?.let { manifestPath ->
             add("--previous-release-versions")

--- a/buildSrc/src/main/kotlin/aws/sdk/VersionsManifest.kt
+++ b/buildSrc/src/main/kotlin/aws/sdk/VersionsManifest.kt
@@ -18,7 +18,6 @@ data class CrateVersion(
 /** Kotlin representation of aws-sdk-rust's `versions.toml` file */
 data class VersionsManifest(
     val smithyRsRevision: String,
-    val awsDocSdkExamplesRevision: String,
     val crates: Map<String, CrateVersion>,
 ) {
     companion object {
@@ -31,7 +30,6 @@ data class VersionsManifest(
             val toml = Toml().read(value)
             return VersionsManifest(
                 smithyRsRevision = toml.getString("smithy_rs_revision"),
-                awsDocSdkExamplesRevision = toml.getString("aws_doc_sdk_examples_revision"),
                 crates =
                     toml.getTable("crates").entrySet().map { entry ->
                         val crate = (entry.value as Toml)

--- a/buildSrc/src/test/kotlin/aws/sdk/IndependentCrateVersionerTest.kt
+++ b/buildSrc/src/test/kotlin/aws/sdk/IndependentCrateVersionerTest.kt
@@ -32,7 +32,6 @@ class IndependentCrateVersionerTest {
             IndependentCrateVersioner(
                 VersionsManifest(
                     smithyRsRevision = "smithy-rs-1",
-                    awsDocSdkExamplesRevision = "dontcare",
                     crates =
                         mapOf(
                             "aws-sdk-dynamodb" to
@@ -93,7 +92,6 @@ class IndependentCrateVersionerTest {
             IndependentCrateVersioner(
                 VersionsManifest(
                     smithyRsRevision = "smithy-rs-1",
-                    awsDocSdkExamplesRevision = "dontcare",
                     crates =
                         mapOf(
                             "aws-sdk-dynamodb" to
@@ -161,7 +159,6 @@ class IndependentCrateVersionerTest {
             IndependentCrateVersioner(
                 VersionsManifest(
                     smithyRsRevision = "smithy-rs-1",
-                    awsDocSdkExamplesRevision = "dontcare",
                     crates =
                         mapOf(
                             "aws-sdk-dynamodb" to
@@ -211,7 +208,6 @@ class IndependentCrateVersionerTest {
             IndependentCrateVersioner(
                 VersionsManifest(
                     smithyRsRevision = "smithy-rs-1",
-                    awsDocSdkExamplesRevision = "dontcare",
                     crates =
                         mapOf(
                             "aws-sdk-dynamodb" to

--- a/buildSrc/src/test/kotlin/aws/sdk/VersionsManifestTest.kt
+++ b/buildSrc/src/test/kotlin/aws/sdk/VersionsManifestTest.kt
@@ -15,7 +15,6 @@ class VersionsManifestTest {
             VersionsManifest.fromString(
                 """
                 smithy_rs_revision = 'some-smithy-rs-revision'
-                aws_doc_sdk_examples_revision = 'some-doc-revision'
 
                 [crates.aws-config]
                 category = 'AwsRuntime'
@@ -31,7 +30,6 @@ class VersionsManifestTest {
             )
 
         assertEquals("some-smithy-rs-revision", manifest.smithyRsRevision)
-        assertEquals("some-doc-revision", manifest.awsDocSdkExamplesRevision)
         assertEquals(
             mapOf(
                 "aws-config" to

--- a/tools/ci-build/changelogger/tests/e2e_test.rs
+++ b/tools/ci-build/changelogger/tests/e2e_test.rs
@@ -58,7 +58,6 @@ const SDK_MODEL_SOURCE_TOML: &str = r#"
 
 const VERSIONS_TOML: &str = r#"
     smithy_rs_revision = '41ca31b85b4ba8c0ad680fe62a230266cc52cc44'
-    aws_doc_sdk_examples_revision = '97a177aab8c3d2fef97416cb66e4b4d0da840138'
 
     [manual_interventions]
     crates_to_remove = []
@@ -383,7 +382,6 @@ fn render_aws_sdk() {
         &previous_versions_manifest_path,
         format!(
             "smithy_rs_revision = '{last_release_commit}'
-                 aws_doc_sdk_examples_revision = 'not-relevant'
                  [crates]",
         ),
     )

--- a/tools/ci-build/publisher/src/subcommand/generate_version_manifest.rs
+++ b/tools/ci-build/publisher/src/subcommand/generate_version_manifest.rs
@@ -24,9 +24,11 @@ pub struct GenerateVersionManifestArgs {
     /// Path to `smithy-build.json`
     #[clap(long)]
     smithy_build: PathBuf,
+    // TODO(examples removal post cleanup): Remove this field once examples revision is removed
+    // from `versions.toml` in the main branch of `aws-sdk-rust` repository.
     /// Revision of `aws-doc-sdk-examples` repository used to retrieve examples
     #[clap(long)]
-    examples_revision: String,
+    examples_revision: Option<String>,
     /// Same as `input_location` but kept for backwards compatibility
     #[clap(long, required_unless_present = "input-location")]
     location: Option<PathBuf>,
@@ -109,7 +111,7 @@ pub async fn subcommand_generate_version_manifest(
     info!("Discovered and hashed {} crates", crates.len());
     let mut versions_manifest = VersionsManifest {
         smithy_rs_revision: smithy_rs_revision.to_string(),
-        aws_doc_sdk_examples_revision: examples_revision.to_string(),
+        aws_doc_sdk_examples_revision: examples_revision.as_ref().map(String::to_string),
         manual_interventions: Default::default(),
         crates,
         release: None,
@@ -260,7 +262,7 @@ mod tests {
     ) -> VersionsManifest {
         VersionsManifest {
             smithy_rs_revision: "dontcare".into(),
-            aws_doc_sdk_examples_revision: "dontcare".into(),
+            aws_doc_sdk_examples_revision: None,
             manual_interventions: manual_interventions.unwrap_or_default(),
             crates: crates
                 .iter()

--- a/tools/ci-build/publisher/src/subcommand/tag_versions_manifest.rs
+++ b/tools/ci-build/publisher/src/subcommand/tag_versions_manifest.rs
@@ -46,7 +46,7 @@ mod tests {
         let versions_manifest_path = tmp_dir.path().join("versions.toml");
         let original = VersionsManifest {
             smithy_rs_revision: "some-revision-smithy-rs".into(),
-            aws_doc_sdk_examples_revision: "some-revision-docs".into(),
+            aws_doc_sdk_examples_revision: None,
             manual_interventions: Default::default(),
             crates: [
                 (

--- a/tools/ci-build/publisher/tests/hydrate_readme_e2e_test.rs
+++ b/tools/ci-build/publisher/tests/hydrate_readme_e2e_test.rs
@@ -16,7 +16,7 @@ fn test_hydrate_readme() {
     let versions_manifest_path = tmp_dir.path().join("versions.toml");
     VersionsManifest {
         smithy_rs_revision: "dontcare".into(),
-        aws_doc_sdk_examples_revision: "dontcare".into(),
+        aws_doc_sdk_examples_revision: None,
         manual_interventions: Default::default(),
         crates: [
             (

--- a/tools/ci-build/sdk-versioner/src/main.rs
+++ b/tools/ci-build/sdk-versioner/src/main.rs
@@ -306,7 +306,7 @@ mod tests {
     fn versions_toml_for(crates: &[(&str, &str)]) -> VersionsManifest {
         VersionsManifest {
             smithy_rs_revision: "doesntmatter".into(),
-            aws_doc_sdk_examples_revision: "doesntmatter".into(),
+            aws_doc_sdk_examples_revision: None,
             manual_interventions: Default::default(),
             crates: crates
                 .iter()

--- a/tools/ci-build/smithy-rs-tool-common/src/versions_manifest.rs
+++ b/tools/ci-build/smithy-rs-tool-common/src/versions_manifest.rs
@@ -23,8 +23,10 @@ pub struct VersionsManifest {
     /// Git commit hash of the version of smithy-rs used to generate this SDK
     pub smithy_rs_revision: String,
 
+    // TODO(examples removal post cleanup): Remove this field once examples revision is removed
+    // from `versions.toml` in the main branch of `aws-sdk-rust` repository.
     /// Git commit hash of the `aws-doc-sdk-examples` repository that was synced into this SDK
-    pub aws_doc_sdk_examples_revision: String,
+    pub aws_doc_sdk_examples_revision: Option<String>,
 
     /// Optional manual interventions to apply to the next release.
     /// These are intended to be filled out manually in the `versions.toml` via pull request

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -688,7 +688,7 @@ default = ["latest"]
             generate_crate_manifest(CrateSource::VersionsManifest {
                 versions: VersionsManifest {
                     smithy_rs_revision: "some-revision-smithy-rs".into(),
-                    aws_doc_sdk_examples_revision: "some-revision-docs".into(),
+                    aws_doc_sdk_examples_revision: None,
                     manual_interventions: Default::default(),
                     crates: [
                         crate_version("aws-config", "0.46.0"),
@@ -750,7 +750,7 @@ aws-smithy-wasm = { path = "some/sdk/path/aws-smithy-wasm" }
         let crate_source = CrateSource::VersionsManifest {
             versions: VersionsManifest {
                 smithy_rs_revision: "some-revision-smithy-rs".into(),
-                aws_doc_sdk_examples_revision: "some-revision-docs".into(),
+                aws_doc_sdk_examples_revision: None,
                 manual_interventions: Default::default(),
                 crates: [
                     crate_version("aws-config", "0.46.0"),
@@ -848,7 +848,7 @@ aws-smithy-wasm = { version = "0.1.0" }
     fn test_notable_versions() {
         let versions = VersionsManifest {
             smithy_rs_revision: "some-revision-smithy-rs".into(),
-            aws_doc_sdk_examples_revision: "some-revision-docs".into(),
+            aws_doc_sdk_examples_revision: None,
             manual_interventions: Default::default(),
             crates: [].into_iter().collect(),
             release: None,


### PR DESCRIPTION
## Motivation and Context
We're in the process of removing `examples` from the `aws-sdk-rust` repository.

This PR updates `publisher` and the SDK codegen to treat [aws_doc_sdk_examples_revision](https://github.com/awslabs/aws-sdk-rust/blob/67af42f0f7dcf8410782aed5c4d061d71eb0eab9/versions.toml#L2) in `versions.toml` as optional. By making that TOML key optional, we allow `publisher` and SDK codegen to continue working with/without it. We can then safely remove `aws_doc_sdk_examples_revision` from `versions.toml`.

Note: There will be a subsequent PR to remove code related to `aws_doc_sdk_examples_revision` from `publisher` and the SDK codegen, once the TOML key `aws_doc_sdk_examples_revision` is removed from `versions.toml` in the `aws-sdk-rust` repository.

## Testing
- CI
- Passed release pipeline with the changes in this PR

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
