### PR TITLE
fix: builder accessor method naming conflicts

### DIFF
--- a/.changelog/fix-builder-accessor-naming.md
+++ b/.changelog/fix-builder-accessor-naming.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client"]
+authors: ["haydenbaker", "nated0g"]
+references: ["smithy-rs#4338"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix builder accessor methods to use symbol provider for naming. This resolves conflicts when struct members are renamed due to reserved words (e.g., `meta` -> `meta_value`), ensuring setter and getter methods use the correct renamed field names.

--- a/.changelog/fix-builder-accessor-naming.md
+++ b/.changelog/fix-builder-accessor-naming.md
@@ -1,5 +1,5 @@
 ---
-applies_to: ["client"]
+applies_to: ["client", "server"]
 authors: ["haydenbaker", "nated0g"]
 references: ["smithy-rs#4338"]
 breaking: false

--- a/.changelog/fix-builder-accessor-naming.md
+++ b/.changelog/fix-builder-accessor-naming.md
@@ -6,4 +6,4 @@ breaking: false
 new_feature: false
 bug_fix: true
 ---
-Fix builder accessor methods to use symbol provider for naming. This resolves conflicts when struct members are renamed due to reserved words (e.g., `meta` -> `meta_value`), ensuring setter and getter methods use the correct renamed field names.
+Fix a duplicate `set_meta` definition when an error structure has a `meta` member. The generated struct field is already renamed to `meta_value`, so the builder's setter and getter now match (`set_meta_value`, `get_meta_value`, `meta_value`). Setters for other renamed members (e.g. `default`, `build`, `builder`) are unchanged.

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/SmokeTestsDecorator.kt
@@ -154,7 +154,7 @@ class SmokeTestsBuilderKindBehavior(val codegenContext: CodegenContext) : Instan
     override fun hasFallibleBuilder(shape: StructureShape): Boolean =
         BuilderGenerator.hasFallibleBuilder(shape, codegenContext.symbolProvider)
 
-    override fun setterName(memberShape: MemberShape): String = memberShape.setterName()
+    override fun setterName(memberShape: MemberShape): String = memberShape.setterName(codegenContext.symbolProvider)
 
     override fun doesSetterTakeInOption(memberShape: MemberShape): Boolean = true
 }

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/OperationInputTestGenerator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/OperationInputTestGenerator.kt
@@ -186,7 +186,7 @@ class OperationInputTestGenerator(_ctx: ClientCodegenContext, private val test: 
             testOperationInput.operationParams.members.forEach { (key, value) ->
                 val member = operationInput.expectMember(key.value)
                 rustTemplate(
-                    ".${member.setterName()}(#{value})",
+                    ".${member.setterName(symbolProvider)}(#{value})",
                     "value" to instantiator.generate(member, value),
                 )
             }

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/OperationInputTestGenerator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/OperationInputTestGenerator.kt
@@ -186,7 +186,7 @@ class OperationInputTestGenerator(_ctx: ClientCodegenContext, private val test: 
             testOperationInput.operationParams.members.forEach { (key, value) ->
                 val member = operationInput.expectMember(key.value)
                 rustTemplate(
-                    ".${member.setterName(symbolProvider)}(#{value})",
+                    ".${member.setterName(ctx.symbolProvider)}(#{value})",
                     "value" to instantiator.generate(member, value),
                 )
             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientBuilderInstantiator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientBuilderInstantiator.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 
 class ClientBuilderInstantiator(private val clientCodegenContext: ClientCodegenContext) : BuilderInstantiator {
     override fun setField(
@@ -23,6 +24,10 @@ class ClientBuilderInstantiator(private val clientCodegenContext: ClientCodegenC
         field: MemberShape,
     ): Writable {
         return setFieldWithSetter(builder, value, field)
+    }
+
+    override fun setterProvider(field: MemberShape): String {
+        return field.setterName(clientCodegenContext.symbolProvider)
     }
 
     /**

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientInstantiator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientInstantiator.kt
@@ -23,7 +23,7 @@ class ClientBuilderKindBehavior(val codegenContext: CodegenContext) : Instantiat
     override fun hasFallibleBuilder(shape: StructureShape): Boolean =
         BuilderGenerator.hasFallibleBuilder(shape, codegenContext.symbolProvider)
 
-    override fun setterName(memberShape: MemberShape): String = memberShape.setterName()
+    override fun setterName(memberShape: MemberShape): String = memberShape.setterName(codegenContext.symbolProvider)
 
     override fun doesSetterTakeInOption(memberShape: MemberShape): Boolean = true
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentBuilderGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentBuilderGenerator.kt
@@ -368,11 +368,11 @@ class FluentBuilderGenerator(
                     else -> renderInputHelper(member, memberName, coreType)
                 }
                 // pure setter
-                val setterName = member.setterName()
+                val setterName = member.setterName(symbolProvider)
                 val optionalInputType = outerType.asOptional()
                 renderInputHelper(member, setterName, optionalInputType)
 
-                val getterName = member.getterName()
+                val getterName = member.getterName(symbolProvider)
                 renderGetterHelper(member, getterName, optionalInputType)
             }
         }
@@ -438,7 +438,7 @@ class FluentBuilderGenerator(
             """
             Appends an item to `${member.memberName}`.
 
-            To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).
+            To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${member.setterName(symbolProvider)}).
             """,
         )
         documentShape(member, model)
@@ -468,7 +468,7 @@ class FluentBuilderGenerator(
             """
             Adds a key-value pair to `${member.memberName}`.
 
-            To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).
+            To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${member.setterName(symbolProvider)}).
             """,
         )
         documentShape(member, model)

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -368,7 +368,7 @@ private fun generateOperationShapeDocs(
         val builderInputDoc = memberShape.asFluentBuilderInputDoc(symbolProvider)
         val builderInputLink = docLink("$fluentBuilderFullyQualifiedName::${symbolProvider.toMemberName(memberShape)}")
         val builderSetterDoc = memberShape.asFluentBuilderSetterDoc(symbolProvider)
-        val builderSetterLink = docLink("$fluentBuilderFullyQualifiedName::${memberShape.setterName()}")
+        val builderSetterLink = docLink("$fluentBuilderFullyQualifiedName::${memberShape.setterName(symbolProvider)}")
 
         val docTrait = memberShape.getMemberTrait(model, DocumentationTrait::class.java).orNull()
         val docs =
@@ -449,7 +449,7 @@ internal fun MemberShape.asFluentBuilderInputDoc(symbolProvider: SymbolProvider)
  *  _NOTE: This function generates the setter type names that appear under **"The fluent builder is configurable:"**_
  */
 private fun MemberShape.asFluentBuilderSetterDoc(symbolProvider: SymbolProvider): String {
-    val memberName = this.setterName()
+    val memberName = this.setterName(symbolProvider)
     val outerType = symbolProvider.toSymbol(this).rustType()
 
     return "$memberName(${outerType.asArgumentType(fullyQualified = false)})"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
@@ -264,7 +264,7 @@ class ProtocolParserGenerator(
             val member = binding.member
             val parsedValue = renderBindingParser(binding, operationShape, httpBindingGenerator, structuredDataParser)
             if (parsedValue != null) {
-                withBlock("output = output.${member.setterName()}(", ");") {
+                withBlock("output = output.${member.setterName(symbolProvider)}(", ");") {
                     parsedValue(this)
                 }
             }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
@@ -139,8 +139,13 @@ class FluentClientGeneratorTest {
         clientIntegrationTest(model)
     }
 
+    // Regression test for https://github.com/smithy-lang/smithy-rs/issues/4338: an error shape
+    // with a `meta` member used to produce a duplicate `set_meta` method on the generated builder
+    // because `ErrorGenerator` injects its own `set_meta` for `ErrorMetadata`. The fix renames
+    // only `meta` members (field, setter, getter) while leaving other members like `default`
+    // untouched so we don't introduce unrelated breaking changes.
     @Test
-    fun `meta field gets renamed to meta_value with correct setter`() {
+    fun `meta field on error shape does not collide with injected set_meta`() {
         val model =
             """
             namespace com.example
@@ -152,10 +157,21 @@ class FluentClientGeneratorTest {
                 version: "1"
             }
 
-            operation TestOperation { input: TestInput }
+            operation TestOperation {
+                input: TestInput,
+                errors: [TestError]
+            }
+
             structure TestInput {
                meta: String,
-               other: String
+               other: String,
+               default: String
+            }
+
+            @error("client")
+            structure TestError {
+                meta: String,
+                message: String
             }
             """.asSmithyModel()
 
@@ -172,24 +188,40 @@ class FluentClientGeneratorTest {
                             .build();
                         let client = $moduleName::Client::from_conf(config);
 
-                        // Test the renamed field and setter
+                        // `meta` is renamed to `meta_value` for field, setter, and getter to
+                        // avoid the `ErrorMetadata` collision on error shapes.
                         let builder = client.test_operation()
                             .meta_value("test_meta")
                             .set_meta_value(Some("test_meta_2".to_string()))
-                            .other("other_value");
+                            .other("other_value")
+                            // `default` keeps `set_default` / `get_default` even though its field
+                            // is renamed to `default_value` — renaming the accessors would be an
+                            // unnecessary breaking change.
+                            .set_default(Some("default_value".to_string()));
 
-                        // Verify getter returns correct value
                         assert_eq!(*builder.get_meta_value(), Some("test_meta_2".to_string()));
                         assert_eq!(*builder.get_other(), Some("other_value".to_string()));
+                        assert_eq!(*builder.get_default(), Some("default_value".to_string()));
 
-                        // Build the input and verify field is accessible
                         let input = builder.as_input();
                         assert_eq!(*input.get_meta_value(), Some("test_meta_2".to_string()));
+
+                        // The error builder must compile without a duplicate `set_meta` — the
+                        // original bug — and `meta_value` must coexist with the injected error
+                        // metadata field.
+                        let _error = $moduleName::types::error::TestError::builder()
+                            .meta_value("user_meta")
+                            .message("boom")
+                            .meta(#{ErrorMetadata}::builder().code("TestError").build())
+                            .build();
                     }
                     """,
                     "NeverClient" to
                         CargoDependency.smithyHttpClientTestUtil(codegenContext.runtimeConfig).toType()
                             .resolve("test_util::NeverClient"),
+                    "ErrorMetadata" to
+                        CargoDependency.smithyTypes(codegenContext.runtimeConfig).toType()
+                            .resolve("error::ErrorMetadata"),
                 )
             }
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -136,11 +136,12 @@ class OperationBuildError(private val runtimeConfig: RuntimeConfig) {
 
 fun MemberShape.setterName(symbolProvider: SymbolProvider): String {
     val unescaped = symbolProvider.toMemberName(this).removePrefix("r##")
-    return "set_${unescaped}"
+    return "set_$unescaped"
 }
+
 fun MemberShape.getterName(symbolProvider: SymbolProvider): String {
     val unescaped = symbolProvider.toMemberName(this).removePrefix("r##")
-    return "get_${unescaped}"
+    return "get_$unescaped"
 }
 
 class BuilderGenerator(
@@ -412,7 +413,13 @@ class BuilderGenerator(
     ) {
         docs("Appends an item to `$memberName`.")
         rust("///")
-        docs("To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${member.setterName(symbolProvider)}).")
+        docs(
+            "To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${
+                member.setterName(
+                    symbolProvider,
+                )
+            }).",
+        )
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
         deprecatedShape(member)
@@ -438,7 +445,13 @@ class BuilderGenerator(
     ) {
         docs("Adds a key-value pair to `$memberName`.")
         rust("///")
-        docs("To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${member.setterName(symbolProvider)}).")
+        docs(
+            "To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${
+                member.setterName(
+                    symbolProvider,
+                )
+            }).",
+        )
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
         deprecatedShape(member)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -134,11 +134,14 @@ class OperationBuildError(private val runtimeConfig: RuntimeConfig) {
     }
 }
 
-// Setter names will never hit a reserved word and therefore never need escaping.
-fun MemberShape.setterName() = "set_${this.memberName.toSnakeCase()}"
-
-// Getter names will never hit a reserved word and therefore never need escaping.
-fun MemberShape.getterName() = "get_${this.memberName.toSnakeCase()}"
+fun MemberShape.setterName(symbolProvider: SymbolProvider): String {
+    val unescaped = symbolProvider.toMemberName(this).removePrefix("r##")
+    return "set_${unescaped}"
+}
+fun MemberShape.getterName(symbolProvider: SymbolProvider): String {
+    val unescaped = symbolProvider.toMemberName(this).removePrefix("r##")
+    return "get_${unescaped}"
+}
 
 class BuilderGenerator(
     private val model: Model,
@@ -192,7 +195,7 @@ class BuilderGenerator(
                         val memberName = member.memberName.toSnakeCase()
                         val setter =
                             if (symbolProvider.toSymbol(member).isOptional()) {
-                                member.setterName()
+                                member.setterName(symbolProvider)
                             } else {
                                 memberName
                             }
@@ -311,7 +314,7 @@ class BuilderGenerator(
 
         writer.documentShape(member, model)
         writer.deprecatedShape(member)
-        writer.rustBlock("pub fn ${member.setterName()}(mut self, input: ${inputType.render(true)}) -> Self") {
+        writer.rustBlock("pub fn ${member.setterName(symbolProvider)}(mut self, input: ${inputType.render(true)}) -> Self") {
             rust("self.$memberName = input; self")
         }
     }
@@ -333,7 +336,7 @@ class BuilderGenerator(
 
         writer.documentShape(member, model)
         writer.deprecatedShape(member)
-        writer.rustBlock("pub fn ${member.getterName()}(&self) -> &${inputType.render(true)}") {
+        writer.rustBlock("pub fn ${member.getterName(symbolProvider)}(&self) -> &${inputType.render(true)}") {
             rust("&self.$memberName")
         }
     }
@@ -409,7 +412,7 @@ class BuilderGenerator(
     ) {
         docs("Appends an item to `$memberName`.")
         rust("///")
-        docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        docs("To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${member.setterName(symbolProvider)}).")
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
         deprecatedShape(member)
@@ -435,7 +438,7 @@ class BuilderGenerator(
     ) {
         docs("Adds a key-value pair to `$memberName`.")
         rust("///")
-        docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        docs("To override the contents of this collection use [`${member.setterName(symbolProvider)}`](Self::${member.setterName(symbolProvider)}).")
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
         deprecatedShape(member)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -134,14 +134,32 @@ class OperationBuildError(private val runtimeConfig: RuntimeConfig) {
     }
 }
 
+// Builder setters/getters keep the raw member name in almost all cases: setter names don't
+// collide with Rust reserved words, and renaming would be a breaking change for consumers of
+// the generated SDK. The one exception is members named `meta` on error-struct builders, where
+// `ErrorGenerator` injects a `set_meta` method for `ErrorMetadata` — we fall back to the
+// symbol-provider-renamed name (`meta_value`) there to avoid a duplicate definition.
+// See https://github.com/smithy-lang/smithy-rs/issues/4338.
 fun MemberShape.setterName(symbolProvider: SymbolProvider): String {
-    val unescaped = symbolProvider.toMemberName(this).removePrefix("r##")
-    return "set_$unescaped"
+    val raw = this.memberName.toSnakeCase()
+    val name =
+        if (raw == "meta") {
+            symbolProvider.toMemberName(this).removePrefix("r##")
+        } else {
+            raw
+        }
+    return "set_$name"
 }
 
 fun MemberShape.getterName(symbolProvider: SymbolProvider): String {
-    val unescaped = symbolProvider.toMemberName(this).removePrefix("r##")
-    return "get_$unescaped"
+    val raw = this.memberName.toSnakeCase()
+    val name =
+        if (raw == "meta") {
+            symbolProvider.toMemberName(this).removePrefix("r##")
+        } else {
+            raw
+        }
+    return "get_$name"
 }
 
 class BuilderGenerator(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
@@ -33,12 +33,14 @@ interface BuilderInstantiator {
         mapErr: Writable? = null,
     ): Writable
 
+    fun setterProvider(field: MemberShape): String;
+
     /** Set a field on a builder using the `$setterName` method. $value will be passed directly. */
     fun setFieldWithSetter(
         builder: String,
         value: Writable,
         field: MemberShape,
     ) = writable {
-        rustTemplate("$builder = $builder.${field.setterName()}(#{value})", "value" to value)
+        rustTemplate("$builder = $builder.${setterProvider(field)}(#{value})", "value" to value)
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
@@ -33,7 +33,7 @@ interface BuilderInstantiator {
         mapErr: Writable? = null,
     ): Writable
 
-    fun setterProvider(field: MemberShape): String;
+    fun setterProvider(field: MemberShape): String
 
     /** Set a field on a builder using the `$setterName` method. $value will be passed directly. */
     fun setFieldWithSetter(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
@@ -271,7 +271,7 @@ class CborParserGenerator(
                     rustBlock("${member.memberName.dq()} =>") {
                         val callBuilderSetMemberFieldWritable =
                             writable {
-                                withBlock("builder.${member.setterName()}(", ")") {
+                                withBlock("builder.${member.setterName(symbolProvider)}(", ")") {
                                     conditionalBlock("Some(", ")", shouldWrapBuilderMemberSetterInputWithOption(member)) {
                                         val symbol = symbolProvider.toSymbol(member)
                                         if (symbol.isRustBoxed()) {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
@@ -273,7 +273,7 @@ class EventStreamUnmarshallerGenerator(
     }
 
     private fun RustWriter.renderUnmarshallEventHeader(member: MemberShape) {
-        withBlock("builder = builder.${member.setterName()}(", ");") {
+        withBlock("builder = builder.${member.setterName(symbolProvider)}(", ");") {
             conditionalBlock("Some(", ")", member.isOptional) {
                 when (val target = model.expectShape(member.target)) {
                     is BooleanShape -> rustTemplate("#{expect_fns}::expect_bool(header)?", *codegenScope)
@@ -306,7 +306,7 @@ class EventStreamUnmarshallerGenerator(
                 *codegenScope,
             )
         }
-        withBlock("builder = builder.${member.setterName()}(", ");") {
+        withBlock("builder = builder.${member.setterName(symbolProvider)}(", ");") {
             conditionalBlock("Some(", ")", member.isOptional) {
                 when (target) {
                     is BlobShape -> {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -267,14 +267,14 @@ class JsonParserGenerator(
                     rustBlock("${jsonName(member).dq()} =>") {
                         when (codegenTarget) {
                             CodegenTarget.CLIENT -> {
-                                withBlock("builder = builder.${member.setterName()}(", ");") {
+                                withBlock("builder = builder.${member.setterName(symbolProvider)}(", ");") {
                                     deserializeMember(member)
                                 }
                             }
 
                             CodegenTarget.SERVER -> {
                                 if (symbolProvider.toSymbol(member).isOptional()) {
-                                    withBlock("builder = builder.${member.setterName()}(", ");") {
+                                    withBlock("builder = builder.${member.setterName(symbolProvider)}(", ");") {
                                         deserializeMember(member)
                                     }
                                 } else {
@@ -283,7 +283,7 @@ class JsonParserGenerator(
                                     rust(
                                         """
                                         {
-                                            builder = builder.${member.setterName()}(v);
+                                            builder = builder.${member.setterName(symbolProvider)}(v);
                                         }
                                         """,
                                     )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -296,7 +296,7 @@ class XmlBindingTraitParserGenerator(
                         Ctx(tag = decoder, accum = "$builder.${symbolProvider.toMemberName(member)}.take()"),
                     )
                 }
-                rust("$builder = $builder.${member.setterName()}($temp);")
+                rust("$builder = $builder.${member.setterName(symbolProvider)}($temp);")
             }
             rustTemplate(
                 "_ => return Err(#{XmlDecodeError}::custom(\"expected ${member.xmlName()} tag\"))",
@@ -335,7 +335,7 @@ class XmlBindingTraitParserGenerator(
                             forceOptional = true,
                         )
                     }
-                    rust("$builder = $builder.${member.setterName()}($temp);")
+                    rust("$builder = $builder.${member.setterName(symbolProvider)}($temp);")
                 }
             }
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/DefaultBuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/DefaultBuilderInstantiator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 
 /**
  * A Default instantiator that uses `builder.build()` in all cases. This exists to support tests in codegen-core
@@ -25,6 +26,10 @@ class DefaultBuilderInstantiator(private val checkFallibleBuilder: Boolean, priv
         field: MemberShape,
     ): Writable {
         return setFieldWithSetter(builder, value, field)
+    }
+
+    override fun setterProvider(field: MemberShape): String {
+        return field.setterName(symbolProvider)
     }
 
     override fun finalizeBuilder(

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/InstantiatorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/InstantiatorTest.kt
@@ -100,7 +100,7 @@ class InstantiatorTest {
         override fun hasFallibleBuilder(shape: StructureShape) =
             BuilderGenerator.hasFallibleBuilder(shape, codegenContext.symbolProvider)
 
-        override fun setterName(memberShape: MemberShape) = memberShape.setterName()
+        override fun setterName(memberShape: MemberShape) = memberShape.setterName(codegenContext.symbolProvider)
 
         override fun doesSetterTakeInOption(memberShape: MemberShape) = true
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
@@ -46,7 +46,6 @@ import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.redactIfNecessary
-import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.canReachConstrainedShape
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocol

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
@@ -32,6 +32,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
 import software.amazon.smithy.rust.codegen.core.smithy.generators.lifetimeDeclaration
+import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.isRustBoxed
 import software.amazon.smithy.rust.codegen.core.smithy.makeMaybeConstrained
@@ -424,8 +425,7 @@ class ServerBuilderGenerator(
         val memberName = symbolProvider.toMemberName(member)
 
         writer.documentShape(member, model)
-        // Setter names will never hit a reserved word and therefore never need escaping.
-        writer.rustBlock("pub(crate) fn set_${member.memberName.toSnakeCase()}(mut self, input: $inputType) -> Self") {
+        writer.rustBlock("pub(crate) fn ${member.setterName(symbolProvider)}(mut self, input: $inputType) -> Self") {
             rust(
                 """
                 self.$memberName = ${

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstant
 import software.amazon.smithy.rust.codegen.core.smithy.generators.Instantiator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.InstantiatorCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.InstantiatorSection
+import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.ReturnSymbolToParse
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
@@ -116,6 +117,10 @@ class ServerBuilderInstantiator(
         } else {
             setFieldWithSetter(builder, value, field)
         }
+    }
+
+    override fun setterProvider(field: MemberShape): String {
+        return field.setterName(symbolProvider)
     }
 
     override fun finalizeBuilder(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -870,7 +870,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                 rustTemplate(
                     """
                     if let Some(value) = #{ParsedValue:W} {
-                        input = input.${member.setterName()}($valueToSet)
+                        input = input.${member.setterName(symbolProvider)}($valueToSet)
                     }
                     """,
                     "ParsedValue" to parsedValue,
@@ -1170,7 +1170,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                     val deserializer = generateParseStrFn(binding, true)
                     rustTemplate(
                         """
-                        input = input.${binding.member.setterName()}(
+                        input = input.${binding.member.setterName(symbolProvider)}(
                             #{deserializer}(m$index)?
                         );
                         """,
@@ -1271,7 +1271,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                     rustTemplate(
                         """
                         if !${memberName}_seen && k == "${it.locationName}" {
-                            input = input.${it.member.setterName()}(
+                            input = input.${it.member.setterName(symbolProvider)}(
                                 #{deserializer}(&v)?
                             );
                             ${memberName}_seen = true;
@@ -1385,7 +1385,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                     unconstrainedShapeSymbolProvider
                         .toSymbol(queryParamsBinding.member)
                         .isOptional()
-                withBlock("input = input.${queryParamsBinding.member.setterName()}(", ");") {
+                withBlock("input = input.${queryParamsBinding.member.setterName(symbolProvider)}(", ");") {
                     conditionalBlock("Some(", ")", conditional = isOptional) {
                         write("query_params")
                     }
@@ -1403,7 +1403,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                 rustBlock("if !$memberName.is_empty()") {
                     withBlock(
                         "input = input.${
-                            binding.member.setterName()
+                            binding.member.setterName(symbolProvider)
                         }(",
                         ");",
                     ) {


### PR DESCRIPTION
## Motivation and Context
https://github.com/smithy-lang/smithy-rs/issues/4338


## Description
fixes a couple stray compilation errors in @haydenbaker's PR (https://github.com/smithy-lang/smithy-rs/pull/4341), and adds a test, adds changelog entry

## Testing

Added a test in `FluentClientGeneratorTest.kt` to verify the bug no longer exists

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
