### PR TITLE
Add free-disk-space to acquire base images that were missing it

### DIFF
--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -48,6 +48,7 @@ jobs:
       with:
         path: smithy-rs
         fetch-depth: 0
+    - uses: ./smithy-rs/.github/actions/free-disk-space
     - name: Acquire base image
       id: acquire
       run: ./smithy-rs/.github/scripts/acquire-build-image

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -63,6 +63,7 @@ jobs:
             # the `docker-build` action won't find the built Docker image.
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
+    - uses: ./smithy-rs/.github/actions/free-disk-space
     - name: Acquire base image
       id: acquire
       run: ./smithy-rs/.github/scripts/acquire-build-image

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -68,6 +68,7 @@ jobs:
             # the branch this workflow was launched from.
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
+    - uses: ./smithy-rs/.github/actions/free-disk-space
     - name: Acquire base image
       id: acquire
       run: ./smithy-rs/.github/scripts/acquire-build-image

--- a/.github/workflows/pull-request-updating-lockfiles.yml
+++ b/.github/workflows/pull-request-updating-lockfiles.yml
@@ -66,6 +66,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: smithy-rs
+    - uses: ./smithy-rs/.github/actions/free-disk-space
     - name: Acquire base image
       id: acquire
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
         path: smithy-rs
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
+    - uses: ./smithy-rs/.github/actions/free-disk-space
     - name: Acquire credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Starting to see more Acquire Base Image failures due to the out of disk space error. Applying the fix from https://github.com/smithy-lang/smithy-rs/pull/4417 to all of the invocations of acquire-base-image instead of just the CI ones. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
