### PR TITLE
Use SDK lockfile for standalone integration tests in CI

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-standalone-integration-tests
+++ b/tools/ci-scripts/check-aws-sdk-standalone-integration-tests
@@ -35,6 +35,7 @@ trap remove_tmp_dir EXIT
 mkdir -p "${tmp_dir}/aws/sdk/build"
 cp -r smithy-rs/aws/sdk/integration-tests "${tmp_dir}/aws/sdk/"
 cp -r aws-sdk-smoketest "${tmp_dir}/aws/sdk/build/aws-sdk"
+cp smithy-rs/aws/sdk/Cargo.lock "${tmp_dir}/aws/sdk/integration-tests/"
 find "${tmp_dir}"
 
 pushd "${tmp_dir}/aws/sdk/integration-tests"


### PR DESCRIPTION
## Motivation and Context
To work around https://github.com/wasm-bindgen/wasm-bindgen/issues/5133 (or any broken dependencies in the future)

## Description
This PR uses SDK lockfile in the CI step in question

## Testing
Passed [CI](https://github.com/smithy-lang/smithy-rs/actions/runs/25138206038)

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
