### PR TITLE
Cache gradle in GitHub workflows

### DIFF
--- a/.github/workflows/ci-tls.yml
+++ b/.github/workflows/ci-tls.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         distribution: corretto
         java-version: 17
+        cache: gradle
     - name: Stop nginx
       run: sudo systemctl stop nginx
     - name: Checkout smithy-rs

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -90,16 +90,6 @@ jobs:
       bot-message: ${{ steps.generate-preview.outputs.bot-message }}
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      name: Gradle Cache
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-      # JDK is needed to generate code
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -106,6 +106,7 @@ jobs:
         distribution: corretto
         java-package: jdk
         java-version: ${{ env.java_version }}
+        cache: gradle
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.rust_nightly_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,7 @@ jobs:
       with:
         distribution: temurin
         java-version: '17'
+        cache: gradle
     - name: Check if publishing is needed
       id: check-publish
       shell: bash

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -42,6 +42,7 @@ jobs:
         distribution: corretto
         java-package: jdk
         java-version: 17
+        cache: gradle
       # Rust is only used to `rustfmt` the generated code; doesn't need to match MSRV
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Motivation and Context
https://github.com/smithy-lang/smithy/pull/2776

## Description
Cache gradle in GitHub workflows

## Testing
CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
