### PR TITLE
Bump p256 to 0.13.2 in aws-sigv4

### DIFF
--- a/.changelog/1777990546.md
+++ b/.changelog/1777990546.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- suzak
+references:
+- smithy-rs#4587
+breaking: false
+new_feature: false
+bug_fix: false
+---
+Upgrade `p256` from 0.11 to 0.13.2 in `aws-sigv4` so the SigV4a signing path uses the same major version already pulled in elsewhere in the SDK and benefits from upstream maintenance fixes.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -165,7 +165,7 @@ version = "1.1.12"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -174,7 +174,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "criterion",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hex-literal",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64-simd"
@@ -747,24 +747,14 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -803,11 +793,12 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -833,6 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -862,14 +854,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -880,17 +874,17 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der",
+ "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -922,9 +916,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1009,6 +1003,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1049,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -1634,12 +1629,13 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -1667,6 +1663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,9 +1691,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -1764,6 +1769,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1934,13 +1948,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
  "hmac 0.12.1",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -2091,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -2241,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -2289,9 +2302,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"
@@ -29,7 +29,7 @@ hex = "0.4.3"
 hmac = "0.13"
 http0 = { package = "http" , version = "0.2.12", optional = true }
 http = { version = "1.3.1", optional = true }
-p256 = { version = "0.11", features = ["ecdsa"], optional = true }
+p256 = { version = "0.13.2", features = ["ecdsa"], optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
 ring = { version = "0.17.5", optional = true }
 sha2 = "0.11"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/test.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/test.rs
@@ -310,7 +310,7 @@ pub(crate) mod v4a {
         sign, PayloadChecksumKind, SessionTokenMode, SignatureLocation, SigningSettings,
     };
     use crate::sign::v4a;
-    use p256::ecdsa::signature::{Signature, Verifier};
+    use p256::ecdsa::signature::Verifier;
     use p256::ecdsa::{DerSignature, SigningKey};
     use std::time::Duration;
     use time::format_description::well_known::Rfc3339;
@@ -369,12 +369,9 @@ pub(crate) mod v4a {
         let creds = params.credentials().unwrap();
         let signing_key =
             v4a::generate_signing_key(creds.access_key_id(), creds.secret_access_key());
-        let sig = DerSignature::from_bytes(&hex::decode(out.signature).unwrap()).unwrap();
-        let sig = sig
-            .try_into()
-            .expect("DER-style signatures are always convertible into fixed-size signatures");
+        let sig = DerSignature::try_from(hex::decode(out.signature).unwrap().as_slice()).unwrap();
 
-        let signing_key = SigningKey::from_bytes(signing_key.as_ref()).unwrap();
+        let signing_key = SigningKey::from_slice(signing_key.as_ref()).unwrap();
         let peer_public_key = signing_key.verifying_key();
         let sts = actual_string_to_sign.as_bytes();
         peer_public_key.verify(sts, &sig).unwrap();

--- a/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
@@ -7,7 +7,7 @@ use aws_smithy_runtime_api::client::identity::Identity;
 use bytes::{BufMut, BytesMut};
 use crypto_bigint::{CheckedAdd, CheckedSub, Encoding, U256};
 use p256::ecdsa::signature::Signer;
-use p256::ecdsa::{Signature, SigningKey};
+use p256::ecdsa::{DerSignature, SigningKey};
 use std::io::Write;
 use std::sync::LazyLock;
 use std::time::SystemTime;
@@ -25,14 +25,9 @@ static BIG_N_MINUS_2: LazyLock<U256> = LazyLock::new(|| {
 
 /// Calculates a Sigv4a signature
 pub fn calculate_signature(signing_key: impl AsRef<[u8]>, string_to_sign: &[u8]) -> String {
-    let signing_key = SigningKey::from_bytes(signing_key.as_ref()).unwrap();
-    let signature: Signature = signing_key.sign(string_to_sign);
-    // This conversion sucks but we have to do it afaict. Because we also use
-    // the HMAC crate, we have to use a compatible (and therefore older) version
-    // of the p256 crate. That older version requires us to convert between
-    // signature types instead of using DER-encoded signatures directly.
-    let signature = signature.to_der();
-    hex::encode(signature.as_ref())
+    let signing_key = SigningKey::from_slice(signing_key.as_ref()).unwrap();
+    let signature: DerSignature = signing_key.sign(string_to_sign);
+    hex::encode(signature.as_bytes())
 }
 
 /// Generates a signing key for Sigv4a signing.
@@ -70,7 +65,7 @@ pub fn generate_signing_key(access_key: &str, secret_access_key: &str) -> impl A
                 .checked_add(&U256::ONE)
                 .expect("k0 is always less than U256::MAX");
             let d = Zeroizing::new(pk.to_be_bytes());
-            break SigningKey::from_bytes(d.as_ref()).unwrap();
+            break SigningKey::from_slice(d.as_ref()).unwrap();
         }
 
         *counter = counter


### PR DESCRIPTION
## Motivation and Context

Follow-up to #4587, which bumped `sha2`/`hmac`/`md-5`/`sha1` in `aws-sigv4` and `aws-smithy-checksums` but left `p256` at 0.11.

The SigV4a-introducing PR (#2939) originally had `p256 = "0.13.2"` but [intentionally downgraded it to 0.11](https://github.com/smithy-lang/smithy-rs/pull/2939#discussion_r1339162417) because of a `digest` trait version conflict with the then-current `hmac 0.12`. Now that #4587 has moved `aws-sigv4` to `hmac 0.13`, that constraint no longer applies and `p256 0.13.2` is already on the resolved tree (via `aws-config`), so this just collapses the duplicate `p256` versions in the SDK lockfile.

## Description

`aws-sigv4`
- `p256`: 0.11 → 0.13.2
- crate version: 1.4.3 → 1.4.4
- `SigningKey::from_bytes(&[u8])` → `SigningKey::from_slice(&[u8])` (the `from_bytes` signature changed to take `&FieldBytes` in `ecdsa 0.16`)
- `calculate_signature` now signs directly to `DerSignature` via `Signer<DerSignature>`, removing the intermediate `Signature::to_der()` conversion. The stale comment about being forced onto an older `p256` is removed.
- The SigV4a test path drops the `DerSignature -> Signature` round-trip and verifies the DER signature directly through `VerifyingKey: Verifier<DerSignature>`.
- `signature` 2.x removed the `Signature` trait that was previously imported from `p256::ecdsa::signature`; that import is dropped accordingly.
- `DerSignature::from_bytes(&[u8])` → `DerSignature::try_from(&[u8])`.

## Testing

- `cargo test --all-features` in `aws/rust-runtime/aws-sigv4` — 123 passed, 0 failed (incl. the full SigV4a test suite, whose verification path exercises the new DER flow end-to-end).
- `cargo check --workspace --all-features` in `aws/rust-runtime` — clean.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.