### PR TITLE
remove aws-smithy-http alias from aws-smithy-legacy-http-server

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.10"
+version = "1.2.11"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.17"
+version = "0.60.18"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.2"
+version = "0.63.3"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -269,14 +269,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.10"
+version = "0.63.11"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.10"
+version = "1.2.11"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-compression"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-dns"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aws-smithy-runtime-api",
  "criterion",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.17"
+version = "0.60.18"
 dependencies = [
  "arbitrary",
  "aws-smithy-types",
@@ -394,7 +394,7 @@ version = "0.2.2"
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.2"
+version = "0.63.3"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.2"
+version = "0.62.3"
 dependencies = [
  "aws-smithy-types",
  "proptest",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-legacy-http"
-version = "0.62.9"
+version = "0.62.10"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aws-smithy-runtime-api",
  "serial_test",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability-otel"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-global-executor",
  "async-task",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.10"
+version = "0.63.11"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.12"
+version = "0.60.13"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-async"
-version = "1.2.10"
+version = "1.2.11"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Async runtime agnostic abstractions for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.64.2"
+version = "0.64.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-compression/Cargo.toml
+++ b/rust-runtime/aws-smithy-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-compression"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-dns/Cargo.toml
+++ b/rust-runtime/aws-smithy-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-dns"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
 # <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.17"
+version = "0.60.18"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.1.8"
+version = "1.1.9"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.63.2"
+version = "0.63.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-json"
-version = "0.62.2"
+version = "0.62.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-legacy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-legacy-http-server/Cargo.toml
@@ -19,7 +19,7 @@ unredacted-logging = []
 request-id = ["dep:uuid"]
 
 [dependencies]
-aws-smithy-http = { path = "../aws-smithy-legacy-http", features = ["rt-tokio"], package = "aws-smithy-legacy-http" }
+aws-smithy-legacy-http = { path = "../aws-smithy-legacy-http", features = ["rt-tokio"] }
 aws-smithy-json = { path = "../aws-smithy-json" }
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["http-02x"] }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-0-4-x", "hyper-0-14-x"] }

--- a/rust-runtime/aws-smithy-legacy-http-server/src/protocol/rest_json_1/rejection.rs
+++ b/rust-runtime/aws-smithy-legacy-http-server/src/protocol/rest_json_1/rejection.rs
@@ -129,7 +129,7 @@ pub enum RequestRejection {
     /// Used when failing to parse HTTP headers that are bound to input members with the `httpHeader`
     /// or the `httpPrefixHeaders` traits.
     #[error("error binding request HTTP headers: {0}")]
-    HeaderParse(#[from] aws_smithy_http::header::ParseError),
+    HeaderParse(#[from] aws_smithy_legacy_http::header::ParseError),
 
     // In theory, the next two errors should never happen because the router should have already
     // rejected the request.

--- a/rust-runtime/aws-smithy-legacy-http-server/src/protocol/rest_xml/rejection.rs
+++ b/rust-runtime/aws-smithy-legacy-http-server/src/protocol/rest_xml/rejection.rs
@@ -41,7 +41,7 @@ pub enum RequestRejection {
     XmlDeserialize(#[from] aws_smithy_xml::decode::XmlDecodeError),
 
     #[error("error binding request HTTP headers: {0}")]
-    HeaderParse(#[from] aws_smithy_http::header::ParseError),
+    HeaderParse(#[from] aws_smithy_legacy_http::header::ParseError),
 
     #[error("request URI does not match pattern because of literal suffix after greedy label was not found")]
     UriPatternGreedyLabelPostfixNotFound,

--- a/rust-runtime/aws-smithy-legacy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-legacy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-legacy-http"
-version = "0.62.9"
+version = "0.62.10"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-observability-otel/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability-otel"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-observability/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-protocol-test"
-version = "0.63.10"
+version = "0.63.11"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "A collection of library functions to validate HTTP requests against Smithy protocol tests."
 edition = "2021"

--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-query"
-version = "0.60.12"
+version = "0.60.13"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "AWSQuery and EC2Query Smithy protocol logic for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.11.2"
+version = "1.11.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.4.2"
+version = "1.4.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
