### PR TITLE
Add BuildError support to aws_json ResponseRejection

### DIFF
--- a/.changelog/1762045039.md
+++ b/.changelog/1762045039.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- server
+authors:
+- drganjoo
+references:
+- smithy-rs#9999
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix missing BuildError support in aws_json ResponseRejection. This fixes compilation errors when using AwsJson protocols with streaming operations.

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/AwsJsonCompilationTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/AwsJsonCompilationTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
+import software.amazon.smithy.rust.codegen.core.testutil.ServerAdditionalSettings
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
+
+/**
+ * Test to verify AwsJson protocols compile correctly with streaming operations.
+ *
+ * This test ensures that the ResponseRejection enum in aws_json protocol
+ * has proper From implementations for BuildError, which is needed when
+ * serializing HTTP payloads for streaming operations.
+ */
+internal class AwsJsonCompilationTest {
+    @ParameterizedTest
+    @EnumSource(
+        value = ModelProtocol::class,
+        names = ["AwsJson10", "AwsJson11"],
+    )
+    fun `AwsJson protocols should compile with streaming operations`(protocol: ModelProtocol) {
+        val (model) = loadSmithyConstraintsModelForProtocol(protocol)
+        serverIntegrationTest(
+            model,
+            IntegrationTestParams(
+                additionalSettings =
+                    ServerAdditionalSettings.builder()
+                        .publicConstrainedTypes(true)
+                        .generateCodegenComments(true)
+                        .toObjectNode(),
+            ),
+        ) { _, _ ->
+            // Test passes if code generation and compilation succeed
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.65.8"
+version = "0.65.9"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/src/protocol/aws_json/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocol/aws_json/rejection.rs
@@ -9,6 +9,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ResponseRejection {
+    #[error("error building HTTP response: {0}")]
+    Build(#[from] aws_smithy_types::error::operation::BuildError),
     #[error("error serializing JSON-encoded body: {0}")]
     Serialization(#[from] aws_smithy_types::error::operation::SerializationError),
     #[error("error building HTTP response: {0}")]


### PR DESCRIPTION
## Summary
- Add missing `From` implementation for `aws_smithy_types::error::operation::BuildError` to `ResponseRejection` enum in aws_json protocol
- Add test to verify AwsJson protocols compile with streaming operations
- Bump aws-smithy-http-server version from 0.65.8 to 0.65.9

## Motivation
Without this implementation, generated code that uses the `?` operator with `BuildError` (e.g., when serializing HTTP payloads for streaming operations) fails to compile with errors like:

```
the trait `From<aws_smithy_types::error::operation::BuildError>` is not 
implemented for `aws_json::rejection::ResponseRejection`
```

This occurs specifically in operations with streaming blob outputs where the payload serialization can return a `BuildError`.

## Changes
- Added `Build` variant to `ResponseRejection` enum in `rust-runtime/aws-smithy-http-server/src/protocol/aws_json/rejection.rs`
- Added `AwsJsonCompilationTest` to verify the fix works for both AwsJson1.0 and AwsJson1.1
- Verified test fails without the fix by commenting out the Build variant
- Bumped crate version to 0.65.9 in `rust-runtime/aws-smithy-http-server/Cargo.toml`
- Added changelog entry in `.changelog/1762045039.md`

This change aligns the aws_json protocol with other protocols like rest_json_1 which already have this variant.

## Test plan
- [x] Added compilation test that verifies AwsJson protocols work with streaming operations
- [x] Verified test fails without the fix
- [x] Verified test passes with the fix
- [x] Ran ktlintFormat to ensure code style compliance