### PR TITLE
Replace `doc_auto_cfg` with `doc_cfg` to allow docsrs build to succeed

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.8.7"
+version = "1.8.8"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-credential-types"
-version = "1.2.7"
+version = "1.2.8"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Types for AWS SDK credentials."
 edition = "2021"

--- a/aws/rust-runtime/aws-credential-types/src/lib.rs
+++ b/aws/rust-runtime/aws-credential-types/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! `aws-credential-types` provides types concerned with AWS SDK credentials including:
 //! * Traits for credentials providers and for credentials caching

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Collection of modules that get conditionally included directly into the code generated
 //! SDK service crates. For example, when generating S3, the `s3_errors` module will get copied

--- a/aws/rust-runtime/aws-runtime-api/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime-api"
-version = "1.1.8"
+version = "1.1.9"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime-api/src/lib.rs
+++ b/aws/rust-runtime/aws-runtime-api/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Runtime support code for the AWS SDK. This crate isn't intended to be used directly.
 

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/lib.rs
+++ b/aws/rust-runtime/aws-runtime/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Runtime support code for the AWS SDK. This crate isn't intended to be used directly.
 

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.3.4"
+version = "1.3.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/lib.rs
+++ b/aws/rust-runtime/aws-sigv4/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Provides functions for calculating Sigv4 signing keys, signatures, and
 //! optional utilities for signing HTTP requests and Event Stream messages.

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-types"
-version = "1.3.8"
+version = "1.3.9"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Cross-service types for the AWS SDK."
 edition = "2021"

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Cross-service types for the AWS SDK.
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/LibRsGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/LibRsGenerator.kt
@@ -55,7 +55,7 @@ class LibRsGenerator(
             if (requireDocs) {
                 rust("##![warn(missing_docs)]")
             }
-            rawRust("#![cfg_attr(docsrs, feature(doc_auto_cfg))]")
+            rawRust("#![cfg_attr(docsrs, feature(doc_cfg))]")
 
             // Allow for overriding the default service docs via customization
             val defaultServiceDocs = settings.getService(model).getTrait<DocumentationTrait>()?.value

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-cbor"
-version = "0.61.1"
+version = "0.61.2"
 dependencies = [
  "aws-smithy-types",
  "criterion",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.8"
+version = "0.63.9"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-compression"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-dns"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aws-smithy-runtime-api",
  "criterion",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.11"
+version = "0.60.12"
 dependencies = [
  "arbitrary",
  "aws-smithy-types",
@@ -403,11 +403,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-experimental"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.3"
+version = "0.62.4"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.65.6"
+version = "0.65.7"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-http",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-python"
-version = "0.66.3"
+version = "0.66.4"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-http-server",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.5"
+version = "0.61.6"
 dependencies = [
  "aws-smithy-types",
  "proptest",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-mocks"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http-client",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aws-smithy-runtime-api",
  "serial_test",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability-otel"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-global-executor",
  "async-task",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.4"
+version = "0.63.5"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.7"
+version = "0.60.8"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "approx",
  "aws-smithy-async",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types-convert"
-version = "0.60.9"
+version = "0.60.10"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-wasm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-runtime-api",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.10"
+version = "0.60.11"
 dependencies = [
  "aws-smithy-protocol-test",
  "base64 0.13.1",

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-async"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Async runtime agnostic abstractions for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-async/src/lib.rs
+++ b/rust-runtime/aws-smithy-async/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-cbor/Cargo.toml
+++ b/rust-runtime/aws-smithy-cbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-cbor"
-version = "0.61.1"
+version = "0.61.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "David Pérez <d@vidp.dev>",

--- a/rust-runtime/aws-smithy-cbor/src/lib.rs
+++ b/rust-runtime/aws-smithy-cbor/src/lib.rs
@@ -6,7 +6,7 @@
 //! CBOR abstractions for Smithy.
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 
 pub mod data;

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.63.8"
+version = "0.63.9"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-checksums/src/lib.rs
+++ b/rust-runtime/aws-smithy-checksums/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-compression/Cargo.toml
+++ b/rust-runtime/aws-smithy-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-compression"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-compression/src/lib.rs
+++ b/rust-runtime/aws-smithy-compression/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-dns/Cargo.toml
+++ b/rust-runtime/aws-smithy-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-dns"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-dns/src/lib.rs
+++ b/rust-runtime/aws-smithy-dns/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 
 //! Built-in DNS resolver implementations for smithy-rs clients.

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
 # <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.11"
+version = "0.60.12"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."

--- a/rust-runtime/aws-smithy-eventstream/src/lib.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-experimental/Cargo.toml
+++ b/rust-runtime/aws-smithy-experimental/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-experimental"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Experiments for the smithy-rs ecosystem"
 edition = "2021"

--- a/rust-runtime/aws-smithy-experimental/src/lib.rs
+++ b/rust-runtime/aws-smithy-experimental/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 
 #[deprecated(

--- a/rust-runtime/aws-smithy-fuzz/Cargo.toml
+++ b/rust-runtime/aws-smithy-fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "aws-smithy-fuzz"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Fuzzing utilities for smithy-rs servers"
 edition = "2021"

--- a/rust-runtime/aws-smithy-fuzz/src/lib.rs
+++ b/rust-runtime/aws-smithy-fuzz/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![cfg(not(windows))]
 use libloading::{os, Library, Symbol};

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.1.2"
+version = "1.1.3"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-client/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 
 //! HTTP client implementation for smithy-rs generated code.
@@ -25,7 +25,6 @@
     unreachable_pub,
     rust_2018_idioms
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // ideally hyper_014 would just be exposed as is but due to
 // https://github.com/rust-lang/rust/issues/47238 we get clippy warnings we can't suppress

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.66.3"
+version = "0.66.4"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server-python/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/lib.rs
@@ -4,10 +4,9 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Rust/Python bindings, runtime and utilities.
 //!

--- a/rust-runtime/aws-smithy-http-server-typescript/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-typescript"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server-typescript/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server-typescript/src/lib.rs
@@ -4,5 +4,5 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.65.6"
+version = "0.65.7"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -4,10 +4,9 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! HTTP server runtime and utilities, loosely based on [axum].
 //!

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.62.3"
+version = "0.62.4"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-http/src/lib.rs
+++ b/rust-runtime/aws-smithy-http/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![warn(
     missing_docs,
@@ -25,7 +25,6 @@
 //! | `event-stream` | Provides Sender/Receiver implementations for Event Stream codegen. |
 
 #![allow(clippy::derive_partial_eq_without_eq)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod endpoint;
 // Marked as `doc(hidden)` because a type in the module is used both by this crate and by the code

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-json"
-version = "0.61.5"
+version = "0.61.6"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-json/src/lib.rs
+++ b/rust-runtime/aws-smithy-json/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-mocks/Cargo.toml
+++ b/rust-runtime/aws-smithy-mocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-mocks"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Testing utilities for smithy-rs generated clients"
 edition = "2021"

--- a/rust-runtime/aws-smithy-mocks/src/lib.rs
+++ b/rust-runtime/aws-smithy-mocks/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![doc = include_str!("../README.md")]
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![warn(
     missing_docs,

--- a/rust-runtime/aws-smithy-observability-otel/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability-otel"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-observability-otel/src/lib.rs
+++ b/rust-runtime/aws-smithy-observability-otel/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![warn(
     missing_docs,

--- a/rust-runtime/aws-smithy-observability/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-observability/src/lib.rs
+++ b/rust-runtime/aws-smithy-observability/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![warn(
     missing_docs,

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-protocol-test"
-version = "0.63.4"
+version = "0.63.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "A collection of library functions to validate HTTP requests against Smithy protocol tests."
 edition = "2021"

--- a/rust-runtime/aws-smithy-protocol-test/src/lib.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![warn(
     // missing_docs,

--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-query"
-version = "0.60.7"
+version = "0.60.8"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "AWSQuery and EC2Query Smithy protocol logic for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-query/src/lib.rs
+++ b/rust-runtime/aws-smithy-query/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/lib.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![warn(
     missing_docs,

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.9.2"
+version = "1.9.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/lib.rs
+++ b/rust-runtime/aws-smithy-runtime/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Runtime support logic and types for smithy-rs generated code.
 //!

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types-convert"
-version = "0.60.9"
+version = "0.60.10"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Conversion of types from aws-smithy-types to other libraries."
 edition = "2021"

--- a/rust-runtime/aws-smithy-types-convert/src/lib.rs
+++ b/rust-runtime/aws-smithy-types-convert/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Conversions between `aws-smithy-types` and the types of frequently used Rust libraries.
 

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 //! Protocol-agnostic types for smithy-rs.
 

--- a/rust-runtime/aws-smithy-wasm/Cargo.toml
+++ b/rust-runtime/aws-smithy-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-wasm"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Eduardo Rodrigues <16357187+eduardomourar@users.noreply.github.com>",

--- a/rust-runtime/aws-smithy-wasm/src/lib.rs
+++ b/rust-runtime/aws-smithy-wasm/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/aws-smithy-xml/Cargo.toml
+++ b/rust-runtime/aws-smithy-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-xml"
-version = "0.60.10"
+version = "0.60.11"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "XML parsing logic for Smithy protocols."
 edition = "2021"

--- a/rust-runtime/aws-smithy-xml/src/lib.rs
+++ b/rust-runtime/aws-smithy-xml/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -4,7 +4,7 @@
  */
 
 /* Automatically managed default lints */
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /* End of automatically managed default lints */
 #[allow(dead_code)]
 mod aws_query_compatible_errors;

--- a/tools/ci-build/sdk-lints/src/lib_rs_attr.rs
+++ b/tools/ci-build/sdk-lints/src/lib_rs_attr.rs
@@ -24,11 +24,11 @@ impl Lint for StandardizedRuntimeCrateLibRsAttributes {
     }
 }
 
-const DOCS_AUTO_CFG: &str = "#![cfg_attr(docsrs, feature(doc_auto_cfg))]";
+const DOCS_CFG: &str = "#![cfg_attr(docsrs, feature(doc_cfg))]";
 
 fn check_for_auto_cfg(path: impl AsRef<Path>) -> anyhow::Result<Vec<LintError>> {
     let contents = std::fs::read_to_string(path)?;
-    if !contents.contains(DOCS_AUTO_CFG) {
+    if !contents.contains(DOCS_CFG) {
         return Ok(vec![LintError::new("missing docsrs header")]);
     }
     Ok(vec![])
@@ -38,7 +38,7 @@ impl Fix for StandardizedRuntimeCrateLibRsAttributes {
     fn fix(&self, path: impl AsRef<Path>) -> anyhow::Result<(Vec<LintError>, String)> {
         let contents = std::fs::read_to_string(&path)?;
         // ensure there is only one in the crate
-        let mut contents = contents.replace(DOCS_AUTO_CFG, "");
+        let mut contents = contents.replace(DOCS_CFG, "");
         let anchor_start = "/* Automatically managed default lints */\n";
         let anchor_end = "\n/* End of automatically managed default lints */";
         // Find the end of the license header
@@ -51,7 +51,7 @@ impl Fix for StandardizedRuntimeCrateLibRsAttributes {
             replace_anchor(
                 &mut contents,
                 &(anchor_start, anchor_end),
-                DOCS_AUTO_CFG,
+                DOCS_CFG,
                 Some(newline),
             )?;
         };


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Our docrs builds started [failing](https://docs.rs/crate/aws-sdk-dynamodb/1.94.0/builds/2555063) recently with the error:
```
[INFO] [stderr]  Documenting aws-sdk-dynamodb v1.94.0 (/opt/rustwide/workdir)
[INFO] [stderr] error[E0557]: feature has been removed
[INFO] [stderr]   --> src/lib.rs:21:29
[INFO] [stderr]    |
[INFO] [stderr] 21 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
[INFO] [stderr]    |                             ^^^^^^^^^^^^ feature has been removed
[INFO] [stderr]    |
[INFO] [stderr]    = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
[INFO] [stderr]    = note: merged into `doc_cfg`
[INFO] [stderr] 
[INFO] [stderr] error: Compilation failed, aborting rustdoc
[INFO] [stderr] 
[INFO] [stderr] For more information about this error, try `rustc --explain E0557`.
[INFO] [stderr] error: could not document `aws-sdk-dynamodb`
```

The [linked issue](https://github.com/rust-lang/rust/pull/138907) shows that `doc_auto_cfg` has recently been merged into `doc_cfg`. docsrs builds with the latest nightly toolchain, so the change has impacted our doc builds. This PR makes that change in codegen and in all of our runtime crates.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
