### PR TITLE
TEST: Verify ARM canary catches crc-fast 1.4 SIGILL (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,7 @@ jobs:
     - name: Run canary
       run: |
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
+        rustup target add aarch64-unknown-linux-musl
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,52 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: run-canary
-        action-arguments: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} ${{ steps.creds.outputs.aws-access-key-id }} ${{ steps.creds.outputs.aws-secret-access-key }} ${{ steps.creds.outputs.aws-session-token }}
+        action-arguments: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} ${{ steps.creds.outputs.aws-access-key-id }} ${{ steps.creds.outputs.aws-secret-access-key }} ${{ steps.creds.outputs.aws-session-token }} x86_64
+
+  canary-arm:
+    name: Canary (aarch64)
+    if: ${{ inputs.run_canary }}
+    needs: generate
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+        ref: ${{ inputs.git_ref }}
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-generate-aws-sdk
+        path: artifacts-generate-aws-sdk
+    - name: Extract artifacts
+      run: tar xfz artifacts-generate-aws-sdk/artifacts-generate-aws-sdk.tar.gz
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: aarch64-unknown-linux-musl
+    - name: Install musl-tools
+      run: sudo apt-get update && sudo apt-get install -y musl-tools
+    - name: Configure credentials
+      id: creds
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+        role-session-name: GitHubActions
+        aws-region: us-west-2
+        output-credentials: true
+    - name: Run canary
+      run: |
+        export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
+        ./smithy-rs/tools/ci-scripts/run-canary \
+          ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
+          ${{ steps.creds.outputs.aws-access-key-id }} \
+          ${{ steps.creds.outputs.aws-secret-access-key }} \
+          ${{ steps.creds.outputs.aws-session-token }} \
+          aarch64
 
   # This is always a failing job since forked repositories do not have necessary repository secrets
   # to run the PR bot workflow or the canary workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
         # Install the pinned toolchain from rust-toolchain.toml and add musl target
         rustup toolchain install 1.91.1
-        rustup target add aarch64-unknown-linux-musl --toolchain 1.91.1
+        rustup target add aarch64-unknown-linux-musl wasm32-wasip2 --toolchain 1.91.1
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,8 +398,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: aarch64-unknown-linux-musl
-    - name: Install musl-tools
-      run: sudo apt-get update && sudo apt-get install -y musl-tools
+    - name: Install build dependencies
+      run: sudo apt-get update && sudo apt-get install -y musl-tools cmake perl clang pkg-config
     - name: Configure credentials
       id: creds
       uses: aws-actions/configure-aws-credentials@v4
@@ -411,7 +411,9 @@ jobs:
     - name: Run canary
       run: |
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
-        rustup target add aarch64-unknown-linux-musl
+        # Install the pinned toolchain from rust-toolchain.toml and add musl target
+        rustup toolchain install 1.91.1
+        rustup target add aarch64-unknown-linux-musl --toolchain 1.91.1
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -145,8 +145,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: aarch64-unknown-linux-musl
-    - name: Install musl-tools
-      run: sudo apt-get update && sudo apt-get install -y musl-tools
+    - name: Install build dependencies
+      run: sudo apt-get update && sudo apt-get install -y musl-tools cmake perl clang pkg-config
     - name: Configure credentials
       id: creds
       uses: aws-actions/configure-aws-credentials@v4
@@ -158,7 +158,9 @@ jobs:
     - name: Run canary
       run: |
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
-        rustup target add aarch64-unknown-linux-musl
+        # Install the pinned toolchain from rust-toolchain.toml and add musl target
+        rustup toolchain install 1.91.1
+        rustup target add aarch64-unknown-linux-musl --toolchain 1.91.1
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -158,6 +158,7 @@ jobs:
     - name: Run canary
       run: |
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
+        rustup target add aarch64-unknown-linux-musl
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -117,4 +117,50 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: run-canary
-        action-arguments: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} ${{ steps.creds.outputs.aws-access-key-id }} ${{ steps.creds.outputs.aws-secret-access-key }} ${{ steps.creds.outputs.aws-session-token }}
+        action-arguments: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} ${{ steps.creds.outputs.aws-access-key-id }} ${{ steps.creds.outputs.aws-secret-access-key }} ${{ steps.creds.outputs.aws-session-token }} x86_64
+
+  canary-arm:
+    name: Canary (aarch64)
+    needs:
+    - generate
+    - get-pr-info
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+        ref: ${{ inputs.commit_sha }}
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-generate-aws-sdk-for-canary
+        path: artifacts-generate-aws-sdk-for-canary
+    - name: Extract artifacts
+      run: tar xfz artifacts-generate-aws-sdk-for-canary/artifacts-generate-aws-sdk-for-canary.tar.gz
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: aarch64-unknown-linux-musl
+    - name: Install musl-tools
+      run: sudo apt-get update && sudo apt-get install -y musl-tools
+    - name: Configure credentials
+      id: creds
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+        role-session-name: GitHubActions
+        aws-region: us-west-2
+        output-credentials: true
+    - name: Run canary
+      run: |
+        export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
+        ./smithy-rs/tools/ci-scripts/run-canary \
+          ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
+          ${{ steps.creds.outputs.aws-access-key-id }} \
+          ${{ steps.creds.outputs.aws-secret-access-key }} \
+          ${{ steps.creds.outputs.aws-session-token }} \
+          aarch64

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -160,7 +160,7 @@ jobs:
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
         # Install the pinned toolchain from rust-toolchain.toml and add musl target
         rustup toolchain install 1.91.1
-        rustup target add aarch64-unknown-linux-musl --toolchain 1.91.1
+        rustup target add aarch64-unknown-linux-musl wasm32-wasip2 --toolchain 1.91.1
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -18,7 +18,7 @@ aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"]}
 bytes = "1.11.1"
 # FIXME(https://github.com/smithy-lang/smithy-rs/issues/3981): Keep pinned until we have more comprehensive testing in place
-crc-fast = "~1.9.0"
+crc-fast = "=1.4.0"
 hex = "0.4.3"
 http-1x = {package = "http", version = "1.3.1"}
 http-body-1x = {package = "http-body", version = "1.0.1"}

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -333,8 +333,9 @@ fn name_hashed_bundle(
     rust_version: Option<&str>,
     sdk_release_tag: Option<&ReleaseTag>,
 ) -> Result<String> {
-    // The Lambda name must be less than 64 characters, so truncate the hash a bit
-    let bin_hash = &bin_hash[..24];
+    // The Lambda name must be less than 64 characters, so truncate the hash a bit.
+    // Using 16 chars leaves headroom for the architecture suffix added in run.rs.
+    let bin_hash = &bin_hash[..16];
     // Lambda function names can't have periods in them
     let rust_version = rust_version.map(|s| s.replace('.', ""));
     let rust_version = rust_version.as_deref().unwrap_or("unknown");
@@ -390,8 +391,8 @@ pub async fn build_bundle(opt: BuildBundleArgs) -> Result<Option<PathBuf>> {
     };
 
     if !opt.manifest_only {
-        // Check if cross is needed and available
-        let use_cross = opt.architecture == Arch::Aarch64;
+        // Only use cross when cross-compiling (host arch != target arch)
+        let use_cross = opt.architecture == Arch::Aarch64 && std::env::consts::ARCH != "aarch64";
         if use_cross {
             let cross_check = Command::new("cross").arg("--version").output();
             if cross_check.is_err() || !cross_check.unwrap().status.success() {
@@ -883,7 +884,7 @@ aws-smithy-wasm = { version = "0.1.0" }
             assert_eq!(expected, actual);
         }
         check(
-            "canary-release20221216-1621-7ae6085d2105d5d1e13b10f8.zip",
+            "canary-release20221216-1621-7ae6085d2105d5d1.zip",
             &name_hashed_bundle(
                 "7ae6085d2105d5d1e13b10f882c6cb072ff5bbf8",
                 Some("1.62.1"),
@@ -892,7 +893,7 @@ aws-smithy-wasm = { version = "0.1.0" }
             .unwrap(),
         );
         check(
-            "canary-release202212162-1621-7ae6085d2105d5d1e13b10f8.zip",
+            "canary-release202212162-1621-7ae6085d2105d5d1.zip",
             &name_hashed_bundle(
                 "7ae6085d2105d5d1e13b10f882c6cb072ff5bbf8",
                 Some("1.62.1"),
@@ -901,7 +902,7 @@ aws-smithy-wasm = { version = "0.1.0" }
             .unwrap(),
         );
         check(
-            "canary-untagged-1621-7ae6085d2105d5d1e13b10f8.zip",
+            "canary-untagged-1621-7ae6085d2105d5d1.zip",
             &name_hashed_bundle(
                 "7ae6085d2105d5d1e13b10f882c6cb072ff5bbf8",
                 Some("1.62.1"),
@@ -910,7 +911,7 @@ aws-smithy-wasm = { version = "0.1.0" }
             .unwrap(),
         );
         check(
-            "canary-release20221216-unknown-7ae6085d2105d5d1e13b10f8.zip",
+            "canary-release20221216-unknown-7ae6085d2105d5d1.zip",
             &name_hashed_bundle(
                 "7ae6085d2105d5d1e13b10f882c6cb072ff5bbf8",
                 None,

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -119,6 +119,10 @@ pub struct RunArgs {
     /// The ARN of the role that the Lambda will execute as
     #[clap(long, required_unless_present = "cdk-output")]
     lambda_execution_role_arn: Option<String>,
+
+    /// Lambda architecture
+    #[clap(long, default_value = "x86_64")]
+    pub(crate) architecture: crate::arch::Arch,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -134,6 +138,7 @@ struct Options {
     lambda_test_s3_mrap_bucket_arn: String,
     lambda_test_s3_express_bucket_name: String,
     lambda_execution_role_arn: String,
+    architecture: crate::arch::Arch,
 }
 
 impl Options {
@@ -203,6 +208,7 @@ impl Options {
                 lambda_test_s3_mrap_bucket_arn,
                 lambda_test_s3_express_bucket_name,
                 lambda_execution_role_arn,
+                architecture: run_opt.architecture,
             })
         } else {
             Ok(Options {
@@ -223,6 +229,7 @@ impl Options {
                     .lambda_test_s3_express_bucket_name
                     .expect("required"),
                 lambda_execution_role_arn: run_opt.lambda_execution_role_arn.expect("required"),
+                architecture: run_opt.architecture,
             })
         }
     }
@@ -319,9 +326,17 @@ async fn run_canary(options: &Options, config: &aws_config::SdkConfig) -> Result
         "Creating the canary Lambda function named {}...",
         bundle_name
     );
+    let function_name = format!(
+        "{}-{}",
+        bundle_name,
+        match options.architecture {
+            crate::arch::Arch::X86_64 => "x86_64",
+            crate::arch::Arch::Aarch64 => "aarch64",
+        }
+    );
     create_lambda_fn(
         lambda_client.clone(),
-        bundle_name,
+        &function_name,
         bundle_file_name,
         options,
     )
@@ -330,11 +345,11 @@ async fn run_canary(options: &Options, config: &aws_config::SdkConfig) -> Result
 
     info!("Invoking the canary Lambda...");
     let invoke_start_time = SystemTime::now();
-    let invoke_result = invoke_lambda(lambda_client.clone(), bundle_name).await;
+    let invoke_result = invoke_lambda(lambda_client.clone(), &function_name).await;
     let invoke_time = invoke_start_time.elapsed().expect("time in range");
 
     info!("Deleting the canary Lambda...");
-    delete_lambda_fn(lambda_client, bundle_name)
+    delete_lambda_fn(lambda_client, &function_name)
         .await
         .context(here!())?;
 
@@ -362,7 +377,7 @@ async fn build_bundle(options: &Options) -> Result<PathBuf> {
         sdk_release_tag: options.sdk_release_tag.clone(),
         sdk_path: options.sdk_path.clone(),
         musl: options.musl,
-        architecture: crate::arch::Arch::X86_64,
+        architecture: options.architecture,
         manifest_only: false,
         disable_jitter_entropy: true,
         feature_override: None,
@@ -433,10 +448,20 @@ async fn create_lambda_fn(
             ),
     };
 
+    let lambda_arch = match options.architecture {
+        crate::arch::Arch::X86_64 => Architecture::X8664,
+        crate::arch::Arch::Aarch64 => Architecture::Arm64,
+    };
+
+    let lambda_runtime = match options.architecture {
+        crate::arch::Arch::X86_64 => Runtime::Providedal2,
+        crate::arch::Arch::Aarch64 => Runtime::Providedal2023,
+    };
+
     lambda_client
         .create_function()
         .function_name(bundle_name)
-        .runtime(Runtime::Providedal2)
+        .runtime(lambda_runtime)
         .role(&options.lambda_execution_role_arn)
         .handler("aws-sdk-rust-lambda-canary")
         .code(
@@ -449,6 +474,7 @@ async fn create_lambda_fn(
         .environment(env_builder.build())
         .timeout(180)
         .memory_size(options.lambda_function_memory_size_in_mb)
+        .architectures(lambda_arch)
         .send()
         .await
         .context(here!("failed to create canary Lambda function"))?;
@@ -565,7 +591,8 @@ mod tests {
                 lambda_test_s3_bucket_name: None,
                 lambda_execution_role_arn: None,
                 lambda_test_s3_mrap_bucket_arn: None,
-                lambda_test_s3_express_bucket_name: None
+                lambda_test_s3_express_bucket_name: None,
+                architecture: crate::arch::Arch::X86_64,
             },
             RunArgs::try_parse_from([
                 "run",
@@ -616,6 +643,7 @@ mod tests {
                 lambda_test_s3_mrap_bucket_arn: "arn:aws:s3::000000000000:accesspoint/example.mrap"
                     .to_owned(),
                 lambda_test_s3_express_bucket_name: "test--usw2-az1--x-s3".to_owned(),
+                architecture: crate::arch::Arch::X86_64,
             },
             Options::load_from(run_args).unwrap(),
         );

--- a/tools/ci-scripts/run-canary
+++ b/tools/ci-scripts/run-canary
@@ -10,6 +10,7 @@ CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME=$1
 export AWS_ACCESS_KEY_ID=$2
 export AWS_SECRET_ACCESS_KEY=$3
 export AWS_SESSION_TOKEN=$4
+ARCHITECTURE="${5:-x86_64}"
 export AWS_REGION=us-west-2
 export RUST_LOG=debug
 
@@ -21,4 +22,5 @@ cargo run -- \
   run --rust-version "${RUST_STABLE_VERSION}" \
       --sdk-path "${SDK_PATH}" \
       --cdk-output cdk-outputs.json \
-      --musl
+      --musl \
+      --architecture "${ARCHITECTURE}"


### PR DESCRIPTION
## DO NOT MERGE — Test PR only

This PR verifies that the ARM64 canary added in #4606 would have caught the
crc-fast 1.4 SIGILL bug that shipped to customers (see #4264, #4380).

**What this does:**
- Includes all canary-arm changes from #4606
- Pins `crc-fast = "=1.4.0"` (the version with the AVX-512 SIGILL bug)

**Expected result:**
- The ARM Lambda canary (`Canary (aarch64)`) should fail with a runtime error
- This proves the multi-arch canary would have caught the original bug before merge

**After verification:** This PR will be closed. The evidence will be linked in #4606.
