### PR TITLE
Add internal trait to validation exception traits

### DIFF
--- a/codegen-traits/src/main/resources/META-INF/smithy/validation-exception.smithy
+++ b/codegen-traits/src/main/resources/META-INF/smithy/validation-exception.smithy
@@ -4,24 +4,29 @@ namespace smithy.framework.rust
 
 /// Marks a structure as a custom validation exception that can replace
 /// smithy.framework#ValidationException in operation error lists.
+@internal
 @trait(selector: "structure")
 structure validationException {}
 
 /// Marks a String member as the primary message field for a validation exception.
 /// Exactly one member in a @validationException structure must have this trait.
+@internal
 @trait(selector: "structure[trait|smithy.framework.rust#validationException] > member")
 structure validationMessage {}
 
 /// Marks a member as containing the list of field-level validation errors.
 /// The target shape must be a List<Structure> where
 /// the structure contains validation field information.
+@internal
 @trait(selector: "structure > member")
 structure validationFieldList {}
 
 /// Marks a String member as containing the field name in a validation field structure.
+@internal
 @trait(selector: "structure > member")
 structure validationFieldName {}
 
 /// Marks a String member as containing the field error message in a validation field structure.
+@internal
 @trait(selector: "structure > member")
 structure validationFieldMessage {}


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Models building with these traits fail with `TRAIT_NOT_ALLOWLISTED` since they are not public smithy traits and are specific to smithy-rs.

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
