### PR TITLE
Fix `codegen-server-test-python` path in CI configuration

### DIFF
--- a/tools/ci-scripts/codegen-diff/diff_lib.py
+++ b/tools/ci-scripts/codegen-diff/diff_lib.py
@@ -69,8 +69,8 @@ def generate_and_commit_generated_code(revision_sha, targets=None):
             get_cmd_output(f"mv {target}/build/smithyprojections/{target} {OUTPUT_PATH}/")
             if target == target_codegen_server:
                 get_cmd_output(f"./gradlew --rerun-tasks {target_codegen_server_python}:stubs")
-                get_cmd_output(f"mv {target}/codegen-server-python/build/smithyprojections/{target}-python {OUTPUT_PATH}/")
-                get_cmd_output(f"mv {target}/codegen-server-typescript/build/smithyprojections/{target}-typescript {OUTPUT_PATH}/")
+                get_cmd_output(f"mv {target}/codegen-server-test-python/build/smithyprojections/{target}-python {OUTPUT_PATH}/")
+                get_cmd_output(f"mv {target}/codegen-server-test-typescript/build/smithyprojections/{target}-typescript {OUTPUT_PATH}/")
 
     # Clean up the SDK directory
     get_cmd_output(f"rm -f {OUTPUT_PATH}/aws-sdk/versions.toml")


### PR DESCRIPTION
This PR resolves the CI failure [occurring in PR #4288](https://github.com/smithy-lang/smithy-rs/actions/runs/17608605180/job/50025264439?pr=4288#step:4:871) by correcting the path reference.