### PR TITLE
Add changelog for enabling retries by default (#4454)

### DIFF
--- a/.changelog/1769183956.md
+++ b/.changelog/1769183956.md
@@ -25,3 +25,5 @@ let config = aws_sdk_s3::Config::builder()
     // ...
     .build();
 ```
+
+For more context, see the [discussion on retry behavior](https://github.com/smithy-lang/smithy-rs/discussions/4466).


### PR DESCRIPTION
Adds missing changelog entry for PR #4454 which enabled retries by default for AWS SDK clients starting with `BehaviorVersion::v2026_01_12()`.