### PR TITLE
Demote connection-poisoning log from `info` to `debug`

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.61.9"
 dependencies = [
  "aws-smithy-runtime-api 1.12.1",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "criterion",
  "minicbor 2.2.1",
 ]
@@ -384,7 +384,7 @@ name = "aws-smithy-checksums"
 version = "0.64.8"
 dependencies = [
  "aws-smithy-http 0.63.6",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
  "crc-fast",
@@ -407,7 +407,7 @@ name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -436,7 +436,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.20"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -478,7 +478,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -502,7 +502,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "base64 0.22.1",
  "bytes",
  "h2 0.3.27",
@@ -574,7 +574,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.6",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -641,7 +641,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.6",
  "aws-smithy-legacy-http-server",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures",
@@ -688,7 +688,7 @@ version = "0.62.6"
 dependencies = [
  "aws-smithy-runtime-api 1.12.1",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "proptest",
  "serde_json",
 ]
@@ -701,7 +701,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -726,7 +726,7 @@ dependencies = [
  "aws-smithy-json 0.62.6",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -756,7 +756,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "http 1.4.0",
  "tokio",
 ]
@@ -806,7 +806,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.15"
 dependencies = [
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "urlencoding",
 ]
 
@@ -821,7 +821,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime-api 1.12.1",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "fastrand 2.4.1",
  "futures-util",
@@ -862,7 +862,7 @@ version = "1.12.1"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api-macros",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "bytes",
  "http 0.2.12",
  "http 1.4.0",
@@ -887,7 +887,7 @@ name = "aws-smithy-schema"
 version = "0.1.0"
 dependencies = [
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "http 1.4.0",
 ]
 
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -957,7 +957,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.14"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "chrono",
  "futures-core",
  "time",
@@ -969,7 +969,7 @@ version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "http-body-util",
  "sync_wrapper",
  "wstd",
@@ -2502,7 +2502,7 @@ dependencies = [
  "aws-smithy-json 0.62.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.1",
- "aws-smithy-types 1.4.8",
+ "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "fastrand 2.4.1",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/connection.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/connection.rs
@@ -22,7 +22,7 @@ pub struct ConnectionMetadata {
 impl ConnectionMetadata {
     /// Poison this connection, ensuring that it won't be reused.
     pub fn poison(&self) {
-        tracing::info!(
+        tracing::debug!(
             see_for_more_info = "https://smithy-lang.github.io/smithy-rs/design/client/detailed_error_explanations.html",
             "Connection encountered an issue and should not be re-used. Marking it for closure"
         );


### PR DESCRIPTION
## Motivation and Context
When S3 returns 503 (SlowDown) or closes connections, `aws-smithy-runtime-api` logs "Connection encountered an issue and should not be re-used" at `info` level for every poisoned   connection. During throttling, this produces tens of thousands of log lines, drowning out useful output.

## Description
This PR demotes the `tracing::info!` in question to `tracing::debug!`

## Testing
- CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
