### PR TITLE
redact additional fields when formatting trace and error log output

### DIFF
--- a/.changelog/fix-ecs-auth-token-plaintext-logging.md
+++ b/.changelog/fix-ecs-auth-token-plaintext-logging.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- aajtodd
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Redact the `AWS_CONTAINER_AUTHORIZATION_TOKEN` value from WARN log output and error `Display` output when the ECS/EKS container credential provider rejects the token as invalid for use as an HTTP header. Previously, if the token contained a byte rejected by `HeaderValue` validation, it was logged at WARN level and embedded in the error string propagated through the credential chain. The value is now redacted.

--- a/.changelog/fix-redact-sensitive-headers-in-debug-display.md
+++ b/.changelog/fix-redact-sensitive-headers-in-debug-display.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- aws-sdk-rust
+- client
+authors:
+- aajtodd
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Improve the `Debug` output of HTTP `Headers` and `Request` in `aws-smithy-runtime-api` to redact values of headers commonly used to carry sensitive data. The header name remains visible and the value is replaced with a placeholder that includes the original byte length to preserve diagnostic utility. The `aws-sigv4` signer applies the same redaction when logging the canonical request. The plain `Display` impl on `CanonicalRequest` is unchanged to preserve the raw canonical form used by downstream consumers.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -165,7 +165,7 @@ version = "1.1.12"
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.17"
+version = "1.8.18"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.8.17"
+version = "1.8.18"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -113,19 +113,31 @@ impl EcsCredentialsProvider {
                 .await
                 .map_err(CredentialsError::provider_error)?;
             Some(HeaderValue::from_bytes(auth.as_slice()).map_err(|err| {
-                let auth_token = String::from_utf8_lossy(auth.as_slice()).to_string();
-                tracing::warn!(token = %auth_token, "invalid auth token");
+                tracing::warn!(
+                    token_length = auth.len(),
+                    ends_with_whitespace = auth
+                        .last()
+                        .map(|b| b.is_ascii_whitespace())
+                        .unwrap_or(false),
+                    "invalid auth token from file; value redacted"
+                );
                 CredentialsError::invalid_configuration(EcsConfigurationError::InvalidAuthToken {
                     err,
-                    value: auth_token,
                 })
             })?)
         } else if let Some(auth_token) = env_token {
             Some(HeaderValue::from_str(&auth_token).map_err(|err| {
-                tracing::warn!(token = %auth_token, "invalid auth token");
+                tracing::warn!(
+                    token_length = auth_token.len(),
+                    ends_with_whitespace = auth_token
+                        .chars()
+                        .last()
+                        .map(|c| c.is_ascii_whitespace())
+                        .unwrap_or(false),
+                    "invalid auth token from env; value redacted"
+                );
                 CredentialsError::invalid_configuration(EcsConfigurationError::InvalidAuthToken {
                     err,
-                    value: auth_token,
                 })
             })?)
         } else {
@@ -245,7 +257,6 @@ enum EcsConfigurationError {
     },
     InvalidAuthToken {
         err: InvalidHeaderValue,
-        value: String,
     },
     NotConfigured,
 }
@@ -263,9 +274,9 @@ impl Display for EcsConfigurationError {
                 f,
                 "No environment variables were set to configure ECS provider"
             ),
-            EcsConfigurationError::InvalidAuthToken { err, value } => write!(
+            EcsConfigurationError::InvalidAuthToken { err } => write!(
                 f,
-                "`{value}` could not be used as a header value for the auth token. {err}",
+                "the auth token could not be used as an HTTP header value (value redacted). {err}",
             ),
         }
     }
@@ -792,6 +803,75 @@ mod test {
             .expect("valid credentials");
         assert_correct(creds);
         http_client.assert_requests_match(&[]);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn invalid_auth_token_env_does_not_log_value() {
+        let env = Env::from_slice(&[
+            ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/credentials"),
+            (
+                "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+                "SECRET-MARKER-DO-NOT-LOG-abc123\n",
+            ),
+        ]);
+        let provider = provider(env, Fs::default(), no_traffic_client());
+        let err = provider
+            .provide_credentials()
+            .await
+            .expect_err("token with trailing newline should fail");
+        assert!(
+            matches!(err, CredentialsError::InvalidConfiguration { .. }),
+            "expected InvalidConfiguration, got: {:?}",
+            err
+        );
+        let error_display = format!("{}", DisplayErrorContext(&err));
+        assert!(
+            !error_display.contains("SECRET-MARKER"),
+            "error display must not contain the raw token value, got: {error_display}"
+        );
+        assert!(
+            !logs_contain("SECRET-MARKER"),
+            "logs must not contain the raw token value"
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn invalid_auth_token_file_does_not_log_value() {
+        let env = Env::from_slice(&[
+            (
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "http://169.254.170.23/v1/credentials",
+            ),
+            (
+                "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+                "/eks-pod-identity-token",
+            ),
+        ]);
+        let fs = Fs::from_raw_map(HashMap::from([(
+            OsString::from("/eks-pod-identity-token"),
+            "SECRET-MARKER-DO-NOT-LOG-abc123\n".into(),
+        )]));
+        let provider = provider(env, fs, no_traffic_client());
+        let err = provider
+            .provide_credentials()
+            .await
+            .expect_err("token with trailing newline should fail");
+        assert!(
+            matches!(err, CredentialsError::InvalidConfiguration { .. }),
+            "expected InvalidConfiguration, got: {:?}",
+            err
+        );
+        let error_display = format!("{}", DisplayErrorContext(&err));
+        assert!(
+            !error_display.contains("SECRET-MARKER"),
+            "error display must not contain the raw token value, got: {error_display}"
+        );
+        assert!(
+            !logs_contain("SECRET-MARKER"),
+            "logs must not contain the raw token value"
+        );
     }
 
     #[tokio::test]

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -119,7 +119,7 @@ impl EcsCredentialsProvider {
                         .last()
                         .map(|b| b.is_ascii_whitespace())
                         .unwrap_or(false),
-                    "invalid auth token from file; value redacted"
+                    "invalid auth token from file"
                 );
                 CredentialsError::invalid_configuration(EcsConfigurationError::InvalidAuthToken {
                     err,
@@ -134,7 +134,7 @@ impl EcsCredentialsProvider {
                         .last()
                         .map(|c| c.is_ascii_whitespace())
                         .unwrap_or(false),
-                    "invalid auth token from env; value redacted"
+                    "invalid auth token from env"
                 );
                 CredentialsError::invalid_configuration(EcsConfigurationError::InvalidAuthToken {
                     err,
@@ -276,7 +276,7 @@ impl Display for EcsConfigurationError {
             ),
             EcsConfigurationError::InvalidAuthToken { err } => write!(
                 f,
-                "the auth token could not be used as an HTTP header value (value redacted). {err}",
+                "the auth token could not be used as an HTTP header value. {err}",
             ),
         }
     }

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -24,6 +24,24 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
 
+const SIGV4_SENSITIVE_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "x-amz-security-token",
+    "cookie",
+    "set-cookie",
+    "x-amz-server-side-encryption-customer-key",
+    "x-amz-server-side-encryption-customer-key-md5",
+    "x-amz-copy-source-server-side-encryption-customer-key",
+    "x-amz-copy-source-server-side-encryption-customer-key-md5",
+];
+
+fn is_sensitive_sigv4(name: &str) -> bool {
+    SIGV4_SENSITIVE_HEADERS
+        .iter()
+        .any(|d| name.eq_ignore_ascii_case(d))
+}
+
 #[cfg(feature = "sigv4a")]
 pub(crate) mod sigv4a;
 
@@ -462,6 +480,27 @@ impl CanonicalRequest<'_> {
             .collect();
         values.join(",")
     }
+
+    fn redacted_header_values_for(&self, key: impl AsHeaderName, key_as_str: &str) -> String {
+        if is_sensitive_sigv4(key_as_str) {
+            let total_len: usize = self
+                .headers
+                .get_all(key)
+                .into_iter()
+                .map(|v| v.as_bytes().len())
+                .sum();
+            format!("** redacted (length={total_len}) **")
+        } else {
+            self.header_values_for(key)
+        }
+    }
+
+    /// Returns a wrapper whose `Display` impl redacts sensitive header values.
+    /// Use this for logging; use the plain `Display` impl (`to_string()`) when the
+    /// raw canonical request is required (e.g. for signature computation).
+    pub(crate) fn redacted(&self) -> RedactedCanonicalRequest<'_, '_> {
+        RedactedCanonicalRequest(self)
+    }
 }
 
 impl fmt::Display for CanonicalRequest<'_> {
@@ -478,6 +517,30 @@ impl fmt::Display for CanonicalRequest<'_> {
         // write out the signed headers
         writeln!(f, "{}", self.values.signed_headers().as_str())?;
         write!(f, "{}", self.values.content_sha256())?;
+        Ok(())
+    }
+}
+
+/// A wrapper around `CanonicalRequest` whose `Display` impl redacts sensitive
+/// header values. Use this when logging a canonical request, to avoid leaking
+/// credentials or session tokens into log output. The plain `Display` impl on
+/// `CanonicalRequest` remains unchanged and produces the raw canonical form
+/// required for signature computation.
+pub(crate) struct RedactedCanonicalRequest<'a, 'b>(&'a CanonicalRequest<'b>);
+
+impl fmt::Display for RedactedCanonicalRequest<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.0.method)?;
+        writeln!(f, "{}", self.0.path)?;
+        writeln!(f, "{}", self.0.params.as_deref().unwrap_or(""))?;
+        for header in &self.0.values.signed_headers().headers {
+            let name = header.0.as_str();
+            write!(f, "{}:", name)?;
+            writeln!(f, "{}", self.0.redacted_header_values_for(&header.0, name))?;
+        }
+        writeln!(f)?;
+        writeln!(f, "{}", self.0.values.signed_headers().as_str())?;
+        write!(f, "{}", self.0.values.content_sha256())?;
         Ok(())
     }
 }
@@ -1132,5 +1195,92 @@ mod tests {
         fn test_trim_all_does_nothing_when_there_are_no_spaces(s in "[^ ]*") {
             assert_eq!(trim_all(&s).as_ref(), s);
         }
+    }
+
+    #[test]
+    fn canonical_request_redacted_display_redacts_security_token() {
+        let request = http::Request::builder()
+            .uri("https://example.amazonaws.com/")
+            .header("x-amz-security-token", "SECRETTOKENMARKER_DO_NOT_LOG")
+            .body("")
+            .unwrap()
+            .into();
+        let request = SignableRequest::from(&request);
+        let settings = SigningSettings {
+            payload_checksum_kind: PayloadChecksumKind::XAmzSha256,
+            session_token_mode: SessionTokenMode::Include,
+            ..Default::default()
+        };
+        let identity = Credentials::for_tests_with_session_token().into();
+        let signing_params = signing_params(&identity, settings);
+        let creq = CanonicalRequest::from(&request, &signing_params).unwrap();
+        let output = format!("{}", creq.redacted());
+        assert!(
+            !output.contains("SECRETTOKENMARKER_DO_NOT_LOG"),
+            "security token must not appear in redacted Display output"
+        );
+        assert!(
+            output.contains("x-amz-security-token:"),
+            "header name must still appear"
+        );
+        assert!(
+            output.contains("** redacted"),
+            "redaction marker must appear"
+        );
+    }
+
+    #[test]
+    fn canonical_request_raw_display_preserves_security_token() {
+        let request = http::Request::builder()
+            .uri("https://example.amazonaws.com/")
+            .body("")
+            .unwrap()
+            .into();
+        let request = SignableRequest::from(&request);
+        let settings = SigningSettings {
+            payload_checksum_kind: PayloadChecksumKind::XAmzSha256,
+            session_token_mode: SessionTokenMode::Include,
+            ..Default::default()
+        };
+        let identity = Credentials::for_tests_with_session_token().into();
+        let signing_params = signing_params(&identity, settings);
+        let creq = CanonicalRequest::from(&request, &signing_params).unwrap();
+        let output = format!("{}", creq);
+        assert!(
+            output.contains("notarealsessiontoken"),
+            "security token must appear verbatim in raw Display output"
+        );
+    }
+
+    #[test]
+    fn canonical_request_display_preserves_non_sensitive() {
+        let request = http::Request::builder()
+            .uri("https://example.amazonaws.com/")
+            .header("x-amz-date", "20210511T154045Z")
+            .body("")
+            .unwrap()
+            .into();
+        let request = SignableRequest::from(&request);
+        let settings = SigningSettings {
+            payload_checksum_kind: PayloadChecksumKind::XAmzSha256,
+            session_token_mode: SessionTokenMode::Exclude,
+            ..Default::default()
+        };
+        let identity = Credentials::for_tests().into();
+        let signing_params = signing_params(&identity, settings);
+        let creq = CanonicalRequest::from(&request, &signing_params).unwrap();
+        let output = format!("{}", creq);
+        assert!(
+            output.contains("host:example.amazonaws.com"),
+            "host value must appear verbatim"
+        );
+        assert!(
+            output.contains("x-amz-date:20210511T154045Z"),
+            "date value must appear verbatim"
+        );
+        assert!(
+            output.contains("x-amz-content-sha256:"),
+            "content-sha256 header must appear"
+        );
     }
 }

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -316,7 +316,7 @@ fn calculate_signing_params<'a>(
             (signature, string_to_sign)
         }
     };
-    tracing::trace!(canonical_request = %creq, string_to_sign = %string_to_sign, "calculated signing parameters");
+    tracing::trace!(canonical_request = %creq.redacted(), string_to_sign = %string_to_sign, "calculated signing parameters");
 
     let values = creq.values.into_query_params().expect("signing with query");
     let mut signing_params = vec![
@@ -370,7 +370,7 @@ fn calculate_signing_headers<'a>(
     let creq = CanonicalRequest::from(request, params)?;
     // Step 2: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-create-string-to-sign.html.
     let encoded_creq = v4::sha256_hex_string(creq.to_string().as_bytes());
-    tracing::trace!(canonical_request = %creq);
+    tracing::trace!(canonical_request = %creq.redacted());
     let mut headers = vec![];
 
     let signature = match params {

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.61.9"
 dependencies = [
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
  "aws-smithy-types 1.4.9",
  "criterion",
@@ -406,7 +406,7 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
@@ -425,7 +425,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.1.12"
 dependencies = [
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -477,7 +477,7 @@ version = "0.63.6"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
@@ -501,7 +501,7 @@ version = "1.1.13"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "base64 0.22.1",
  "bytes",
@@ -573,7 +573,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.9",
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.6",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -686,7 +686,7 @@ dependencies = [
 name = "aws-smithy-json"
 version = "0.62.6"
 dependencies = [
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
  "aws-smithy-types 1.4.9",
  "proptest",
@@ -700,7 +700,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "bytes",
  "bytes-utils",
@@ -725,7 +725,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.9",
  "aws-smithy-json 0.62.6",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -755,7 +755,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "http 1.4.0",
  "tokio",
@@ -765,7 +765,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.2.6"
 dependencies = [
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "serial_test",
 ]
 
@@ -789,7 +789,7 @@ name = "aws-smithy-protocol-test"
 version = "0.63.14"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -819,7 +819,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
  "aws-smithy-types 1.4.9",
  "bytes",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api-macros",
@@ -886,7 +886,7 @@ dependencies = [
 name = "aws-smithy-schema"
 version = "0.1.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "http 1.4.0",
 ]
@@ -968,7 +968,7 @@ name = "aws-smithy-wasm"
 version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "http-body-util",
  "sync_wrapper",
@@ -2501,7 +2501,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.6",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.12.2",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
  "bytes",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.12.2"
+version = "1.12.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/http/headers.rs
@@ -10,10 +10,46 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::str::FromStr;
 
+/// Header names whose values must be redacted in Debug output to prevent
+/// credential / session-token / customer-key leakage via tracing.
+const DENYLIST: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "x-amz-security-token",
+    "cookie",
+    "set-cookie",
+    "x-amz-server-side-encryption-customer-key",
+    "x-amz-server-side-encryption-customer-key-md5",
+    "x-amz-copy-source-server-side-encryption-customer-key",
+    "x-amz-copy-source-server-side-encryption-customer-key-md5",
+];
+
+fn is_sensitive(name: &str) -> bool {
+    DENYLIST.iter().any(|d| name.eq_ignore_ascii_case(d))
+}
+
 /// An immutable view of headers
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 pub struct Headers {
     pub(super) headers: http_02x::HeaderMap<HeaderValue>,
+}
+
+impl Debug for Headers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut map = f.debug_map();
+        for (key, value) in self.headers.iter() {
+            let name = key.as_str();
+            if is_sensitive(name) {
+                map.entry(
+                    &name,
+                    &format_args!("** redacted (length={}) **", value.as_ref().len()),
+                );
+            } else {
+                map.entry(&name, &value.as_ref());
+            }
+        }
+        map.finish()
+    }
 }
 
 impl<'a> IntoIterator for &'a Headers {
@@ -597,5 +633,78 @@ mod tests {
             let mut headers = Headers::new();
             let _ = headers.try_append(input.clone(), input);
         }
+    }
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_authorization() {
+        let mut headers = Headers::new();
+        headers.insert(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAXXX/.../Signature=SECRETSIGMARKER",
+        );
+        let output = format!("{:?}", headers);
+        assert!(!output.contains("SECRETSIGMARKER"));
+        assert!(output.contains("authorization"));
+        assert!(output.contains("** redacted"));
+    }
+
+    #[test]
+    fn debug_redacts_security_token() {
+        let mut headers = Headers::new();
+        headers.insert("x-amz-security-token", "IQoJb3JpZ2luSECRETTOKENMARKERzzz");
+        let output = format!("{:?}", headers);
+        assert!(!output.contains("SECRETTOKENMARKER"));
+        assert!(output.contains("x-amz-security-token"));
+        assert!(output.contains("length="));
+    }
+
+    #[test]
+    fn debug_redacts_mixed_case_header_name() {
+        let mut headers = Headers::new();
+        headers.insert(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAXXX/.../Signature=SECRETSIGMARKER",
+        );
+        let output = format!("{:?}", headers);
+        assert!(!output.contains("SECRETSIGMARKER"));
+        assert!(output.contains("** redacted"));
+    }
+
+    #[test]
+    fn debug_preserves_non_sensitive_headers() {
+        let mut headers = Headers::new();
+        headers.insert("host", "example.com");
+        headers.insert("x-amz-user-agent", "aws-sdk-rust/1.0");
+        let output = format!("{:?}", headers);
+        assert!(output.contains("example.com"));
+        assert!(output.contains("aws-sdk-rust/1.0"));
+    }
+
+    #[test]
+    fn debug_handles_sse_customer_key() {
+        let mut headers = Headers::new();
+        headers.insert(
+            "x-amz-server-side-encryption-customer-key",
+            "BASE64KEYMARKER_DO_NOT_LOG",
+        );
+        let output = format!("{:?}", headers);
+        assert!(!output.contains("BASE64KEYMARKER_DO_NOT_LOG"));
+        assert!(output.contains("x-amz-server-side-encryption-customer-key"));
+        assert!(output.contains("** redacted"));
+    }
+
+    #[test]
+    fn debug_includes_length() {
+        let value = "exactly-twenty-chars";
+        assert_eq!(value.len(), 20);
+        let mut headers = Headers::new();
+        headers.insert("authorization", value);
+        let output = format!("{:?}", headers);
+        assert!(output.contains("length=20"));
     }
 }


### PR DESCRIPTION
# Customize `Debug` and `Display` formatting for HTTP types in trace and error output

Adjusts how a few HTTP-related types are formatted for `Debug`, `Display`, and structured tracing output. 

internal refs: `H06`, `H27`, `H28`

## aws-config

The ECS/EKS container credential provider's `tracing::warn!` event for invalid container auth tokens now emits structured diagnostic fields (token byte length, and a boolean indicating whether the value ends in ASCII whitespace) rather than interpolating the value into the message. The `Display` impl of `EcsConfigurationError::InvalidAuthToken` is updated to match.

The `value: String` field is removed from the private `InvalidAuthToken` enum variant. No public API changes.

## aws-smithy-runtime-api

`Headers` now has a manual `Debug` impl. For a small denylist of header names (matched case-insensitively), the value is replaced with a placeholder that includes the original byte length. All other header values format as before. `Request<B>` continues to derive `Debug` and picks up the new `Headers` formatting transitively.

## aws-sigv4

Adds a `pub(crate) RedactedCanonicalRequest` wrapper, returned by `CanonicalRequest::redacted()`, whose `Display` impl applies the same per-header policy used by `aws-smithy-runtime-api`. The signer's `tracing::trace!` call sites that log the canonical request now route through this wrapper.

`Display for CanonicalRequest` is unchanged. It produces the raw canonical form required for SigV4 signature computation; both smithy-rs and external callers of `aws-sigv4` rely on this contract.


## Checklist

- [x] I have read the [Contributing Guide](https://github.com/smithy-lang/smithy-rs/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
