### PR TITLE
Add extra logging to publisher to capture errors

### DIFF
--- a/tools/ci-build/publisher/src/cargo/publish.rs
+++ b/tools/ci-build/publisher/src/cargo/publish.rs
@@ -44,8 +44,9 @@ impl ShellOperation for Publish {
             .arg("1")
             .arg("--no-verify"); // The crates have already been built in previous CI steps
         let output = command.output()?;
+        let (stdout, stderr) = output_text(&output);
+
         if !output.status.success() {
-            let (stdout, stderr) = output_text(&output);
             let already_uploaded_msg = format!(
                 "error: crate version `{}` is already uploaded",
                 self.package_handle.expect_version()
@@ -56,8 +57,14 @@ impl ShellOperation for Publish {
                     self.package_handle
                 );
             } else {
+                info!(
+                    "cargo publish failed for {}\nStdout:\n{}\nStderr:\n{}",
+                    self.package_handle, stdout, stderr
+                );
                 return Err(capture_error("cargo publish", &output));
             }
+        } else {
+            info!("cargo publish succeeded for {}", self.package_handle);
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We recently had a failing release run without enough logs to debug what actually happened: https://github.com/smithy-lang/smithy-rs/actions/runs/21417345086/job/61691325413

The final logs are below, note that they don't include any of the output from the failed runs of `cargo publish`:
```
2026-01-28T04:24:12.316457Z  INFO publish{handle=PackageHandle { name: "aws-smithy-legacy-http-server", version: Some(Version { major: 0, minor: 65, patch: 11 }) } crate_path="./aws-smithy-legacy-http-server"}: publisher::publish: new
2026-01-28T04:24:12.316503Z  INFO publish{handle=PackageHandle { name: "aws-smithy-legacy-http-server", version: Some(Version { major: 0, minor: 65, patch: 11 }) } crate_path="./aws-smithy-legacy-http-server"}: publisher::publish: Publishing `aws-smithy-legacy-http-server-0.65.11`...
2026-01-28T04:28:14.187956Z  INFO publish{handle=PackageHandle { name: "aws-smithy-legacy-http-server", version: Some(Version { major: 0, minor: 65, patch: 11 }) } crate_path="./aws-smithy-legacy-http-server"}: publisher::publish: close time.busy=769µs time.idle=242s
Error: failed 5 times and won't be retried again
Error: Process completed with exit code 1.
```


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
