### PR TITLE
Optimize interceptor code paths

### DIFF
--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AccountIdEndpointParamsDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AccountIdEndpointParamsDecorator.kt
@@ -253,10 +253,12 @@ class AccountIdEndpointModeBuiltInParamDecorator : ConditionalDecorator(
 
 private class AccountIdEndpointFeatureTrackerInterceptor(codegenContext: ClientCodegenContext) :
     ServiceRuntimePluginCustomization() {
+    private val runtimeConfig = codegenContext.runtimeConfig
+
     override fun section(section: ServiceRuntimePluginSection) =
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(runtimeConfig, this) {
                     rustTemplate(
                         "#{Interceptor}",
                         "Interceptor" to

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsChunkedContentEncodingDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsChunkedContentEncodingDecorator.kt
@@ -159,7 +159,7 @@ private class AwsChunkedOperationCustomization(
                 is OperationSection.AdditionalInterceptors -> {
                     if (!operationRequiresAwsChunked(codegenContext, operation)) return@writable
 
-                    section.registerInterceptor(runtimeConfig, this) {
+                    section.registerPermanentInterceptor(runtimeConfig, this) {
                         rustTemplate(
                             """
                             #{AwsChunkedContentEncodingInterceptor}

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointOverrideMetricDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointOverrideMetricDecorator.kt
@@ -41,6 +41,7 @@ class EndpointOverrideMetricDecorator : ClientCodegenDecorator {
                 ##[derive(Debug, Default)]
                 pub(crate) struct EndpointOverrideFeatureTrackerInterceptor;
 
+                ##[#{dyn_dispatch_hint}]
                 impl #{Intercept} for EndpointOverrideFeatureTrackerInterceptor {
                     fn name(&self) -> &'static str {
                         "EndpointOverrideFeatureTrackerInterceptor"
@@ -60,6 +61,7 @@ class EndpointOverrideMetricDecorator : ClientCodegenDecorator {
                 }
                 """,
                 "Intercept" to smithyRuntimeApi.resolve("client::interceptors::Intercept"),
+                "dyn_dispatch_hint" to smithyRuntimeApi.resolve("client::interceptors::dyn_dispatch_hint"),
                 "BeforeSerializationInterceptorContextRef" to
                     smithyRuntimeApi.resolve("client::interceptors::context::BeforeSerializationInterceptorContextRef"),
                 "ConfigBag" to smithyTypes.resolve("config_bag::ConfigBag"),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointOverrideMetricDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointOverrideMetricDecorator.kt
@@ -84,7 +84,7 @@ private class EndpointOverrideFeatureTrackerRegistration(
     override fun section(section: ServiceRuntimePluginSection) =
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                     rustTemplate("crate::config::endpoint::EndpointOverrideFeatureTrackerInterceptor")
                 }
             }

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -174,7 +174,7 @@ class HttpRequestChecksumCustomization(
             when (section) {
                 is OperationSection.AdditionalInterceptors -> {
                     if (requestAlgorithmMemberName != null) {
-                        section.registerInterceptor(runtimeConfig, this) {
+                        section.registerPermanentInterceptor(runtimeConfig, this) {
                             val runtimeApi = RuntimeType.smithyRuntimeApiClient(runtimeConfig)
                             rustTemplate(
                                 """

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
@@ -131,7 +131,7 @@ class HttpResponseChecksumCustomization(
 
             when (section) {
                 is OperationSection.AdditionalInterceptors -> {
-                    section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                    section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                         // CRC32, CRC32C, SHA256, SHA1 -> "crc32", "crc32c", "sha256", "sha1"
                         val responseAlgorithms =
                             checksumTrait.responseAlgorithms

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/ObservabilityMetricDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/ObservabilityMetricDecorator.kt
@@ -34,7 +34,7 @@ private class ObservabilityFeatureTrackerInterceptor(private val codegenContext:
     override fun section(section: ServiceRuntimePluginSection) =
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                     val runtimeConfig = codegenContext.runtimeConfig
                     rustTemplate(
                         "#{Interceptor}",

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/RecursionDetectionDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/RecursionDetectionDecorator.kt
@@ -30,7 +30,7 @@ private class RecursionDetectionRuntimePluginCustomization(
     override fun section(section: ServiceRuntimePluginSection): Writable =
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                     rust(
                         "#T::new()",
                         AwsRuntimeType.awsRuntime(codegenContext.runtimeConfig)

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/RetryInformationHeaderDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/RetryInformationHeaderDecorator.kt
@@ -33,7 +33,7 @@ private class AddRetryInformationHeaderInterceptors(codegenContext: ClientCodege
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
                 // Track the latency between client and server.
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(runtimeConfig, this) {
                     rust(
                         "#T::new()",
                         awsRuntime.resolve("service_clock_skew::ServiceClockSkewInterceptor"),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/apigateway/ApiGatewayDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/apigateway/ApiGatewayDecorator.kt
@@ -32,7 +32,7 @@ private class ApiGatewayAcceptHeaderInterceptorCustomization(private val codegen
     override fun section(section: ServiceRuntimePluginSection): Writable =
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                     rustTemplate(
                         "#{Interceptor}::default()",
                         "Interceptor" to

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/GlacierDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/GlacierDecorator.kt
@@ -89,7 +89,7 @@ private class GlacierApiVersionCustomization(private val codegenContext: ClientC
         writable {
             if (section is ServiceRuntimePluginSection.RegisterRuntimeComponents) {
                 val apiVersion = codegenContext.serviceShape.version
-                section.registerInterceptor(this) {
+                section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                     rustTemplate(
                         "#{Interceptor}::new(${apiVersion.dq()})",
                         "Interceptor" to inlineModule(codegenContext.runtimeConfig).resolve("GlacierApiVersionInterceptor"),
@@ -113,7 +113,7 @@ private class GlacierOperationInterceptorsCustomization(private val codegenConte
                 val inputShape = codegenContext.model.expectShape(section.operationShape.inputShape) as StructureShape
                 val inlineModule = inlineModule(codegenContext.runtimeConfig)
                 if (inputShape.inputWithAccountId()) {
-                    section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                    section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                         rustTemplate(
                             "#{Interceptor}::<#{Input}>::new()",
                             "Interceptor" to inlineModule.resolve("GlacierAccountIdAutofillInterceptor"),
@@ -122,7 +122,7 @@ private class GlacierOperationInterceptorsCustomization(private val codegenConte
                     }
                 }
                 if (section.operationShape.requiresTreeHashHeader()) {
-                    section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                    section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                         rustTemplate(
                             "#{Interceptor}::default()",
                             "Interceptor" to inlineModule.resolve("GlacierTreeHashHeaderInterceptor"),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/route53/Route53Decorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/route53/Route53Decorator.kt
@@ -80,7 +80,7 @@ class TrimResourceIdCustomization(
         writable {
             when (section) {
                 is OperationSection.AdditionalInterceptors -> {
-                    section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                    section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                         val smithyRuntimeApi = RuntimeType.smithyRuntimeApiClient(codegenContext.runtimeConfig)
                         val interceptor =
                             RuntimeType.forInlineDependency(

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpiresDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3ExpiresDecorator.kt
@@ -129,7 +129,7 @@ class ParseExpiresFieldsCustomization(
         writable {
             when (section) {
                 is OperationSection.AdditionalInterceptors -> {
-                    section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                    section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                         val interceptor =
                             RuntimeType.forInlineDependency(
                                 InlineAwsDependency.forRustFile("s3_expires_interceptor"),

--- a/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/UserAgentDecoratorTest.kt
+++ b/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/UserAgentDecoratorTest.kt
@@ -277,9 +277,6 @@ class UserAgentDecoratorTest {
                             AwsRuntimeType.awsRuntimeTestUtil(rc)
                                 .resolve("user_agent::test_util::assert_ua_contains_metric_values"),
                         "capture_request" to RuntimeType.captureRequest(rc),
-                        "disable_interceptor" to
-                            RuntimeType.smithyRuntimeApiClient(rc)
-                                .resolve("client::interceptors::disable_interceptor"),
                         "UserAgentInterceptor" to
                             AwsRuntimeType.awsRuntime(rc)
                                 .resolve("user_agent::UserAgentInterceptor"),
@@ -361,9 +358,6 @@ class UserAgentDecoratorTest {
                             AwsRuntimeType.awsRuntimeTestUtil(rc)
                                 .resolve("user_agent::test_util::assert_ua_contains_metric_values"),
                         "capture_request" to RuntimeType.captureRequest(rc),
-                        "disable_interceptor" to
-                            RuntimeType.smithyRuntimeApiClient(rc)
-                                .resolve("client::interceptors::disable_interceptor"),
                         "UserAgentInterceptor" to
                             AwsRuntimeType.awsRuntime(rc)
                                 .resolve("user_agent::UserAgentInterceptor"),
@@ -394,9 +388,6 @@ class UserAgentDecoratorTest {
                             AwsRuntimeType.awsRuntimeTestUtil(rc)
                                 .resolve("user_agent::test_util::assert_ua_contains_metric_values"),
                         "capture_request" to RuntimeType.captureRequest(rc),
-                        "disable_interceptor" to
-                            RuntimeType.smithyRuntimeApiClient(rc)
-                                .resolve("client::interceptors::disable_interceptor"),
                         "UserAgentInterceptor" to
                             AwsRuntimeType.awsRuntime(rc)
                                 .resolve("user_agent::UserAgentInterceptor"),

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -322,9 +322,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -333,6 +334,15 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-inlineable/src/account_id_endpoint.rs
+++ b/aws/rust-runtime/aws-inlineable/src/account_id_endpoint.rs
@@ -6,7 +6,9 @@
 use aws_runtime::sdk_feature::AwsSdkFeature;
 use aws_smithy_runtime_api::{
     box_error::BoxError,
-    client::interceptors::{context::BeforeSerializationInterceptorContextRef, Intercept},
+    client::interceptors::{
+        context::BeforeSerializationInterceptorContextRef, dyn_dispatch_hint, Intercept,
+    },
 };
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_types::endpoint_config::AccountIdEndpointMode;
@@ -15,6 +17,7 @@ use aws_types::endpoint_config::AccountIdEndpointMode;
 #[derive(Debug, Default)]
 pub(crate) struct AccountIdEndpointFeatureTrackerInterceptor;
 
+#[dyn_dispatch_hint]
 impl Intercept for AccountIdEndpointFeatureTrackerInterceptor {
     fn name(&self) -> &'static str {
         "AccountIdEndpointFeatureTrackerInterceptor"

--- a/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
@@ -7,7 +7,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use http_1x::header::ACCEPT;
@@ -19,6 +19,7 @@ pub(crate) struct AcceptHeaderInterceptor {
     _priv: (),
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for AcceptHeaderInterceptor {
     fn name(&self) -> &'static str {
         "AcceptHeaderInterceptor"

--- a/aws/rust-runtime/aws-inlineable/src/aws_chunked.rs
+++ b/aws/rust-runtime/aws-inlineable/src/aws_chunked.rs
@@ -17,7 +17,9 @@ use aws_runtime::{
 use aws_smithy_runtime_api::{
     box_error::BoxError,
     client::{
-        interceptors::{context::BeforeTransmitInterceptorContextMut, Intercept},
+        interceptors::{
+            context::BeforeTransmitInterceptorContextMut, dyn_dispatch_hint, Intercept,
+        },
         runtime_components::RuntimeComponents,
         runtime_plugin::RuntimePlugin,
     },
@@ -96,6 +98,7 @@ impl std::error::Error for Error {}
 #[derive(Debug)]
 pub(crate) struct AwsChunkedContentEncodingInterceptor;
 
+#[dyn_dispatch_hint]
 impl Intercept for AwsChunkedContentEncodingInterceptor {
     fn name(&self) -> &'static str {
         "AwsChunkedContentEncodingInterceptor"

--- a/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
@@ -19,7 +19,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, BeforeTransmitInterceptorContextMut,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, LoadedRequestBody};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::byte_stream;
@@ -65,6 +65,7 @@ impl<I> GlacierAccountIdAutofillInterceptor<I> {
     }
 }
 
+#[dyn_dispatch_hint]
 impl<I: GlacierAccountId + Send + Sync + 'static> Intercept
     for GlacierAccountIdAutofillInterceptor<I>
 {
@@ -100,6 +101,7 @@ impl GlacierApiVersionInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for GlacierApiVersionInterceptor {
     fn name(&self) -> &'static str {
         "GlacierApiVersionInterceptor"
@@ -125,6 +127,7 @@ pub(crate) struct GlacierTreeHashHeaderInterceptor {
     _priv: (),
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for GlacierTreeHashHeaderInterceptor {
     fn name(&self) -> &'static str {
         "GlacierTreeHashHeaderInterceptor"

--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -18,7 +18,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, BeforeTransmitInterceptorContextMut, Input,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_runtime_api::http::Request;
 use aws_smithy_types::body::SdkBody;
@@ -136,6 +136,7 @@ impl<AP, CM> RequestChecksumInterceptor<AP, CM> {
     }
 }
 
+#[dyn_dispatch_hint]
 impl<AP, CM> Intercept for RequestChecksumInterceptor<AP, CM>
 where
     AP: Fn(&Input) -> (Option<String>, bool) + Send + Sync,

--- a/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
@@ -13,7 +13,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeDeserializationInterceptorContextMut, BeforeSerializationInterceptorContextMut, Input,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_runtime_api::http::Headers;
 use aws_smithy_types::body::SdkBody;
@@ -57,6 +57,7 @@ impl<VE, CM> ResponseChecksumInterceptor<VE, CM> {
     }
 }
 
+#[dyn_dispatch_hint]
 impl<VE, CM> Intercept for ResponseChecksumInterceptor<VE, CM>
 where
     VE: Fn(&Input) -> bool + Send + Sync,

--- a/aws/rust-runtime/aws-inlineable/src/observability_feature.rs
+++ b/aws/rust-runtime/aws-inlineable/src/observability_feature.rs
@@ -6,7 +6,9 @@
 use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
 use aws_smithy_runtime_api::{
     box_error::BoxError,
-    client::interceptors::{context::BeforeSerializationInterceptorContextRef, Intercept},
+    client::interceptors::{
+        context::BeforeSerializationInterceptorContextRef, dyn_dispatch_hint, Intercept,
+    },
 };
 use aws_smithy_types::config_bag::ConfigBag;
 
@@ -14,6 +16,7 @@ use aws_smithy_types::config_bag::ConfigBag;
 #[derive(Debug, Default)]
 pub(crate) struct ObservabilityFeatureTrackerInterceptor;
 
+#[dyn_dispatch_hint]
 impl Intercept for ObservabilityFeatureTrackerInterceptor {
     fn name(&self) -> &'static str {
         "ObservabilityFeatureTrackerInterceptor"

--- a/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
@@ -101,10 +101,9 @@ impl SigV4PresigningRuntimePlugin {
         let time_source = SharedTimeSource::new(StaticTimeSource::new(config.start_time()));
         Self {
             runtime_components: RuntimeComponentsBuilder::new("SigV4PresigningRuntimePlugin")
-                .with_interceptor(SharedInterceptor::new(SigV4PresigningInterceptor::new(
-                    config,
-                    payload_override,
-                )))
+                .with_interceptor(SharedInterceptor::permanent(
+                    SigV4PresigningInterceptor::new(config, payload_override),
+                ))
                 .with_retry_strategy(Some(SharedRetryStrategy::new(NeverRetryStrategy::new())))
                 .with_time_source(Some(time_source)),
         }

--- a/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
@@ -19,7 +19,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, BeforeTransmitInterceptorContextMut,
 };
 use aws_smithy_runtime_api::client::interceptors::{
-    disable_interceptor, Intercept, SharedInterceptor,
+    disable_interceptor, dyn_dispatch_hint, Intercept, SharedInterceptor,
 };
 use aws_smithy_runtime_api::client::retries::SharedRetryStrategy;
 use aws_smithy_runtime_api::client::runtime_components::{
@@ -46,6 +46,7 @@ impl SigV4PresigningInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for SigV4PresigningInterceptor {
     fn name(&self) -> &'static str {
         "SigV4PresigningInterceptor"

--- a/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
+++ b/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
@@ -7,7 +7,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use std::fmt;
@@ -67,6 +67,7 @@ where
     }
 }
 
+#[dyn_dispatch_hint]
 impl<G, T> Intercept for Route53ResourceIdInterceptor<G, T>
 where
     G: for<'a> Fn(&'a mut T) -> &'a mut Option<String> + Send + Sync,

--- a/aws/rust-runtime/aws-inlineable/src/s3_expires_interceptor.rs
+++ b/aws/rust-runtime/aws-inlineable/src/s3_expires_interceptor.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::date_time::{DateTime, Format};
@@ -20,6 +20,7 @@ pub(crate) struct S3ExpiresInterceptor;
 const EXPIRES: &str = "Expires";
 const EXPIRES_STRING: &str = "ExpiresString";
 
+#[dyn_dispatch_hint]
 impl Intercept for S3ExpiresInterceptor {
     fn name(&self) -> &'static str {
         "S3ExpiresInterceptor"

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -11,7 +11,7 @@ use http_1x::{HeaderName, HeaderValue};
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 #[cfg(feature = "test-util")]
@@ -93,6 +93,7 @@ impl InvocationIdInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for InvocationIdInterceptor {
     fn name(&self) -> &'static str {
         "InvocationIdInterceptor"

--- a/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_types::os_shim_internal::Env;
@@ -39,6 +39,7 @@ impl RecursionDetectionInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for RecursionDetectionInterceptor {
     fn name(&self) -> &'static str {
         "RecursionDetectionInterceptor"

--- a/aws/rust-runtime/aws-runtime/src/request_info.rs
+++ b/aws/rust-runtime/aws-runtime/src/request_info.rs
@@ -7,7 +7,7 @@ use crate::service_clock_skew::ServiceClockSkew;
 use aws_smithy_async::time::TimeSource;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::retries::RequestAttempts;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -91,6 +91,7 @@ impl RequestInfoInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for RequestInfoInterceptor {
     fn name(&self) -> &'static str {
         "RequestInfoInterceptor"

--- a/aws/rust-runtime/aws-runtime/src/service_clock_skew.rs
+++ b/aws/rust-runtime/aws-runtime/src/service_clock_skew.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::date_time::Format;
@@ -63,6 +63,7 @@ fn extract_time_sent_from_response(
     DateTime::from_str(date_header, Format::HttpDate).map_err(Into::into)
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for ServiceClockSkewInterceptor {
     fn name(&self) -> &'static str {
         "ServiceClockSkewInterceptor"

--- a/aws/rust-runtime/aws-runtime/src/user_agent/interceptor.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent/interceptor.rs
@@ -15,7 +15,7 @@ use aws_smithy_runtime_api::client::http::HttpClient;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeTransmitInterceptorContextMut, BeforeTransmitInterceptorContextRef,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_types::app_name::AppName;
@@ -119,6 +119,7 @@ fn header_values(
     ))
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for UserAgentInterceptor {
     fn name(&self) -> &'static str {
         "UserAgentInterceptor"

--- a/aws/sdk/benchmarks/previous-release-comparison/Cargo.lock
+++ b/aws/sdk/benchmarks/previous-release-comparison/Cargo.lock
@@ -53,25 +53,25 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.12"
+version = "1.9.0"
 dependencies = [
- "aws-credential-types 1.2.11",
- "aws-runtime 1.6.0",
+ "aws-credential-types 1.2.14",
+ "aws-runtime 1.7.3",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
- "aws-smithy-async 1.2.7",
- "aws-smithy-http 0.63.0",
- "aws-smithy-json 0.62.0",
- "aws-smithy-runtime 1.9.5",
- "aws-smithy-runtime-api 1.9.3",
- "aws-smithy-types 1.3.5",
- "aws-types 1.3.11",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-runtime 1.11.0",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
+ "aws-types 1.4.0",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
- "ring",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -82,6 +82,8 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
 dependencies = [
  "aws-smithy-async 1.2.7",
  "aws-smithy-runtime-api 1.9.3",
@@ -91,13 +93,11 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+version = "1.2.14"
 dependencies = [
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
  "zeroize",
 ]
 
@@ -129,15 +129,15 @@ version = "1.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81b5b2898f6798ad58f484856768bca817e3cd9de0974c24ae0f1113fe88f1b"
 dependencies = [
- "aws-credential-types 1.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-sigv4 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-credential-types 1.2.11",
+ "aws-sigv4 1.3.7",
+ "aws-smithy-async 1.2.7",
+ "aws-smithy-eventstream 0.60.14",
  "aws-smithy-http 0.62.6",
- "aws-smithy-runtime 1.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types 1.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime 1.9.5",
+ "aws-smithy-runtime-api 1.9.3",
+ "aws-smithy-types 1.3.5",
+ "aws-types 1.3.11",
  "bytes",
  "fastrand",
  "http 0.2.12",
@@ -150,18 +150,19 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.6.0"
+version = "1.7.3"
 dependencies = [
- "aws-credential-types 1.2.11",
- "aws-sigv4 1.3.7",
- "aws-smithy-async 1.2.7",
- "aws-smithy-eventstream 0.60.14",
- "aws-smithy-http 0.63.0",
- "aws-smithy-runtime 1.9.5",
- "aws-smithy-runtime-api 1.9.3",
- "aws-smithy-types 1.3.5",
- "aws-types 1.3.11",
+ "aws-credential-types 1.2.14",
+ "aws-sigv4 1.4.3",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime 1.11.0",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
+ "aws-types 1.4.0",
  "bytes",
+ "bytes-utils",
  "fastrand",
  "http 0.2.12",
  "http 1.4.0",
@@ -177,14 +178,49 @@ dependencies = [
 name = "aws-sdk-s3"
 version = "0.0.0-local"
 dependencies = [
+ "aws-credential-types 1.2.14",
+ "aws-runtime 1.7.3",
+ "aws-sigv4 1.4.3",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-checksums 0.64.7",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime 1.11.0",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
+ "aws-smithy-xml 0.60.15",
+ "aws-types 1.4.0",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "lru 0.16.3",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ddb925e840f49446aa6338b67abdbec04b4ebf923b7da038ec4c35afb916cd"
+dependencies = [
  "aws-credential-types 1.2.11",
- "aws-runtime 1.6.0",
+ "aws-runtime 1.5.17",
  "aws-sigv4 1.3.7",
  "aws-smithy-async 1.2.7",
- "aws-smithy-checksums 0.64.0",
+ "aws-smithy-checksums 0.63.6",
  "aws-smithy-eventstream 0.60.14",
- "aws-smithy-http 0.63.0",
- "aws-smithy-json 0.62.0",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.8",
  "aws-smithy-runtime 1.9.5",
  "aws-smithy-runtime-api 1.9.3",
  "aws-smithy-types 1.3.5",
@@ -193,49 +229,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
- "lru",
+ "lru 0.12.5",
  "percent-encoding",
  "regex-lite",
- "sha2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "1.117.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134e2d1ad1ad23a8cf88ceccf39d515914f385e670ffc12226013bd16dfe825"
-dependencies = [
- "aws-credential-types 1.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-runtime 1.5.17",
- "aws-sigv4 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-checksums 0.63.12",
- "aws-smithy-eventstream 0.60.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.8",
- "aws-smithy-runtime 1.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-xml 0.60.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-types 1.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "fastrand",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "lru",
- "percent-encoding",
- "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -244,15 +245,16 @@ dependencies = [
 name = "aws-sdk-sso"
 version = "0.0.0-local"
 dependencies = [
- "aws-credential-types 1.2.11",
- "aws-runtime 1.6.0",
- "aws-smithy-async 1.2.7",
- "aws-smithy-http 0.63.0",
- "aws-smithy-json 0.62.0",
- "aws-smithy-runtime 1.9.5",
- "aws-smithy-runtime-api 1.9.3",
- "aws-smithy-types 1.3.5",
- "aws-types 1.3.11",
+ "aws-credential-types 1.2.14",
+ "aws-runtime 1.7.3",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime 1.11.0",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
+ "aws-types 1.4.0",
  "bytes",
  "fastrand",
  "http 0.2.12",
@@ -265,15 +267,16 @@ dependencies = [
 name = "aws-sdk-ssooidc"
 version = "0.0.0-local"
 dependencies = [
- "aws-credential-types 1.2.11",
- "aws-runtime 1.6.0",
- "aws-smithy-async 1.2.7",
- "aws-smithy-http 0.63.0",
- "aws-smithy-json 0.62.0",
- "aws-smithy-runtime 1.9.5",
- "aws-smithy-runtime-api 1.9.3",
- "aws-smithy-types 1.3.5",
- "aws-types 1.3.11",
+ "aws-credential-types 1.2.14",
+ "aws-runtime 1.7.3",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime 1.11.0",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
+ "aws-types 1.4.0",
  "bytes",
  "fastrand",
  "http 0.2.12",
@@ -286,17 +289,18 @@ dependencies = [
 name = "aws-sdk-sts"
 version = "0.0.0-local"
 dependencies = [
- "aws-credential-types 1.2.11",
- "aws-runtime 1.6.0",
- "aws-smithy-async 1.2.7",
- "aws-smithy-http 0.63.0",
- "aws-smithy-json 0.62.0",
+ "aws-credential-types 1.2.14",
+ "aws-runtime 1.7.3",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-query",
- "aws-smithy-runtime 1.9.5",
- "aws-smithy-runtime-api 1.9.3",
- "aws-smithy-types 1.3.5",
- "aws-smithy-xml 0.60.13",
- "aws-types 1.3.11",
+ "aws-smithy-runtime 1.11.0",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
+ "aws-smithy-xml 0.60.15",
+ "aws-types 1.4.0",
  "fastrand",
  "http 0.2.12",
  "http 1.4.0",
@@ -307,23 +311,25 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
 dependencies = [
  "aws-credential-types 1.2.11",
  "aws-smithy-eventstream 0.60.14",
- "aws-smithy-http 0.63.0",
+ "aws-smithy-http 0.62.6",
  "aws-smithy-runtime-api 1.9.3",
  "aws-smithy-types 1.3.5",
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -332,39 +338,28 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+version = "1.4.3"
 dependencies = [
- "aws-credential-types 1.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-eventstream 0.60.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.62.6",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-credential-types 1.2.14",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.7"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -379,51 +374,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "aws-smithy-checksums"
-version = "0.63.12"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+checksum = "9054b4cc5eda331cde3096b1576dec45365c5cbbca61d1fffa5f236e251dfce7"
 dependencies = [
  "aws-smithy-http 0.62.6",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.3.5",
  "bytes",
  "crc-fast",
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.0"
+version = "0.64.7"
 dependencies = [
- "aws-smithy-http 0.63.0",
- "aws-smithy-types 1.3.5",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-types 1.4.7",
  "bytes",
  "crc-fast",
  "hex",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.11.0",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.60.14"
-dependencies = [
- "aws-smithy-types 1.3.5",
- "bytes",
- "crc32fast",
 ]
 
 [[package]]
@@ -432,7 +427,16 @@ version = "0.60.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
 dependencies = [
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.3.5",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+dependencies = [
+ "aws-smithy-types 1.4.7",
  "bytes",
  "crc32fast",
 ]
@@ -443,9 +447,9 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
- "aws-smithy-eventstream 0.60.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-eventstream 0.60.14",
+ "aws-smithy-runtime-api 1.9.3",
+ "aws-smithy-types 1.3.5",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -461,11 +465,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.0"
+version = "0.63.6"
 dependencies = [
- "aws-smithy-eventstream 0.60.14",
- "aws-smithy-runtime-api 1.9.3",
- "aws-smithy-types 1.3.5",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -482,6 +486,8 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http-client"
 version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
 dependencies = [
  "aws-smithy-async 1.2.7",
  "aws-smithy-protocol-test 0.63.7",
@@ -515,14 +521,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
+version = "1.1.12"
 dependencies = [
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-protocol-test 0.63.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-protocol-test 0.63.14",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
  "bytes",
  "h2 0.3.27",
  "h2 0.4.12",
@@ -555,21 +559,14 @@ version = "0.61.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6864c190cbb8e30cf4b77b2c8f3b6dfffa697a09b7218d2f7cd3d4c4065a9f7"
 dependencies = [
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.62.0"
-dependencies = [
  "aws-smithy-types 1.3.5",
 ]
 
 [[package]]
-name = "aws-smithy-observability"
-version = "0.1.5"
+name = "aws-smithy-json"
+version = "0.62.5"
 dependencies = [
- "aws-smithy-runtime-api 1.9.3",
+ "aws-smithy-types 1.4.7",
 ]
 
 [[package]]
@@ -578,12 +575,21 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a"
 dependencies = [
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.9.3",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+dependencies = [
+ "aws-smithy-runtime-api 1.12.0",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
 version = "0.63.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01317a9e3c5c06f1af35001ef0c873c1e34e458c20b2ee1eee0fb431e6dbb010"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api 1.9.3",
@@ -600,12 +606,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01317a9e3c5c06f1af35001ef0c873c1e34e458c20b2ee1eee0fb431e6dbb010"
+version = "0.63.14"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.12.0",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -619,18 +623,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.9"
+version = "0.60.15"
 dependencies = [
- "aws-smithy-types 1.3.5",
+ "aws-smithy-types 1.4.7",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
 version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a392db6c583ea4a912538afb86b7be7c5d8887d91604f50eb55c262ee1b4a5f5"
 dependencies = [
  "aws-smithy-async 1.2.7",
- "aws-smithy-http 0.63.0",
+ "aws-smithy-http 0.62.6",
  "aws-smithy-http-client 1.1.5",
  "aws-smithy-observability 0.1.5",
  "aws-smithy-runtime-api 1.9.3",
@@ -641,7 +647,6 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -651,32 +656,32 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a392db6c583ea4a912538afb86b7be7c5d8887d91604f50eb55c262ee1b4a5f5"
+version = "1.11.0"
 dependencies = [
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-http 0.62.6",
- "aws-smithy-http-client 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-observability 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-http-client 1.1.12",
+ "aws-smithy-observability 0.2.6",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
  "bytes",
  "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2"
 dependencies = [
  "aws-smithy-async 1.2.7",
  "aws-smithy-types 1.3.5",
@@ -691,12 +696,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2"
+version = "1.12.0"
 dependencies = [
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types 1.4.7",
  "bytes",
  "http 0.2.12",
  "http 1.4.0",
@@ -707,27 +711,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.3.5"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -757,10 +746,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-xml"
-version = "0.60.13"
+name = "aws-smithy-types"
+version = "1.4.7"
 dependencies = [
- "xmlparser",
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -773,8 +779,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "aws-types"
 version = "1.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
 dependencies = [
  "aws-credential-types 1.2.11",
  "aws-smithy-async 1.2.7",
@@ -786,14 +801,12 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+version = "1.4.0"
 dependencies = [
- "aws-credential-types 1.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-async 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-credential-types 1.2.14",
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-runtime-api 1.12.0",
+ "aws-smithy-types 1.4.7",
  "rustc_version",
  "tracing",
 ]
@@ -842,6 +855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,9 +880,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -986,10 +1008,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -1017,10 +1051,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1033,15 +1076,14 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
- "rand",
- "regex",
+ "digest 0.10.7",
  "rustversion",
+ "spin",
 ]
 
 [[package]]
@@ -1129,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1140,7 +1182,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1155,6 +1197,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,7 +1226,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1191,9 +1251,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1240,12 +1312,12 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1269,7 +1341,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1290,6 +1362,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1407,7 +1485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1468,7 +1546,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1476,6 +1554,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1495,7 +1578,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1564,6 +1656,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1661,7 +1762,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1809,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1841,9 +1942,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "litemap"
@@ -1867,6 +1968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,7 +1992,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1899,9 +2019,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2004,7 +2124,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2079,15 +2199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,13 +2213,13 @@ name = "previous-release-comparison"
 version = "0.1.0"
 dependencies = [
  "aws-config",
- "aws-credential-types 1.2.11",
+ "aws-credential-types 1.2.14",
  "aws-sdk-s3 0.0.0-local",
- "aws-sdk-s3 1.117.0",
- "aws-smithy-runtime 1.9.5",
- "aws-smithy-runtime 1.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-sdk-s3 1.102.0",
+ "aws-smithy-http-client 1.1.12",
+ "aws-smithy-http-client 1.1.5",
  "criterion",
- "http 0.2.12",
+ "http 1.4.0",
  "tokio",
 ]
 
@@ -2137,41 +2248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2236,7 +2318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -2349,9 +2431,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2462,16 +2544,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2481,8 +2563,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2492,8 +2585,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2526,8 +2630,8 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
- "rand_core 0.6.4",
+ "digest 0.10.7",
+ "rand_core",
 ]
 
 [[package]]
@@ -2554,13 +2658,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -2702,25 +2812,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2749,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2784,9 +2894,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2806,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3042,16 +3152,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3069,31 +3170,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3103,22 +3187,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3127,22 +3199,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3151,22 +3211,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3175,22 +3223,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -3318,3 +3354,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/aws/sdk/benchmarks/previous-release-comparison/Cargo.toml
+++ b/aws/sdk/benchmarks/previous-release-comparison/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
-aws-smithy-runtime = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime", features = ["test-util"] }
+aws-smithy-http-client = { path = "../../build/aws-sdk/sdk/aws-smithy-http-client", features = ["test-util"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
-http = "0.2.3"
+http = "1"
+previous-http-client = { version = "1", package = "aws-smithy-http-client", features = ["test-util"] }
 previous-s3 = { version = "1", package = "aws-sdk-s3", features = ["test-util"] }
-previous-runtime = { version = "1", package = "aws-smithy-runtime", features = ["test-util"] }
 tokio = { version = "1.23.1", features = ["macros", "test-util", "rt-multi-thread"] }
 
 [profile.release]

--- a/aws/sdk/benchmarks/previous-release-comparison/README.md
+++ b/aws/sdk/benchmarks/previous-release-comparison/README.md
@@ -1,0 +1,36 @@
+# Previous Release Comparison Benchmark
+
+Compares the **current locally-built SDK** against the **latest published release** on crates.io
+using [Criterion](https://github.com/bheisler/criterion.rs) for statistically rigorous measurement.
+
+This is useful for measuring the performance impact of local changes (on any branch) relative to
+the last released version. The benchmark uses a mock HTTP client so results reflect pure SDK
+overhead with no network variability.
+
+## Running
+
+First, build the SDK from your current branch and navigate to the benchmark directory:
+
+```bash
+./gradlew :aws:sdk:assemble
+cd aws/sdk/benchmarks/previous-release-comparison
+```
+
+Then run benchmarks:
+
+```bash
+# Run all benchmarks (previous release vs current)
+cargo bench
+
+# Run only the current (local build) benchmark
+cargo bench -- "compare/current"
+
+# Run only the previous (published release) benchmark
+cargo bench -- "compare/previous"
+```
+
+## Output
+
+Criterion reports per-iteration timing with confidence intervals for both `previous` (published
+release) and `current` (local build). On subsequent runs it also reports whether performance
+changed relative to the last run.

--- a/aws/sdk/benchmarks/previous-release-comparison/benches/README.md
+++ b/aws/sdk/benchmarks/previous-release-comparison/benches/README.md
@@ -1,6 +1,0 @@
-### Middleware vs. Orchestrator Benchmark
-
-To run the benchmark:
-```bash
-./gradlew :aws:sdk:assemble && (cd aws/sdk/benchmarks/previous-release-comparison && cargo bench)
-```

--- a/aws/sdk/benchmarks/previous-release-comparison/benches/previous_release_comparison.rs
+++ b/aws/sdk/benchmarks/previous-release-comparison/benches/previous_release_comparison.rs
@@ -7,38 +7,37 @@
 extern crate criterion;
 use criterion::{BenchmarkId, Criterion};
 
+const LIST_OBJECTS_RESPONSE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+    <ListBucketResult>
+        <Name>test-bucket</Name>
+        <Prefix>prefix~</Prefix>
+        <KeyCount>1</KeyCount>
+        <MaxKeys>1000</MaxKeys>
+        <IsTruncated>false</IsTruncated>
+        <Contents>
+            <Key>some-file.file</Key>
+            <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+            <Size>434234</Size>
+            <StorageClass>STANDARD</StorageClass>
+        </Contents>
+    </ListBucketResult>"#;
+
 macro_rules! test_client {
     (previous) => {
-        test_client!(@internal previous_runtime)
+        test_client!(@internal previous_http_client)
     };
-    (main) => {
-        test_client!(@internal aws_smithy_runtime)
+    (current) => {
+        test_client!(@internal aws_smithy_http_client)
     };
-    (@internal $runtime_crate:ident) => {
-        $runtime_crate::client::http::test_util::infallible_client_fn(|req| {
+    (@internal $crate_path:ident) => {
+        $crate_path::test_util::infallible_client_fn(|req| {
             assert_eq!(
                 "https://test-bucket.s3.us-east-1.amazonaws.com/?list-type=2&prefix=prefix~",
                 req.uri().to_string()
             );
             http::Response::builder()
                 .status(200)
-                .body(
-                    r#"<?xml version="1.0" encoding="UTF-8"?>
-                    <ListBucketResult>
-                        <Name>test-bucket</Name>
-                        <Prefix>prefix~</Prefix>
-                        <KeyCount>1</KeyCount>
-                        <MaxKeys>1000</MaxKeys>
-                        <IsTruncated>false</IsTruncated>
-                        <Contents>
-                            <Key>some-file.file</Key>
-                            <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-                            <Size>434234</Size>
-                            <StorageClass>STANDARD</StorageClass>
-                        </Contents>
-                    </ListBucketResult>
-                    "#,
-                )
+                .body(LIST_OBJECTS_RESPONSE)
                 .unwrap()
         })
     };
@@ -48,7 +47,7 @@ macro_rules! test {
     (previous, $client:ident) => {
         test!(@internal, $client)
     };
-    (main, $client:ident) => {
+    (current, $client:ident) => {
         test!(@internal, $client)
     };
     (@internal, $client:ident) => {
@@ -63,8 +62,8 @@ macro_rules! test {
 }
 
 fn bench(c: &mut Criterion) {
-    let main_client = {
-        let http_client = test_client!(main);
+    let current_client = {
+        let http_client = test_client!(current);
         let config = aws_sdk_s3::Config::builder()
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
             .credentials_provider(aws_sdk_s3::config::Credentials::for_tests())
@@ -88,11 +87,11 @@ fn bench(c: &mut Criterion) {
     let param = "S3 ListObjectsV2";
     group.bench_with_input(BenchmarkId::new("previous", param), param, |b, _| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async { test!(previous, previous_client) })
+            .iter(|| async { std::hint::black_box(test!(previous, previous_client)) })
     });
-    group.bench_with_input(BenchmarkId::new("main", param), param, |b, _| {
+    group.bench_with_input(BenchmarkId::new("current", param), param, |b, _| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async { test!(main, main_client) })
+            .iter(|| async { std::hint::black_box(test!(current, current_client)) })
     });
     group.finish();
 }

--- a/buildSrc/src/main/kotlin/CrateSet.kt
+++ b/buildSrc/src/main/kotlin/CrateSet.kt
@@ -28,6 +28,7 @@ object CrateSet {
             // smithy crates
             "aws-smithy-async",
             "aws-smithy-runtime-api",
+            "aws-smithy-runtime-api-macros",
             "aws-smithy-runtime",
             "aws-smithy-types",
             "aws-smithy-http-client",
@@ -72,6 +73,7 @@ object CrateSet {
             "aws-smithy-query",
             "aws-smithy-runtime",
             "aws-smithy-runtime-api",
+            "aws-smithy-runtime-api-macros",
             "aws-smithy-types",
             "aws-smithy-types-convert",
             "aws-smithy-wasm",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ConnectionPoisoningConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ConnectionPoisoningConfigCustomization.kt
@@ -24,7 +24,7 @@ class ConnectionPoisoningRuntimePluginCustomization(
                 is ServiceRuntimePluginSection.RegisterRuntimeComponents -> {
                     // This interceptor assumes that a compatible Connector is set. Otherwise, connection poisoning
                     // won't work and an error message will be logged.
-                    section.registerInterceptor(this) {
+                    section.registerPermanentInterceptor(runtimeConfig, this) {
                         rust(
                             "#T::new()",
                             smithyRuntime(runtimeConfig).resolve("client::http::connection_poisoning::ConnectionPoisoningInterceptor"),

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/RetryModeFeatureTrackerRuntimePluginCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/RetryModeFeatureTrackerRuntimePluginCustomization.kt
@@ -22,7 +22,7 @@ class RetryModeFeatureTrackerRuntimePluginCustomization(codegenContext: ClientCo
         writable {
             when (section) {
                 is ServiceRuntimePluginSection.RegisterRuntimeComponents -> {
-                    section.registerInterceptor(this) {
+                    section.registerPermanentInterceptor(runtimeConfig, this) {
                         rust(
                             "#T::new()",
                             RuntimeType.forInlineDependency(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/StaticSdkFeatureTrackerDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/StaticSdkFeatureTrackerDecorator.kt
@@ -42,7 +42,7 @@ private class RpcV2CborFeatureTrackerRuntimePluginCustomization(private val code
             when (section) {
                 is ServiceRuntimePluginSection.RegisterRuntimeComponents -> {
                     if (codegenContext.protocol == rpcV2CborProtocolShapeId) {
-                        section.registerInterceptor(this) {
+                        section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                             rustTemplate(
                                 "#{RpcV2CborFeatureTrackerInterceptor}::new()",
                                 "RpcV2CborFeatureTrackerInterceptor" to

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointParamsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointParamsDecorator.kt
@@ -42,7 +42,7 @@ private class EndpointParametersCustomization(
             val symbolProvider = codegenContext.symbolProvider
             val operationName = symbolProvider.toSymbol(operation).name
             if (section is OperationSection.AdditionalInterceptors) {
-                section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                section.registerPermanentInterceptor(codegenContext.runtimeConfig, this) {
                     rust("${operationName}EndpointParamsInterceptor")
                 }
             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -66,6 +66,7 @@ class EndpointParamsInterceptorGenerator(
                 "HttpRequest" to orchestrator.resolve("HttpRequest"),
                 "HttpResponse" to orchestrator.resolve("HttpResponse"),
                 "Intercept" to RuntimeType.intercept(rc),
+                "dyn_dispatch_hint" to RuntimeType.dynDispatchHint(rc),
                 "InterceptorContext" to RuntimeType.interceptorContext(rc),
                 "BeforeSerializationInterceptorContextRef" to RuntimeType.beforeSerializationInterceptorContextRef(rc),
                 "Input" to interceptors.resolve("context::Input"),
@@ -88,6 +89,7 @@ class EndpointParamsInterceptorGenerator(
             ##[derive(Debug)]
             struct $interceptorName;
 
+            ##[#{dyn_dispatch_hint}]
             impl #{Intercept} for $interceptorName {
                 fn name(&self) -> &'static str {
                     ${interceptorName.dq()}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationCustomization.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -78,6 +79,18 @@ sealed class OperationSection(name: String) : Section(name) {
         ) {
             writer.rustTemplate(
                 ".with_interceptor(#{interceptor})",
+                "interceptor" to interceptor,
+            )
+        }
+
+        fun registerPermanentInterceptor(
+            runtimeConfig: RuntimeConfig,
+            writer: RustWriter,
+            interceptor: Writable,
+        ) {
+            writer.rustTemplate(
+                ".with_interceptor(#{SharedInterceptor}::permanent(#{interceptor}))",
+                "SharedInterceptor" to RuntimeType.sharedInterceptor(runtimeConfig),
                 "interceptor" to interceptor,
             )
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.isNotEmpty
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
@@ -49,6 +50,19 @@ sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
             interceptor: Writable,
         ) {
             writer.rust("runtime_components.push_interceptor(#T);", interceptor)
+        }
+
+        /** Generates the code to register a permanent interceptor that cannot be disabled */
+        fun registerPermanentInterceptor(
+            runtimeConfig: RuntimeConfig,
+            writer: RustWriter,
+            interceptor: Writable,
+        ) {
+            writer.rustTemplate(
+                "runtime_components.push_interceptor(#{SharedInterceptor}::permanent(#{interceptor}));",
+                "SharedInterceptor" to RuntimeType.sharedInterceptor(runtimeConfig),
+                "interceptor" to interceptor,
+            )
         }
 
         fun registerAuthScheme(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/StalledStreamProtectionConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/StalledStreamProtectionConfigCustomization.kt
@@ -131,7 +131,7 @@ class StalledStreamProtectionOperationCustomization(
             when (section) {
                 is OperationSection.AdditionalInterceptors -> {
                     val stalledStreamProtectionModule = RuntimeType.smithyRuntime(rc).resolve("client::stalled_stream_protection")
-                    section.registerInterceptor(rc, this) {
+                    section.registerPermanentInterceptor(rc, this) {
                         rustTemplate(
                             """
                             #{StalledStreamProtectionInterceptor}::default()

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -476,6 +476,9 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         fun intercept(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyRuntimeApiClient(runtimeConfig).resolve("client::interceptors::Intercept")
 
+        fun dynDispatchHint(runtimeConfig: RuntimeConfig): RuntimeType =
+            smithyRuntimeApiClient(runtimeConfig).resolve("client::interceptors::dyn_dispatch_hint")
+
         fun interceptorContext(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyRuntimeApiClient(runtimeConfig)
                 .resolve("client::interceptors::context::InterceptorContext")

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "bytes",
  "bytes-utils",
@@ -423,7 +423,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.1.12"
 dependencies = [
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -454,7 +454,7 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
- "aws-smithy-runtime-api 1.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.11.6",
  "aws-smithy-types 1.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "bytes-utils",
@@ -475,7 +475,7 @@ version = "0.63.6"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "bytes",
  "bytes-utils",
@@ -499,7 +499,7 @@ version = "1.1.12"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "base64 0.22.1",
  "bytes",
@@ -543,7 +543,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.6",
  "aws-smithy-http 0.62.6",
  "aws-smithy-json 0.61.9",
- "aws-smithy-runtime-api 1.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.11.6",
  "aws-smithy-types 1.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-xml 0.60.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
@@ -566,12 +566,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.66.3"
+version = "0.66.4"
 dependencies = [
  "aws-smithy-cbor 0.61.7",
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.5",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -602,7 +602,7 @@ name = "aws-smithy-http-server-metrics"
 version = "0.1.2"
 dependencies = [
  "aws-smithy-http-server 0.65.10",
- "aws-smithy-http-server 0.66.3",
+ "aws-smithy-http-server 0.66.4",
  "aws-smithy-http-server-metrics-macro",
  "aws-smithy-legacy-http-server",
  "futures",
@@ -696,7 +696,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "bytes",
  "bytes-utils",
@@ -721,7 +721,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.7",
  "aws-smithy-json 0.62.5",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -751,7 +751,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "http 1.4.0",
  "tokio",
@@ -761,7 +761,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.2.6"
 dependencies = [
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "serial_test",
 ]
 
@@ -785,7 +785,7 @@ name = "aws-smithy-protocol-test"
 version = "0.63.14"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -808,14 +808,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.0"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.14",
  "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "bytes",
  "fastrand 2.3.0",
@@ -838,22 +838,6 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.11.6"
-dependencies = [
- "aws-smithy-async 1.2.14",
- "aws-smithy-types 1.4.7",
- "bytes",
- "http 0.2.12",
- "http 1.4.0",
- "pin-project-lite",
- "proptest",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
@@ -865,6 +849,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+dependencies = [
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-types 1.4.7",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "proptest",
+ "tokio",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -944,7 +944,7 @@ name = "aws-smithy-wasm"
 version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "http-body-util",
  "sync_wrapper",
@@ -2472,7 +2472,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.5",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.11.6",
+ "aws-smithy-runtime-api 1.12.0",
  "aws-smithy-types 1.4.7",
  "aws-smithy-xml 0.60.15",
  "bytes",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -856,6 +856,7 @@ name = "aws-smithy-runtime-api"
 version = "1.12.0"
 dependencies = [
  "aws-smithy-async 1.2.14",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types 1.4.7",
  "bytes",
  "http 0.2.12",
@@ -865,6 +866,15 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rust-runtime/Cargo.toml
+++ b/rust-runtime/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "aws-smithy-query",
     "aws-smithy-runtime",
     "aws-smithy-runtime-api",
+    "aws-smithy-runtime-api-macros",
     "aws-smithy-types",
     "aws-smithy-types-convert",
     "aws-smithy-wasm",

--- a/rust-runtime/aws-smithy-runtime-api-macros/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api-macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+description = "Proc macros for aws-smithy-runtime-api."
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/smithy-lang/smithy-rs"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.106"
+quote = "1.0.44"
+syn = { version = "2.0.114", features = ["full"] }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of docs.rs metadata
+
+[package.metadata.smithy-rs-release-tooling]
+stable = true

--- a/rust-runtime/aws-smithy-runtime-api-macros/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api-macros/Cargo.toml
@@ -6,6 +6,7 @@ description = "Proc macros for aws-smithy-runtime-api."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
+rust-version = "1.91.0"
 
 [lib]
 proc-macro = true

--- a/rust-runtime/aws-smithy-runtime-api-macros/LICENSE
+++ b/rust-runtime/aws-smithy-runtime-api-macros/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/rust-runtime/aws-smithy-runtime-api-macros/README.md
+++ b/rust-runtime/aws-smithy-runtime-api-macros/README.md
@@ -1,0 +1,7 @@
+# aws-smithy-runtime-api-macros
+
+Proc macros for `aws-smithy-runtime-api`. See [aws-smithy-runtime-api](https://crates.io/crates/aws-smithy-runtime-api) for more information.
+
+<!-- anchor_start:footer -->
+This crate is part of the [AWS SDK for Rust](https://awslabs.github.io/aws-sdk-rust/) and the [smithy-rs](https://github.com/smithy-lang/smithy-rs) code generator. In most cases, it should not be used directly.
+<!-- anchor_end:footer -->

--- a/rust-runtime/aws-smithy-runtime-api-macros/external-types.toml
+++ b/rust-runtime/aws-smithy-runtime-api-macros/external-types.toml
@@ -1,1 +1,0 @@
-allowed_external_types = []

--- a/rust-runtime/aws-smithy-runtime-api-macros/external-types.toml
+++ b/rust-runtime/aws-smithy-runtime-api-macros/external-types.toml
@@ -1,0 +1,1 @@
+allowed_external_types = []

--- a/rust-runtime/aws-smithy-runtime-api-macros/src/lib.rs
+++ b/rust-runtime/aws-smithy-runtime-api-macros/src/lib.rs
@@ -13,6 +13,9 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, ImplItem, ItemImpl};
 
+// If you update this list, also update:
+//   - `OverriddenHooks` constants in `aws-smithy-runtime-api/src/client/interceptors.rs`
+//   - Hook methods on the `Intercept` trait in the same file
 const KNOWN_HOOKS: &[&str] = &[
     "read_before_execution",
     "modify_before_serialization",

--- a/rust-runtime/aws-smithy-runtime-api-macros/src/lib.rs
+++ b/rust-runtime/aws-smithy-runtime-api-macros/src/lib.rs
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Automatically managed default lints */
+#![cfg_attr(docsrs, feature(doc_cfg))]
+/* End of automatically managed default lints */
+
+//! Proc macros for `aws-smithy-runtime-api`.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ImplItem, ItemImpl};
+
+const KNOWN_HOOKS: &[&str] = &[
+    "read_before_execution",
+    "modify_before_serialization",
+    "read_before_serialization",
+    "read_after_serialization",
+    "modify_before_retry_loop",
+    "read_before_attempt",
+    "modify_before_signing",
+    "read_before_signing",
+    "read_after_signing",
+    "modify_before_transmit",
+    "read_before_transmit",
+    "read_after_transmit",
+    "modify_before_deserialization",
+    "read_before_deserialization",
+    "read_after_deserialization",
+    "modify_before_attempt_completion",
+    "read_after_attempt",
+    "modify_before_completion",
+    "read_after_execution",
+];
+
+const _: () = assert!(
+    KNOWN_HOOKS.len() <= 32,
+    "OverriddenHooks uses a u32 bitmask; widen to u64 in interceptors.rs if more hooks are needed"
+);
+
+/// Automatically generates an `overridden_hooks()` method on an `impl Intercept` block
+/// based on which hook methods are overridden.
+///
+/// This attribute must be placed on an `impl Intercept for T` block. It inspects
+/// which hook methods are overridden and generates a corresponding
+/// `overridden_hooks()` method that returns the correct `OverriddenHooks` bitmask.
+///
+/// # Example
+/// ```ignore
+/// #[dyn_dispatch_hint]
+/// impl Intercept for MyInterceptor {
+///     fn name(&self) -> &'static str { "MyInterceptor" }
+///     fn modify_before_signing(...) -> ... { ... }
+/// }
+/// // Generates: fn overridden_hooks(&self) -> OverriddenHooks { OverriddenHooks::MODIFY_BEFORE_SIGNING }
+/// ```
+#[proc_macro_attribute]
+pub fn dyn_dispatch_hint(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut impl_block = parse_macro_input!(item as ItemImpl);
+
+    let overridden: Vec<String> = impl_block
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let ImplItem::Fn(method) = item {
+                let name = method.sig.ident.to_string();
+                if KNOWN_HOOKS.contains(&name.as_str()) {
+                    Some(name)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let flags: Vec<proc_macro2::TokenStream> = overridden
+        .iter()
+        .map(|name| {
+            let upper = name.to_uppercase();
+            let ident = syn::Ident::new(&upper, proc_macro2::Span::call_site());
+            quote! { ::aws_smithy_runtime_api::client::interceptors::OverriddenHooks::#ident }
+        })
+        .collect();
+
+    let body = if flags.is_empty() {
+        quote! { ::aws_smithy_runtime_api::client::interceptors::OverriddenHooks::none() }
+    } else {
+        quote! { #(#flags)|* }
+    };
+
+    let method: ImplItem = syn::parse_quote! {
+        fn overridden_hooks(&self) -> ::aws_smithy_runtime_api::client::interceptors::OverriddenHooks {
+            #body
+        }
+    };
+    impl_block.items.push(method);
+
+    quote! { #impl_block }.into()
+}

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -20,6 +20,7 @@ http-1x = []
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
+aws-smithy-runtime-api-macros = { path = "../aws-smithy-runtime-api-macros" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"] }
 bytes = "1.11.1"
 http-02x = { package = "http", version = "0.2.12" }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -65,6 +65,9 @@ macro_rules! interceptor_trait_fn {
 ///   of the SDK ’s request execution pipeline. Hooks are either "read" hooks, which make it possible
 ///   to read in-flight request or response messages, or "read/write" hooks, which make it possible
 ///   to modify in-flight request or output messages.
+// If you add hook methods, also update:
+//   - `KNOWN_HOOKS` in `aws-smithy-runtime-api-macros/src/lib.rs`
+//   - `OverriddenHooks` constants (below in this file)
 pub trait Intercept: fmt::Debug + Send + Sync {
     /// The name of this interceptor, used in error messages for debugging.
     fn name(&self) -> &'static str;
@@ -616,6 +619,9 @@ impl OverriddenHooks {
         Self(0)
     }
 
+    // If you update these constants, also update:
+    //   - `KNOWN_HOOKS` in `aws-smithy-runtime-api-macros/src/lib.rs`
+    //   - Hook methods on the `Intercept` trait (above in this file)
     /// Hint for [`Intercept::read_before_execution`].
     pub const READ_BEFORE_EXECUTION: Self = Self(1 << 0);
     /// Hint for [`Intercept::modify_before_serialization`].

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -585,7 +585,92 @@ pub trait Intercept: fmt::Debug + Send + Sync {
         let (_ctx, _rc, _cfg) = (context, runtime_components, cfg);
         Ok(())
     }
+
+    /// Returns a bitmask of which hooks this interceptor overrides.
+    ///
+    /// The default returns [`OverriddenHooks::all()`], meaning all hooks are
+    /// called (safe, same behavior as before overridden hooks existed). Use
+    /// [`#[dyn_dispatch_hint]`](dyn_dispatch_hint) on your `impl Intercept` block to
+    /// auto-generate this method from the overridden hooks.
+    #[doc(hidden)]
+    fn overridden_hooks(&self) -> OverriddenHooks {
+        OverriddenHooks::all()
+    }
 }
+
+/// Bitmask indicating which interceptor hooks a [`SharedInterceptor`] actually overrides.
+///
+/// When returned from [`Intercept::overridden_hooks`], the interceptor loop can skip
+/// dyn dispatch for hooks that are not in the mask.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OverriddenHooks(u32);
+
+impl OverriddenHooks {
+    /// All hooks — the safe default.
+    pub const fn all() -> Self {
+        Self(u32::MAX)
+    }
+    /// No hooks.
+    pub const fn none() -> Self {
+        Self(0)
+    }
+
+    /// Hint for [`Intercept::read_before_execution`].
+    pub const READ_BEFORE_EXECUTION: Self = Self(1 << 0);
+    /// Hint for [`Intercept::modify_before_serialization`].
+    pub const MODIFY_BEFORE_SERIALIZATION: Self = Self(1 << 1);
+    /// Hint for [`Intercept::read_before_serialization`].
+    pub const READ_BEFORE_SERIALIZATION: Self = Self(1 << 2);
+    /// Hint for [`Intercept::read_after_serialization`].
+    pub const READ_AFTER_SERIALIZATION: Self = Self(1 << 3);
+    /// Hint for [`Intercept::modify_before_retry_loop`].
+    pub const MODIFY_BEFORE_RETRY_LOOP: Self = Self(1 << 4);
+    /// Hint for [`Intercept::read_before_attempt`].
+    pub const READ_BEFORE_ATTEMPT: Self = Self(1 << 5);
+    /// Hint for [`Intercept::modify_before_signing`].
+    pub const MODIFY_BEFORE_SIGNING: Self = Self(1 << 6);
+    /// Hint for [`Intercept::read_before_signing`].
+    pub const READ_BEFORE_SIGNING: Self = Self(1 << 7);
+    /// Hint for [`Intercept::read_after_signing`].
+    pub const READ_AFTER_SIGNING: Self = Self(1 << 8);
+    /// Hint for [`Intercept::modify_before_transmit`].
+    pub const MODIFY_BEFORE_TRANSMIT: Self = Self(1 << 9);
+    /// Hint for [`Intercept::read_before_transmit`].
+    pub const READ_BEFORE_TRANSMIT: Self = Self(1 << 10);
+    /// Hint for [`Intercept::read_after_transmit`].
+    pub const READ_AFTER_TRANSMIT: Self = Self(1 << 11);
+    /// Hint for [`Intercept::modify_before_deserialization`].
+    pub const MODIFY_BEFORE_DESERIALIZATION: Self = Self(1 << 12);
+    /// Hint for [`Intercept::read_before_deserialization`].
+    pub const READ_BEFORE_DESERIALIZATION: Self = Self(1 << 13);
+    /// Hint for [`Intercept::read_after_deserialization`].
+    pub const READ_AFTER_DESERIALIZATION: Self = Self(1 << 14);
+    /// Hint for [`Intercept::modify_before_attempt_completion`].
+    pub const MODIFY_BEFORE_ATTEMPT_COMPLETION: Self = Self(1 << 15);
+    /// Hint for [`Intercept::read_after_attempt`].
+    pub const READ_AFTER_ATTEMPT: Self = Self(1 << 16);
+    /// Hint for [`Intercept::modify_before_completion`].
+    pub const MODIFY_BEFORE_COMPLETION: Self = Self(1 << 17);
+    /// Hint for [`Intercept::read_after_execution`].
+    pub const READ_AFTER_EXECUTION: Self = Self(1 << 18);
+
+    /// Returns `true` if `self` contains any of the hooks in `other`.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+}
+
+impl std::ops::BitOr for OverriddenHooks {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// Re-export the proc macro for deriving [`Intercept::overridden_hooks`] automatically.
+#[doc(hidden)]
+pub use aws_smithy_runtime_api_macros::dyn_dispatch_hint;
 
 /// Interceptor wrapper that may be shared
 #[derive(Clone)]
@@ -594,6 +679,8 @@ pub struct SharedInterceptor {
     /// When `None`, the interceptor is always enabled (permanent mode).
     #[allow(clippy::type_complexity)]
     check_enabled: Option<Arc<dyn Fn(&ConfigBag) -> bool + Send + Sync>>,
+    /// Cached bitmask of which [`Intercept`] hooks this interceptor overrides.
+    overridden_hooks: OverriddenHooks,
     /// In debug builds, asserts that nobody tried to disable a permanent interceptor.
     #[cfg(debug_assertions)]
     debug_assert_not_disabled: Option<fn(&ConfigBag) -> bool>,
@@ -603,6 +690,7 @@ impl fmt::Debug for SharedInterceptor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SharedInterceptor")
             .field("interceptor", &self.interceptor)
+            .field("permanent", &self.check_enabled.is_none())
             .finish()
     }
 }
@@ -611,6 +699,7 @@ impl SharedInterceptor {
     /// Create a new `SharedInterceptor` from `Interceptor`.
     pub fn new<T: Intercept + 'static>(interceptor: T) -> Self {
         Self {
+            overridden_hooks: interceptor.overridden_hooks(),
             interceptor: Arc::new(interceptor),
             check_enabled: Some(Arc::new(|conf: &ConfigBag| {
                 conf.load::<DisableInterceptor<T>>().is_none()
@@ -623,10 +712,15 @@ impl SharedInterceptor {
     /// Creates a `SharedInterceptor` that is always enabled.
     ///
     /// Unlike [`SharedInterceptor::new`], this skips the per-invocation
-    /// [`DisableInterceptor`] lookup in the config bag, reducing dispatch
-    /// overhead for SDK-internal interceptors that should never be disabled.
+    /// [`DisableInterceptor`] lookup in the config bag.
+    ///
+    /// Note: In debug builds, if [`disable_interceptor`] is called for an
+    /// interceptor wrapped with `permanent`, a panic will occur to flag the
+    /// misconfiguration. Use [`SharedInterceptor::new`] instead if the
+    /// interceptor needs to be disabled.
     pub fn permanent<T: Intercept + 'static>(interceptor: T) -> Self {
         Self {
+            overridden_hooks: interceptor.overridden_hooks(),
             interceptor: Arc::new(interceptor),
             check_enabled: None,
             #[cfg(debug_assertions)]
@@ -654,6 +748,11 @@ impl SharedInterceptor {
                 true
             }
         }
+    }
+
+    /// Returns the overridden hooks.
+    pub fn overridden_hooks(&self) -> OverriddenHooks {
+        self.overridden_hooks
     }
 }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -591,7 +591,12 @@ pub trait Intercept: fmt::Debug + Send + Sync {
 #[derive(Clone)]
 pub struct SharedInterceptor {
     interceptor: Arc<dyn Intercept>,
-    check_enabled: Arc<dyn Fn(&ConfigBag) -> bool + Send + Sync>,
+    /// When `None`, the interceptor is always enabled (permanent mode).
+    #[allow(clippy::type_complexity)]
+    check_enabled: Option<Arc<dyn Fn(&ConfigBag) -> bool + Send + Sync>>,
+    /// In debug builds, asserts that nobody tried to disable a permanent interceptor.
+    #[cfg(debug_assertions)]
+    debug_assert_not_disabled: Option<fn(&ConfigBag) -> bool>,
 }
 
 impl fmt::Debug for SharedInterceptor {
@@ -607,7 +612,25 @@ impl SharedInterceptor {
     pub fn new<T: Intercept + 'static>(interceptor: T) -> Self {
         Self {
             interceptor: Arc::new(interceptor),
-            check_enabled: Arc::new(|conf: &ConfigBag| {
+            check_enabled: Some(Arc::new(|conf: &ConfigBag| {
+                conf.load::<DisableInterceptor<T>>().is_none()
+            })),
+            #[cfg(debug_assertions)]
+            debug_assert_not_disabled: None,
+        }
+    }
+
+    /// Creates a `SharedInterceptor` that is always enabled.
+    ///
+    /// Unlike [`SharedInterceptor::new`], this skips the per-invocation
+    /// [`DisableInterceptor`] lookup in the config bag, reducing dispatch
+    /// overhead for SDK-internal interceptors that should never be disabled.
+    pub fn permanent<T: Intercept + 'static>(interceptor: T) -> Self {
+        Self {
+            interceptor: Arc::new(interceptor),
+            check_enabled: None,
+            #[cfg(debug_assertions)]
+            debug_assert_not_disabled: Some(|conf: &ConfigBag| {
                 conf.load::<DisableInterceptor<T>>().is_none()
             }),
         }
@@ -615,7 +638,22 @@ impl SharedInterceptor {
 
     /// Checks if this interceptor is enabled in the given config.
     pub fn enabled(&self, conf: &ConfigBag) -> bool {
-        (self.check_enabled)(conf)
+        match &self.check_enabled {
+            Some(check) => check(conf),
+            None => {
+                #[cfg(debug_assertions)]
+                if let Some(check) = &self.debug_assert_not_disabled {
+                    debug_assert!(
+                        check(conf),
+                        "attempted to disable permanent interceptor `{}`; \
+                         use SharedInterceptor::new() instead of ::permanent() \
+                         if this interceptor needs to be disabled",
+                        self.interceptor.name()
+                    );
+                }
+                true
+            }
+        }
     }
 }
 

--- a/rust-runtime/aws-smithy-runtime-api/tests/dyn_dispatch_hint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/tests/dyn_dispatch_hint.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#![cfg(feature = "client")]
+
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextRef, BeforeTransmitInterceptorContextMut,

--- a/rust-runtime/aws-smithy-runtime-api/tests/dyn_dispatch_hint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/tests/dyn_dispatch_hint.rs
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::context::{
+    BeforeSerializationInterceptorContextRef, BeforeTransmitInterceptorContextMut,
+    FinalizerInterceptorContextRef,
+};
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept, OverriddenHooks};
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::ConfigBag;
+
+#[derive(Debug)]
+struct SingleHook;
+
+#[dyn_dispatch_hint]
+impl Intercept for SingleHook {
+    fn name(&self) -> &'static str {
+        "SingleHook"
+    }
+    fn modify_before_signing(
+        &self,
+        _context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn single_hook_sets_one_flag() {
+    assert_eq!(
+        SingleHook.overridden_hooks(),
+        OverriddenHooks::MODIFY_BEFORE_SIGNING,
+    );
+}
+
+#[derive(Debug)]
+struct MultipleHooks;
+
+#[dyn_dispatch_hint]
+impl Intercept for MultipleHooks {
+    fn name(&self) -> &'static str {
+        "MultipleHooks"
+    }
+    fn read_before_execution(
+        &self,
+        _context: &BeforeSerializationInterceptorContextRef<'_>,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        Ok(())
+    }
+    fn read_after_execution(
+        &self,
+        _context: &FinalizerInterceptorContextRef<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn multiple_hooks_or_flags_together() {
+    let flags = MultipleHooks.overridden_hooks();
+    let expected = OverriddenHooks::READ_BEFORE_EXECUTION | OverriddenHooks::READ_AFTER_EXECUTION;
+    assert_eq!(
+        flags, expected,
+        "should contain exactly the two overridden hooks and nothing else"
+    );
+}
+
+#[derive(Debug)]
+struct NoHooks;
+
+#[dyn_dispatch_hint]
+impl Intercept for NoHooks {
+    fn name(&self) -> &'static str {
+        "NoHooks"
+    }
+}
+
+#[test]
+fn no_hooks_returns_none() {
+    assert_eq!(NoHooks.overridden_hooks(), OverriddenHooks::none());
+}
+
+#[derive(Debug)]
+struct NoMacro;
+
+impl Intercept for NoMacro {
+    fn name(&self) -> &'static str {
+        "NoMacro"
+    }
+}
+
+#[test]
+fn without_macro_returns_all() {
+    assert_eq!(NoMacro.overridden_hooks(), OverriddenHooks::all());
+}

--- a/rust-runtime/aws-smithy-runtime-api/tests/permanent_interceptor.rs
+++ b/rust-runtime/aws-smithy-runtime-api/tests/permanent_interceptor.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#![cfg(feature = "client")]
+
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
 use aws_smithy_runtime_api::client::interceptors::{

--- a/rust-runtime/aws-smithy-runtime-api/tests/permanent_interceptor.rs
+++ b/rust-runtime/aws-smithy-runtime-api/tests/permanent_interceptor.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
+use aws_smithy_runtime_api::client::interceptors::{
+    disable_interceptor, Intercept, SharedInterceptor,
+};
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::{ConfigBag, Layer};
+
+#[derive(Debug)]
+struct TestInterceptor;
+
+impl Intercept for TestInterceptor {
+    fn name(&self) -> &'static str {
+        "TestInterceptor"
+    }
+    fn modify_before_signing(
+        &self,
+        _context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn permanent_interceptor_is_always_enabled() {
+    let interceptor = SharedInterceptor::permanent(TestInterceptor);
+    let cfg = ConfigBag::base();
+    assert!(interceptor.enabled(&cfg));
+}
+
+#[test]
+fn new_interceptor_can_be_disabled() {
+    let interceptor = SharedInterceptor::new(TestInterceptor);
+    let mut cfg = ConfigBag::base();
+    let mut layer = Layer::new("test");
+    layer.store_put(disable_interceptor::<TestInterceptor>("test"));
+    cfg.push_shared_layer(layer.freeze());
+    assert!(!interceptor.enabled(&cfg));
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "attempted to disable permanent interceptor")]
+fn permanent_interceptor_panics_on_disable_in_debug() {
+    let interceptor = SharedInterceptor::permanent(TestInterceptor);
+    let mut cfg = ConfigBag::base();
+    let mut layer = Layer::new("test");
+    layer.store_put(disable_interceptor::<TestInterceptor>("test"));
+    cfg.push_shared_layer(layer.freeze());
+    interceptor.enabled(&cfg);
+}

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
@@ -19,6 +19,7 @@ use aws_smithy_async::time::SystemTimeSource;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
 use aws_smithy_runtime_api::client::http::SharedHttpClient;
+use aws_smithy_runtime_api::client::interceptors::SharedInterceptor;
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponentsBuilder, SharedConfigValidator,
 };
@@ -139,7 +140,9 @@ pub fn default_retry_config_plugin(
                 .with_config_validator(SharedConfigValidator::base_client_config_fn(
                     validate_retry_config,
                 ))
-                .with_interceptor(TokenBucketProvider::new(retry_partition.clone()))
+                .with_interceptor(SharedInterceptor::permanent(TokenBucketProvider::new(
+                    retry_partition.clone(),
+                )))
         })
         .with_config(layer("default_retry_config", |layer| {
             layer.store_put(RetryConfig::disabled());
@@ -172,7 +175,9 @@ pub fn default_retry_config_plugin_v2(params: &DefaultPluginParams) -> Option<Sh
                 .with_config_validator(SharedConfigValidator::base_client_config_fn(
                     validate_retry_config,
                 ))
-                .with_interceptor(TokenBucketProvider::new(retry_partition.clone()))
+                .with_interceptor(SharedInterceptor::permanent(TokenBucketProvider::new(
+                    retry_partition.clone(),
+                )))
         })
         .with_config(layer("default_retry_config", |layer| {
             let retry_config =

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
@@ -9,8 +9,8 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeDeserializationInterceptorContextMut, BeforeTransmitInterceptorContextRef,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::interceptors::SharedInterceptor;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -122,6 +122,7 @@ impl Storable for EnableContentLengthEnforcement {
     type Storer = StoreReplace<EnableContentLengthEnforcement>;
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for EnforceContentLengthInterceptor {
     fn name(&self) -> &'static str {
         "EnforceContentLength"

--- a/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/body/content_length_enforcement.rs
@@ -10,6 +10,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeDeserializationInterceptorContextMut, BeforeTransmitInterceptorContextRef,
 };
 use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::SharedInterceptor;
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -200,8 +201,9 @@ impl RuntimePlugin for EnforceContentLengthRuntimePlugin {
         _current_components: &RuntimeComponentsBuilder,
     ) -> Cow<'_, RuntimeComponentsBuilder> {
         Cow::Owned(
-            RuntimeComponentsBuilder::new("EnforceContentLength")
-                .with_interceptor(EnforceContentLengthInterceptor {}),
+            RuntimeComponentsBuilder::new("EnforceContentLength").with_interceptor(
+                SharedInterceptor::permanent(EnforceContentLengthInterceptor {}),
+            ),
         )
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/http/connection_poisoning.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/connection_poisoning.rs
@@ -8,7 +8,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     AfterDeserializationInterceptorContextRef, BeforeTransmitInterceptorContextMut,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::retries::classifiers::RetryAction;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -43,6 +43,7 @@ impl ConnectionPoisoningInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for ConnectionPoisoningInterceptor {
     fn name(&self) -> &'static str {
         "ConnectionPoisoningInterceptor"

--- a/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
@@ -12,7 +12,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
     Error, Input, InterceptorContext, Output,
 };
 use aws_smithy_runtime_api::client::interceptors::{
-    Intercept, InterceptorError, SharedInterceptor,
+    dyn_dispatch_hint, Intercept, InterceptorError, OverriddenHooks, SharedInterceptor,
 };
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
@@ -24,7 +24,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 macro_rules! interceptor_impl_fn {
-    (mut $interceptor:ident) => {
+    (mut $interceptor:ident, $hint:ident) => {
         pub(crate) fn $interceptor(
             self,
             ctx: &mut InterceptorContext,
@@ -39,26 +39,28 @@ macro_rules! interceptor_impl_fn {
             let mut result: Result<(), (&str, BoxError)> = Ok(());
             let mut ctx = ctx.into();
             for interceptor in self.into_iter() {
-                if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                    if let Err(new_error) =
-                        interceptor.$interceptor(&mut ctx, runtime_components, cfg)
-                    {
-                        if let Err(last_error) = result {
-                            tracing::debug!(
-                                "{}::{}: {}",
-                                last_error.0,
-                                stringify!($interceptor),
-                                DisplayErrorContext(&*last_error.1)
-                            );
+                if interceptor.hook_overridden(OverriddenHooks::$hint) {
+                    if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                        if let Err(new_error) =
+                            interceptor.$interceptor(&mut ctx, runtime_components, cfg)
+                        {
+                            if let Err(last_error) = result {
+                                tracing::debug!(
+                                    "{}::{}: {}",
+                                    last_error.0,
+                                    stringify!($interceptor),
+                                    DisplayErrorContext(&*last_error.1)
+                                );
+                            }
+                            result = Err((interceptor.name(), new_error));
                         }
-                        result = Err((interceptor.name(), new_error));
                     }
                 }
             }
             result.map_err(|(name, err)| InterceptorError::$interceptor(name, err))
         }
     };
-    (ref $interceptor:ident) => {
+    (ref $interceptor:ident, $hint:ident) => {
         pub(crate) fn $interceptor(
             self,
             ctx: &InterceptorContext,
@@ -73,18 +75,21 @@ macro_rules! interceptor_impl_fn {
             let mut result: Result<(), (&str, BoxError)> = Ok(());
             let ctx = ctx.into();
             for interceptor in self.into_iter() {
-                if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                    if let Err(new_error) = interceptor.$interceptor(&ctx, runtime_components, cfg)
-                    {
-                        if let Err(last_error) = result {
-                            tracing::debug!(
-                                "{}::{}: {}",
-                                last_error.0,
-                                stringify!($interceptor),
-                                DisplayErrorContext(&*last_error.1)
-                            );
+                if interceptor.hook_overridden(OverriddenHooks::$hint) {
+                    if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                        if let Err(new_error) =
+                            interceptor.$interceptor(&ctx, runtime_components, cfg)
+                        {
+                            if let Err(last_error) = result {
+                                tracing::debug!(
+                                    "{}::{}: {}",
+                                    last_error.0,
+                                    stringify!($interceptor),
+                                    DisplayErrorContext(&*last_error.1)
+                                );
+                            }
+                            result = Err((interceptor.name(), new_error));
                         }
-                        result = Err((interceptor.name(), new_error));
                     }
                 }
             }
@@ -123,37 +128,42 @@ where
         let mut result: Result<(), (&str, BoxError)> = Ok(());
         let ctx: BeforeSerializationInterceptorContextRef<'_> = ctx.into();
         for interceptor in self.into_iter() {
-            if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                if let Err(new_error) = interceptor.read_before_execution(&ctx, cfg) {
-                    if let Err(last_error) = result {
-                        tracing::debug!(
-                            "{}::{}: {}",
-                            last_error.0,
-                            "read_before_execution",
-                            DisplayErrorContext(&*last_error.1)
-                        );
+            if interceptor.hook_overridden(OverriddenHooks::READ_BEFORE_EXECUTION) {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) = interceptor.read_before_execution(&ctx, cfg) {
+                        if let Err(last_error) = result {
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                "read_before_execution",
+                                DisplayErrorContext(&*last_error.1)
+                            );
+                        }
+                        result = Err((interceptor.name(), new_error));
                     }
-                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
         result.map_err(|(name, err)| InterceptorError::read_before_execution(name, err))
     }
 
-    interceptor_impl_fn!(mut modify_before_serialization);
-    interceptor_impl_fn!(ref read_before_serialization);
-    interceptor_impl_fn!(ref read_after_serialization);
-    interceptor_impl_fn!(mut modify_before_retry_loop);
-    interceptor_impl_fn!(ref read_before_attempt);
-    interceptor_impl_fn!(mut modify_before_signing);
-    interceptor_impl_fn!(ref read_before_signing);
-    interceptor_impl_fn!(ref read_after_signing);
-    interceptor_impl_fn!(mut modify_before_transmit);
-    interceptor_impl_fn!(ref read_before_transmit);
-    interceptor_impl_fn!(ref read_after_transmit);
-    interceptor_impl_fn!(mut modify_before_deserialization);
-    interceptor_impl_fn!(ref read_before_deserialization);
-    interceptor_impl_fn!(ref read_after_deserialization);
+    interceptor_impl_fn!(mut modify_before_serialization, MODIFY_BEFORE_SERIALIZATION);
+    interceptor_impl_fn!(ref read_before_serialization, READ_BEFORE_SERIALIZATION);
+    interceptor_impl_fn!(ref read_after_serialization, READ_AFTER_SERIALIZATION);
+    interceptor_impl_fn!(mut modify_before_retry_loop, MODIFY_BEFORE_RETRY_LOOP);
+    interceptor_impl_fn!(ref read_before_attempt, READ_BEFORE_ATTEMPT);
+    interceptor_impl_fn!(mut modify_before_signing, MODIFY_BEFORE_SIGNING);
+    interceptor_impl_fn!(ref read_before_signing, READ_BEFORE_SIGNING);
+    interceptor_impl_fn!(ref read_after_signing, READ_AFTER_SIGNING);
+    interceptor_impl_fn!(mut modify_before_transmit, MODIFY_BEFORE_TRANSMIT);
+    interceptor_impl_fn!(ref read_before_transmit, READ_BEFORE_TRANSMIT);
+    interceptor_impl_fn!(ref read_after_transmit, READ_AFTER_TRANSMIT);
+    interceptor_impl_fn!(
+        mut modify_before_deserialization,
+        MODIFY_BEFORE_DESERIALIZATION
+    );
+    interceptor_impl_fn!(ref read_before_deserialization, READ_BEFORE_DESERIALIZATION);
+    interceptor_impl_fn!(ref read_after_deserialization, READ_AFTER_DESERIALIZATION);
 
     pub(crate) fn modify_before_attempt_completion(
         self,
@@ -165,19 +175,23 @@ where
         let mut result: Result<(), (&str, BoxError)> = Ok(());
         let mut ctx: FinalizerInterceptorContextMut<'_> = ctx.into();
         for interceptor in self.into_iter() {
-            if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                if let Err(new_error) =
-                    interceptor.modify_before_attempt_completion(&mut ctx, runtime_components, cfg)
-                {
-                    if let Err(last_error) = result {
-                        tracing::debug!(
-                            "{}::{}: {}",
-                            last_error.0,
-                            "modify_before_attempt_completion",
-                            DisplayErrorContext(&*last_error.1)
-                        );
+            if interceptor.hook_overridden(OverriddenHooks::MODIFY_BEFORE_ATTEMPT_COMPLETION) {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) = interceptor.modify_before_attempt_completion(
+                        &mut ctx,
+                        runtime_components,
+                        cfg,
+                    ) {
+                        if let Err(last_error) = result {
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                "modify_before_attempt_completion",
+                                DisplayErrorContext(&*last_error.1)
+                            );
+                        }
+                        result = Err((interceptor.name(), new_error));
                     }
-                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
@@ -194,19 +208,21 @@ where
         let mut result: Result<(), (&str, BoxError)> = Ok(());
         let ctx: FinalizerInterceptorContextRef<'_> = ctx.into();
         for interceptor in self.into_iter() {
-            if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                if let Err(new_error) =
-                    interceptor.read_after_attempt(&ctx, runtime_components, cfg)
-                {
-                    if let Err(last_error) = result {
-                        tracing::debug!(
-                            "{}::{}: {}",
-                            last_error.0,
-                            "read_after_attempt",
-                            DisplayErrorContext(&*last_error.1)
-                        );
+            if interceptor.hook_overridden(OverriddenHooks::READ_AFTER_ATTEMPT) {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) =
+                        interceptor.read_after_attempt(&ctx, runtime_components, cfg)
+                    {
+                        if let Err(last_error) = result {
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                "read_after_attempt",
+                                DisplayErrorContext(&*last_error.1)
+                            );
+                        }
+                        result = Err((interceptor.name(), new_error));
                     }
-                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
@@ -223,19 +239,21 @@ where
         let mut result: Result<(), (&str, BoxError)> = Ok(());
         let mut ctx: FinalizerInterceptorContextMut<'_> = ctx.into();
         for interceptor in self.into_iter() {
-            if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                if let Err(new_error) =
-                    interceptor.modify_before_completion(&mut ctx, runtime_components, cfg)
-                {
-                    if let Err(last_error) = result {
-                        tracing::debug!(
-                            "{}::{}: {}",
-                            last_error.0,
-                            "modify_before_completion",
-                            DisplayErrorContext(&*last_error.1)
-                        );
+            if interceptor.hook_overridden(OverriddenHooks::MODIFY_BEFORE_COMPLETION) {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) =
+                        interceptor.modify_before_completion(&mut ctx, runtime_components, cfg)
+                    {
+                        if let Err(last_error) = result {
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                "modify_before_completion",
+                                DisplayErrorContext(&*last_error.1)
+                            );
+                        }
+                        result = Err((interceptor.name(), new_error));
                     }
-                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
@@ -252,19 +270,21 @@ where
         let mut result: Result<(), (&str, BoxError)> = Ok(());
         let ctx: FinalizerInterceptorContextRef<'_> = ctx.into();
         for interceptor in self.into_iter() {
-            if let Some(interceptor) = interceptor.if_enabled(cfg) {
-                if let Err(new_error) =
-                    interceptor.read_after_execution(&ctx, runtime_components, cfg)
-                {
-                    if let Err(last_error) = result {
-                        tracing::debug!(
-                            "{}::{}: {}",
-                            last_error.0,
-                            "read_after_execution",
-                            DisplayErrorContext(&*last_error.1)
-                        );
+            if interceptor.hook_overridden(OverriddenHooks::READ_AFTER_EXECUTION) {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) =
+                        interceptor.read_after_execution(&ctx, runtime_components, cfg)
+                    {
+                        if let Err(last_error) = result {
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                "read_after_execution",
+                                DisplayErrorContext(&*last_error.1)
+                            );
+                        }
+                        result = Err((interceptor.name(), new_error));
                     }
-                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
@@ -282,6 +302,10 @@ impl ConditionallyEnabledInterceptor {
         } else {
             None
         }
+    }
+
+    fn hook_overridden(&self, hint: OverriddenHooks) -> bool {
+        self.0.overridden_hooks().contains(hint)
     }
 }
 
@@ -307,6 +331,7 @@ impl<F, E> MapRequestInterceptor<F, E> {
     }
 }
 
+#[dyn_dispatch_hint]
 impl<F, E> Intercept for MapRequestInterceptor<F, E>
 where
     F: Fn(HttpRequest) -> Result<HttpRequest, E> + Send + Sync + 'static,
@@ -349,6 +374,7 @@ impl<F> MutateRequestInterceptor<F> {
     }
 }
 
+#[dyn_dispatch_hint]
 impl<F> Intercept for MutateRequestInterceptor<F>
 where
     F: Fn(&mut HttpRequest) + Send + Sync + 'static,

--- a/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
@@ -9,7 +9,9 @@ use aws_smithy_observability::{
     ObservabilityError,
 };
 use aws_smithy_runtime_api::client::{
-    interceptors::Intercept, orchestrator::Metadata, runtime_components::RuntimeComponentsBuilder,
+    interceptors::{Intercept, SharedInterceptor},
+    orchestrator::Metadata,
+    runtime_components::RuntimeComponentsBuilder,
     runtime_plugin::RuntimePlugin,
 };
 use aws_smithy_types::config_bag::{FrozenLayer, Layer, Storable, StoreReplace};
@@ -208,7 +210,10 @@ impl RuntimePlugin for MetricsRuntimePlugin {
     ) -> Cow<'_, RuntimeComponentsBuilder> {
         let interceptor = MetricsInterceptor::new(self.time_source.clone());
         if let Ok(interceptor) = interceptor {
-            Cow::Owned(RuntimeComponentsBuilder::new("Metrics").with_interceptor(interceptor))
+            Cow::Owned(
+                RuntimeComponentsBuilder::new("Metrics")
+                    .with_interceptor(SharedInterceptor::permanent(interceptor)),
+            )
         } else {
             Cow::Owned(RuntimeComponentsBuilder::new("Metrics"))
         }

--- a/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
@@ -9,7 +9,7 @@ use aws_smithy_observability::{
     ObservabilityError,
 };
 use aws_smithy_runtime_api::client::{
-    interceptors::{Intercept, SharedInterceptor},
+    interceptors::{dyn_dispatch_hint, Intercept, SharedInterceptor},
     orchestrator::Metadata,
     runtime_components::RuntimeComponentsBuilder,
     runtime_plugin::RuntimePlugin,
@@ -107,6 +107,7 @@ impl MetricsInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for MetricsInterceptor {
     fn name(&self) -> &'static str {
         "MetricsInterceptor"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -192,8 +192,7 @@ fn apply_configuration(
     continue_on_err!([ctx] => Interceptors::new(operation_rc_builder.interceptors()).read_before_execution(true, ctx, cfg));
 
     // The order below is important. Client interceptors must run before operation interceptors.
-    let components = RuntimeComponents::builder("merged orchestrator components")
-        .merge_from(&client_rc_builder)
+    let components = client_rc_builder
         .merge_from(&operation_rc_builder)
         .build()?;
 

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -13,7 +13,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeTransmitInterceptorContextMut, InterceptorContext,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::retries::classifiers::{RetryAction, RetryReason};
 use aws_smithy_runtime_api::client::retries::{RequestAttempts, RetryStrategy, ShouldAttempt};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
@@ -383,6 +383,7 @@ impl TokenBucketProvider {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for TokenBucketProvider {
     fn name(&self) -> &'static str {
         "TokenBucketProvider"

--- a/rust-runtime/aws-smithy-runtime/src/client/stalled_stream_protection.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/stalled_stream_protection.rs
@@ -13,7 +13,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeDeserializationInterceptorContextMut, BeforeTransmitInterceptorContextMut,
 };
-use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_runtime_api::client::stalled_stream_protection::StalledStreamProtectionConfig;
 use aws_smithy_types::body::SdkBody;
@@ -52,6 +52,7 @@ impl StalledStreamProtectionInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for StalledStreamProtectionInterceptor {
     fn name(&self) -> &'static str {
         "StalledStreamProtectionInterceptor"

--- a/rust-runtime/inlineable/src/client_http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/client_http_checksum_required.rs
@@ -7,7 +7,9 @@ use std::borrow::Cow;
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
+use aws_smithy_runtime_api::client::interceptors::{
+    dyn_dispatch_hint, Intercept, SharedInterceptor,
+};
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -43,6 +45,7 @@ impl RuntimePlugin for HttpChecksumRequiredRuntimePlugin {
 #[derive(Debug)]
 struct HttpChecksumRequiredInterceptor;
 
+#[dyn_dispatch_hint]
 impl Intercept for HttpChecksumRequiredInterceptor {
     fn name(&self) -> &'static str {
         "HttpChecksumRequiredInterceptor"

--- a/rust-runtime/inlineable/src/client_http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/client_http_checksum_required.rs
@@ -24,7 +24,9 @@ impl HttpChecksumRequiredRuntimePlugin {
     pub(crate) fn new() -> Self {
         Self {
             runtime_components: RuntimeComponentsBuilder::new("HttpChecksumRequiredRuntimePlugin")
-                .with_interceptor(SharedInterceptor::new(HttpChecksumRequiredInterceptor)),
+                .with_interceptor(SharedInterceptor::permanent(
+                    HttpChecksumRequiredInterceptor,
+                )),
         }
     }
 }

--- a/rust-runtime/inlineable/src/client_idempotency_token.rs
+++ b/rust-runtime/inlineable/src/client_idempotency_token.rs
@@ -31,7 +31,7 @@ impl IdempotencyTokenRuntimePlugin {
     {
         Self {
             runtime_components: RuntimeComponentsBuilder::new("IdempotencyTokenRuntimePlugin")
-                .with_interceptor(SharedInterceptor::new(IdempotencyTokenInterceptor {
+                .with_interceptor(SharedInterceptor::permanent(IdempotencyTokenInterceptor {
                     set_token,
                 })),
         }

--- a/rust-runtime/inlineable/src/client_idempotency_token.rs
+++ b/rust-runtime/inlineable/src/client_idempotency_token.rs
@@ -10,7 +10,9 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, Input,
 };
-use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
+use aws_smithy_runtime_api::client::interceptors::{
+    dyn_dispatch_hint, Intercept, SharedInterceptor,
+};
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -57,6 +59,7 @@ impl<S> fmt::Debug for IdempotencyTokenInterceptor<S> {
     }
 }
 
+#[dyn_dispatch_hint]
 impl<S> Intercept for IdempotencyTokenInterceptor<S>
 where
     S: Fn(IdempotencyTokenProvider, &mut Input) + Send + Sync,

--- a/rust-runtime/inlineable/src/client_request_compression.rs
+++ b/rust-runtime/inlineable/src/client_request_compression.rs
@@ -11,7 +11,9 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextRef, BeforeTransmitInterceptorContextMut,
 };
-use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
+use aws_smithy_runtime_api::client::interceptors::{
+    dyn_dispatch_hint, Intercept, SharedInterceptor,
+};
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
@@ -74,6 +76,7 @@ impl RequestCompressionInterceptor {
     }
 }
 
+#[dyn_dispatch_hint]
 impl Intercept for RequestCompressionInterceptor {
     fn name(&self) -> &'static str {
         "RequestCompressionInterceptor"

--- a/rust-runtime/inlineable/src/client_request_compression.rs
+++ b/rust-runtime/inlineable/src/client_request_compression.rs
@@ -32,7 +32,9 @@ impl RequestCompressionRuntimePlugin {
     pub(crate) fn new() -> Self {
         Self {
             runtime_components: RuntimeComponentsBuilder::new("RequestCompressionRuntimePlugin")
-                .with_interceptor(SharedInterceptor::new(RequestCompressionInterceptor::new())),
+                .with_interceptor(SharedInterceptor::permanent(
+                    RequestCompressionInterceptor::new(),
+                )),
         }
     }
 }

--- a/rust-runtime/inlineable/src/http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/http_checksum_required.rs
@@ -6,7 +6,7 @@
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
 use aws_smithy_runtime_api::client::interceptors::{
-    Interceptor, InterceptorRegistrar, SharedInterceptor,
+    dyn_dispatch_hint, Intercept, Interceptor, InterceptorRegistrar, SharedInterceptor,
 };
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_types::base64;
@@ -27,6 +27,7 @@ impl RuntimePlugin for HttpChecksumRequiredRuntimePlugin {
 #[derive(Debug)]
 struct HttpChecksumRequiredInterceptor;
 
+#[dyn_dispatch_hint]
 impl Intercept for HttpChecksumRequiredInterceptor {
     fn modify_before_signing(
         &self,

--- a/rust-runtime/inlineable/src/http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/http_checksum_required.rs
@@ -18,7 +18,9 @@ pub(crate) struct HttpChecksumRequiredRuntimePlugin;
 
 impl RuntimePlugin for HttpChecksumRequiredRuntimePlugin {
     fn interceptors(&self, interceptors: &mut InterceptorRegistrar) {
-        interceptors.register(SharedInterceptor::new(HttpChecksumRequiredInterceptor));
+        interceptors.register(SharedInterceptor::permanent(
+            HttpChecksumRequiredInterceptor,
+        ));
     }
 }
 

--- a/rust-runtime/inlineable/src/sdk_feature_tracker.rs
+++ b/rust-runtime/inlineable/src/sdk_feature_tracker.rs
@@ -8,7 +8,7 @@ pub(crate) mod rpc_v2_cbor {
     use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
     use aws_smithy_runtime_api::box_error::BoxError;
     use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
-    use aws_smithy_runtime_api::client::interceptors::Intercept;
+    use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
     use aws_smithy_types::config_bag::ConfigBag;
 
@@ -21,6 +21,7 @@ pub(crate) mod rpc_v2_cbor {
         }
     }
 
+    #[dyn_dispatch_hint]
     impl Intercept for RpcV2CborFeatureTrackerInterceptor {
         fn name(&self) -> &'static str {
             "RpcV2CborFeatureTrackerInterceptor"
@@ -44,7 +45,9 @@ pub(crate) mod paginator {
     use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
     use aws_smithy_runtime_api::box_error::BoxError;
     use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
-    use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
+    use aws_smithy_runtime_api::client::interceptors::{
+        dyn_dispatch_hint, Intercept, SharedInterceptor,
+    };
     use aws_smithy_runtime_api::client::runtime_components::{
         RuntimeComponents, RuntimeComponentsBuilder,
     };
@@ -61,6 +64,7 @@ pub(crate) mod paginator {
         }
     }
 
+    #[dyn_dispatch_hint]
     impl Intercept for PaginatorFeatureTrackerInterceptor {
         fn name(&self) -> &'static str {
             "PaginatorFeatureTrackerInterceptor"
@@ -111,7 +115,9 @@ pub(crate) mod waiter {
     use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
     use aws_smithy_runtime_api::box_error::BoxError;
     use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
-    use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
+    use aws_smithy_runtime_api::client::interceptors::{
+        dyn_dispatch_hint, Intercept, SharedInterceptor,
+    };
     use aws_smithy_runtime_api::client::runtime_components::{
         RuntimeComponents, RuntimeComponentsBuilder,
     };
@@ -128,6 +134,7 @@ pub(crate) mod waiter {
         }
     }
 
+    #[dyn_dispatch_hint]
     impl Intercept for WaiterFeatureTrackerInterceptor {
         fn name(&self) -> &'static str {
             "WaiterFeatureTrackerInterceptor"
@@ -178,7 +185,7 @@ pub(crate) mod retry_mode {
     use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
     use aws_smithy_runtime_api::box_error::BoxError;
     use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextRef;
-    use aws_smithy_runtime_api::client::interceptors::Intercept;
+    use aws_smithy_runtime_api::client::interceptors::{dyn_dispatch_hint, Intercept};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
     use aws_smithy_types::config_bag::ConfigBag;
     use aws_smithy_types::retry::{RetryConfig, RetryMode};
@@ -192,6 +199,7 @@ pub(crate) mod retry_mode {
         }
     }
 
+    #[dyn_dispatch_hint]
     impl Intercept for RetryModeFeatureTrackerInterceptor {
         fn name(&self) -> &'static str {
             "RetryModeFeatureTrackerInterceptor"

--- a/rust-runtime/inlineable/src/sdk_feature_tracker.rs
+++ b/rust-runtime/inlineable/src/sdk_feature_tracker.rs
@@ -89,7 +89,7 @@ pub(crate) mod paginator {
                 runtime_components: RuntimeComponentsBuilder::new(
                     "PaginatorFeatureTrackerRuntimePlugin",
                 )
-                .with_interceptor(SharedInterceptor::new(
+                .with_interceptor(SharedInterceptor::permanent(
                     PaginatorFeatureTrackerInterceptor::new(),
                 )),
             }
@@ -156,7 +156,7 @@ pub(crate) mod waiter {
                 runtime_components: RuntimeComponentsBuilder::new(
                     "WaiterFeatureTrackerRuntimePlugin",
                 )
-                .with_interceptor(SharedInterceptor::new(
+                .with_interceptor(SharedInterceptor::permanent(
                     WaiterFeatureTrackerInterceptor::new(),
                 )),
             }

--- a/tools/ci-build/sdk-lints/src/lint_cargo_toml.rs
+++ b/tools/ci-build/sdk-lints/src/lint_cargo_toml.rs
@@ -127,15 +127,27 @@ impl Check for CrateAuthor {
     }
 }
 
+fn manifest<T>(path: impl AsRef<Path>) -> Result<Manifest<T>>
+where
+    T: DeserializeOwned,
+{
+    Manifest::from_path_with_metadata(path).context("failed to parse Cargo.toml")
+}
+
+fn package_from_manifest<T>(
+    manifest: Manifest<T>,
+) -> std::result::Result<Package<T>, Vec<LintError>> {
+    match manifest.package {
+        Some(package) => Ok(package),
+        None => Err(vec![LintError::new("missing `[package]` section")]),
+    }
+}
+
 fn package<T>(path: impl AsRef<Path>) -> Result<std::result::Result<Package<T>, Vec<LintError>>>
 where
     T: DeserializeOwned,
 {
-    let parsed = Manifest::from_path_with_metadata(path).context("failed to parse Cargo.toml")?;
-    match parsed.package {
-        Some(package) => Ok(Ok(package)),
-        None => Ok(Err(vec![LintError::new("missing `[package]` section")])),
-    }
+    Ok(package_from_manifest(manifest(path)?))
 }
 
 fn check_crate_author(package: Package) -> Result<Vec<LintError>> {
@@ -324,12 +336,19 @@ impl Check for SdkExternalLintsExposesStableCrates {
 
 impl Check for StableCratesExposeStableCrates {
     fn check(&self, path: impl AsRef<Path>) -> Result<Vec<LintError>> {
-        let parsed = match package(path.as_ref()) {
-            // if the package doesn't parse, someone else figured that out
+        let manifest: Manifest<SmithyRsMetadata> = match manifest(path.as_ref()) {
+            // if the manifest doesn't parse, someone else figured that out
             Err(_) => return Ok(vec![]),
+            Ok(m) => m,
+        };
+        // Proc-macro crates don't expose types in their public API
+        if manifest.lib.as_ref().is_some_and(|lib| lib.proc_macro) {
+            return Ok(vec![]);
+        }
+        let parsed = match package_from_manifest(manifest) {
+            Ok(pkg) => pkg,
             // if there is something wrong, someone figured that out too
-            Ok(Err(_errs)) => return Ok(vec![]),
-            Ok(Ok(pkg)) => pkg,
+            Err(_errs) => return Ok(vec![]),
         };
         self.check_stable_crates_only_expose_stable_crates(parsed, path)
     }


### PR DESCRIPTION
## Motivation and Context

Addresses https://github.com/smithy-lang/smithy-rs/issues/4114

Every SDK operation invokes ~16 interceptor hooks via dyn dispatch. Most interceptors only override 1–2 hooks, meaning the majority of calls dispatch into no-op defaults. Additionally, every interceptor checks `DisableInterceptor<T>` in the config bag on every invocation, even for SDK-internal interceptors that are never disabled.

### Benchmark summary

The existing [`previous-release-comparison`](https://github.com/smithy-lang/smithy-rs/tree/main/aws/sdk/benchmarks/previous-release-comparison) benchmark crate (updated in this PR) was used to measure the impact of each change. S3 `ListObjectsV2` with mock HTTP client (no network). The S3 crate was generated locally with `endpointRuleSet` trait (not BDD) for apples-to-apples comparison against the published release.

| Step | Commit | Description | Avg | Δ from prev step | Cumulative Δ |
|------|--------|-------------|-----|-------------------|--------------|
| Baseline | — | Previous release (1.129.0) | 66.64 µs | — | — |
| 1 | [`7d8a725`](https://github.com/smithy-lang/smithy-rs/commit/7d8a72583c340a69a51230d240787f083fb78c02) | Skip disable check for permanent interceptors | 55.22 µs ±0.50 | −11.42 µs (−17.1%) | −11.42 µs (−17.1%) |
| 2 | [`cb490c0`](https://github.com/smithy-lang/smithy-rs/commit/cb490c0f265abb6d291edcbe3bac5b696caa7689) | Skip dyn dispatch for unoverridden hooks | 53.46 µs ±0.52 | −1.76 µs (−3.2%) | −13.18 µs (−19.8%) |
| 3 | [`62a725b`](https://github.com/smithy-lang/smithy-rs/commit/62a725b0fb15f70454a08b19a7ac579d33eeebc2) | Reuse client builder for merged RuntimeComponents | 50.79 µs ±0.12 | −2.67 µs (−5.0%) | −15.85 µs (−23.8%) |

The description below breaks down each optimization in the order listed above.

## Description

### Skip disable check for permanent interceptors (−17.1%)

Introduces `SharedInterceptor::permanent()`, which skips the per-invocation `DisableInterceptor<T>` config bag lookup. SDK-internal interceptors that are never disabled (content length enforcement, metrics, token bucket, checksum, idempotency token, request compression, feature trackers) are now registered via this path.

Interceptors that *can* be disabled — `InvocationIdInterceptor`, `UserAgentInterceptor`, `RequestInfoInterceptor` (disabled during presigning) — remain registered via `SharedInterceptor::new()`.

In debug builds, a `debug_assert!` fires if someone attempts to call `disable_interceptor` on a permanent interceptor, catching the misconfiguration early with a clear error message. This uses a type-erased `fn(&ConfigBag) -> bool` pointer captured at construction time (when the concrete type `T` is still known), gated behind `#[cfg(debug_assertions)]` so there is zero cost in release builds.

### Skip dyn dispatch for unoverridden hooks (−3.2%)

Adds a new proc-macro crate `aws-smithy-runtime-api-macros` with a `#[dyn_dispatch_hint]` attribute macro. Placed on an `impl Intercept` block, it inspects which hook methods are overridden and auto-generates an `overridden_hooks()` method returning the correct `OverriddenHooks` bitmask. The interceptor dispatch loop checks this bitmask before calling each hook, skipping dyn dispatch into no-op defaults.

A new crate was necessary because manually specifying bitflags at the `SharedInterceptor` construction site would be error-prone and drift over time. For example, without the macro, callers would need to write something like:

```rust
SharedInterceptor::permanent(MyInterceptor::new())
    .with_override_hint(OverriddenHooks::MODIFY_BEFORE_SIGNING | OverriddenHooks::MODIFY_BEFORE_TRANSMIT)
```

This creates a maintenance hazard: if someone adds or removes a hook override in the `impl Intercept` block but forgets to update the construction site, the flags silently go out of sync. The macro derives the flags directly from the impl block, so they can never drift. Interceptors not annotated with `#[dyn_dispatch_hint]` default to `overridden_hooks() -> all()`, preserving existing behavior.

All internal interceptors are annotated with `#[dyn_dispatch_hint]`. The trait method, `OverriddenHooks` type, and macro re-export are all `#[doc(hidden)]`.

### Reuse client builder for merged RuntimeComponents (−5.0%)

Eliminates an extra `RuntimeComponents::builder()` + `merge_from` in `apply_configuration` by merging the operation builder directly into the existing client builder.

## Testing
- CI
- New integration tests in `aws-smithy-runtime-api/tests/permanent_interceptor.rs`: permanent vs disableable behavior, debug assertion on misuse
- New integration tests in `aws-smithy-runtime-api/tests/dyn_dispatch_hint.rs`: macro generates correct `OverriddenHooks` flags for single hook, multiple hooks, no hooks, and without-macro cases

### Compile time impact

The new proc-macro crate (`aws-smithy-runtime-api-macros`) adds `syn`, `quote`, and `proc-macro2` as dependencies. No measurable compile time regression on `aws-sdk-s3` release builds (hyperfine, 10 runs with `cargo clean` between each on `m7i.xlarge`):

| Branch | Mean | ±σ | Range | Instance |
|--------|------|----|-------|----------|
| `main` | 125.367s | ±2.538s | 123.2–132.0s | m7i.xlarge, Amazon Linux 2023 |
| This PR | 124.770s | ±1.216s | 122.3–127.0s | m7i.xlarge, Amazon Linux 2023 |