### PR TITLE
Exclude `aws-smithy-runtime-api-macros` from semver checks

### DIFF
--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -68,7 +68,8 @@ def main(skip_generation=False):
 
     failures = []
     deny_list = [
-        # add crate names here to exclude them from the semver checks
+        # Proc-macro crates have no library target
+        "aws-smithy-runtime-api-macros",
     ]
     for path in os.listdir():
         eprint(f'checking {path}...', end='')


### PR DESCRIPTION
`cargo-semver-checks` has [started failing](https://github.com/smithy-lang/smithy-rs/actions/runs/24416017040/job/71330199142?pr=4596#step:5:412) now that the `aws-smithy-runtime-api-macros` crate is part of the main branch:
```
error: no crates with library targets selected, nothing to semver-check
```

This PR excludes the crate from the check as suggested in the error message.

## Testing
Verified semver checks [skipped](https://github.com/smithy-lang/smithy-rs/actions/runs/24422285668/job/71348150317?pr=4603#step:5:457) the `aws-smithy-runtime-api-macros` crate.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
