### PR TITLE
Loosen crc-fast version bounds to allow 1.10+

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.64.8"
 dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-types 1.4.7",
@@ -1377,29 +1377,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rustversion",
  "spin 0.10.0",
 ]
 

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -18,7 +18,7 @@ aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"]}
 bytes = "1.11.1"
 # FIXME(https://github.com/smithy-lang/smithy-rs/issues/3981): Keep pinned until we have more comprehensive testing in place
-crc-fast = ">=1.9, <2"
+crc-fast = "1.9.0"
 hex = "0.4.3"
 http-1x = {package = "http", version = "1.3.1"}
 http-body-1x = {package = "http-body", version = "1.0.1"}

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.64.8"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",
@@ -18,7 +18,7 @@ aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"]}
 bytes = "1.11.1"
 # FIXME(https://github.com/smithy-lang/smithy-rs/issues/3981): Keep pinned until we have more comprehensive testing in place
-crc-fast = "~1.9.0"
+crc-fast = ">=1.9, <2"
 hex = "0.4.3"
 http-1x = {package = "http", version = "1.3.1"}
 http-body-1x = {package = "http-body", version = "1.0.1"}


### PR DESCRIPTION
Fixes #4598.

Changes `crc-fast = "~1.9.0"` to `crc-fast = ">=1.9"` in `aws-smithy-checksums`, bumps version to 0.64.8.

The `~1.9.0` constraint (>=1.9.0, <1.10.0) blocked downstream users from resolving crc-fast 1.10.