### PR TITLE
Fix EventStream initial message handling to prevent hangs

### DIFF
--- a/codegen-server-test/integration-tests/Cargo.lock
+++ b/codegen-server-test/integration-tests/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-cbor"
-version = "0.61.3"
+version = "0.61.4"
 dependencies = [
  "aws-smithy-types",
  "minicbor",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.13"
+version = "0.60.14"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.65.9"
+version = "0.65.10"
 dependencies = [
  "aws-smithy-cbor",
  "aws-smithy-http",
@@ -148,21 +148,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.7"
+version = "0.61.8"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.6"
+version = "0.63.7"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.4"
+version = "1.9.5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.12"
+version = "0.60.13"
 dependencies = [
  "xmlparser",
 ]

--- a/examples/pokemon-service/tests/event_streaming.rs
+++ b/examples/pokemon-service/tests/event_streaming.rs
@@ -6,13 +6,14 @@
 pub mod common;
 
 use async_stream::stream;
-use rand::Rng;
-use serial_test::serial;
-
 use pokemon_service_client::types::{
     error::{AttemptCapturingPokemonEventError, MasterBallUnsuccessful},
     AttemptCapturingPokemonEvent, CapturingEvent, CapturingPayload,
 };
+use rand::Rng;
+use serial_test::serial;
+use std::time::Duration;
+use tokio::time::sleep;
 
 fn get_pokemon_to_capture() -> String {
     let pokemons = vec!["Charizard", "Pikachu", "Regieleki"];
@@ -31,6 +32,36 @@ fn get_pokeball() -> String {
         "Smithy Ball"
     };
     pokeball.to_string()
+}
+
+#[tokio::test]
+#[serial]
+async fn event_stream_empty_stream() {
+    let _child = common::run_server().await;
+    let client = common::client();
+    let stream = stream! {
+        sleep(Duration::from_secs(10000)).await;
+        // this line never hit
+        yield Ok(AttemptCapturingPokemonEvent::Event(
+            CapturingEvent::builder()
+            .payload(CapturingPayload::builder()
+                .name("Pikachu")
+                .pokeball("Master Ball")
+                .build())
+            .build()
+        ));
+    };
+    let _output = tokio::time::timeout(
+        Duration::from_secs(1),
+        client
+            .capture_pokemon()
+            .region("Kanto")
+            .events(stream.into())
+            .send(),
+    )
+    .await
+    .expect("timed out")
+    .expect("error from service");
 }
 
 #[tokio::test]

--- a/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
@@ -120,6 +120,9 @@ pub struct Receiver<T, E> {
     /// initial response, then the message will be stored in `buffered_message` so that it can
     /// be returned with the next call of `recv()`.
     buffered_message: Option<Message>,
+    /// Stores initial-request or initial-response messages that were filtered out by `recv()`.
+    /// These are only returned when `try_recv_initial()` is explicitly called.
+    buffered_initial_message: Option<Message>,
     _phantom: PhantomData<E>,
 }
 
@@ -152,8 +155,20 @@ impl<T, E> Receiver<T, E> {
             buffer: RecvBuf::Empty,
             body,
             buffered_message: None,
+            buffered_initial_message: None,
             _phantom: Default::default(),
         }
+    }
+
+    /// Checks if a message is an initial-request or initial-response message.
+    fn is_initial_message(message: &Message) -> bool {
+        message
+            .headers()
+            .iter()
+            .find(|h| h.name().as_str() == ":event-type")
+            .and_then(|h| h.value().as_string().ok())
+            .map(|s| s.as_str() == "initial-request" || s.as_str() == "initial-response")
+            .unwrap_or(false)
     }
 
     fn unmarshall(&self, message: Message) -> Result<Option<T>, SdkError<E, RawMessage>> {
@@ -240,6 +255,8 @@ impl<T, E> Receiver<T, E> {
     /// and return metadata alongside the transformed message. If the transformed message
     /// matches the expected `message_type`, both the message and metadata are returned.
     /// Otherwise, the transformed message is buffered and `Ok(None)` is returned.
+    ///
+    /// This method will block waiting for a message if no initial message has been buffered yet.
     #[doc(hidden)]
     pub async fn try_recv_initial_with_preprocessor<F, M>(
         &mut self,
@@ -249,27 +266,37 @@ impl<T, E> Receiver<T, E> {
     where
         F: FnOnce(Message) -> Result<(Message, M), ResponseError<RawMessage>>,
     {
-        if let Some(message) = self.next_message().await? {
-            let (processed_message, metadata) =
-                preprocessor(message.clone()).map_err(|err| SdkError::ResponseError(err))?;
-
-            if let Some(event_type) = processed_message
-                .headers()
-                .iter()
-                .find(|h| h.name().as_str() == ":event-type")
-            {
-                if event_type
-                    .value()
-                    .as_string()
-                    .map(|s| s.as_str() == message_type.as_str())
-                    .unwrap_or(false)
-                {
-                    return Ok(Some((processed_message, metadata)));
-                }
+        // Check if we already have a buffered initial message from recv()
+        let message = if let Some(buffered) = self.buffered_initial_message.take() {
+            buffered
+        } else {
+            // Otherwise, block waiting for the next message
+            match self.next_message().await? {
+                Some(msg) => msg,
+                None => return Ok(None),
             }
-            // Buffer the processed message so that it can be returned by the next call to `recv()`
-            self.buffered_message = Some(message);
+        };
+
+        let (processed_message, metadata) =
+            preprocessor(message.clone()).map_err(|err| SdkError::ResponseError(err))?;
+
+        if let Some(event_type) = processed_message
+            .headers()
+            .iter()
+            .find(|h| h.name().as_str() == ":event-type")
+        {
+            if event_type
+                .value()
+                .as_string()
+                .ok()
+                .map(|s| s.as_str() == message_type.as_str())
+                .unwrap_or(false)
+            {
+                return Ok(Some((processed_message, metadata)));
+            }
         }
+        // Buffer the original message so that it can be returned by the next call to `recv()`
+        self.buffered_message = Some(message);
         Ok(None)
     }
 
@@ -277,26 +304,36 @@ impl<T, E> Receiver<T, E> {
     /// it returns an `Ok(None)`. If there is a transport layer error, it will return
     /// `Err(SdkError::DispatchFailure)`. Service-modeled errors will be a part of the returned
     /// messages.
+    ///
+    /// This method filters out initial-request and initial-response messages. Those messages
+    /// are only returned when `try_recv_initial()` is explicitly called.
     pub async fn recv(&mut self) -> Result<Option<T>, SdkError<E, RawMessage>> {
-        if let Some(buffered) = self.buffered_message.take() {
-            return match self.unmarshall(buffered) {
-                Ok(message) => Ok(message),
-                Err(error) => {
-                    self.buffer = RecvBuf::Terminated;
-                    Err(error)
-                }
-            };
-        }
-        if let Some(message) = self.next_message().await? {
-            match self.unmarshall(message) {
-                Ok(message) => Ok(message),
-                Err(error) => {
-                    self.buffer = RecvBuf::Terminated;
-                    Err(error)
-                }
+        loop {
+            if let Some(buffered) = self.buffered_message.take() {
+                return match self.unmarshall(buffered) {
+                    Ok(message) => Ok(message),
+                    Err(error) => {
+                        self.buffer = RecvBuf::Terminated;
+                        Err(error)
+                    }
+                };
             }
-        } else {
-            Ok(None)
+            if let Some(message) = self.next_message().await? {
+                // Filter out initial messages - store them separately
+                if Self::is_initial_message(&message) {
+                    self.buffered_initial_message = Some(message);
+                    continue;
+                }
+                match self.unmarshall(message) {
+                    Ok(message) => return Ok(message),
+                    Err(error) => {
+                        self.buffer = RecvBuf::Terminated;
+                        return Err(error);
+                    }
+                }
+            } else {
+                return Ok(None);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #4435

Previously, codegen would always call `try_recv_initial()` for event streams, which would block waiting for an initial-request or initial-response message. This caused hangs when operations didn't have modeled initial messages.

**Changes:**

Runtime (aws-smithy-http & aws-smithy-legacy-http):
- `recv()` now filters out initial-request/initial-response messages and stores them in a separate buffer
- `try_recv_initial()` checks the buffer first before blocking
- Initial messages are discarded if never explicitly read
- Added `try_recv_initial_with_preprocessor()` to legacy version for SigV4 support

Codegen:
- Server: Only calls `try_recv_initial()` when `httpBindingResolver.handlesEventStreamInitialRequest()` returns true
- Client: Only calls `try_recv_initial_response()` when there's a parser for non-event-stream output members

Tests:
- Added `test_no_hang_without_initial_message()` to verify operations without modeled initial messages don't hang
- Added `test_waits_for_initial_message_when_modeled()` to verify operations with modeled initial messages still block correctly
- Added `wait_for_response_ready()` to ManualEventStreamClient for testing connection readiness

Documentation:
- Updated AGENTS.md with EventStream initial message handling behavior
- Added conditional mutability pattern to AGENTS.md

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
