### PR TITLE
fix: Add secure defaults for aws-smithy-http-server

### DIFF
--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.66.4"
+version = "0.66.5"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/src/serve/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/serve/mod.rs
@@ -137,10 +137,10 @@
 //!
 //! | Timeout Type | What It Does | How to Configure |
 //! |--------------|--------------|------------------|
-//! | **Header Read** | Time limit for reading HTTP headers | `.configure_hyper()` with `.http1().header_read_timeout()` |
+//! | **Header Read** | Time limit for reading HTTP headers | 30 s by default; override via `.configure_hyper()` with `.http1().header_read_timeout()` |
 //! | **Request** | Time limit for processing one request | Tower's `TimeoutLayer` |
 //! | **Connection Duration** | Total connection lifetime limit | Custom accept loop with `tokio::time::timeout` |
-//! | **HTTP/2 Keep-Alive** | Idle timeout between HTTP/2 requests | `.configure_hyper()` with `.http2().keep_alive_*()` |
+//! | **HTTP/2 Keep-Alive** | Idle timeout between HTTP/2 requests | 20 s ping interval by default; override via `.configure_hyper()` with `.http2().keep_alive_*()` |
 //!
 //! **Examples:**
 //! - `examples/header_read_timeout.rs` - Configure header read timeout
@@ -288,7 +288,7 @@ use std::time::Duration;
 
 use http_body::Body as HttpBody;
 use hyper::body::Incoming;
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use hyper_util::server::conn::auto::Builder;
 use hyper_util::service::TowerToHyperService;
 use tower::{Service, ServiceExt as _};
@@ -448,6 +448,9 @@ where
 
 /// Serve the service with the supplied listener.
 ///
+/// The default connection builder applies a 30-second HTTP/1 header-read timeout
+/// and a 20-second HTTP/2 keep-alive ping interval.
+///
 /// This implementation provides zero-cost abstraction for shutdown coordination.
 /// When graceful shutdown is not used, there is no runtime overhead - no watch channels
 /// are allocated and no `tokio::select!` is used.
@@ -596,6 +599,9 @@ where
     ///
     /// This allows you to customize Hyper's HTTP/1 and HTTP/2 settings,
     /// such as timeouts, max concurrent streams, keep-alive behavior, etc.
+    ///
+    /// **Note:** Calling this replaces the default builder entirely, opting out of the built-in
+    /// defaults. You are responsible for setting your own timeouts.
     ///
     /// The configuration is applied once and the configured builder is cloned
     /// for each connection, providing optimal performance.
@@ -911,10 +917,20 @@ async fn handle_connection<L, M, S, B>(
 
     let hyper_service = TowerToHyperService::new(tower_service);
 
-    // Clone the Arc (cheap - just increments refcount) or create a default builder
-    let builder = hyper_builder
-        .map(Arc::clone)
-        .unwrap_or_else(|| Arc::new(Builder::new(TokioExecutor::new())));
+    // Clone the Arc (cheap - just increments refcount) or create a default builder.
+    // A TokioTimer is required to activate hyper's header_read_timeout (default 30 s).
+    // HTTP/2 keep_alive_interval (20 s) detects idle connections; timeout defaults to 20 s.
+    let builder = hyper_builder.map(Arc::clone).unwrap_or_else(|| {
+        let mut b = Builder::new(TokioExecutor::new());
+        b.http1()
+            .timer(TokioTimer::new())
+            .header_read_timeout(Duration::from_secs(30));
+        b.http2()
+            .timer(TokioTimer::new())
+            .keep_alive_interval(Some(Duration::from_secs(20)))
+            .keep_alive_timeout(Duration::from_secs(20));
+        Arc::new(b)
+    });
 
     tokio::spawn(async move {
         let result = if use_upgrades {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->
Activate hyper's dormant 30 s HTTP/1 header_read_timeout by setting a TokioTimer on the default builder (mitigates Slowloris DoS), and enable HTTP/2 keep-alive pings with a 20 s interval to detect idle connections.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
