### PR TITLE
fix: strip trailing whitespace on codegenned new lines

### DIFF
--- a/.changelog/fix-generated-trailing-whitespace.md
+++ b/.changelog/fix-generated-trailing-whitespace.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- server
+authors:
+- jlizen
+references:
+- smithy-rs#4634
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Strip trailing whitespace from generated Rust code. Smithy's `AbstractCodeWriter` adds indentation to blank lines, producing whitespace-only lines that cause `cargo fmt` to fail with `error[internal]: left behind trailing whitespace`.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -598,6 +598,8 @@ class RustWriter private constructor(
 ) :
     SymbolWriter<RustWriter, UseDeclarations>(UseDeclarations(namespace)) {
         companion object {
+            private val TRAILING_WHITESPACE_RE = Regex("[ \\t]+\\n")
+
             fun root() = forModule(null)
 
             fun forModule(module: String?): RustWriter =
@@ -925,6 +927,7 @@ class RustWriter private constructor(
                     null
                 }
             return listOfNotNull(preheader, header, useDecls, contents).joinToString(separator = "\n", postfix = "\n")
+                .replace(TRAILING_WHITESPACE_RE, "\n")
         }
 
         fun format(r: Any) = formatter.apply(r, "")

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriterTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriterTest.kt
@@ -259,8 +259,6 @@ class RustWriterTest {
             output.lines().filter { line ->
                 line != line.trimEnd()
             }
-        // BUG: trailing whitespace is currently produced (inverted assertion).
-        // This will be flipped once the fix is applied.
-        trailingWhitespaceLines.size shouldBe 2
+        trailingWhitespaceLines shouldBe emptyList()
     }
 }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriterTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriterTest.kt
@@ -228,4 +228,39 @@ class RustWriterTest {
         val sut = RustWriter.forModule("src/module_name")
         sut.module().shouldBe("module_name")
     }
+
+    // Regression test for https://github.com/smithy-lang/smithy-rs/issues/4634
+    @Test
+    fun `output does not contain trailing whitespace`() {
+        val sut = RustWriter.root()
+        // Reproduce the two patterns from the issue:
+        sut.rustBlock("fn example()") {
+            // join("\n") separator creates a blank line that gets indented
+            val writables =
+                listOf(
+                    writable { rust("let a = 1;") },
+                    writable { rust("let b = 2;") },
+                )
+            writables.join("\n")(this)
+
+            // Empty string interpolation leaves a blank line that gets indented
+            val empty = ""
+            rust(
+                """
+                something
+                    .method()
+                    $empty
+                    .chain()
+                """,
+            )
+        }
+        val output = sut.toString()
+        val trailingWhitespaceLines =
+            output.lines().filter { line ->
+                line != line.trimEnd()
+            }
+        // BUG: trailing whitespace is currently produced (inverted assertion).
+        // This will be flipped once the fix is applied.
+        trailingWhitespaceLines.size shouldBe 2
+    }
 }


### PR DESCRIPTION
## Motivation and Context

Part of the solution for https://github.com/smithy-lang/smithy-rs/issues/4634

Generated Rust server code contains whitespace-only lines that cause `cargo fmt` to fail with `error[internal]: left behind trailing whitespace`. This reproduces on the stock `smithy-rust-quickstart` template with no modifications.

## Description

Smithy's `AbstractCodeWriter` prepends the current indentation to every line it writes, including blank lines. When codegen templates produce empty lines (via `join("\n")` separators between writables, or empty string interpolations like `$boxIt`/`$boxErr`), the writer turns them into whitespace-only lines.

This change strips trailing whitespace (spaces and tabs before a newline) from all lines in `RustWriter.toString()` using a single regex replace. Blank lines are preserved; only the invisible indentation on them is removed. This is a global fix that catches all current and future instances rather than patching individual templates.

The alternative would be to patch each template that produces blank lines (the `join("\n")` separator in `SmithyValidationExceptionDecorator`, the `$boxIt`/`$boxErr` interpolations in `UnconstrainedUnionGenerator`, etc.). That approach is fragile since any new template could reintroduce the problem. The `toString()` approach is a single chokepoint that all generated output passes through.

The performance cost is negligible: the regex (`[ \t]+\n`) is pre-compiled as a `companion object` val, and it runs a simple character class scan with no backtracking. `toString()` is called once per output file during `flushWriters()` (plus once per inline module writer). In the `codegen-server-test` suite (~2500 generated `.rs` files, ~18MB total), this adds no measurable overhead compared to the model traversal, template rendering, and `cargo fmt` invocation that dominate the build.

This is a partial fix: it eliminates all trailing whitespace produced by codegen, which resolves the whitespace-only blank lines described in the issue. However, both reproducers in the issue also generate `pub(crate)` tuple structs with long type paths (e.g. constrained map/collection wrappers), and `rustfmt` itself reintroduces trailing whitespace when wrapping those fields. That means `cargo fmt` will still fail on a freshly generated workspace for models that produce these types. That is an upstream `rustfmt` bug ([rust-lang/rustfmt#6880](https://github.com/rust-lang/rustfmt/issues/6880)). The codegen pipeline already catches and logs `cargo fmt` failures, so those cases are non-blocking.

## Testing

Added a regression test in `RustWriterTest` that reproduces both patterns from the issue (join separator blank lines and empty string interpolation blank lines inside indented blocks) and asserts no trailing whitespace in the output. Full `codegen-core` test suite passes.

Verified end-to-end with a clean `codegen-server-test:assemble` build (~2500 generated `.rs` files). All codegen-produced trailing whitespace is eliminated. The only remaining trailing whitespace in generated files comes from `rustfmt` reintroducing it on `pub(crate)` tuple struct fields (the upstream bug).

Benchmarked `codegen-server-test:clean assemble` over 10 runs each: 25.2s +/- 0.6s with the fix vs 24.9s +/- 0.7s without. Within noise, no measurable performance impact.

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
