### PR TITLE
Prevent memory leak in identity cache on config override

### DIFF
--- a/.changelog/1776299142.md
+++ b/.changelog/1776299142.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- ysaito
+references:
+- smithy-rs#4340
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Prevent memory leak in identity cache when overriding credentials via `config_override`. Each `config_override` that sets a credentials provider now uses an operation-scoped identity cache instead of the shared client-level cache, preventing unbounded partition growth. Additionally, the client-level identity cache now enforces a configurable `max_partitions` cap (default: 64) as a safety net.

--- a/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/CredentialProviderConfigTest.kt
+++ b/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/CredentialProviderConfigTest.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rustsdk
 
 import SdkCodegenIntegrationTest
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
@@ -131,6 +132,156 @@ internal class CredentialProviderConfigTest {
                         *codegenScope,
                     )
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `config override credentials should not leak and should be cached across retries`() {
+        awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { ctx, rustCrate ->
+            val rc = ctx.runtimeConfig
+            val codegenScope =
+                arrayOf(
+                    *RuntimeType.preludeScope,
+                    "Credentials" to
+                        AwsRuntimeType.awsCredentialTypesTestUtil(rc)
+                            .resolve("Credentials"),
+                    "Region" to AwsRuntimeType.awsTypes(rc).resolve("region::Region"),
+                    "ProvideCredentials" to
+                        AwsRuntimeType.awsCredentialTypes(rc)
+                            .resolve("provider::ProvideCredentials"),
+                    "ProvideCredentialsFuture" to
+                        AwsRuntimeType.awsCredentialTypes(rc)
+                            .resolve("provider::future::ProvideCredentials"),
+                    "RetryConfig" to
+                        RuntimeType.smithyTypes(rc).resolve("retry::RetryConfig"),
+                    "SharedAsyncSleep" to
+                        RuntimeType.smithyAsync(rc).resolve("rt::sleep::SharedAsyncSleep"),
+                    "TokioSleep" to
+                        CargoDependency.smithyAsync(rc).withFeature("rt-tokio")
+                            .toType().resolve("rt::sleep::TokioSleep"),
+                )
+            val moduleName = ctx.moduleUseName()
+            rustCrate.integrationTest("credentials_provider") {
+                addDependency(CargoDependency.TracingTest.toDevDependency())
+                addDependency(CargoDependency.Tracing.toDevDependency())
+                addDependency(CargoDependency.Tokio.toDevDependency().withFeature("test-util"))
+
+                rustTemplate(
+                    """
+                    ##[tracing_test::traced_test]
+                    ##[::tokio::test]
+                    async fn config_override_credentials_should_not_grow_client_cache_partitions() {
+                        use aws_smithy_runtime::client::http::test_util::infallible_client_fn;
+                        use aws_smithy_types::body::SdkBody;
+
+                        let http_client = infallible_client_fn(|_req| {
+                            http::Response::builder().body(SdkBody::empty()).unwrap()
+                        });
+                        let client_config = $moduleName::Config::builder()
+                            .http_client(http_client)
+                            .credentials_provider(#{Credentials}::new("base", "base", #{None}, #{None}, "base"))
+                            .region(#{Region}::new("us-west-2"))
+                            .build();
+                        let client = $moduleName::Client::from_conf(client_config);
+
+                        // Make one call without config_override to establish the baseline partition
+                        let _ = client.some_operation().send().await;
+
+                        // Now make 10 calls, each with a different credentials provider via config_override
+                        for i in 0..10 {
+                            let creds = #{Credentials}::new(
+                                format!("akid_{i}"), format!("secret_{i}"), #{None}, #{None}, "test",
+                            );
+                            let _ = client
+                                .some_operation()
+                                .customize()
+                                .config_override($moduleName::Config::builder().credentials_provider(creds))
+                                .send()
+                                .await;
+                        }
+
+                        // The client-level identity cache should not have grown beyond the initial
+                        // partition. Each config_override gets its own short-lived cache, so the
+                        // client cache should still have partition_count=1.
+                        // If the client cache grew, it would log partition_count=2 on the second
+                        // override — which is the first sign of the leak this test guards against.
+                        assert!(logs_contain("partition_count=1"));
+                        assert!(!logs_contain("partition_count=2"));
+                    }
+
+                    ##[::tokio::test]
+                    async fn config_override_credentials_are_cached_across_retries() {
+                        use std::sync::{Arc, Mutex};
+                        use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
+                        use aws_smithy_types::body::SdkBody;
+
+                        // A credentials provider backed by a list. Each call to provide_credentials
+                        // removes and returns the first element. If the cache works, only the first
+                        // element should be consumed; the second should remain.
+                        ##[derive(Debug, Clone)]
+                        struct CredentialsList(Arc<Mutex<Vec<#{Credentials}>>>);
+                        impl #{ProvideCredentials} for CredentialsList {
+                            fn provide_credentials<'a>(&'a self) -> #{ProvideCredentialsFuture}<'a>
+                            where Self: 'a,
+                            {
+                                let next = self.0.lock().unwrap().remove(0);
+                                #{ProvideCredentialsFuture}::ready(#{Ok}(next))
+                            }
+                        }
+
+                        let http_client = StaticReplayClient::new(vec![
+                            // First attempt: 500 triggers retry
+                            ReplayEvent::new(
+                                http::Request::builder().body(SdkBody::from("")).unwrap(),
+                                http::Response::builder().status(500).body(SdkBody::from("{}")).unwrap(),
+                            ),
+                            // Second attempt: 200 succeeds
+                            ReplayEvent::new(
+                                http::Request::builder().body(SdkBody::from("")).unwrap(),
+                                http::Response::builder().status(200).body(SdkBody::from("{}")).unwrap(),
+                            ),
+                        ]);
+
+                        let client_config = $moduleName::Config::builder()
+                            .http_client(http_client)
+                            .credentials_provider(#{Credentials}::new("base", "base", #{None}, #{None}, "base"))
+                            .region(#{Region}::new("us-west-2"))
+                            .retry_config(#{RetryConfig}::standard())
+                            .sleep_impl(#{SharedAsyncSleep}::new(#{TokioSleep}::new()))
+                            .build();
+                        let client = $moduleName::Client::from_conf(client_config);
+
+                        let creds_list = Arc::new(Mutex::new(vec![
+                            #{Credentials}::new("first", "first", #{None}, #{None}, "first"),
+                            #{Credentials}::new("second", "second", #{None}, #{None}, "second"),
+                        ]));
+                        let override_provider = CredentialsList(creds_list.clone());
+
+                        let _ = client
+                            .some_operation()
+                            .customize()
+                            .config_override(
+                                $moduleName::Config::builder().credentials_provider(override_provider),
+                            )
+                            .send()
+                            .await;
+
+                        // Only the first credentials should have been consumed. The retry should
+                        // have served the identity from the operation-scoped cache, leaving the
+                        // second credentials untouched.
+                        let remaining = creds_list.lock().unwrap();
+                        assert_eq!(
+                            1,
+                            remaining.len(),
+                            "expected one credentials remaining (retry should use cache), but found {}",
+                            remaining.len(),
+                        );
+                        assert_eq!("second", remaining[0].access_key_id());
+                    }
+                    """,
+                    *codegenScope,
+                )
             }
         }
     }

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
@@ -30,6 +30,7 @@ class ConfigOverrideRuntimePluginGenerator(
                 "InterceptorRegistrar" to runtimeApi.resolve("client::interceptors::InterceptorRegistrar"),
                 "Layer" to smithyTypes.resolve("config_bag::Layer"),
                 "Resolver" to RuntimeType.smithyRuntime(rc).resolve("client::config_override::Resolver"),
+                "IdentityCache" to RuntimeType.smithyRuntime(rc).resolve("client::identity::IdentityCache"),
                 "RuntimeComponentsBuilder" to RuntimeType.runtimeComponentsBuilder(rc),
                 "RuntimePlugin" to RuntimeType.runtimePlugin(rc),
             )
@@ -66,6 +67,18 @@ class ConfigOverrideRuntimePluginGenerator(
                     #{config}
 
                     let _ = resolver;
+
+                    // When the config override supplies an identity resolver for any auth scheme
+                    // known to the client or the override itself, we give this operation its own
+                    // short-lived identity cache so that new partitions don't accumulate in the
+                    // shared client cache. A lazy cache (not `no_cache`) is used so that resolved
+                    // identities are served from the short-lived identity cache on retries.
+                    //
+                    // This is skipped if the override already sets its own identity cache.
+                    if components.has_identity_resolvers() && components.identity_cache().is_none() {
+                        components.set_identity_cache(#{Some}(#{IdentityCache}::lazy().max_partitions(1).build()));
+                    }
+
                     Self {
                         config: #{Layer}::from(layer)
                             .with_name("$moduleUseName::config::ConfigOverrideRuntimePlugin").freeze(),

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
@@ -259,4 +259,198 @@ internal class ConfigOverrideRuntimePluginGeneratorTest {
             }
         }
     }
+
+    private val authModel =
+        """
+        namespace com.example
+        use aws.protocols#restJson1
+
+        @restJson1
+        @httpBearerAuth
+        @auth([httpBearerAuth])
+        service HelloService {
+            operations: [SayHello],
+            version: "1"
+        }
+
+        @http(uri: "/SayHello", method: "POST")
+        operation SayHello { input: TestInput }
+        structure TestInput {
+           foo: String,
+        }
+        """.asSmithyModel()
+
+    @Test
+    fun `config override with identity resolver gets operation-scoped cache`() {
+        clientIntegrationTest(authModel) { clientCodegenContext, rustCrate ->
+            val runtimeConfig = clientCodegenContext.runtimeConfig
+            val codegenScope =
+                arrayOf(
+                    *preludeScope,
+                    "BearerAuthScheme" to
+                        CargoDependency.smithyRuntime(runtimeConfig).withFeature("http-auth")
+                            .toType().resolve("client::auth::http::BearerAuthScheme"),
+                    "ConfigBag" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::ConfigBag"),
+                    "HTTP_BEARER_AUTH_SCHEME_ID" to
+                        CargoDependency.smithyRuntimeApiClient(runtimeConfig).withFeature("http-auth")
+                            .toType().resolve("client::auth::http::HTTP_BEARER_AUTH_SCHEME_ID"),
+                    "IdentityFuture" to
+                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                            .resolve("client::identity::IdentityFuture"),
+                    "Identity" to
+                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                            .resolve("client::identity::Identity"),
+                    "ResolveIdentity" to
+                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                            .resolve("client::identity::ResolveIdentity"),
+                    "RuntimeComponents" to
+                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                            .resolve("client::runtime_components::RuntimeComponents"),
+                    "RuntimeComponentsBuilder" to RuntimeType.runtimeComponentsBuilder(runtimeConfig),
+                    "RuntimePlugin" to RuntimeType.runtimePlugin(runtimeConfig),
+                    "SharedAuthScheme" to
+                        RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                            .resolve("client::auth::SharedAuthScheme"),
+                    "IdentityCache" to
+                        RuntimeType.smithyRuntime(runtimeConfig)
+                            .resolve("client::identity::IdentityCache"),
+                )
+            rustCrate.testModule {
+                addDependency(CargoDependency.Tokio.toDevDependency().withFeature("test-util"))
+                unitTest("config_override_with_identity_resolver_gets_scoped_cache") {
+                    rustTemplate(
+                        """
+                        use #{RuntimePlugin};
+
+                        ##[derive(Debug)]
+                        struct FakeResolver;
+                        impl #{ResolveIdentity} for FakeResolver {
+                            fn resolve_identity<'a>(
+                                &'a self,
+                                _: &'a #{RuntimeComponents},
+                                _: &'a #{ConfigBag},
+                            ) -> #{IdentityFuture}<'a> {
+                                #{IdentityFuture}::ready(#{Ok}(#{Identity}::new("fake", #{None})))
+                            }
+                        }
+
+                        let client_config = crate::config::Config::builder().build();
+
+                        // Override with an identity resolver
+                        let mut override_builder = crate::config::Config::builder();
+                        override_builder.runtime_components.set_identity_resolver(
+                            #{HTTP_BEARER_AUTH_SCHEME_ID},
+                            FakeResolver,
+                        );
+
+                        let sut = crate::config::ConfigOverrideRuntimePlugin::new(
+                            override_builder,
+                            client_config.config.clone(),
+                            &client_config.runtime_components,
+                        );
+
+                        // The override should have its own identity cache
+                        let components = sut.runtime_components(&#{RuntimeComponentsBuilder}::new("test"));
+                        assert!(
+                            components.identity_cache().is_some(),
+                            "config override with identity resolver should get an operation-scoped identity cache"
+                        );
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("config_override_without_identity_resolver_has_no_scoped_cache") {
+                    rustTemplate(
+                        """
+                        use #{RuntimePlugin};
+
+                        let client_config = crate::config::Config::builder().build();
+
+                        // Override without an identity resolver
+                        let override_builder = crate::config::Config::builder();
+
+                        let sut = crate::config::ConfigOverrideRuntimePlugin::new(
+                            override_builder,
+                            client_config.config.clone(),
+                            &client_config.runtime_components,
+                        );
+
+                        // The override should NOT have its own identity cache
+                        let components = sut.runtime_components(&#{RuntimeComponentsBuilder}::new("test"));
+                        assert!(
+                            components.identity_cache().is_none(),
+                            "config override without identity resolver should not set an identity cache"
+                        );
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("config_override_explicit_identity_cache_is_not_overridden") {
+                    rustTemplate(
+                        """
+                        use #{RuntimePlugin};
+                        use aws_smithy_runtime_api::client::identity::ResolveCachedIdentity;
+
+                        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+                        ##[derive(Debug)]
+                        struct CountingResolver(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+                        impl #{ResolveIdentity} for CountingResolver {
+                            fn resolve_identity<'a>(
+                                &'a self,
+                                _: &'a #{RuntimeComponents},
+                                _: &'a #{ConfigBag},
+                            ) -> #{IdentityFuture}<'a> {
+                                self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                #{IdentityFuture}::ready(#{Ok}(#{Identity}::new("fake", #{None})))
+                            }
+                        }
+
+                        ##[derive(Debug)]
+                        struct StubCache;
+                        impl ResolveCachedIdentity for StubCache {
+                            fn resolve_cached_identity<'a>(
+                                &'a self,
+                                _resolver: aws_smithy_runtime_api::client::identity::SharedIdentityResolver,
+                                _components: &'a #{RuntimeComponents},
+                                _config_bag: &'a #{ConfigBag},
+                            ) -> #{IdentityFuture}<'a> {
+                                #{IdentityFuture}::ready(#{Ok}(#{Identity}::new("stub", #{None})))
+                            }
+                        }
+
+                        let client_config = crate::config::Config::builder().build();
+
+                        // Override with both an identity resolver and an explicit custom cache
+                        let mut override_builder = crate::config::Config::builder();
+                        override_builder.runtime_components.set_identity_resolver(
+                            #{HTTP_BEARER_AUTH_SCHEME_ID},
+                            CountingResolver(call_count.clone()),
+                        );
+                        override_builder.runtime_components.set_identity_cache(#{Some}(StubCache));
+
+                        let sut = crate::config::ConfigOverrideRuntimePlugin::new(
+                            override_builder,
+                            client_config.config.clone(),
+                            &client_config.runtime_components,
+                        );
+
+                        // Verify the explicit cache was preserved by checking the debug output
+                        // contains "StubCache" (our custom type) rather than "LazyCache"
+                        let sut_components = sut.runtime_components(&#{RuntimeComponentsBuilder}::new("empty"));
+                        let cache = sut_components.identity_cache().expect("identity cache should be set");
+                        let debug_str = format!("{:?}", cache);
+                        assert!(
+                            debug_str.contains("StubCache"),
+                            "explicit identity cache should be preserved, got: {debug_str}"
+                        );
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
 }

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "approx",
  "aws-smithy-async 1.2.14",

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -647,6 +647,13 @@ impl RuntimeComponentsBuilder {
             .map(|tracked| tracked.value.clone())
     }
 
+    /// Returns `true` if any identity resolvers have been configured in this builder.
+    pub fn has_identity_resolvers(&self) -> bool {
+        self.identity_resolvers
+            .as_ref()
+            .is_some_and(|resolvers| !resolvers.is_empty())
+    }
+
     /// This method is broken since it does not replace an existing identity resolver of the given auth scheme ID.
     /// Use `set_identity_resolver` instead.
     #[deprecated(

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/cache/lazy.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/cache/lazy.rs
@@ -26,6 +26,7 @@ const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_EXPIRATION: Duration = Duration::from_secs(15 * 60);
 const DEFAULT_BUFFER_TIME: Duration = Duration::from_secs(10);
 const DEFAULT_BUFFER_TIME_JITTER_FRACTION: fn() -> f64 = || fastrand::f64() * 0.5;
+const DEFAULT_MAX_PARTITIONS: usize = 64;
 
 /// Builder for lazy identity caching.
 #[derive(Default, Debug)]
@@ -36,6 +37,7 @@ pub struct LazyCacheBuilder {
     buffer_time: Option<Duration>,
     buffer_time_jitter_fraction: Option<fn() -> f64>,
     default_expiration: Option<Duration>,
+    max_partitions: Option<usize>,
 }
 
 impl LazyCacheBuilder {
@@ -161,6 +163,41 @@ impl LazyCacheBuilder {
         self
     }
 
+    /// Maximum number of identity cache partitions before eviction occurs.
+    ///
+    /// A normally functioning application should not have more than 5-10
+    /// credential providers active at any given time. This limit acts as
+    /// a safety net against memory leaks.
+    ///
+    /// Defaults to 64.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max` is 0.
+    pub fn max_partitions(mut self, max: usize) -> Self {
+        self.set_max_partitions(Some(max));
+        self
+    }
+
+    /// Maximum number of identity cache partitions before eviction occurs.
+    ///
+    /// A normally functioning application should not have more than 5-10
+    /// credential providers active at any given time. This limit acts as
+    /// a safety net against memory leaks.
+    ///
+    /// Defaults to 64.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max` is `Some(0)`.
+    pub fn set_max_partitions(&mut self, max: Option<usize>) -> &mut Self {
+        if let Some(0) = max {
+            panic!("max_partitions must be greater than 0");
+        }
+        self.max_partitions = max;
+        self
+    }
+
     /// Builds a [`SharedIdentityCache`] from this builder.
     ///
     /// # Panics
@@ -178,6 +215,7 @@ impl LazyCacheBuilder {
             self.buffer_time_jitter_fraction
                 .unwrap_or(DEFAULT_BUFFER_TIME_JITTER_FRACTION),
             default_expiration,
+            self.max_partitions.unwrap_or(DEFAULT_MAX_PARTITIONS),
         )
         .into_shared()
     }
@@ -187,32 +225,44 @@ impl LazyCacheBuilder {
 struct CachePartitions {
     partitions: RwLock<HashMap<IdentityCachePartition, ExpiringCache<Identity, BoxError>>>,
     buffer_time: Duration,
+    max_partitions: usize,
 }
 
 impl CachePartitions {
-    fn new(buffer_time: Duration) -> Self {
+    fn new(buffer_time: Duration, max_partitions: usize) -> Self {
         Self {
             partitions: RwLock::new(HashMap::new()),
             buffer_time,
+            max_partitions,
         }
     }
 
     fn partition(&self, key: IdentityCachePartition) -> ExpiringCache<Identity, BoxError> {
-        let mut partition = self.partitions.read().unwrap().get(&key).cloned();
-        // Add the partition to the cache if it doesn't already exist.
-        // Partitions will never be removed.
-        if partition.is_none() {
-            let mut partitions = self.partitions.write().unwrap();
-            // Another thread could have inserted the partition before we acquired the lock,
-            // so double check before inserting it.
-            partitions
-                .entry(key)
-                .or_insert_with(|| ExpiringCache::new(self.buffer_time));
-            drop(partitions);
-
-            partition = self.partitions.read().unwrap().get(&key).cloned();
+        // Fast path: read lock for cache hits
+        if let Some(partition) = self.partitions.read().unwrap().get(&key).cloned() {
+            return partition;
         }
-        partition.expect("inserted above if not present")
+        // Slow path: write lock for cache misses
+        let mut partitions = self.partitions.write().unwrap();
+        // Another thread may have inserted while we waited for the write lock
+        if let Some(partition) = partitions.get(&key).cloned() {
+            return partition;
+        }
+        // Evict an arbitrary entry if at capacity. Eviction order doesn't matter
+        // because a normally functioning application should not have more than
+        // 5-10 credential providers active at any given time, well under the cap.
+        if partitions.len() >= self.max_partitions {
+            if let Some(&evict_key) = partitions.keys().next() {
+                partitions.remove(&evict_key);
+            }
+        }
+        let partition = ExpiringCache::new(self.buffer_time);
+        partitions.insert(key, partition.clone());
+        tracing::debug!(
+            partition_count = partitions.len(),
+            "identity cache partition created or accessed"
+        );
+        partition
     }
 }
 
@@ -231,9 +281,10 @@ impl LazyCache {
         buffer_time: Duration,
         buffer_time_jitter_fraction: fn() -> f64,
         default_expiration: Duration,
+        max_partitions: usize,
     ) -> Self {
         Self {
-            partitions: CachePartitions::new(buffer_time),
+            partitions: CachePartitions::new(buffer_time, max_partitions),
             load_timeout,
             buffer_time,
             buffer_time_jitter_fraction,
@@ -458,6 +509,7 @@ mod tests {
             DEFAULT_BUFFER_TIME,
             buffer_time_jitter_fraction,
             DEFAULT_EXPIRATION,
+            DEFAULT_MAX_PARTITIONS,
         );
         (cache, identity_resolver)
     }
@@ -503,6 +555,7 @@ mod tests {
             DEFAULT_BUFFER_TIME,
             BUFFER_TIME_NO_JITTER,
             DEFAULT_EXPIRATION,
+            DEFAULT_MAX_PARTITIONS,
         );
         assert_eq!(
             epoch_secs(1000),
@@ -641,6 +694,7 @@ mod tests {
             DEFAULT_BUFFER_TIME,
             BUFFER_TIME_NO_JITTER,
             DEFAULT_EXPIRATION,
+            DEFAULT_MAX_PARTITIONS,
         );
 
         let err: BoxError = cache
@@ -767,5 +821,185 @@ mod tests {
         assert_eq!("A", identity.data::<Token>().unwrap().token());
         assert_eq!(1, resolver_a_calls.load(Ordering::Relaxed));
         assert_eq!(1, resolver_b_calls.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn eviction_when_at_capacity() {
+        let time = ManualTimeSource::new(epoch_secs(0));
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(TokioSleep::new()))
+            .build()
+            .unwrap();
+        // Create a cache with max_partitions=2
+        let cache = LazyCache::new(
+            DEFAULT_LOAD_TIMEOUT,
+            DEFAULT_BUFFER_TIME,
+            BUFFER_TIME_NO_JITTER,
+            DEFAULT_EXPIRATION,
+            2,
+        );
+
+        #[allow(clippy::disallowed_methods)]
+        let far_future = SystemTime::now() + Duration::from_secs(10_000);
+
+        let resolver_a_calls = Arc::new(AtomicUsize::new(0));
+        let resolver_b_calls = Arc::new(AtomicUsize::new(0));
+        let resolver_c_calls = Arc::new(AtomicUsize::new(0));
+
+        let resolver_a = resolver_fn({
+            let calls = resolver_a_calls.clone();
+            move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                IdentityFuture::ready(Ok(Identity::new(
+                    Token::new("A", Some(far_future)),
+                    Some(far_future),
+                )))
+            }
+        });
+        let resolver_b = resolver_fn({
+            let calls = resolver_b_calls.clone();
+            move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                IdentityFuture::ready(Ok(Identity::new(
+                    Token::new("B", Some(far_future)),
+                    Some(far_future),
+                )))
+            }
+        });
+        let resolver_c = resolver_fn({
+            let calls = resolver_c_calls.clone();
+            move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                IdentityFuture::ready(Ok(Identity::new(
+                    Token::new("C", Some(far_future)),
+                    Some(far_future),
+                )))
+            }
+        });
+
+        let config_bag = ConfigBag::base();
+
+        // Fill the cache with A and B
+        cache
+            .resolve_cached_identity(resolver_a.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        cache
+            .resolve_cached_identity(resolver_b.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        assert_eq!(1, resolver_a_calls.load(Ordering::Relaxed));
+        assert_eq!(1, resolver_b_calls.load(Ordering::Relaxed));
+
+        // Adding C should evict one of A or B (arbitrary eviction order)
+        cache
+            .resolve_cached_identity(resolver_c.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        assert_eq!(1, resolver_c_calls.load(Ordering::Relaxed));
+
+        // Resolve all three again — exactly one of A or B should need re-resolution
+        cache
+            .resolve_cached_identity(resolver_a.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        cache
+            .resolve_cached_identity(resolver_b.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        let total_calls = resolver_a_calls.load(Ordering::Relaxed)
+            + resolver_b_calls.load(Ordering::Relaxed)
+            + resolver_c_calls.load(Ordering::Relaxed);
+        // Initial: 3 calls (A, B, C). One of A or B was evicted and re-resolved: +1 = 4.
+        assert_eq!(
+            4, total_calls,
+            "one entry should have been evicted and re-resolved"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_partition_cache() {
+        let time = ManualTimeSource::new(epoch_secs(0));
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(TokioSleep::new()))
+            .build()
+            .unwrap();
+        // Mimics the operation-scoped cache used for config overrides
+        let cache = LazyCache::new(
+            DEFAULT_LOAD_TIMEOUT,
+            DEFAULT_BUFFER_TIME,
+            BUFFER_TIME_NO_JITTER,
+            DEFAULT_EXPIRATION,
+            1,
+        );
+
+        #[allow(clippy::disallowed_methods)]
+        let far_future = SystemTime::now() + Duration::from_secs(10_000);
+
+        let resolver_a_calls = Arc::new(AtomicUsize::new(0));
+        let resolver_b_calls = Arc::new(AtomicUsize::new(0));
+
+        let resolver_a = resolver_fn({
+            let calls = resolver_a_calls.clone();
+            move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                IdentityFuture::ready(Ok(Identity::new(
+                    Token::new("A", Some(far_future)),
+                    Some(far_future),
+                )))
+            }
+        });
+        let resolver_b = resolver_fn({
+            let calls = resolver_b_calls.clone();
+            move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                IdentityFuture::ready(Ok(Identity::new(
+                    Token::new("B", Some(far_future)),
+                    Some(far_future),
+                )))
+            }
+        });
+
+        let config_bag = ConfigBag::base();
+
+        // First call resolves A
+        let identity = cache
+            .resolve_cached_identity(resolver_a.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        assert_eq!("A", identity.data::<Token>().unwrap().token());
+        assert_eq!(1, resolver_a_calls.load(Ordering::Relaxed));
+
+        // Second call with same resolver is cached
+        let identity = cache
+            .resolve_cached_identity(resolver_a.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        assert_eq!("A", identity.data::<Token>().unwrap().token());
+        assert_eq!(1, resolver_a_calls.load(Ordering::Relaxed));
+
+        // Resolving B evicts A (only 1 partition)
+        let identity = cache
+            .resolve_cached_identity(resolver_b.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        assert_eq!("B", identity.data::<Token>().unwrap().token());
+        assert_eq!(1, resolver_b_calls.load(Ordering::Relaxed));
+
+        // A must be re-resolved
+        let identity = cache
+            .resolve_cached_identity(resolver_a.clone(), &components, &config_bag)
+            .await
+            .unwrap();
+        assert_eq!("A", identity.data::<Token>().unwrap().token());
+        assert_eq!(2, resolver_a_calls.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    #[should_panic(expected = "max_partitions must be greater than 0")]
+    fn max_partitions_zero_panics() {
+        LazyCacheBuilder::new().max_partitions(0);
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/cache/lazy.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/cache/lazy.rs
@@ -899,7 +899,9 @@ mod tests {
             .unwrap();
         assert_eq!(1, resolver_c_calls.load(Ordering::Relaxed));
 
-        // Resolve all three again — exactly one of A or B should need re-resolution
+        // Resolve all three again — at least one of A or B must be re-resolved because
+        // the cache only holds 2 partitions. Depending on HashMap iteration order, re-inserting
+        // the evicted entry may cascade-evict the other, leading to 4 or 5 total calls.
         cache
             .resolve_cached_identity(resolver_a.clone(), &components, &config_bag)
             .await
@@ -911,10 +913,11 @@ mod tests {
         let total_calls = resolver_a_calls.load(Ordering::Relaxed)
             + resolver_b_calls.load(Ordering::Relaxed)
             + resolver_c_calls.load(Ordering::Relaxed);
-        // Initial: 3 calls (A, B, C). One of A or B was evicted and re-resolved: +1 = 4.
-        assert_eq!(
-            4, total_calls,
-            "one entry should have been evicted and re-resolved"
+        // Initial: 3 calls (A, B, C). At least one of A or B was evicted and re-resolved (+1).
+        // If re-inserting the evicted entry cascade-evicts the other, both need re-resolution (+2).
+        assert!(
+            (4..=5).contains(&total_calls),
+            "expected 4 or 5 total calls (3 initial + 1 or 2 re-resolutions), got {total_calls}"
         );
     }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/cache/lazy.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/cache/lazy.rs
@@ -260,7 +260,7 @@ impl CachePartitions {
         partitions.insert(key, partition.clone());
         tracing::debug!(
             partition_count = partitions.len(),
-            "identity cache partition created or accessed"
+            "identity cache partition created"
         );
         partition
     }


### PR DESCRIPTION
## Motivation and Context
Fixes #4340

When users set credentials via `config_override` on a per-operation basis, each call creates a new `SharedCredentialsProvider` which allocates a new globally-unique `IdentityCachePartition`. These partitions accumulate in the shared client-level `LazyCache` and are never evicted, causing unbounded memory growth.

## Description
Two complementary changes:

**Operation-scoped identity cache (codegen):** When `ConfigOverrideRuntimePlugin` detects that the config override sets any identity resolvers (via `has_identity_resolvers()` on `RuntimeComponentsBuilder`), it assigns the operation its own short-lived `IdentityCache::lazy().max_partitions(1)` instead of using the client-level cache. A lazy cache (rather than `no_cache`) is used so that resolved identities are served from this short-lived cache on retries. The cache lives for the duration of the operation and is dropped on completion. If the override already provides its own identity cache, it is respected.

**Partition cap on client-level cache (runtime):** `CachePartitions` in `LazyCache` now enforces a configurable `max_partitions` (default: 64). When the cap is reached, an arbitrary entry is evicted before inserting a new one. This acts as a safety net — in normal operation with the codegen fix, the client cache holds only a few stable partitions and eviction never triggers. The existing `RwLock<HashMap>` is preserved for zero-contention concurrent reads on the hot path. `RwLock<LruCache>` was considered but showed a reproducible regression in [end-to-end benchmarks](https://github.com/smithy-lang/smithy-rs/tree/main/aws/sdk/benchmarks/standardized-benches#e2e-benchmarks) on `m7i.xlarge`:

  | Benchmark | Run | Avg Time (s) | Throughput (Gbps) |
  |-----------|-----|--------------|-------------------| 
  | PutObject | HashMap | 5.78 | 3.64 |
  | PutObject | LruCache | 5.81 | 3.61 |
  | GetObject | HashMap | 4.88 | 4.32 |
  | GetObject | LruCache | 5.45 | 3.92 |

## Testing
- **Unit tests (aws-smithy-runtime):** `eviction_when_at_capacity`, `single_partition_cache`, `max_partitions_zero_panics` — verify eviction behavior, single-partition operation-scoped cache, and builder validation      
- **Codegen tests (codegen-client):** Three tests in `ConfigOverrideRuntimePluginGeneratorTest` verify: (1) override with identity resolver gets scoped cache, (2) override without identity resolver doesn't set a cache, (3) explicit identity cache on override is not overridden
- **Integration tests (aws-codegen-sdk):** `config_override_credentials_should_not_grow_client_cache_partitions` uses `traced_test` to verify the client-level cache partition count stays at 1 after 10 operations with different `config_override` credentials. `config_override_credentials_are_cached_across_retries` verifies the override provider is called only once when a retry occurs (second call served from the operation-scoped cache).                                                                                                                                                                                                           
- End-to-end benchmarks above show no regression vs main for PutObject/GetObject throughput

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.
