### PR TITLE
fix gradle caching in docker build

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -99,7 +99,7 @@ RUN set -eux; \
     git init smithy-rs && cd smithy-rs; \
     git remote add origin https://github.com/smithy-lang/smithy-rs.git; \
     git sparse-checkout init --cone; \
-    git sparse-checkout set gradlew gradle/wrapper gradle.properties; \
+    git sparse-checkout set gradlew gradle/wrapper gradle.properties buildSrc; \
     git fetch --depth=1 origin ${smithy_rs_commit_hash}; \
     git checkout FETCH_HEAD; \
     # Run the gradle wrapper with no args to download the gradle binary and cache it in the image


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

https://github.com/smithy-lang/smithy-rs/pull/4218 broke the docker image build in a subtle way which is that we added Gradle build logic to `buildSrc` that is used in the root `build.gradle.kts` file. This wasn't found in PR:4218 because the docker build does a sparse checkout of the `main` branch which did not have the new logic/issue and thus was not triggered until after merging. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local + CI build succeeds

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
