### PR TITLE
Fix deprecated as_slice() calls in aws-smithy-checksums

### DIFF
--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.63.9"
+version = "0.63.10"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-checksums/src/lib.rs
+++ b/rust-runtime/aws-smithy-checksums/src/lib.rs
@@ -266,7 +266,7 @@ impl Sha1 {
 
     fn finalize(self) -> Bytes {
         use sha1::Digest;
-        Bytes::copy_from_slice(self.hasher.finalize().as_slice())
+        Bytes::copy_from_slice(self.hasher.finalize().as_ref())
     }
 
     // Size of the checksum in bytes
@@ -302,7 +302,7 @@ impl Sha256 {
 
     fn finalize(self) -> Bytes {
         use sha2::Digest;
-        Bytes::copy_from_slice(self.hasher.finalize().as_slice())
+        Bytes::copy_from_slice(self.hasher.finalize().as_ref())
     }
 
     // Size of the checksum in bytes
@@ -340,7 +340,7 @@ impl Md5 {
     #[warn(dead_code)]
     fn finalize(self) -> Bytes {
         use md5::Digest;
-        Bytes::copy_from_slice(self.hasher.finalize().as_slice())
+        Bytes::copy_from_slice(self.hasher.finalize().as_ref())
     }
 
     // Size of the checksum in bytes


### PR DESCRIPTION
## Motivation and Context

This PR fixes deprecation warnings from the generic-array crate upgrade by replacing deprecated `as_slice()` method calls with `as_ref()`.

## Description

- Replaced `as_slice()` with `as_ref()` in SHA1, SHA256, and MD5 checksum implementations
- Bumped aws-smithy-checksums version from 0.63.9 to 0.63.10

## Testing

- ✅ `cargo check` passes
- ✅ `cargo test` passes (all 20 tests)
- ✅ Pre-commit hooks pass

## Checklist

- [x] I have updated `Cargo.toml` if I made changes to dependencies
- [x] I have updated the version number if I made changes to the crate
- [x] I have run `cargo test` locally and it passes
- [x] I have run `cargo clippy` locally and it passes

Fixes the following compilation warnings:
```
error: use of deprecated method `sha1::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
```