### PR TITLE
Add server request metrics support for aws-smithy-http-server 0.65

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -348,11 +348,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-async"
+version = "1.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "aws-smithy-cbor"
 version = "0.61.5"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 1.4.5",
  "criterion",
+ "minicbor",
+]
+
+[[package]]
+name = "aws-smithy-cbor"
+version = "0.61.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765f0b8c7728db30a230663df67ba25b9c650c1cc9ba553df15dfe0fadaa529c"
+dependencies = [
+ "aws-smithy-types 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "minicbor",
 ]
 
@@ -360,8 +381,8 @@ dependencies = [
 name = "aws-smithy-checksums"
 version = "0.64.5"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "bytes-utils",
  "crc-fast",
@@ -383,8 +404,8 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.1.5"
 dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -402,7 +423,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.1.11"
 dependencies = [
- "aws-smithy-runtime-api",
+ "aws-smithy-runtime-api 1.11.5",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -413,7 +434,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.19"
 dependencies = [
  "arbitrary",
- "aws-smithy-types",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -429,12 +450,33 @@ version = "0.2.3"
 
 [[package]]
 name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-runtime-api 1.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
 version = "0.63.5"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -455,10 +497,10 @@ dependencies = [
 name = "aws-smithy-http-client"
 version = "1.1.11"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 1.2.13",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "base64 0.22.1",
  "bytes",
  "h2 0.3.27",
@@ -494,14 +536,44 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
+version = "0.65.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9af5ea8c9237159cc5ef0da15f77ed37321f94e121d6c9e9eb6f4f25b583de"
+dependencies = [
+ "aws-smithy-cbor 0.61.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime-api 1.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-xml 0.60.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "regex",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http 0.3.5",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-smithy-http-server"
 version = "0.66.2"
 dependencies = [
- "aws-smithy-cbor",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-cbor 0.61.5",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
+ "aws-smithy-xml 0.60.14",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -527,13 +599,17 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "aws-smithy-http-server",
+ "aws-smithy-http-server 0.65.10",
+ "aws-smithy-http-server 0.66.2",
  "aws-smithy-http-server-metrics-macro",
  "futures",
+ "http 0.2.12",
  "http 1.4.0",
+ "http-body 0.4.6",
  "http-body 1.0.1",
+ "hyper 0.14.32",
  "hyper 1.8.1",
  "metrique",
  "metrique-core",
@@ -548,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics-macro"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -559,11 +635,11 @@ dependencies = [
 name = "aws-smithy-http-server-python"
 version = "0.67.0"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-legacy-http-server",
- "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-types 1.4.5",
+ "aws-smithy-xml 0.60.14",
  "bytes",
  "futures",
  "futures-util",
@@ -596,9 +672,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aws-smithy-json"
 version = "0.62.4"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 1.4.5",
  "proptest",
  "serde_json",
 ]
@@ -609,8 +694,8 @@ version = "0.62.12"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -631,12 +716,12 @@ dependencies = [
 name = "aws-smithy-legacy-http-server"
 version = "0.65.13"
 dependencies = [
- "aws-smithy-cbor",
- "aws-smithy-json",
+ "aws-smithy-cbor 0.61.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
+ "aws-smithy-xml 0.60.14",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -661,11 +746,11 @@ dependencies = [
 name = "aws-smithy-mocks"
 version = "0.2.5"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 1.2.13",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "http 1.4.0",
  "tokio",
 ]
@@ -674,7 +759,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.2.5"
 dependencies = [
- "aws-smithy-runtime-api",
+ "aws-smithy-runtime-api 1.11.5",
  "serial_test",
 ]
 
@@ -698,7 +783,7 @@ name = "aws-smithy-protocol-test"
 version = "0.63.13"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api",
+ "aws-smithy-runtime-api 1.11.5",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -715,7 +800,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.14"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 1.4.5",
  "urlencoding",
 ]
 
@@ -724,12 +809,12 @@ name = "aws-smithy-runtime"
 version = "1.10.2"
 dependencies = [
  "approx",
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 1.2.13",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "fastrand",
  "futures-util",
@@ -752,8 +837,8 @@ dependencies = [
 name = "aws-smithy-runtime-api"
 version = "1.11.5"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 1.2.13",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "http 0.2.12",
  "http 1.4.0",
@@ -762,6 +847,22 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4af6e5def28be846479bbeac55aa4603d6f7986fc5da4601ba324dd5d377516"
+dependencies = [
+ "aws-smithy-async 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -799,11 +900,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-types"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 0.14.32",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "aws-smithy-types-convert"
 version = "0.60.13"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 1.2.13",
+ "aws-smithy-types 1.4.5",
  "chrono",
  "futures-core",
  "time",
@@ -813,9 +941,9 @@ dependencies = [
 name = "aws-smithy-wasm"
 version = "0.1.9"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
  "bytes",
  "http 1.4.0",
  "tracing",
@@ -829,6 +957,15 @@ dependencies = [
  "aws-smithy-protocol-test",
  "base64 0.13.1",
  "proptest",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b53543b4b86ed43f051644f704a98c7291b3618b67adf057ee77a366fa52fcaa"
+dependencies = [
  "xmlparser",
 ]
 
@@ -2250,14 +2387,14 @@ dependencies = [
 name = "inlineable"
 version = "0.1.0"
 dependencies = [
- "aws-smithy-cbor",
+ "aws-smithy-cbor 0.61.5",
  "aws-smithy-compression",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-runtime-api 1.11.5",
+ "aws-smithy-types 1.4.5",
+ "aws-smithy-xml 0.60.14",
  "bytes",
  "fastrand",
  "futures-util",

--- a/rust-runtime/aws-smithy-http-server-metrics-macro/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics-macro/Cargo.toml
@@ -3,7 +3,7 @@ proc-macro = true
 
 [package]
 name = "aws-smithy-http-server-metrics-macro"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",

--- a/rust-runtime/aws-smithy-http-server-metrics-macro/src/macro_impl.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics-macro/src/macro_impl.rs
@@ -142,7 +142,7 @@ fn generate_ext_trait_impl(
                 {
                     fn build(self) -> aws_smithy_http_server_metrics::layer::MetricsLayer<#struct_ident, Sink, Init, Res> {
                         let default_metrics_extension_fn =
-                            |req: &mut http::Request<aws_smithy_http_server_metrics::types::ReqBody>,
+                            |req: &mut aws_smithy_http_server_metrics::types::HttpRequest,
                             metrics: &mut #struct_ident,
                             req_config: aws_smithy_http_server_metrics::default::DefaultRequestMetricsConfig,
                             res_config: aws_smithy_http_server_metrics::default::DefaultResponseMetricsConfig,

--- a/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-metrics"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",
@@ -12,27 +12,41 @@ repository = "https://github.com/smithy-lang/smithy-rs"
 rust-version = "1.91"
 
 [dependencies]
-metrique = "0.1.17"
-metrique-core = "0.1.15"
-metrique-writer = "0.1.17"
-
-tower = "0.4.13"
-futures = "0.3"
-http = "1.3.1"
-http-body = "1.0.1"
-hyper = "1.6.0"
-thiserror = "2"
-pin-project-lite = "0.2.14"
-tracing = "0.1.44"
-
 aws-smithy-http-server = { path = "../aws-smithy-http-server", features = [
     "request-id",
 ] }
 aws-smithy-http-server-metrics-macro = { path = "../aws-smithy-http-server-metrics-macro" }
+http = "1.3.1"
+http-body = "1.0.1"
+hyper = "1.6.0"
+futures = "0.3"
+metrique = "0.1.17"
+metrique-core = "0.1.15"
+metrique-writer = "0.1.17"
+pin-project-lite = "0.2.14"
+thiserror = "2"
+tower = "0.4.13"
+tracing = "0.1.44"
+
+# Optional dependencies for aws-smithy-http-server 0.65 support
+aws-smithy-http-server-065 = { package = "aws-smithy-http-server", version = "0.65", optional = true, features = [
+    "request-id",
+] }
+http-02 = { package = "http", version = "0.2.12", optional = true }
+http-body-04 = { package = "http-body", version = "0.4.6", optional = true }
+hyper-014 = { package = "hyper", version = "0.14.26", optional = true }
 
 [dev-dependencies]
 tracing-appender = "0.2"
 metrique-writer-format-emf = "0.1.16"
+
+[features]
+aws-smithy-http-server-065 = [
+    "dep:aws-smithy-http-server-065",
+    "dep:http-02",
+    "dep:hyper-014",
+    "dep:http-body-04",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/aws-smithy-http-server-metrics/src/layer.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/layer.rs
@@ -5,7 +5,6 @@
 
 use std::marker::PhantomData;
 
-use http::Request;
 use metrique::DefaultSink;
 use metrique::ServiceMetrics;
 use metrique_writer::GlobalEntrySink;
@@ -26,7 +25,7 @@ use crate::traits::ThreadSafeCloseEntry;
 use crate::traits::ThreadSafeEntrySink;
 use crate::types::DefaultInit;
 use crate::types::DefaultRs;
-use crate::types::ReqBody;
+use crate::types::HttpRequest;
 
 pub mod builder;
 
@@ -100,7 +99,7 @@ pub struct MetricsLayer<
     pub(crate) init_metrics: Init,
     pub(crate) response_metrics: Option<Res>,
     pub(crate) default_metrics_extension_fn: fn(
-        &mut Request<ReqBody>,
+        &mut HttpRequest,
         &mut Entry,
         DefaultRequestMetricsConfig,
         DefaultResponseMetricsConfig,
@@ -134,7 +133,7 @@ where
         init_metrics: Init,
         response_metrics: Option<Res>,
         default_metrics_extension_fn: fn(
-            &mut Request<ReqBody>,
+            &mut HttpRequest,
             &mut Entry,
             DefaultRequestMetricsConfig,
             DefaultResponseMetricsConfig,

--- a/rust-runtime/aws-smithy-http-server-metrics/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/lib.rs
@@ -14,7 +14,7 @@
 //! [`DefaultMetricsPlugin`] automatically collects standard metrics for every request at operation time.
 //! See the Collected Metrics section below:
 //!
-//! ```rust
+//! ```rust, ignore
 //! use aws_smithy_http_server_metrics::plugin::DefaultMetricsPlugin;
 //! use aws_smithy_http_server::plugin::HttpPlugins;
 //!

--- a/rust-runtime/aws-smithy-http-server-metrics/src/plugin.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/plugin.rs
@@ -10,13 +10,6 @@ use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 
-use aws_smithy_http_server::operation::OperationShape;
-use aws_smithy_http_server::plugin::HttpMarker;
-use aws_smithy_http_server::plugin::Plugin;
-use aws_smithy_http_server::request::request_id::ServerRequestId;
-use aws_smithy_http_server::service::ServiceShape;
-use http::Request;
-use http::Response;
 use metrique::timers::OwnedTimerGuard;
 use metrique::timers::Stopwatch;
 use metrique::OnParentDrop;
@@ -33,8 +26,13 @@ use crate::default::DefaultRequestMetrics;
 use crate::default::DefaultResponseMetrics;
 use crate::default::DefaultResponseMetricsConfig;
 use crate::default::DefaultResponseMetricsExtension;
-use crate::types::ReqBody;
-use crate::types::ResBody;
+use crate::types::aws_smithy_http_server::operation::OperationShape;
+use crate::types::aws_smithy_http_server::plugin::HttpMarker;
+use crate::types::aws_smithy_http_server::plugin::Plugin;
+use crate::types::aws_smithy_http_server::request::request_id::ServerRequestId;
+use crate::types::aws_smithy_http_server::service::ServiceShape;
+use crate::types::HttpRequest;
+use crate::types::HttpResponse;
 
 pin_project! {
     /// Future returned by [`DefaultMetricsPluginService`].
@@ -66,9 +64,9 @@ pin_project! {
 
 impl<F, Err> Future for DefaultMetricsFuture<F>
 where
-    F: Future<Output = Result<Response<ResBody>, Err>>,
+    F: Future<Output = Result<HttpResponse, Err>>,
 {
-    type Output = Result<Response<ResBody>, Err>;
+    type Output = Result<HttpResponse, Err>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project() {
@@ -206,13 +204,13 @@ where
 }
 impl<Ser> DefaultMetricsPluginService<Ser>
 where
-    Ser: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    Ser: Service<HttpRequest, Response = HttpResponse>,
     Ser::Future: Send + 'static,
 {
     /// Gets the default request metrics that can be retrieved from the request object directly
     ///
     /// Assigns None to those that need information from the outer metrics layer to be set
-    fn get_default_request_metrics(&self, req: &Request<ReqBody>) -> DefaultRequestMetrics {
+    fn get_default_request_metrics(&self, req: &HttpRequest) -> DefaultRequestMetrics {
         DefaultRequestMetrics {
             service_name: Some(self.service_name.to_string()),
             service_version: self.service_version.map(|n| n.to_string()),
@@ -226,16 +224,16 @@ where
     }
 }
 
-impl<Ser> Service<Request<ReqBody>> for DefaultMetricsPluginService<Ser>
+impl<Ser> Service<HttpRequest> for DefaultMetricsPluginService<Ser>
 where
-    Ser: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    Ser: Service<HttpRequest, Response = HttpResponse>,
     Ser::Future: Send + 'static,
 {
     type Response = Ser::Response;
     type Error = Ser::Error;
     type Future = DefaultMetricsFuture<Ser::Future>;
 
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+    fn call(&mut self, mut req: HttpRequest) -> Self::Future {
         let mut stopwatch = Stopwatch::new();
         let operation_timer_guard = stopwatch.start_owned();
 
@@ -306,7 +304,7 @@ where
 }
 
 fn get_default_response_metrics(
-    res: &Response<ResBody>,
+    res: &HttpResponse,
     operation_time: Option<Duration>,
 ) -> DefaultResponseMetrics {
     let status = res.status();

--- a/rust-runtime/aws-smithy-http-server-metrics/src/traits.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/traits.rs
@@ -3,15 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use http::Request;
-use http::Response;
 use metrique::AppendAndCloseOnDrop;
 use metrique::RootEntry;
 use metrique_core::CloseEntry;
 use metrique_writer::EntrySink;
 
-use crate::types::ReqBody;
-use crate::types::ResBody;
+use crate::types::HttpRequest;
+use crate::types::HttpResponse;
 
 /// A thread safe [`CloseEntry`]
 pub trait ThreadSafeCloseEntry: CloseEntry + Send + Sync + 'static {}
@@ -41,7 +39,7 @@ where
 /// })
 /// ```
 pub trait InitMetrics<Entry, Sink>:
-    Fn(&mut Request<ReqBody>) -> AppendAndCloseOnDrop<Entry, Sink> + Clone + Send + Sync + 'static
+    Fn(&mut HttpRequest) -> AppendAndCloseOnDrop<Entry, Sink> + Clone + Send + Sync + 'static
 where
     Entry: ThreadSafeCloseEntry,
     Sink: ThreadSafeEntrySink<Entry>,
@@ -51,11 +49,7 @@ impl<T, Entry, Sink> InitMetrics<Entry, Sink> for T
 where
     Entry: ThreadSafeCloseEntry,
     Sink: ThreadSafeEntrySink<Entry>,
-    T: Fn(&mut Request<ReqBody>) -> AppendAndCloseOnDrop<Entry, Sink>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    T: Fn(&mut HttpRequest) -> AppendAndCloseOnDrop<Entry, Sink> + Clone + Send + Sync + 'static,
 {
 }
 
@@ -73,7 +67,7 @@ where
 /// })
 /// ```
 pub trait ResponseMetrics<Entry>:
-    Fn(&mut Response<ResBody>, &mut Entry) + Clone + Send + Sync + 'static
+    Fn(&mut HttpResponse, &mut Entry) + Clone + Send + Sync + 'static
 where
     Entry: ThreadSafeCloseEntry,
 {
@@ -81,6 +75,6 @@ where
 impl<T, Entry> ResponseMetrics<Entry> for T
 where
     Entry: ThreadSafeCloseEntry,
-    T: Fn(&mut Response<ResBody>, &mut Entry) + Clone + Send + Sync + 'static,
+    T: Fn(&mut HttpResponse, &mut Entry) + Clone + Send + Sync + 'static,
 {
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
