### PR TITLE
Update sdk-versioner to properly find underlying crate name when depdendency has an alias

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.8"
+version = "1.2.10"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.0"
+version = "0.64.2"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.15"
+version = "0.60.17"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.0"
+version = "0.63.2"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -269,14 +269,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.8"
+version = "0.63.10"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.0"
+version = "1.11.2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.0"
+version = "1.4.2"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.9"
+version = "1.2.10"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.1"
+version = "0.64.2"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-compression"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-dns"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aws-smithy-runtime-api",
  "criterion",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.16"
+version = "0.60.17"
 dependencies = [
  "arbitrary",
  "aws-smithy-types",
@@ -394,7 +394,7 @@ version = "0.2.2"
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.1"
+version = "0.63.2"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.1"
+version = "0.62.2"
 dependencies = [
  "aws-smithy-types",
  "proptest",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-legacy-http"
-version = "0.62.8"
+version = "0.62.9"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aws-smithy-runtime-api",
  "serial_test",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability-otel"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-global-executor",
  "async-task",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.9"
+version = "0.63.10"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.11"
+version = "0.60.12"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-async"
-version = "1.2.9"
+version = "1.2.10"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Async runtime agnostic abstractions for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.64.1"
+version = "0.64.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-compression/Cargo.toml
+++ b/rust-runtime/aws-smithy-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-compression"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-dns/Cargo.toml
+++ b/rust-runtime/aws-smithy-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-dns"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
 # <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.16"
+version = "0.60.17"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.1.7"
+version = "1.1.8"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.63.1"
+version = "0.63.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-json"
-version = "0.62.1"
+version = "0.62.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-legacy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-legacy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-legacy-http"
-version = "0.62.8"
+version = "0.62.9"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-observability-otel/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability-otel"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-observability/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-protocol-test"
-version = "0.63.9"
+version = "0.63.10"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "A collection of library functions to validate HTTP requests against Smithy protocol tests."
 edition = "2021"

--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-query"
-version = "0.60.11"
+version = "0.60.12"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "AWSQuery and EC2Query Smithy protocol logic for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.11.1"
+version = "1.11.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.4.1"
+version = "1.4.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/tools/ci-build/sdk-versioner/src/main.rs
+++ b/tools/ci-build/sdk-versioner/src/main.rs
@@ -201,16 +201,13 @@ fn update_dependencies(
 /// Extracts the real name of the underlying crate when the dependency has an alias
 fn extract_real_crate_name(key: &toml_edit::KeyMut, value: &Item) -> String {
     match value {
-        Item::Value(value) => match value {
-            Value::InlineTable(inline_table) => {
-                if let Some(Value::String(real_package)) = inline_table.get("package") {
-                    real_package.value()
-                } else {
-                    key.get()
-                }
+        Item::Value(Value::InlineTable(inline_table)) => {
+            if let Some(Value::String(real_package)) = inline_table.get("package") {
+                real_package.value()
+            } else {
+                key.get()
             }
-            _ => key.get(),
-        },
+        }
         _ => key.get(),
     }
     .to_string()


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We recently experienced some failing [smithy-rs releases ](https://github.com/smithy-lang/smithy-rs/actions/runs/21495302587/job/61935829887), the logs for which look like:
```
2026-01-29T22:59:56.566904Z  INFO publisher::cargo::publish: cargo publish failed for aws-smithy-legacy-http-server-0.65.11
Stdout:

Stderr:
\x1b[1m\x1b[32m    Updating\x1b[0m crates.io index
\x1b[1m\x1b[32m   Packaging\x1b[0m aws-smithy-legacy-http-server v0.65.11 (/home/runner/work/smithy-rs/smithy-rs/smithy-rs-release/crates-to-publish/aws-smithy-legacy-http-server)
\x1b[1m\x1b[32m    Updating\x1b[0m crates.io index
\x1b[1m\x1b[31merror\x1b[0m\x1b[1m:\x1b[0m failed to prepare local package for uploading

Caused by:
  failed to select a version for the requirement `aws-smithy-legacy-http = "^0.63.1"`
  candidate versions found which didn't match: 0.62.8, 0.62.7, 0.62.6
  location searched: crates.io index
  required by package `aws-smithy-legacy-http-server v0.65.11 (/home/runner/work/smithy-rs/smithy-rs/smithy-rs-release/crates-to-publish/aws-smithy-legacy-http-server)`

2026-01-29T23:00:56.745127Z  INFO pub
```

This is odd because the version of `aws-smithy-legacy-http` in main is:
```toml
[package]
name = "aws-smithy-legacy-http"
version = "0.62.8"
```

Looking at the Cargo.toml of `aws-smithy-legacy-http-server` it has this entry:
```toml
aws-smithy-http = { path = "../aws-smithy-legacy-http", features = ["rt-tokio"], package = "aws-smithy-legacy-http" }
```

And that points us to the actual issue. The current version of `aws-smithy-http` is:
```toml
[package]
name = "aws-smithy-http"
version = "0.63.1"
```

And that `0.63.1` is what we were seeing injected into `aws-smithy-legacy-http-server` as the incorrect version for `aws-smithy-legacy-http`.

When a dependency had an alias (ex: `alias = {package = "the-real-package"}`) our `sdk-versioner` tooling was accepting that alias as the real crate name. When that alias happened to be name of another valid SDK crate this led to it inserting the incorrect version number in the generated Cargol.toml. We hadn't encountered this previously because:
* We only recently published a crate that aliased an `aws-smithy-*` crate
* Prior to this release the version of the alias crate and the underlying crate were both the same so, by chance, the replacement worked

## Description
<!--- Describe your changes in detail -->
This change adds a new `extract_real_crate_name` function to the `sdk-versioner` that pulls out the underlying crate name if a dependency has an alias. This real name is then used for all subsequent steps. 

Note: I also bumped the dependencies that were already published as part of the failed release to get around the audit failure which would block another release attempt

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a new test to confirm that this behavior works as expected. Also ran `sdk-versioner` on a local build of the SDK that included `aws-smithy-legacy-http-server` and it generated the expected dependency version:
```toml
aws-smithy-http= { version = "0.62.8", package = "aws-smithy-legacy-http", features = ["rt-tokio"] }
```


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
