### PR TITLE
Bump Smithy to 1.63.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin-version = "2.1.0"
 ktlint-version = "1.0.1"
 
 # codegen
-smithy-version = "1.62.0"
+smithy-version = "1.63.0"
 smithy-gradle-plugin-version = "1.3.0"
 
 # publishing


### PR DESCRIPTION
## Motivation and Context
Bumps Smithy to [1.63.0](https://github.com/smithy-lang/smithy/releases/tag/1.63.0). The key feature is that it supports the `AWS_PARTITIONS_FILE_OVERRIDE` env variable. 

## Testing
CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
