### PR TITLE
fix: use Java stream methods for filtering

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
@@ -34,6 +34,7 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.logging.Level
+import java.util.stream.Collectors
 
 private sealed class UnsupportedConstraintMessageKind {
     private val constraintTraitsUberIssue = "https://github.com/smithy-lang/smithy-rs/issues/1401"
@@ -330,7 +331,7 @@ fun validateModelHasAtMostOneValidationException(
         model
             .shapes()
             .filter { it.hasTrait(ValidationExceptionTrait.ID) && it.isReachableFromOperationErrors(model) }
-            .toList()
+            .collect(Collectors.toUnmodifiableList())
 
     val messages = mutableListOf<LogMessage>()
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
@@ -81,12 +81,13 @@ class UserProvidedValidationExceptionDecorator : ServerCodegenDecorator {
             )
         }
 
+    // Defining multiple validation exceptions is unsupported. See `ValidateUnsupportedConstraints`
     internal fun firstStructureShapeWithValidationExceptionTrait(model: Model): StructureShape? =
         model
             .shapes(StructureShape::class.java)
-            .toList()
-            // Defining multiple validation exceptions is unsupported. See `ValidateUnsupportedConstraints`
-            .firstOrNull({ it.hasTrait(ValidationExceptionTrait.ID) })
+            .filter { it.hasTrait(ValidationExceptionTrait.ID) }
+            .findFirst()
+            .orElse(null)
 
     internal fun validationMessageMember(validationExceptionStructure: StructureShape): MemberShape =
         validationExceptionStructure

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.4
+codegenVersion=0.1.5


### PR DESCRIPTION
`toList` is not supported prior to JDK16. To prevent build failures, use Java stream methods directly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
