### PR TITLE
Update crc-fast dependency to 1.5.0

### DIFF
--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -16,8 +16,7 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1.10.0"
-# FIXME(https://github.com/smithy-lang/smithy-rs/pull/4257): pin to <1.4.0 until https://github.com/awesomized/crc-fast-rust/issues/14 is resolved
-crc-fast = "~1.3.0"
+crc-fast = "1.5.0"
 hex = "0.4.3"
 http = "0.2.9"
 http-body = "0.4.5"


### PR DESCRIPTION

## Motivation and Context

fix for https://github.com/awesomized/crc-fast-rust/issues/14 is present in 1.4.1+

## Description

stop pinning to 1.3

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
