### PR TITLE
Bump python server major version

### DIFF
--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.66.10"
+version = "0.67.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
###  Summary

`aws-smithy-http-server-python` v0.66.8 introduced a breaking dependency change — replacing `aws-smithy-http-server` with `aws-smithy-legacy-http-server` — without a corresponding major version bump. The code generator still emits code referencing `aws-smithy-http-server` types, causing compilation failures for downstream Python SDK builds.

###  Root Cause

The `aws-smithy-http-server-python` crate changed its dependency from `aws-smithy-http-server` to `aws-smithy-legacy-http-server`. This is a breaking change because public API types (e.g., body::Body, body::BoxBody, error::Error) now resolve to the legacy crate's types. The semver major version was not bumped, so the code generator resolves v0.66.8 as a compatible upgrade and pulls it in automatically.

### Solution

This PR bumps the major version for Python server runtime.