### PR TITLE
Add feature flag to server metrics for aws-smithy-legacy-http-server support

### DIFF
--- a/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-metrics"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",
@@ -36,6 +36,11 @@ http-02 = { package = "http", version = "0.2.12", optional = true }
 http-body-04 = { package = "http-body", version = "0.4.6", optional = true }
 hyper-014 = { package = "hyper", version = "0.14.26", optional = true }
 
+# Optional dependencies for aws-smithy-legacy-http-server support
+aws-smithy-legacy-http-server = { path = "../aws-smithy-legacy-http-server", optional = true, features = [
+    "request-id",
+] }
+
 [dev-dependencies]
 tracing-appender = "0.2"
 metrique-writer-format-emf = "0.1.16"
@@ -43,6 +48,12 @@ metrique-writer-format-emf = "0.1.16"
 [features]
 aws-smithy-http-server-065 = [
     "dep:aws-smithy-http-server-065",
+    "dep:http-02",
+    "dep:hyper-014",
+    "dep:http-body-04",
+]
+aws-smithy-legacy-http-server = [
+    "dep:aws-smithy-legacy-http-server",
     "dep:http-02",
     "dep:hyper-014",
     "dep:http-body-04",

--- a/rust-runtime/aws-smithy-http-server-metrics/src/types.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/types.rs
@@ -3,16 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[cfg(not(feature = "aws-smithy-http-server-065"))]
+#[cfg(not(any(
+    feature = "aws-smithy-http-server-065",
+    feature = "aws-smithy-legacy-http-server"
+)))]
 pub(crate) type RequestBody = hyper::body::Incoming;
-#[cfg(not(feature = "aws-smithy-http-server-065"))]
+#[cfg(not(any(
+    feature = "aws-smithy-http-server-065",
+    feature = "aws-smithy-legacy-http-server"
+)))]
 pub(crate) use aws_smithy_http_server;
 
-#[cfg(feature = "aws-smithy-http-server-065")]
+/// For pre-http1x codegen version support
+#[cfg(all(
+    feature = "aws-smithy-http-server-065",
+    not(feature = "aws-smithy-legacy-http-server")
+))]
 pub(crate) use aws_smithy_http_server_065 as aws_smithy_http_server;
-#[cfg(feature = "aws-smithy-http-server-065")]
+
+/// For post-http1x codegen version support, if http1x is not used
+/// Takes precedence if both "aws-smithy-http-server-065" and "aws-smithy-legacy-http-server" are enabled
+#[cfg(feature = "aws-smithy-legacy-http-server")]
+pub(crate) use aws_smithy_legacy_http_server as aws_smithy_http_server;
+#[cfg(any(
+    feature = "aws-smithy-http-server-065",
+    feature = "aws-smithy-legacy-http-server"
+))]
 use http_02 as http;
-#[cfg(feature = "aws-smithy-http-server-065")]
+#[cfg(any(
+    feature = "aws-smithy-http-server-065",
+    feature = "aws-smithy-legacy-http-server"
+))]
 pub(crate) type RequestBody = hyper_014::Body;
 
 pub(crate) type ResponseBody = aws_smithy_http_server::body::BoxBody;
@@ -26,8 +47,14 @@ pub(crate) type DefaultInit<Entry, Sink> =
 pub(crate) type DefaultRs<Entry> = fn(&mut HttpResponse, &mut Entry);
 
 pub(crate) fn empty_response_body() -> ResponseBody {
-    #[cfg(not(feature = "aws-smithy-http-server-065"))]
+    #[cfg(not(any(
+        feature = "aws-smithy-http-server-065",
+        feature = "aws-smithy-legacy-http-server"
+    )))]
     return aws_smithy_http_server::body::empty();
-    #[cfg(feature = "aws-smithy-http-server-065")]
+    #[cfg(any(
+        feature = "aws-smithy-http-server-065",
+        feature = "aws-smithy-legacy-http-server"
+    ))]
     return aws_smithy_http_server::body::boxed(http_body_04::Empty::new());
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

https://github.com/smithy-lang/smithy-rs/issues/4557

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
