### PR TITLE
Support JMESPath truthiness coercion for non-boolean types

### DIFF
--- a/.changelog/1775065975.md
+++ b/.changelog/1775065975.md
@@ -3,7 +3,7 @@ applies_to:
 - client
 - aws-sdk-rust
 authors:
-- awsaito
+- ysaito1001
 references:
 - smithy-rs#4587
 breaking: false

--- a/.changelog/1775488619.md
+++ b/.changelog/1775488619.md
@@ -3,7 +3,7 @@ applies_to:
 - client
 - aws-sdk-rust
 authors:
-- awsaito
+- ysaito1001
 references:
 - smithy-rs#4591
 breaking: false

--- a/.changelog/1776127189.md
+++ b/.changelog/1776127189.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#4599
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix waiter codegen failure when JMESPath `&&` or `||` expressions have non-boolean operands (e.g., a list field used as a truthiness check). Non-boolean types are now coerced to booleans using JMESPath truthiness rules: arrays and strings check `!is_empty()`, all other non-null types are truthy.

--- a/.changelog/file-visibility.md
+++ b/.changelog/file-visibility.md
@@ -2,7 +2,7 @@
 applies_to:
   - client
 authors:
-  - lnj
+  - landonxjames
 references:
 breaking: true
 new_feature: false

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
@@ -197,6 +197,31 @@ data class GeneratedExpression(
             this
         }
 
+    /**
+     * Coerces this expression to a boolean using JMESPath truthiness rules.
+     * - Booleans: used as-is
+     * - Arrays/Strings: truthy if non-empty (`!is_empty()`)
+     * - Numbers/Objects/Enums: always truthy (non-null values; null is handled by `?` short-circuiting)
+     */
+    internal fun coerceToBool(namer: SafeNamer): GeneratedExpression {
+        if (isBool()) return dereference(namer)
+        return namer.safeName("_truthy").let { tmp ->
+            GeneratedExpression(
+                identifier = tmp,
+                outputType = RustType.Bool,
+                outputShape = TraversedShape.Bool(null),
+                output =
+                    output +
+                        writable {
+                            when {
+                                isArray() || isString() -> rust("let $tmp = !$identifier.is_empty();")
+                                else -> rust("let $tmp = true;")
+                            }
+                        },
+            )
+        }
+    }
+
     /** Converts a number expression into a specific number type */
     internal fun convertToNumberPrimitive(
         namer: SafeNamer,
@@ -670,9 +695,6 @@ class RustJmespathShapeTraversalGenerator(
     ): GeneratedExpression {
         val left = generate(expr.left, bindings, context)
         val right = generate(expr.right, bindings, context)
-        if (!left.isBool() || !right.isBool()) {
-            throw UnsupportedJmesPathException("Applying the `$op` operation doesn't support non-boolean types in smithy-rs")
-        }
 
         return safeNamer.safeName("_bo").let { ident ->
             GeneratedExpression(
@@ -681,8 +703,8 @@ class RustJmespathShapeTraversalGenerator(
                 outputShape = TraversedShape.Bool(null),
                 output =
                     writable {
-                        val leftBool = left.dereference(safeNamer).also { it.output(this) }
-                        val rightBool = right.dereference(safeNamer).also { it.output(this) }
+                        val leftBool = left.coerceToBool(safeNamer).also { it.output(this) }
+                        val rightBool = right.coerceToBool(safeNamer).also { it.output(this) }
                         rust("let $ident = ${leftBool.identifier} $op ${rightBool.identifier};")
                     },
             )

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGeneratorTest.kt
@@ -612,8 +612,15 @@ class RustJmespathShapeTraversalGeneratorTest {
         test("bool_or_bool", "primitives.boolean || primitives.boolean", expectTrue)
         test("paren_expressions", "(`true` || `false`) && `true`", expectTrue)
 
-        unsupported("`5` || `true`", "Applying the `||` operation doesn't support non-bool")
-        unsupported("`5` && `true`", "Applying the `&&` operation doesn't support non-bool")
+        // Truthiness coercion: non-boolean types in && and ||
+        test("list_and_bool", "lists.integers && `true`", expectTrue)
+        test("string_and_bool", "primitives.string && `true`", expectTrue)
+        test("number_and_bool", "primitives.integer && `true`", expectTrue)
+        test("number_or_bool", "`5` || `true`", expectTrue)
+        test("number_and_bool_lit", "`5` && `true`", expectTrue)
+        // ECS-like pattern: list && length(list) == N
+        test("list_and_length_eq", "lists.integers && length(lists.integers) == `2`", expectTrue)
+
         unsupported("!`5`", "Negation of a non-boolean type")
     }
 


### PR DESCRIPTION
## Motivation and Context 
P414113898

A service model has updated JMESPath expressions for its waiter where a non-boolean type (e.g., a list) appears as an operand in `&&` or `||`. Specifically, they change from
```
length(deployments || '[]')
```
to
```
deployments && length(deployments) == 1
```
This is a valid JMESPath; the spec defines truthiness for all types, but `generateBooleanOp` in our codegen only accepted pure boolean operands and threw `UnsupportedJmesPathException` (at least we acknowledged limitation).

## Description
To lift the limitation, this PR
- Adds `coerceToBool()` method to `GeneratedExpression` that converts any JMESPath type to a boolean using truthiness rules:
  - Booleans: used as-is                                                                                                                                                     
  - Arrays/Strings: `!is_empty()`
  - Numbers/Objects/Enums: always truthy (null is already handled by `?` short-circuiting)
- Updates call sites in `generateBooldeanOp()` to use `coerceToBool()`

## Testing
- CI
- Updated `RustJmespathShapeTraversalGeneratorTest`: replaced 2 unsupported() assertions with 6 new test cases covering list, string, number truthiness
- Successfully built SDK from the service model in question

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
