### PR TITLE
make the idle pool timeout configurable

### DIFF
--- a/.changelog/1760632713.md
+++ b/.changelog/1760632713.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+  - client
+authors:
+  - arielby
+references: [ "smithy-rs#4349" ]
+breaking: false
+new_feature: true
+bug_fix: true
+---
+
+Make Hyper idle pool timeout configurable, and fix the bug where pool timeouts
+would not work if the client was built directly.

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.1.3"
+version = "1.1.4"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/src/test_util/never.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/never.rs
@@ -131,7 +131,7 @@ mod hyper1_support {
         /// Convert this connector into a usable HTTP client for testing
         #[doc(hidden)]
         pub fn into_client(self) -> SharedHttpClient {
-            crate::client::build_with_tcp_conn_fn(None, NeverTcpConnector::new)
+            crate::client::build_with_tcp_conn_fn(None, None, NeverTcpConnector::new)
         }
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/test_util/wire.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/wire.rs
@@ -338,7 +338,7 @@ impl WireMockServer {
     /// **Note**: This must be used in tandem with [`Self::dns_resolver`]
     pub fn http_client(&self) -> SharedHttpClient {
         let resolver = self.dns_resolver();
-        crate::client::build_with_tcp_conn_fn(None, move || {
+        crate::client::build_with_tcp_conn_fn(None, None, move || {
             hyper_util::client::legacy::connect::HttpConnector::new_with_resolver(
                 resolver.clone().0,
             )


### PR DESCRIPTION
Fixes #4349

## Motivation and Context

Make the Hyper idle pool timeout configurable.

Also fix a bug where the hyper pool timeout did not work due to a missing timer configuration.

## Testing

Added unit tests.

The tests are a bit annoying because of hyperium/hyper#3950 - hopefully they fix that soon.

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
