### PR TITLE
Remove ring dependency from aws-sigv4

### DIFF
--- a/.changelog/1777990546.md
+++ b/.changelog/1777990546.md
@@ -1,11 +1,10 @@
 ---
 applies_to:
-- client
 - aws-sdk-rust
 authors:
 - suzak
 references:
-- smithy-rs#4587
+- smithy-rs#4648
 breaking: false
 new_feature: false
 bug_fix: false

--- a/.changelog/remove-ring-from-aws-sigv4.md
+++ b/.changelog/remove-ring-from-aws-sigv4.md
@@ -1,7 +1,6 @@
 ---
 applies_to:
 - aws-sdk-rust
-- client
 authors:
 - suzak
 references:

--- a/.changelog/remove-ring-from-aws-sigv4.md
+++ b/.changelog/remove-ring-from-aws-sigv4.md
@@ -4,7 +4,8 @@ applies_to:
 - client
 authors:
 - suzak
-references: []
+references:
+- smithy-rs#4650
 breaking: false
 new_feature: false
 bug_fix: false

--- a/.changelog/remove-ring-from-aws-sigv4.md
+++ b/.changelog/remove-ring-from-aws-sigv4.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- suzak
+references: []
+breaking: false
+new_feature: false
+bug_fix: false
+---
+
+Remove the `ring` dependency from `aws-sigv4`. The `sigv4a` feature previously pulled in `ring` solely for HMAC-SHA256 in the SigV4a signing-key derivation; this is now done with the `hmac`/`sha2` (RustCrypto) crates that were already used by the SigV4 signer. `ring` is in maintenance hibernation, and the original reason for using it (a version conflict with the older `p256` crate at the time SigV4a was introduced) no longer applies. Users of the `sigv4a` feature will see `ring` removed from their dependency tree.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "percent-encoding",
  "pretty_assertions",
  "proptest",
- "ring",
  "serde",
  "serde_derive",
  "serde_json",

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -15,7 +15,7 @@ http0-compat = ["dep:http0"]
 http1 = ["dep:http"]
 sign-http = ["dep:http0", "dep:percent-encoding", "dep:form_urlencoded"]
 sign-eventstream = ["dep:aws-smithy-eventstream"]
-sigv4a = ["dep:p256", "dep:crypto-bigint", "dep:subtle", "dep:zeroize", "dep:ring"]
+sigv4a = ["dep:p256", "dep:crypto-bigint", "dep:subtle", "dep:zeroize"]
 
 [dependencies]
 aws-credential-types = { path = "../aws-credential-types" }
@@ -31,7 +31,6 @@ http0 = { package = "http" , version = "0.2.12", optional = true }
 http = { version = "1.3.1", optional = true }
 p256 = { version = "0.13.2", features = ["ecdsa"], optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
-ring = { version = "0.17.5", optional = true }
 sha2 = "0.11"
 crypto-bigint = { version = "0.5.4", optional = true }
 subtle = { version = "2.5.0", optional = true }
@@ -53,9 +52,6 @@ serde_json = "1.0.104"
 time = { version = "0.3.5", features = ["parsing"] }
 
 criterion = "0.5"
-
-[target.'cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))'.dev-dependencies]
-ring = "0.17.5"
 
 [[bench]]
 name = "hmac"

--- a/aws/rust-runtime/aws-sigv4/benches/hmac.rs
+++ b/aws/rust-runtime/aws-sigv4/benches/hmac.rs
@@ -6,8 +6,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use hmac::digest::FixedOutput;
 use hmac::{Hmac, KeyInit, Mac};
-#[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-use ring::hmac::{sign, Context, Key, HMAC_SHA256};
 use sha2::Sha256;
 
 pub fn hmac(c: &mut Criterion) {
@@ -21,43 +19,6 @@ pub fn hmac(c: &mut Criterion) {
     });
 }
 
-#[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-pub fn ring_multipart(c: &mut Criterion) {
-    c.bench_function("ring_multipart", |b| {
-        b.iter(|| {
-            let k = Key::new(HMAC_SHA256, b"secret");
-            let mut ctx = Context::with_key(&k);
-
-            for slice in ["hello", ", ", "world"] {
-                ctx.update(slice.as_ref());
-            }
-
-            ctx.sign()
-        })
-    });
-}
-
-#[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-pub fn ring_one_shot(c: &mut Criterion) {
-    c.bench_function("ring_one_shot", |b| {
-        b.iter(|| {
-            let k = Key::new(HMAC_SHA256, b"secret");
-
-            sign(&k, b"hello, world")
-        })
-    });
-}
-
-#[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))]
-criterion_group! {
-    name = benches;
-
-    config = Criterion::default();
-
-    targets = hmac, ring_multipart, ring_one_shot
-}
-
-#[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
 criterion_group! {
     name = benches;
 

--- a/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign/v4a.rs
@@ -6,8 +6,10 @@
 use aws_smithy_runtime_api::client::identity::Identity;
 use bytes::{BufMut, BytesMut};
 use crypto_bigint::{CheckedAdd, CheckedSub, Encoding, U256};
+use hmac::{digest::FixedOutput, Hmac, KeyInit, Mac};
 use p256::ecdsa::signature::Signer;
 use p256::ecdsa::{DerSignature, SigningKey};
+use sha2::Sha256;
 use std::io::Write;
 use std::sync::LazyLock;
 use std::time::SystemTime;
@@ -48,15 +50,14 @@ pub fn generate_signing_key(access_key: &str, secret_access_key: &str) -> impl A
         fis.append(&mut kdf_context);
         fis.put_i32(256);
 
-        let key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &input_key);
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(&input_key).expect("HMAC can take key of any size");
 
         let mut buf = BytesMut::new();
         buf.put_i32(1);
         buf.put_slice(&fis);
-        let tag = ring::hmac::sign(&key, &buf);
-        let tag = &tag.as_ref()[0..32];
-
-        let k0 = U256::from_be_bytes(tag.try_into().expect("convert to [u8; 32]"));
+        mac.update(&buf);
+        let k0 = U256::from_be_bytes(mac.finalize_fixed().into());
 
         // It would be more secure for this to be a constant time comparison, but because this
         // is for client usage, that's not as big a deal.


### PR DESCRIPTION
## Motivation and Context

`ring` is in maintenance hibernation, so reducing its use across the ecosystem is preferable when alternatives are available. In `aws-sigv4`, `ring` was pulled in solely for HMAC-SHA256 inside the SigV4a signing-key derivation; the SigV4 signer already uses RustCrypto's `hmac` + `sha2` for the same primitive.

The original reason for the split — a transitive crate-version conflict between `hmac` and the `p256` crate at the time SigV4a was introduced (#2939) — no longer applies after #4648 bumped `p256` to `0.13.2`, which is on aligned RustCrypto deps.

## Description

- Replaced `ring::hmac::{Key, sign}` in `aws/rust-runtime/aws-sigv4/src/sign/v4a.rs` with `Hmac::<Sha256>` from the existing `hmac`/`sha2` deps (same primitives the SigV4 signer uses).
- Removed `ring` from `aws/rust-runtime/aws-sigv4/Cargo.toml`:
  - dropped `dep:ring` from the `sigv4a` feature,
  - removed the `ring` entry from `[dependencies]`,
  - removed the PowerPC-cfg `[target.'cfg(...)'.dev-dependencies]` block (which existed only to gate `ring` on non-PowerPC).
- Removed the `ring_multipart` / `ring_one_shot` benches from `aws/rust-runtime/aws-sigv4/benches/hmac.rs`; the file now benchmarks the RustCrypto path only. Cleaning these out also lets the bench compile uniformly across all targets.
- `aws/rust-runtime/Cargo.lock` updated (one transitive entry removed from `aws-sigv4`'s dev-dependencies).

Out of scope: other crates that still use `ring` (e.g., `aws-inlineable/src/glacier_interceptors.rs` for streaming SHA-256). Those can be migrated in follow-up PRs.

## Testing

Locally on this branch:

- `cargo build --features sigv4a` — OK
- `cargo test --features sigv4a` — 121 passed / 0 failed (full v4a interop test suite included)
- `cargo clippy --features sigv4a --all-targets` — no warnings
- `cargo bench --features sigv4a --no-run` — bench targets build cleanly

The SigV4a interop suite (`http_request::sign::tests::v4a_suite::*`) covers the signing path that uses the swapped HMAC, so functional equivalence is exercised by these tests.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
