### PR TITLE
Provide SDK codegen unit tests with more space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           runner: smithy_ubuntu-latest_8-core
           fetch-depth: 0
         - action: check-sdk-codegen-unit-tests
-          runner: ubuntu-latest
+          runner: smithy_ubuntu-latest_8-core
         - action: check-fuzzgen
           runner: ubuntu-latest
         - action: check-server-codegen-integration-tests


### PR DESCRIPTION
## Motivation and Context
The latest release workflow encountered no space left on device in `check-sdk-codegen-unit-tests`:
```
       = note: /usr/bin/ld: final link failed: No space left on device
              collect2: error: ld returned 1 exit status
```

This PR updates its runner to `smithy_ubuntu-latest_8-core` to resolve the issue. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
