### PR TITLE
Expand client metrics coverage

### DIFF
--- a/.changelog/expand-client-metrics.md
+++ b/.changelog/expand-client-metrics.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- vcjana
+references:
+- smithy-rs#4248
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add 7 new client metrics to MetricsInterceptor: `smithy.client.call.attempts`, `smithy.client.call.errors`, `smithy.client.call.serialization_duration`, `smithy.client.call.deserialization_duration`, `smithy.client.call.auth.signing_duration`, `smithy.client.call.auth.resolve_identity_duration`, and `smithy.client.call.resolve_endpoint_duration`.

--- a/aws/sdk/benchmarks/standardized-benches/Cargo.lock
+++ b/aws/sdk/benchmarks/standardized-benches/Cargo.lock
@@ -68,6 +68,167 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +242,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.9.0"
+version = "1.8.17"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -141,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -348,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.64.8"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -437,6 +598,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-observability-otel"
+version = "0.1.11"
+dependencies = [
+ "async-global-executor",
+ "async-task",
+ "aws-smithy-observability",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "value-bag",
+]
+
+[[package]]
 name = "aws-smithy-query"
 version = "0.60.15"
 dependencies = [
@@ -446,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.4"
+version = "1.11.2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -469,9 +642,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.7"
+version = "1.12.1"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -480,6 +654,15 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -515,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.4.0"
+version = "1.3.15"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -575,6 +758,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -677,6 +873,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -949,6 +1154,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1278,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1364,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1446,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1536,10 +1805,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1561,6 +1845,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -1650,6 +1937,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1988,12 @@ dependencies = [
  "elliptic-curve",
  "sha2 0.10.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1708,6 +2037,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,6 +2055,20 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1731,6 +2085,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1755,6 +2118,27 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -1832,6 +2216,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2158,9 +2555,13 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-lambda",
  "aws-sdk-s3",
+ "aws-smithy-observability",
+ "aws-smithy-observability-otel",
  "aws-smithy-types",
  "clap",
  "futures",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "sysinfo",
@@ -2214,6 +2615,26 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2301,6 +2722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.37",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2435,6 +2867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2922,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2965,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2683,6 +3145,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/aws/sdk/benchmarks/standardized-benches/Cargo.toml
+++ b/aws/sdk/benchmarks/standardized-benches/Cargo.toml
@@ -12,9 +12,13 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
 aws-sdk-lambda = { path = "../../build/aws-sdk/sdk/lambda" }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
+aws-smithy-observability = { path = "../../build/aws-sdk/sdk/aws-smithy-observability" }
+aws-smithy-observability-otel = { path = "../../build/aws-sdk/sdk/aws-smithy-observability-otel" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
+opentelemetry = { version = "0.26", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.26", features = ["metrics", "testing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.30"

--- a/aws/sdk/benchmarks/standardized-benches/bench-config-test.json
+++ b/aws/sdk/benchmarks/standardized-benches/bench-config-test.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "name": "ddb-putitem-metrics-test",
+  "service": "dynamodb",
+  "action": "putitem",
+  "actionConfig": {
+    "tableName": "smithy-rs-metrics-bench-test",
+    "region": "us-west-2",
+    "keyPrefix": "test-",
+    "deleteTableAfterBenchmark": true
+  },
+  "batch": { "numberOfActions": 10 },
+  "warmup": { "batches": 1 },
+  "measurement": { "batches": 2, "metricsInterval": 1 },
+  "waiterTimeoutSecs": 120
+}

--- a/aws/sdk/benchmarks/standardized-benches/e2e-configs/ddb-putitem-metrics-test.json
+++ b/aws/sdk/benchmarks/standardized-benches/e2e-configs/ddb-putitem-metrics-test.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "name": "ddb-putitem-metrics-test",
+  "description": "Test SDK metrics capture with DynamoDB PutItem",
   "service": "dynamodb",
   "action": "putitem",
   "actionConfig": {
@@ -9,8 +10,12 @@
     "keyPrefix": "test-",
     "deleteTableAfterBenchmark": true
   },
-  "batch": { "numberOfActions": 10 },
+  "batch": {
+    "description": "PutItem 1KB items",
+    "numberOfActions": 10,
+    "sequentialExecution": true
+  },
   "warmup": { "batches": 1 },
-  "measurement": { "batches": 2, "metricsInterval": 1 },
+  "measurement": { "batches": 2, "collectMetrics": true, "metricsInterval": 1 },
   "waiterTimeoutSecs": 120
 }

--- a/aws/sdk/benchmarks/standardized-benches/src/e2e/ddb.rs
+++ b/aws/sdk/benchmarks/standardized-benches/src/e2e/ddb.rs
@@ -9,8 +9,15 @@ use crate::bench_utils::{basic_stats, percentile};
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::Client;
+use aws_smithy_observability::global::set_telemetry_provider;
+use aws_smithy_observability::TelemetryProvider;
+use aws_smithy_observability_otel::meter::OtelMeterProvider;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::runtime::Tokio;
+use opentelemetry_sdk::testing::metrics::InMemoryMetricsExporter;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 #[derive(Debug, Deserialize)]
@@ -30,6 +37,22 @@ pub struct BenchmarkResults {
     pub latency_stats: LatencyStats,
     pub cpu_stats: ResourceStats,
     pub memory_stats: ResourceStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sdk_metrics: Option<SdkMetrics>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkMetrics {
+    pub call_duration_mean_ms: f64,
+    pub attempt_duration_mean_ms: f64,
+    pub serialization_duration_mean_ms: f64,
+    pub deserialization_duration_mean_ms: f64,
+    pub signing_duration_mean_ms: f64,
+    pub resolve_identity_duration_mean_ms: f64,
+    pub resolve_endpoint_duration_mean_ms: f64,
+    pub total_attempts: u64,
+    pub total_errors: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -43,6 +66,14 @@ pub struct LatencyStats {
 }
 
 pub async fn run_benchmark(config: BenchmarkConfig<ActionConfig>) -> BenchmarkResults {
+    // Set up in-memory metrics collection
+    let exporter = InMemoryMetricsExporter::default();
+    let reader = PeriodicReader::builder(exporter.clone(), Tokio).build();
+    let otel_mp = SdkMeterProvider::builder().with_reader(reader).build();
+    let sdk_mp = Arc::new(OtelMeterProvider::new(otel_mp.clone()));
+    let sdk_tp = TelemetryProvider::builder().meter_provider(sdk_mp).build();
+    let _ = set_telemetry_provider(sdk_tp);
+
     let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .region(aws_config::Region::new(config.action_config.region.clone()))
         .load()
@@ -88,6 +119,7 @@ pub async fn run_benchmark(config: BenchmarkConfig<ActionConfig>) -> BenchmarkRe
         latency_stats: calculate_latency_stats(&all_latencies),
         cpu_stats: basic_stats(&cpu).into(),
         memory_stats: basic_stats(&mem).into(),
+        sdk_metrics: extract_sdk_metrics(&otel_mp, &exporter),
     }
 }
 
@@ -230,4 +262,125 @@ fn calculate_latency_stats(latencies: &[f64]) -> LatencyStats {
         p99_ms: percentile(&sorted, 0.99),
         std_dev_ms: stats.std_dev,
     }
+}
+
+fn extract_sdk_metrics(
+    otel_mp: &SdkMeterProvider,
+    exporter: &InMemoryMetricsExporter,
+) -> Option<SdkMetrics> {
+    otel_mp.force_flush().ok()?;
+    let metrics = exporter.get_finished_metrics().ok()?;
+
+    let mut call_duration_sum = 0.0;
+    let mut call_duration_count = 0u64;
+    let mut attempt_duration_sum = 0.0;
+    let mut attempt_duration_count = 0u64;
+    let mut serialization_sum = 0.0;
+    let mut serialization_count = 0u64;
+    let mut deserialization_sum = 0.0;
+    let mut deserialization_count = 0u64;
+    let mut signing_sum = 0.0;
+    let mut signing_count = 0u64;
+    let mut identity_sum = 0.0;
+    let mut identity_count = 0u64;
+    let mut endpoint_sum = 0.0;
+    let mut endpoint_count = 0u64;
+    let mut total_attempts = 0u64;
+    let mut total_errors = 0u64;
+
+    for resource_metrics in &metrics {
+        for scope_metrics in &resource_metrics.scope_metrics {
+            for metric in &scope_metrics.metrics {
+                match metric.name.as_ref() {
+                    "smithy.client.call.duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                call_duration_sum += dp.sum;
+                                call_duration_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.attempt.duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                attempt_duration_sum += dp.sum;
+                                attempt_duration_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.serialization_duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                serialization_sum += dp.sum;
+                                serialization_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.deserialization_duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                deserialization_sum += dp.sum;
+                                deserialization_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.auth.signing_duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                signing_sum += dp.sum;
+                                signing_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.auth.resolve_identity_duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                identity_sum += dp.sum;
+                                identity_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.resolve_endpoint_duration" => {
+                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                            for dp in &hist.data_points {
+                                endpoint_sum += dp.sum;
+                                endpoint_count += dp.count;
+                            }
+                        }
+                    }
+                    "smithy.client.call.attempts" => {
+                        if let Some(sum) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>() {
+                            for dp in &sum.data_points {
+                                total_attempts += dp.value;
+                            }
+                        }
+                    }
+                    "smithy.client.call.errors" => {
+                        if let Some(sum) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>() {
+                            for dp in &sum.data_points {
+                                total_errors += dp.value;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let mean_ms = |sum: f64, count: u64| -> f64 {
+        if count > 0 { (sum / count as f64) * 1000.0 } else { 0.0 }
+    };
+
+    Some(SdkMetrics {
+        call_duration_mean_ms: mean_ms(call_duration_sum, call_duration_count),
+        attempt_duration_mean_ms: mean_ms(attempt_duration_sum, attempt_duration_count),
+        serialization_duration_mean_ms: mean_ms(serialization_sum, serialization_count),
+        deserialization_duration_mean_ms: mean_ms(deserialization_sum, deserialization_count),
+        signing_duration_mean_ms: mean_ms(signing_sum, signing_count),
+        resolve_identity_duration_mean_ms: mean_ms(identity_sum, identity_count),
+        resolve_endpoint_duration_mean_ms: mean_ms(endpoint_sum, endpoint_count),
+        total_attempts,
+        total_errors,
+    })
 }

--- a/aws/sdk/benchmarks/standardized-benches/src/e2e/ddb.rs
+++ b/aws/sdk/benchmarks/standardized-benches/src/e2e/ddb.rs
@@ -293,7 +293,11 @@ fn extract_sdk_metrics(
             for metric in &scope_metrics.metrics {
                 match metric.name.as_ref() {
                     "smithy.client.call.duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 call_duration_sum += dp.sum;
                                 call_duration_count += dp.count;
@@ -301,7 +305,11 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.attempt.duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 attempt_duration_sum += dp.sum;
                                 attempt_duration_count += dp.count;
@@ -309,7 +317,11 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.serialization_duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 serialization_sum += dp.sum;
                                 serialization_count += dp.count;
@@ -317,7 +329,11 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.deserialization_duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 deserialization_sum += dp.sum;
                                 deserialization_count += dp.count;
@@ -325,7 +341,11 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.auth.signing_duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 signing_sum += dp.sum;
                                 signing_count += dp.count;
@@ -333,7 +353,11 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.auth.resolve_identity_duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 identity_sum += dp.sum;
                                 identity_count += dp.count;
@@ -341,7 +365,11 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.resolve_endpoint_duration" => {
-                        if let Some(hist) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>() {
+                        if let Some(hist) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
+                        ) {
                             for dp in &hist.data_points {
                                 endpoint_sum += dp.sum;
                                 endpoint_count += dp.count;
@@ -349,14 +377,22 @@ fn extract_sdk_metrics(
                         }
                     }
                     "smithy.client.call.attempts" => {
-                        if let Some(sum) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>() {
+                        if let Some(sum) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>()
+                        {
                             for dp in &sum.data_points {
                                 total_attempts += dp.value;
                             }
                         }
                     }
                     "smithy.client.call.errors" => {
-                        if let Some(sum) = metric.data.as_any().downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>() {
+                        if let Some(sum) = metric
+                            .data
+                            .as_any()
+                            .downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>()
+                        {
                             for dp in &sum.data_points {
                                 total_errors += dp.value;
                             }
@@ -369,7 +405,11 @@ fn extract_sdk_metrics(
     }
 
     let mean_ms = |sum: f64, count: u64| -> f64 {
-        if count > 0 { (sum / count as f64) * 1000.0 } else { 0.0 }
+        if count > 0 {
+            (sum / count as f64) * 1000.0
+        } else {
+            0.0
+        }
     };
 
     Some(SdkMetrics {

--- a/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
@@ -16,7 +16,7 @@ use aws_smithy_runtime_api::client::{
     runtime_plugin::RuntimePlugin,
 };
 use aws_smithy_types::config_bag::{FrozenLayer, Layer, Storable, StoreReplace};
-use std::{borrow::Cow, sync::Arc, time::Duration, time::SystemTime};
+use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 /// Struct to hold metric data in the ConfigBag
 #[derive(Debug, Clone)]
@@ -33,23 +33,10 @@ impl Storable for MeasurementsContainer {
     type Storer = StoreReplace<Self>;
 }
 
-/// Duration of identity resolution, stored in ConfigBag by the orchestrator.
-#[derive(Debug, Clone)]
-pub(crate) struct IdentityResolutionDuration(pub(crate) Duration);
-
-impl Storable for IdentityResolutionDuration {
-    type Storer = StoreReplace<Self>;
-}
-
-/// Duration of endpoint resolution, stored in ConfigBag by the orchestrator.
-#[derive(Debug, Clone)]
-pub(crate) struct EndpointResolutionDuration(pub(crate) Duration);
-
-impl Storable for EndpointResolutionDuration {
-    type Storer = StoreReplace<Self>;
-}
-
-/// Instruments for recording a single operation
+/// Instruments for recording a single operation.
+///
+/// On retries: `operation_duration`, `serialization_duration`, and `call_errors` are
+/// recorded once per call. All other metrics are recorded per-attempt.
 #[derive(Debug, Clone)]
 pub(crate) struct OperationTelemetry {
     pub(crate) operation_duration: Arc<dyn Histogram>,
@@ -246,26 +233,12 @@ impl Intercept for MetricsInterceptor {
         let (measurements, instruments) = self.get_measurements_and_instruments(cfg);
         let attributes = self.get_attrs_from_cfg(cfg);
 
-        if let (Some(start), Some(ref attrs)) = (measurements.signing_start, &attributes) {
+        if let (Some(start), Some(attrs)) = (measurements.signing_start, attributes) {
             let now = self.time_source.now();
             if let Ok(elapsed) = now.duration_since(start) {
                 instruments
                     .signing_duration
-                    .record(elapsed.as_secs_f64(), Some(attrs), None);
-            }
-        }
-
-        // Record identity and endpoint resolution durations stored by the orchestrator
-        if let Some(attrs) = attributes {
-            if let Some(IdentityResolutionDuration(d)) = cfg.load::<IdentityResolutionDuration>() {
-                instruments
-                    .resolve_identity_duration
-                    .record(d.as_secs_f64(), Some(&attrs), None);
-            }
-            if let Some(EndpointResolutionDuration(d)) = cfg.load::<EndpointResolutionDuration>() {
-                instruments
-                    .resolve_endpoint_duration
-                    .record(d.as_secs_f64(), Some(&attrs), None);
+                    .record(elapsed.as_secs_f64(), Some(&attrs), None);
             }
         }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/metrics.rs
@@ -5,8 +5,9 @@
 
 use aws_smithy_async::time::{SharedTimeSource, TimeSource};
 use aws_smithy_observability::{
-    global::get_telemetry_provider, instruments::Histogram, AttributeValue, Attributes,
-    ObservabilityError,
+    global::get_telemetry_provider,
+    instruments::{Histogram, MonotonicCounter},
+    AttributeValue, Attributes, ObservabilityError,
 };
 use aws_smithy_runtime_api::client::{
     interceptors::{dyn_dispatch_hint, Intercept, SharedInterceptor},
@@ -15,7 +16,7 @@ use aws_smithy_runtime_api::client::{
     runtime_plugin::RuntimePlugin,
 };
 use aws_smithy_types::config_bag::{FrozenLayer, Layer, Storable, StoreReplace};
-use std::{borrow::Cow, sync::Arc, time::SystemTime};
+use std::{borrow::Cow, sync::Arc, time::Duration, time::SystemTime};
 
 /// Struct to hold metric data in the ConfigBag
 #[derive(Debug, Clone)]
@@ -23,9 +24,28 @@ pub(crate) struct MeasurementsContainer {
     call_start: SystemTime,
     attempts: u32,
     attempt_start: SystemTime,
+    serialization_start: Option<SystemTime>,
+    deserialization_start: Option<SystemTime>,
+    signing_start: Option<SystemTime>,
 }
 
 impl Storable for MeasurementsContainer {
+    type Storer = StoreReplace<Self>;
+}
+
+/// Duration of identity resolution, stored in ConfigBag by the orchestrator.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentityResolutionDuration(pub(crate) Duration);
+
+impl Storable for IdentityResolutionDuration {
+    type Storer = StoreReplace<Self>;
+}
+
+/// Duration of endpoint resolution, stored in ConfigBag by the orchestrator.
+#[derive(Debug, Clone)]
+pub(crate) struct EndpointResolutionDuration(pub(crate) Duration);
+
+impl Storable for EndpointResolutionDuration {
     type Storer = StoreReplace<Self>;
 }
 
@@ -34,6 +54,13 @@ impl Storable for MeasurementsContainer {
 pub(crate) struct OperationTelemetry {
     pub(crate) operation_duration: Arc<dyn Histogram>,
     pub(crate) attempt_duration: Arc<dyn Histogram>,
+    pub(crate) call_attempts: Arc<dyn MonotonicCounter>,
+    pub(crate) call_errors: Arc<dyn MonotonicCounter>,
+    pub(crate) serialization_duration: Arc<dyn Histogram>,
+    pub(crate) deserialization_duration: Arc<dyn Histogram>,
+    pub(crate) signing_duration: Arc<dyn Histogram>,
+    pub(crate) resolve_identity_duration: Arc<dyn Histogram>,
+    pub(crate) resolve_endpoint_duration: Arc<dyn Histogram>,
 }
 
 impl OperationTelemetry {
@@ -53,6 +80,41 @@ impl OperationTelemetry {
                 .set_units("s")
                 .set_description("The time it takes to connect to the service, send the request, and get back HTTP status code and headers (including time queued waiting to be sent)")
                 .build(),
+            call_attempts: meter
+                .create_monotonic_counter("smithy.client.call.attempts")
+                .set_units("{attempt}")
+                .set_description("The number of attempts for an operation call")
+                .build(),
+            call_errors: meter
+                .create_monotonic_counter("smithy.client.call.errors")
+                .set_units("{error}")
+                .set_description("The number of calls that result in an error")
+                .build(),
+            serialization_duration: meter
+                .create_histogram("smithy.client.call.serialization_duration")
+                .set_units("s")
+                .set_description("The time it takes to serialize a request body")
+                .build(),
+            deserialization_duration: meter
+                .create_histogram("smithy.client.call.deserialization_duration")
+                .set_units("s")
+                .set_description("The time it takes to deserialize a response body")
+                .build(),
+            signing_duration: meter
+                .create_histogram("smithy.client.call.auth.signing_duration")
+                .set_units("s")
+                .set_description("The time it takes to sign a request")
+                .build(),
+            resolve_identity_duration: meter
+                .create_histogram("smithy.client.call.auth.resolve_identity_duration")
+                .set_units("s")
+                .set_description("The time it takes to acquire an identity (credentials, bearer token, etc.) from an identity provider")
+                .build(),
+            resolve_endpoint_duration: meter
+                .create_histogram("smithy.client.call.resolve_endpoint_duration")
+                .set_units("s")
+                .set_description("The time it takes to resolve an endpoint for the request")
+                .build(),
         })
     }
 }
@@ -63,9 +125,6 @@ impl Storable for OperationTelemetry {
 
 #[derive(Debug)]
 pub(crate) struct MetricsInterceptor {
-    // Holding a TimeSource here isn't ideal, but RuntimeComponents aren't available in
-    // the read_before_execution hook and that is when we need to start the timer for
-    // the operation.
     time_source: SharedTimeSource,
 }
 
@@ -122,14 +181,100 @@ impl Intercept for MetricsInterceptor {
             call_start: self.time_source.now(),
             attempts: 0,
             attempt_start: SystemTime::UNIX_EPOCH,
+            serialization_start: None,
+            deserialization_start: None,
+            signing_start: None,
         });
+
+        Ok(())
+    }
+
+    fn read_before_serialization(
+        &self,
+        _context: &aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextRef<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let measurements = cfg
+            .get_mut::<MeasurementsContainer>()
+            .expect("set in `read_before_execution`");
+        measurements.serialization_start = Some(self.time_source.now());
+        Ok(())
+    }
+
+    fn read_after_serialization(
+        &self,
+        _context: &aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextRef<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let (measurements, instruments) = self.get_measurements_and_instruments(cfg);
+        let attributes = self.get_attrs_from_cfg(cfg);
+
+        if let (Some(start), Some(attrs)) = (measurements.serialization_start, attributes) {
+            let now = self.time_source.now();
+            if let Ok(elapsed) = now.duration_since(start) {
+                instruments.serialization_duration.record(
+                    elapsed.as_secs_f64(),
+                    Some(&attrs),
+                    None,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn read_before_signing(
+        &self,
+        _context: &aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextRef<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let measurements = cfg
+            .get_mut::<MeasurementsContainer>()
+            .expect("set in `read_before_execution`");
+        measurements.signing_start = Some(self.time_source.now());
+        Ok(())
+    }
+
+    fn read_after_signing(
+        &self,
+        _context: &aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextRef<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let (measurements, instruments) = self.get_measurements_and_instruments(cfg);
+        let attributes = self.get_attrs_from_cfg(cfg);
+
+        if let (Some(start), Some(ref attrs)) = (measurements.signing_start, &attributes) {
+            let now = self.time_source.now();
+            if let Ok(elapsed) = now.duration_since(start) {
+                instruments
+                    .signing_duration
+                    .record(elapsed.as_secs_f64(), Some(attrs), None);
+            }
+        }
+
+        // Record identity and endpoint resolution durations stored by the orchestrator
+        if let Some(attrs) = attributes {
+            if let Some(IdentityResolutionDuration(d)) = cfg.load::<IdentityResolutionDuration>() {
+                instruments
+                    .resolve_identity_duration
+                    .record(d.as_secs_f64(), Some(&attrs), None);
+            }
+            if let Some(EndpointResolutionDuration(d)) = cfg.load::<EndpointResolutionDuration>() {
+                instruments
+                    .resolve_endpoint_duration
+                    .record(d.as_secs_f64(), Some(&attrs), None);
+            }
+        }
 
         Ok(())
     }
 
     fn read_after_execution(
         &self,
-        _context: &aws_smithy_runtime_api::client::interceptors::context::FinalizerInterceptorContextRef<'_>,
+        context: &aws_smithy_runtime_api::client::interceptors::context::FinalizerInterceptorContextRef<'_>,
         _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
         cfg: &mut aws_smithy_types::config_bag::ConfigBag,
     ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
@@ -144,6 +289,11 @@ impl Intercept for MetricsInterceptor {
                 instruments
                     .operation_duration
                     .record(elapsed.as_secs_f64(), Some(&attrs), None);
+            }
+
+            // Increment error counter if the call failed
+            if let Some(Err(_)) = context.output_or_error() {
+                instruments.call_errors.add(1, Some(&attrs), None);
             }
         }
 
@@ -184,6 +334,44 @@ impl Intercept for MetricsInterceptor {
             instruments
                 .attempt_duration
                 .record(elapsed.as_secs_f64(), Some(&attrs), None);
+
+            // Increment attempts counter
+            instruments.call_attempts.add(1, Some(&attrs), None);
+        }
+        Ok(())
+    }
+
+    fn read_before_deserialization(
+        &self,
+        _context: &aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextRef<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let measurements = cfg
+            .get_mut::<MeasurementsContainer>()
+            .expect("set in `read_before_execution`");
+        measurements.deserialization_start = Some(self.time_source.now());
+        Ok(())
+    }
+
+    fn read_after_deserialization(
+        &self,
+        _context: &aws_smithy_runtime_api::client::interceptors::context::AfterDeserializationInterceptorContextRef<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let (measurements, instruments) = self.get_measurements_and_instruments(cfg);
+        let attributes = self.get_attrs_from_cfg(cfg);
+
+        if let (Some(start), Some(attrs)) = (measurements.deserialization_start, attributes) {
+            let now = self.time_source.now();
+            if let Ok(elapsed) = now.duration_since(start) {
+                instruments.deserialization_duration.record(
+                    elapsed.as_secs_f64(),
+                    Some(&attrs),
+                    None,
+                );
+            }
         }
         Ok(())
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -37,6 +37,8 @@ use endpoints::apply_endpoint;
 use std::mem;
 use tracing::{debug, debug_span, instrument, trace, Instrument};
 
+use crate::client::metrics::{EndpointResolutionDuration, IdentityResolutionDuration};
+
 mod auth;
 pub use auth::AuthSchemeAndEndpointOrchestrationV2;
 
@@ -387,8 +389,18 @@ async fn try_attempt(
 ) {
     run_interceptors!(halt_on_err: read_before_attempt(ctx, runtime_components, cfg));
 
+    let identity_start = runtime_components.time_source().map(|ts| ts.now());
     let (scheme_id, identity, endpoint) = halt_on_err!([ctx] => resolve_identity(runtime_components, cfg).await.map_err(OrchestratorError::other));
+    if let Some(start) = identity_start {
+        if let Some(ts) = runtime_components.time_source() {
+            if let Ok(d) = ts.now().duration_since(start) {
+                cfg.interceptor_state()
+                    .store_put(IdentityResolutionDuration(d));
+            }
+        }
+    }
 
+    let endpoint_start = runtime_components.time_source().map(|ts| ts.now());
     match endpoint {
         Some(endpoint) => {
             // This branch is for backward compatibility when `AuthSchemeAndEndpointOrchestrationV2` is not present in the config bag.
@@ -402,6 +414,14 @@ async fn try_attempt(
 				    .instrument(debug_span!("orchestrate_endpoint"))
 				    .await
 				    .map_err(OrchestratorError::other));
+        }
+    }
+    if let Some(start) = endpoint_start {
+        if let Some(ts) = runtime_components.time_source() {
+            if let Ok(d) = ts.now().duration_since(start) {
+                cfg.interceptor_state()
+                    .store_put(EndpointResolutionDuration(d));
+            }
         }
     }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -37,7 +37,9 @@ use endpoints::apply_endpoint;
 use std::mem;
 use tracing::{debug, debug_span, instrument, trace, Instrument};
 
-use crate::client::metrics::{EndpointResolutionDuration, IdentityResolutionDuration, OperationTelemetry};
+use crate::client::metrics::{
+    EndpointResolutionDuration, IdentityResolutionDuration, OperationTelemetry,
+};
 
 mod auth;
 pub use auth::AuthSchemeAndEndpointOrchestrationV2;

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -37,7 +37,7 @@ use endpoints::apply_endpoint;
 use std::mem;
 use tracing::{debug, debug_span, instrument, trace, Instrument};
 
-use crate::client::metrics::{EndpointResolutionDuration, IdentityResolutionDuration};
+use crate::client::metrics::{EndpointResolutionDuration, IdentityResolutionDuration, OperationTelemetry};
 
 mod auth;
 pub use auth::AuthSchemeAndEndpointOrchestrationV2;
@@ -389,7 +389,12 @@ async fn try_attempt(
 ) {
     run_interceptors!(halt_on_err: read_before_attempt(ctx, runtime_components, cfg));
 
-    let identity_start = runtime_components.time_source().map(|ts| ts.now());
+    let should_measure = cfg.load::<OperationTelemetry>().is_some();
+    let identity_start = if should_measure {
+        runtime_components.time_source().map(|ts| ts.now())
+    } else {
+        None
+    };
     let (scheme_id, identity, endpoint) = halt_on_err!([ctx] => resolve_identity(runtime_components, cfg).await.map_err(OrchestratorError::other));
     if let Some(start) = identity_start {
         if let Some(ts) = runtime_components.time_source() {
@@ -400,7 +405,11 @@ async fn try_attempt(
         }
     }
 
-    let endpoint_start = runtime_components.time_source().map(|ts| ts.now());
+    let endpoint_start = if should_measure {
+        runtime_components.time_source().map(|ts| ts.now())
+    } else {
+        None
+    };
     match endpoint {
         Some(endpoint) => {
             // This branch is for backward compatibility when `AuthSchemeAndEndpointOrchestrationV2` is not present in the config bag.

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -37,9 +37,7 @@ use endpoints::apply_endpoint;
 use std::mem;
 use tracing::{debug, debug_span, instrument, trace, Instrument};
 
-use crate::client::metrics::{
-    EndpointResolutionDuration, IdentityResolutionDuration, OperationTelemetry,
-};
+use crate::client::metrics::OperationTelemetry;
 
 mod auth;
 pub use auth::AuthSchemeAndEndpointOrchestrationV2;
@@ -401,8 +399,11 @@ async fn try_attempt(
     if let Some(start) = identity_start {
         if let Some(ts) = runtime_components.time_source() {
             if let Ok(d) = ts.now().duration_since(start) {
-                cfg.interceptor_state()
-                    .store_put(IdentityResolutionDuration(d));
+                if let Some(telemetry) = cfg.load::<OperationTelemetry>() {
+                    telemetry
+                        .resolve_identity_duration
+                        .record(d.as_secs_f64(), None, None);
+                }
             }
         }
     }
@@ -430,8 +431,11 @@ async fn try_attempt(
     if let Some(start) = endpoint_start {
         if let Some(ts) = runtime_components.time_source() {
             if let Ok(d) = ts.now().duration_since(start) {
-                cfg.interceptor_state()
-                    .store_put(EndpointResolutionDuration(d));
+                if let Some(telemetry) = cfg.load::<OperationTelemetry>() {
+                    telemetry
+                        .resolve_endpoint_duration
+                        .record(d.as_secs_f64(), None, None);
+                }
             }
         }
     }


### PR DESCRIPTION
Addresses #4248. Adds 7 new metrics to MetricsInterceptor

- `call.attempts`
- `call.errors`
- `serialization_duration`
- `deserialization_duration`
- `auth.signing_duration`
- `auth.resolve_identity_duration`
- `resolve_endpoint_duration`.

Identity/endpoint resolution timed in the orchestrator (no interceptor hooks for these phases), stored in ConfigBag.

## Testing

Ran DDB PutItem benchmark with TelemetryProvider configured. the output confirms all 7 metrics are captured end-to-end

```json
"sdkMetrics": {
 "callDurationMeanMs": 8.02,
 "attemptDurationMeanMs": 7.95,
 "serializationDurationMeanMs": 0.018,
 "deserializationDurationMeanMs": 0.027,
 "signingDurationMeanMs": 0.072,
 "resolveIdentityDurationMeanMs": 0.007,
 "resolveEndpointDurationMeanMs": 0.011,
 "totalAttempts": 36,
 "totalErrors": 1
}
```