### PR TITLE
Bump Smithy to 1.69.0

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointBddGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointBddGenerator.kt
@@ -78,6 +78,7 @@ class EndpointBddGenerator(
         private val allowLintsForBddResolver =
             listOf(
                 "unused_variables",
+                "unused_parens",
                 "clippy::double_parens",
                 "clippy::useless_conversion",
                 "clippy::bool_comparison",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointBddGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointBddGenerator.kt
@@ -45,6 +45,8 @@ import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.BddEx
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.ExpressionGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.Ownership
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute.Companion.allow
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -72,6 +74,19 @@ class EndpointBddGenerator(
         private const val RESULT_PREFIX = "Result"
         private const val BINDING_PREFIX = "binding_"
         private const val CONDITION_FN_PREFIX = "cond_"
+
+        private val allowLintsForBddResolver =
+            listOf(
+                "unused_variables",
+                "clippy::double_parens",
+                "clippy::useless_conversion",
+                "clippy::bool_comparison",
+                "clippy::comparison_to_empty",
+                "clippy::needless_borrow",
+                "clippy::useless_asref",
+                "clippy::redundant_closure_call",
+                "clippy::clone_on_copy",
+            )
     }
 
     private data class GenerationContext(
@@ -171,9 +186,7 @@ class EndpointBddGenerator(
                         }
                     }
 
-                    ##[allow(unused_variables, unused_parens, clippy::double_parens,
-                        clippy::useless_conversion, clippy::bool_comparison, clippy::comparison_to_empty,
-                        clippy::needless_borrow, clippy::useless_asref, clippy::redundant_closure_call)]
+                    #{AllowLints:W}
                     fn resolve_endpoint<'a>(&'a self, params: &'a #{Params}) -> #{Result}<#{SmithyEndpoint}, #{BoxError}> {
                         let mut _diagnostic_collector = #{DiagnosticCollector}::new();
                         ##[allow(unused_mut)]
@@ -225,6 +238,7 @@ class EndpointBddGenerator(
                 }
                 """,
                 *preludeScope,
+                "AllowLints" to writable { Attribute(allow(allowLintsForBddResolver)).render(this) },
                 "ArcSwap" to CargoDependency.ArcSwap.toType().resolve("ArcSwap"),
                 "BoxError" to RuntimeType.boxError(runtimeConfig),
                 "CustomFields" to
@@ -265,12 +279,13 @@ class EndpointBddGenerator(
                         """
                         $idx => (|_diagnostic_collector: &mut #{DiagnosticCollector}| -> bool {
                             #{NonParamRefBindings:W}
-                            let partition_resolver = &self.partition_resolver;
+                            #{CustomFieldBindings:W}
                             #{body:W}
                         })(&mut _diagnostic_collector),
                         """,
                         "DiagnosticCollector" to EndpointsLib.DiagnosticCollector,
                         "NonParamRefBindings" to generateNonParamReferences(),
+                        "CustomFieldBindings" to generateCustomFieldBindings(genContext),
                         "body" to condBody,
                     )
                 }
@@ -390,9 +405,7 @@ class EndpointBddGenerator(
                 }
 
                 impl ConditionFn {
-                    ##[allow(unused_variables, unused_parens, clippy::double_parens,
-                        clippy::useless_conversion, clippy::bool_comparison, clippy::comparison_to_empty,
-                        clippy::needless_borrow, clippy::useless_asref, )]
+                    #{AllowLints:W}
                     fn evaluate<'a>(&self, params: &'a Params, context: &mut ConditionContext<'a>#{AdditionalArgsSigPrefix}#{AdditionalArgsSig}, _diagnostic_collector: &mut #{DiagnosticCollector}) -> bool {
                         // Param bindings
                         #{ParamBindings:W}
@@ -410,6 +423,7 @@ class EndpointBddGenerator(
                 ];
                 """,
                 *preludeScope,
+                "AllowLints" to writable { Attribute(allow(allowLintsForBddResolver)).render(this) },
                 "AdditionalArgsSig" to
                     writable {
                         genContext.additionalArgsSignature.forEachIndexed { i, it ->
@@ -506,6 +520,19 @@ class EndpointBddGenerator(
             val varRefs = allRefs.variableRefs()
             varRefs.forEach {
                 rust("let ${it.value.name} = &mut context.${it.value.name};")
+            }
+        }
+
+    /**
+     * Generate bindings for custom fields (e.g. partition_resolver) from self into the condition closure.
+     * Only emits bindings for functions that are actually used by the endpoint rules.
+     */
+    private fun generateCustomFieldBindings(genContext: GenerationContext) =
+        writable {
+            genContext.fnsUsed.forEach { fn ->
+                if (fn.structFieldBdd() != null) {
+                    rust("let partition_resolver = &self.partition_resolver;")
+                }
             }
         }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/BddExpressionGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/BddExpressionGenerator.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
 
+import software.amazon.smithy.rulesengine.language.evaluation.type.ArrayType
 import software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType
 import software.amazon.smithy.rulesengine.language.evaluation.type.OptionalType
 import software.amazon.smithy.rulesengine.language.evaluation.type.StringType
@@ -269,7 +270,17 @@ class BddExpressionGenerator(
         ): Writable =
             writable {
                 when {
-                    !isOptionalArgument(arg) -> rust("#W", expressionGenerator.generateExpression(arg))
+                    !isOptionalArgument(arg) -> {
+                        rust("#W", expressionGenerator.generateExpression(arg))
+                        // Coalesce macro's autoderef specialization requires owned values to
+                        // match the (Option<T>, T) impl. Params are bound as references,
+                        // and string literals are &str — need conversion to owned types.
+                        if (arg is Reference) {
+                            rust(".clone()")
+                        } else if (arg is Literal && arg.type() is StringType) {
+                            rust(".to_string()")
+                        }
+                    }
                     arg is LibraryFunction && arg.functionDefinition.returnType is OptionalType ->
                         rust(
                             """
@@ -282,7 +293,7 @@ class BddExpressionGenerator(
                             expressionGenerator.generateExpression(arg),
                         )
 
-                    else -> rust("*#W", expressionGenerator.generateExpression(arg))
+                    else -> rust("#W.clone()", expressionGenerator.generateExpression(arg))
                 }
             }
 
@@ -450,7 +461,9 @@ class BddExpressionGenerator(
             writable {
                 val innerGen = createChildGenerator()
                 val fnExpr = innerGen.generateExpression(condition.function)
-                val fnReturnType = condition.function.functionDefinition.returnType
+                // Use .type() for the actual resolved return type (not functionDefinition.returnType
+                // which is the generic declared type and doesn't account for coalesce's type-dependent returns)
+                val fnReturnType = condition.function.type()
 
                 if (condition.result.isPresent) {
                     rust("#W", generateLibraryFunctionAssignment(fnExpr, fnReturnType))
@@ -467,6 +480,11 @@ class BddExpressionGenerator(
                 val resultName = condition.result.get().rustName()
                 val isOptional = returnType is OptionalType
                 val isBoolean = returnType is BooleanType
+                val innerType = if (isOptional) (returnType as OptionalType).inner() else returnType
+                val isArray = innerType is ArrayType
+
+                // Conversion expression: .into() for scalars, .into_iter().map(...).collect() for arrays
+                val intoExpr = if (isArray) ".into_iter().map(|s| s.to_owned()).collect()" else ".into()"
 
                 when {
                     // Non-optional boolean: assign and return the value
@@ -486,7 +504,7 @@ class BddExpressionGenerator(
                         rustTemplate(
                             """
                             {
-                                *$resultName = Some(#{FN:W}.into());
+                                *$resultName = Some(#{FN:W}$intoExpr);
                                 true
                             }
                             """.trimIndent(),
@@ -497,7 +515,7 @@ class BddExpressionGenerator(
                         rustTemplate(
                             """
                             {
-                                *$resultName = #{FN:W}.map(|inner| inner.into());
+                                *$resultName = #{FN:W}.map(|inner| inner$intoExpr);
                                 $resultName.is_some()
                             }
                             """.trimIndent(),

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/EndpointTestDiscovery.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/EndpointTestDiscovery.kt
@@ -9,58 +9,39 @@ import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.loader.ModelAssembler
-import software.amazon.smithy.model.loader.ModelDiscovery
+import software.amazon.smithy.model.neighbor.Walker
 import software.amazon.smithy.model.transform.ModelTransformer
-import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.letIf
 
 class EndpointTestDiscovery {
     fun testCases(): List<Model> {
-        // Find models from smithy-rules-engine-tests on the classpath
-        val testModels =
-            ModelDiscovery.findModels().filter { url ->
-                url.toString().contains("smithy-rules-engine-tests") &&
-                    url.toString().endsWith(".smithy")
-            }
+        // Load the full model from classpath (includes smithy-rules-engine-tests).
+        // As of Smithy 1.69, test models are compiled into a single model.json
+        // rather than discoverable as individual .smithy files.
+        val fullModel = ModelAssembler().discoverModels().assemble().unwrap()
 
-        // Find trait definitions (exclude test models)
-        val traitModels =
-            ModelDiscovery.findModels().filter { url ->
-                val urlString = url.toString()
-                // Include trait definitions but exclude test models
-                !urlString.contains("smithy-rules-engine-tests") &&
-                    !urlString.contains("smithy-protocol-tests") &&
-                    urlString.endsWith(".smithy")
-            }
-
-        // Assemble each test model individually with trait definitions
-        val assembledModels =
-            testModels.map { testUrl ->
-                val assembler = ModelAssembler()
-                // Add all trait definitions
-                traitModels.forEach { assembler.addImport(it) }
-                // Add the specific test model
-                assembler.addImport(testUrl)
-                assembler.assemble().unwrap()
-            }
-
-        // Add protocol trait if needed
-        return assembledModels.map { model ->
-            if (model.serviceShapes.size > 1) {
-                PANIC("too many services")
-            }
-            val service = model.serviceShapes.first()
-            if (ServiceIndex.of(model).getProtocols(service).isEmpty()) {
-                ModelTransformer.create().mapShapes(model) { s ->
-                    s.letIf(s == service) {
-                        s.asServiceShape().get().toBuilder().addTrait(
-                            AwsJson1_0Trait.builder().build(),
-                        ).build()
+        val transformer = ModelTransformer.create()
+        // Extract per-service models for endpoint rule test services
+        return fullModel.serviceShapes
+            .filter { it.id.namespace == "smithy.rules.tests" }
+            .map { service ->
+                val connected = Walker(fullModel).walkShapes(service).map { it.id }.toSet()
+                val perServiceModel =
+                    transformer.filterShapes(fullModel) { shape ->
+                        connected.contains(shape.id) || !shape.id.namespace.startsWith("smithy.rules.tests")
                     }
+                // Add protocol trait if needed
+                if (ServiceIndex.of(perServiceModel).getProtocols(service).isEmpty()) {
+                    transformer.mapShapes(perServiceModel) { s ->
+                        s.letIf(s == service) {
+                            s.asServiceShape().get().toBuilder().addTrait(
+                                AwsJson1_0Trait.builder().build(),
+                            ).build()
+                        }
+                    }
+                } else {
+                    perServiceModel
                 }
-            } else {
-                model
             }
-        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin-version = "2.1.0"
 ktlint-version = "1.0.1"
 
 # codegen
-smithy-version = "1.67.0"
+smithy-version = "1.69.0"
 smithy-gradle-plugin-version = "1.3.0"
 
 # publishing


### PR DESCRIPTION
## Motivation and Context
Bump Smithy from 1.67.0 to 1.69.0. [Smithy 1.69](https://github.com/smithy-lang/smithy/releases/tag/1.69.0) added automatic BDD generation to endpoint `rules-engine-tests`, requiring updates to the BDD endpoint codegen.

## Description
#### 1) BDD endpoint codegen fixes (`EndpointBddGenerator.kt`)
- Made `partition_resolver` binding conditional — only emit when the endpoint rules actually use the `aws.partition function`. Previously it was unconditional, causing no field `partition_resolver` for services that don't use partitions:
```
    error[E0609]: no field `partition_resolver` on type `&'a DefaultResolver`
       --> smithy-test12709321913895361668/src/config/endpoint.rs:378:60
        |
    378 | ...                   let partition_resolver = &self.partition_resolver;
        |                                                      ^^^^^^^^^^^^^^^^^^ unknown field
        |
        = note: available field is: `endpoint_cache`
```
- Refactored hardcoded #[allow(...)] attributes into a reusable list, `allowLintsForBddResolver`
- Added `unused_parens` and `unused_variables` to `allowLintsForBddResolver` to suppress warnings from Smithy 1.69's generated expressions:
```
error: unnecessary parentheses around function argument
     --> /tmp/smithy-rs-ci-VR0RKfcT/aws/sdk/build/aws-sdk/sdk/s3/src/config/endpoint.rs:13918:51
      |
13918 | ...                   (region) == &mut Some(("us-east-1".into()))
```

#### 2) BDD expression generator fixes (`BddExpressionGenerator.kt`)
- Used `.type()` instead of `functionDefinition.returnType` to get the actual resolved return type. Coalesce's declared return type is `Optional<String>` but the resolved type after type inference is `String`:
```
error[E0277]: the trait bound `std::string::String: From<Option<std::string::String>>` is not satisfied
   --> src/config/endpoint.rs:318:51
    | 
318 | ...  *opt1_req1 = Some(crate::endpoint_lib::coalesce::coalesce!(*opt1, req1).into());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---- required by a bound introduced by this call
```
- Added array type handling with `.into_iter().map(|s| s.to_owned()).collect()` instead of `.into()` for functions like split:
```
error[E0277]: the trait bound `Vec<std::string::String>: From<Vec<&str>>` is not satisfied
```
- Fixed coalesce argument ownership: added `.clone()` for reference args and `.to_string()` for string literals, replaced `*expr` with `expr.clone()` — fixes type mismatches where the coalesce macro's autoderef specialization requires owned values.

#### 3) Test discovery update (`EndpointTestDiscovery.kt`)
- The BDD traits added by Smithy 1.69 only exist in the compiled `model.json`, not in individual `.smithy` source files. Updated discovery to assemble the full model and extract per-service models using `Walker` so the BDD traits are available to codegen.

## Testing
- CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
