### PR TITLE
Fix field creation when validation field list structure has no `@validationFieldMessage`

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
@@ -252,7 +252,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                 "ValidationException" to codegenContext.symbolProvider.toSymbol(validationExceptionStructure),
                 "FieldCreation" to
                     writable {
-                        if (maybeValidationFieldList?.maybeValidationFieldMessageMember != null) {
+                        if (maybeValidationFieldList != null) {
                             rust("""let first_validation_exception_field = constraint_violation.as_validation_exception_field("".to_owned());""")
                         }
                     },
@@ -319,6 +319,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                             .get(stringTraitInfo) as LengthTrait
                                     rustTemplate(
                                         """
+                                        ##[allow(unused_variables)]
                                         Self::Length(length) => #{ValidationExceptionField} {
                                             #{FieldAssignments}
                                         },
@@ -384,6 +385,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                         blobConstraintsInfo.forEach { blobLength ->
                             rustTemplate(
                                 """
+                                ##[allow(unused_variables)]
                                 Self::Length(length) => #{ValidationExceptionField} {
                                     #{FieldAssignments}
                                 },
@@ -424,6 +426,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                     shape.getTrait<LengthTrait>()?.also {
                         rustTemplate(
                             """
+                            ##[allow(unused_variables)]
                             Self::Length(length) => #{ValidationExceptionField} {
                                 #{FieldAssignments}
                             },""",
@@ -557,6 +560,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                 is CollectionTraitInfo.Length -> {
                                     rustTemplate(
                                         """
+                                        ##[allow(unused_variables)]
                                         Self::Length(length) => #{ValidationExceptionField} {
                                             #{FieldAssignments}
                                         },
@@ -640,7 +644,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                         val pathExpression = member.wrapValueIfOptional(rawPathExpression)
                         val messageExpression = member.wrapValueIfOptional(rawMessageExpression)
                         when {
-                            member.hasTrait(ValidationFieldNameTrait.ID) ->
+                            member.isValidationFieldName() ->
                                 "$memberName: $pathExpression"
 
                             member.hasTrait(ValidationFieldMessageTrait.ID) ->

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecoratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecoratorTest.kt
@@ -384,4 +384,61 @@ internal class UserProvidedValidationExceptionDecoratorTest {
     fun `code compiles with custom validation exception using optionals`() {
         serverIntegrationTest(completeTestModelWithOptionals)
     }
+
+    private val completeTestModelWithImplicitNamesWithoutFieldMessage =
+        """
+        namespace com.aws.example
+
+        use aws.protocols#restJson1
+        use smithy.framework.rust#validationException
+        use smithy.framework.rust#validationFieldList
+
+        @restJson1
+        service CustomValidationExample {
+            version: "1.0.0"
+            operations: [
+                TestOperation
+            ]
+            errors: [
+                MyCustomValidationException
+            ]
+        }
+
+        @http(method: "POST", uri: "/test")
+        operation TestOperation {
+            input: TestInput
+        }
+
+        structure TestInput {
+            @required
+            @length(min: 1, max: 10)
+            name: String
+
+            @range(min: 1, max: 100)
+            age: Integer
+        }
+
+        @error("client")
+        @httpError(400)
+        @validationException
+        structure MyCustomValidationException {
+            message: String
+
+            @validationFieldList
+            customFieldList: CustomValidationFieldList
+        }
+
+        structure CustomValidationField {
+            name: String,
+        }
+
+        list CustomValidationFieldList {
+            member: CustomValidationField
+        }
+        """.asSmithyModel(smithyVersion = "2.0")
+
+    @Test
+    fun `code compiles with implicit message and field name and without field message`() {
+        serverIntegrationTest(completeTestModelWithImplicitNamesWithoutFieldMessage)
+    }
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Solves bugs in the custom validation exception logic.

## Description
<!--- Describe your changes in detail -->

Fixes bugs where:
- Due to an incorrect conditional, the `first_validation_exception_field` wasn't being created in the optional case when no member of the validation field list structure has the `@validationFieldMessage` trait.
- The validation field name field wasn't being set properly when using the implicit "name" field rather than the @validationFieldName trait explicitly.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Adds a compilation test case with a model that tests these two.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
