### PR TITLE
fix: TCP_NODELAY default applies to default_https_client

### DIFF
--- a/.changelog/fix-default-https-client-tcp-nodelay.md
+++ b/.changelog/fix-default-https-client-tcp-nodelay.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- PeterUlb
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Fix `ConnectorBuilder::default()` to enable `TCP_NODELAY` by default. Previously, the auto-derived `Default` impl left `enable_tcp_nodelay` at `false`, while the curated `Connector::builder()` initialized it to `true`. The `Default` impl on `ConnectorBuilder` is now hand-written to match `Connector::builder()`, so all construction paths, including the SDK's `default_https_client`, get `enable_tcp_nodelay = true` consistently. Without `TCP_NODELAY`, Nagle's algorithm can hold small writes in the kernel waiting for ACKs; on request shapes emitted as multiple small sub-MSS writes, such as the tested HTTP/2 small-body SDK path where HEADERS and DATA are flushed separately, this can add roughly one RTT plus delayed-ACK time. Callers who relied on the previous unintended `enable_tcp_nodelay = false` default of `ConnectorBuilder::default()` can restore that behavior with `.enable_tcp_nodelay(false)`.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.61.9"
 dependencies = [
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-schema",
  "aws-smithy-types 1.4.9",
  "criterion",
@@ -406,7 +406,7 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
@@ -425,7 +425,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.1.12"
 dependencies = [
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -477,7 +477,7 @@ version = "0.63.6"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
@@ -497,11 +497,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "base64 0.22.1",
  "bytes",
@@ -568,12 +568,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.66.4"
+version = "0.66.5"
 dependencies = [
  "aws-smithy-cbor 0.61.9",
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.6",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -604,7 +604,7 @@ name = "aws-smithy-http-server-metrics"
 version = "0.1.2"
 dependencies = [
  "aws-smithy-http-server 0.65.10",
- "aws-smithy-http-server 0.66.4",
+ "aws-smithy-http-server 0.66.5",
  "aws-smithy-http-server-metrics-macro",
  "aws-smithy-legacy-http-server",
  "futures",
@@ -686,7 +686,7 @@ dependencies = [
 name = "aws-smithy-json"
 version = "0.62.6"
 dependencies = [
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-schema",
  "aws-smithy-types 1.4.9",
  "proptest",
@@ -700,7 +700,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
@@ -725,7 +725,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.9",
  "aws-smithy-json 0.62.6",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -755,7 +755,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "http 1.4.0",
  "tokio",
@@ -765,7 +765,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.2.6"
 dependencies = [
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "serial_test",
 ]
 
@@ -789,7 +789,7 @@ name = "aws-smithy-protocol-test"
 version = "0.63.14"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -819,7 +819,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-schema",
  "aws-smithy-types 1.4.9",
  "bytes",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api-macros",
@@ -886,7 +886,7 @@ dependencies = [
 name = "aws-smithy-schema"
 version = "0.1.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "http 1.4.0",
 ]
@@ -968,7 +968,7 @@ name = "aws-smithy-wasm"
 version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "http-body-util",
  "sync_wrapper",
@@ -2501,7 +2501,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.6",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.12.1",
+ "aws-smithy-runtime-api 1.12.2",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.1.12"
+version = "1.1.13"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -94,10 +94,7 @@ pub struct Connector {
 impl Connector {
     /// Builder for an HTTP connector.
     pub fn builder() -> ConnectorBuilder {
-        ConnectorBuilder {
-            enable_tcp_nodelay: true,
-            ..Default::default()
-        }
+        ConnectorBuilder::default()
     }
 }
 
@@ -108,7 +105,7 @@ impl HttpConnector for Connector {
 }
 
 /// Builder for [`Connector`].
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ConnectorBuilder<Tls = TlsUnset> {
     connector_settings: Option<HttpConnectorSettings>,
     sleep_impl: Option<SharedAsyncSleep>,
@@ -119,6 +116,26 @@ pub struct ConnectorBuilder<Tls = TlsUnset> {
     proxy_config: Option<proxy::ProxyConfig>,
     #[allow(unused)]
     tls: Tls,
+}
+
+impl<Tls: Default> Default for ConnectorBuilder<Tls> {
+    fn default() -> Self {
+        Self {
+            connector_settings: None,
+            sleep_impl: None,
+            client_builder: None,
+            pool_idle_timeout: None,
+            // Curated default: TCP_NODELAY on. Without it, Nagle's algorithm
+            // can hold a small write while earlier data is unacknowledged. On
+            // request shapes emitted as multiple sub-MSS writes, this can add
+            // an ACK wait, often RTT plus delayed-ACK time. Opt out with
+            // `enable_tcp_nodelay(false)`.
+            enable_tcp_nodelay: true,
+            interface: None,
+            proxy_config: None,
+            tls: Tls::default(),
+        }
+    }
 }
 
 /// Initial builder state, `TlsProvider` choice required


### PR DESCRIPTION
### Motivation and Context

`ConnectorBuilder::default()` in `aws-smithy-http-client` returned a builder with `enable_tcp_nodelay = false`, because the `Default` impl was auto-derived and `bool::default()` is `false`. The curated `Connector::builder()` initialised `enable_tcp_nodelay = true`:

```rust
// aws-smithy-http-client/src/client.rs (before this PR)
impl Connector {
    pub fn builder() -> ConnectorBuilder {
        ConnectorBuilder {
            enable_tcp_nodelay: true,
            ..Default::default()
        }
    }
}

#[derive(Default, Debug, Clone)]   // <-- this Default left enable_tcp_nodelay = false
pub struct ConnectorBuilder<Tls = TlsUnset> { ... }
```

Every caller of the default path silently got the wrong value, including the SDK's `default_https_client` (used by `aws_config::from_env()` when no `.http_client(...)` is provided), which constructs its connector via `ConnectorBuilder::default()`. So users on the default code path got `TCP_NODELAY = false`; users who explicitly went through `aws_smithy_http_client::Builder::new()...build_https()` (which routes through `Connector::builder()`) got `TCP_NODELAY = true`.

Why this matters in practice: in the SDK/hyper/h2 path tested here, requests with bodies are emitted as separate HEADERS and DATA writes. I verified this via `RUST_LOG=h2=trace`: the body future calls `SendStream::send_data` only after `send_request` already returned, so the connection task flushes HEADERS first and DATA on a later wake-up. Whether those writes also become separate TCP segments on the wire, and whether Nagle stalls the DATA write, depends on the amount of DATA available to TCP:

* **DATA write < MSS** (typical small-body SDK call, e.g. `IsAuthorized`): HEADERS are sent first as a sub-MSS segment. The later DATA write is also sub-MSS, so with Nagle enabled the kernel holds it until the HEADERS segment is ACKed. The observed HEADERS→DATA gap is therefore roughly one RTT, plus the receiver's delayed-ACK timer when delayed ACK is active. As a rough sizing rule, the threshold is around one MSS minus TLS record overhead, h2 DATA-frame overhead, and any socket/TLS framing effects for the DATA write; in practice, request-body plaintext above roughly ~1.4 KB crossed into the multi-MSS regime in my captures, while smaller request bodies hit this stall regime.
* **DATA write produces ≥ 1 full MSS** (e.g. `BatchIsAuthorized` with a multi-KB body): on the wire I see full-MSS DATA segments back-to-back with no Nagle stall (gaps between segments are <0.1 ms, vs. ~RTT for the small-body case). Two parts of Nagle as generally specified (RFC 896 plus Minshall's modification) combine here. First, original Nagle always allows a full-sized segment out immediately regardless of what is unacked, so the full-MSS portion of the DATA ships right away even with the small HEADERS segment still in flight. Second, Minshall's modification avoids the classic large-write penalty: after a large write has emitted one or more full-sized segments, the trailing partial segment is allowed out instead of being held merely because earlier data on the connection is still unacknowledged. In other words, the problematic shape is "small after small"; a partial tail after full-sized DATA segments is not held in the observed Linux/hyper path. Per the Nagle's-algorithm Wikipedia page, Minshall's modification makes the algorithm "always send if the last packet is full-sized, only waiting for an acknowledgement when the last packet is partial."
* **Body streamed across multiple `send_data` calls** (uploads, gRPC long bodies): each chunk can hit TCP separately, and Nagle can re-engage between chunks whenever a write leaves a sub-MSS segment behind and the next write is also sub-MSS.

**This behavior is per TCP socket.** Because Nagle operates per socket, not per h2 stream or SDK operation, the same stall shape can also occur across logical requests on a reused HTTP/2 connection: if one small write leaves a sub-MSS segment unacknowledged, a later sub-MSS write from another stream on the same connection can be held until the ACK arrives. I did not separately isolate this cross-stream case in the captures below, but it follows from the same per-socket "small write after small unacked write" condition. Large non-streaming request bodies are less affected in the observed path because the DATA write emits at least one full-MSS segment, which TCP sends immediately even when earlier data is unacknowledged.

The SDK HTTP/1.1 paths I tested did not hit this shape, because for these known-size request bodies hyper's HTTP/1.1 client buffers headers and body together and flushes them in a single write per request (`hyper-1.9.0/src/proto/h1/io.rs::Buffered`: `WriteStrategy::Flatten` concatenates into one buffer; `WriteStrategy::Queue` issues one `writev`). This is empirically consistent with KMS and DynamoDB on the same Lambda not showing the bug. Streaming or differently-shaped HTTP/1.1 bodies could still produce multiple TCP writes; the issue itself is on the TCP layer and is not protocol-specific. HTTP/2 just happens to be the case that produces this multi-write shape in the SDK path tested here.

The observed HEADERS→DATA gap has two components that respond differently to server behavior:

* a **bonus round trip** from Nagle serializing HEADERS+DATA writes. The client sends HEADERS, then the later sub-MSS DATA write cannot be sent until the HEADERS segment is ACKed. If the receiver ACKs immediately, this costs roughly one RTT. If the receiver applies delayed ACK, the same client-side wait becomes roughly RTT + the delayed-ACK timer.
* a **~40 ms delayed-ACK timer** from the server's TCP stack waiting for a possible piggyback. In my captures this appeared only after the connection left its initial quick-ACK phase, and it was paid consistently when the service replied fast enough to keep the connection in the request/response pattern that triggers delayed ACK.

For AVP both components fire on every steady-state small-body call (server processing is ~13-16 ms for `IsAuthorized` measured via tcpdump, well inside the kernel's ~40 ms delayed-ACK timescale). For an h2 service that consistently took >40 ms to respond, only the bonus RTT may remain from the second request onward, depending on the receiver's ACK heuristics.

The delayed-ACK component appears consistent with Linux's interactive/ping-pong ACK heuristics: after the connection leaves the initial quick-ACK phase, ACKs for single small request segments are delayed by roughly the kernel delayed-ACK timer (~40 ms in the captures). Fast request/response services like AVP keep producing this pattern; slower or larger-body request shapes can hit different immediate-ACK branches. The bonus RTT from Nagle is unaffected by server-side application speed; it is a client-side wait for an ACK before sending the second small segment.

I observed this directly against AVP in `eu-central-1`: loading a policy store with ~290 policies so `BatchIsAuthorized` took ~80 ms server-side dropped the stalled rate from 96% (single-decision `IsAuthorized` at ~15 ms) to 2% (heavy `BatchIsAuthorized`). Caveat: that experiment doesn't isolate the cause. `BatchIsAuthorized`'s body crosses 1 MSS at the receiver and hits a separate immediate-ACK branch in `__tcp_ack_snd_check`, and the multi-MSS body doesn't show a Nagle stall on the send side either way. A separate run against an empty policy store (fast server + multi-MSS body) confirmed 0% stalled in both `nodelay=on` and `nodelay=off` modes, so the multi-MSS no-stall behavior is a sender-side property for this request shape, independent of server speed. The suppression in the heavy-policy table is real, but the captured data is consistent with two simultaneous mechanisms; a small-body slow-replying server, which I didn't test directly, might still pay the +40 ms timer depending on receiver ACK state. The fix removes the bonus RTT regardless of which server-side branch fires.

I noticed this calling AVP from a Rust Lambda (with HTTP/2 negotiated; HTTP/1.1 services like DDB did not show a performance penalty in my tests). A controlled experiment confirmed that flipping only `enable_tcp_nodelay` reproduces the gap: same SDK construction shape with `enable_tcp_nodelay(false)` is slow, with `enable_tcp_nodelay(true)` is fast (see Testing).

**End-to-end win** (same Rust SDK code, single-line construction-path change). The fix is most visible on **small-body requests against fast-responding services** (where the ~40 ms timer dominates) and on **high-RTT paths** (where the bonus round trip alone is a meaningful fraction of total time). For the non-streaming multi-MSS request bodies tested here, the fix is effectively a no-op because the request body already takes the no-stall send path:

| environment | RTT | request shape | warm p50 before | warm p50 after | savings | speedup |
|---|---:|---|---:|---:|---:|---:|
| Lambda → AVP, in-region (`us-east-2`) | ~14 ms | small body (`IsAuthorized`) | 58 ms | 16 ms | **42 ms** | **3.6×** |
| Lambda → AVP, in-region (`us-east-2`) | ~14 ms | big body (`BatchIsAuthorized`, empty store) | ~20 ms | ~19 ms | ~0 ms | 1.0× |
| Developer laptop → AVP `us-east-2` over WAN | ~120 ms | small body (`IsAuthorized`) | 309 ms | 128 ms | **181 ms** | **2.4×** |
| Developer laptop → AVP `us-east-2` over WAN | ~120 ms | big body (`BatchIsAuthorized`, empty store) | ~141 ms | ~142 ms | ~0 ms | 1.0× |

The rows that show savings are all small-body requests: h2 emits HEADERS and DATA as separate writes in this SDK/hyper path, and on the small-body wire shape they remain two sub-MSS TCP segments. Nagle holds the second segment until the first is ACKed (the bonus RTT, client-side), and fast-replying services like AVP also pay the +40 ms delayed-ACK timer on steady-state calls. In my captures, the very first application call on a fresh connection escaped the delayed-ACK component because the receiver-side TCP state had not yet transitioned to delayed-ACK mode, but it still paid the bonus RTT. The big-body rows show no savings because a full-sized segment is always allowed out immediately, and the trailing partial tail of the same large write is not held in the observed Linux/hyper path. Wire-level evidence and the quickack-to-delayed-ACK transition count are in the Testing section.

### Description

`rust-runtime/aws-smithy-http-client/src/client.rs`:

* Replace `ConnectorBuilder`'s auto-derived `Default` with a hand-written impl that explicitly initialises every field, with `enable_tcp_nodelay: true`. The bound `Tls: Default` is now explicit (was implicit under the old derive). All existing fields are present with unchanged semantics.
* Simplify `Connector::builder()` to delegate to `ConnectorBuilder::default()` so there's a single source of truth for field initialisation; the explicit `enable_tcp_nodelay: true` it used to set inline is now carried by the new `Default` impl.
* Add an inline comment in the `Default` impl explaining the curated `enable_tcp_nodelay = true` choice and the `enable_tcp_nodelay(false)` opt-out.

`rust-runtime/aws-smithy-http-client/Cargo.toml`:

* Patch bump 1.1.12 → 1.1.13 (bug fix in this crate's behavior, no API break).

`rust-runtime/Cargo.lock`:

* Regenerated to pick up the patch bump.

`.changelog/fix-default-https-client-tcp-nodelay.md`:

* New changelog entry, marked `bug_fix: true`, applying to both `client` and `aws-sdk-rust`.

### Why hand-write `Default` instead of just rerouting `default_https_client`?

A narrower fix would be to change `default_https_client` in `aws-smithy-runtime` to call `Connector::builder()` instead of `ConnectorBuilder::default()`. That would route the SDK around the trap, but it would leave the trap in place for any other caller of `ConnectorBuilder::default()` (now or in the future). The hand-written `Default` removes the trap at its source: the two construction paths can no longer disagree, and any future code that lands on `ConnectorBuilder::default()` gets the right behavior automatically.

### Testing

Local checks:

```bash
cd rust-runtime/aws-smithy-runtime
cargo check --features default-https-client    # passes
cargo test --lib --features default-https-client    # passes
cargo clippy --lib --features default-https-client -- -D warnings    # passes
cargo fmt --check    # clean
```

Performance test:

End-to-end against AWS Verified Permissions (`us-east-2`) **from a developer laptop on a ~120 ms-RTT WAN path**, n=20 sequential `IsAuthorized` calls per binary on a single shared SDK client, same TLS provider/crypto mode/hyper version across all four:

| how the SDK client is built | nodelay | p50 |
|---|:---:|---:|
|  `aws_config::from_env().load()` | false | 309 ms |
| `aws_smithy_http_client::Builder::new()...build_https()` + `aws_config.http_client(...)` | true | 128 ms |
| Builder + `enable_tcp_nodelay(false)` explicit | false | 295 ms |
| Builder + `enable_tcp_nodelay(true)` explicit | true | 135 ms |

Only the `enable_tcp_nodelay` bit varies between the bottom two. The fix routes the default path through the same behavior that the second row already gets.

The ~165 ms per-call delta on this WAN path matches the **RTT + ~40 ms** formula (~120 ms RTT + ~40 ms delayed-ACK timer; see Motivation for the two-component breakdown). I confirmed this with a tcpdump on the same path: every request from the `enable_tcp_nodelay(false)` binary shows exactly two client writes (h2 HEADERS, h2 DATA) with one ~163 ms gap between them; the `enable_tcp_nodelay(true)` binary shows the two writes back-to-back with no gap. The in-region Lambda path (~42 ms delta) and the WAN laptop path (~165 ms delta) are the same single ACK-wait mechanism with different RTTs.

#### First-request behavior, on the wire

In my captures, the very first application call on a fresh connection escaped the +40 ms delayed-ACK component, but still paid the bonus round trip Nagle adds; that part is not conditional. The second call onward paid both consistently for fast-replying services like AVP. Three independent tcpdump captures of the WAN bench above show the same pattern:

* The first 10-11 server-to-client ACKs arrive ~one RTT after the client TX that triggered them, with no delayed-ACK signature.
* The first delayed-ACK signature appears consistently at the eleventh or twelfth ACK (counts: 10, 10, 11 fast ACKs across the three runs).
* Every subsequent naked ACK on the same connection follows the delayed-ACK pattern (~RTT + 40 ms).

A single application request produces several server-side ACKs (TLS, h2 setup, response), so the quick-ACK phase is exhausted before the second `IsAuthorized` call goes out. Nothing on the client changes between fast-ACK and delayed-ACK runs (same kernel, same socket, same h2 frame pattern), so the transition is receiver-side TCP behavior.

The signature is consistent with Linux defaulting to quick-ACK mode early in a connection's life, then transitioning to delayed-ACK mode as the connection reaches steady-state. The pattern is tightly reproducible across runs.

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
