### PR TITLE
Update S3 e2e benchmark for accurate throughput measurement

### DIFF
--- a/aws/sdk/benchmarks/standardized-benches/Cargo.toml
+++ b/aws/sdk/benchmarks/standardized-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "standardized-benches"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]
@@ -19,3 +19,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.30"
 tokio = { version = "1", features = ["full"] }
+bytes = "1"

--- a/aws/sdk/benchmarks/standardized-benches/src/e2e/s3.rs
+++ b/aws/sdk/benchmarks/standardized-benches/src/e2e/s3.rs
@@ -68,16 +68,14 @@ pub async fn run_benchmark(config: BenchmarkConfig<ActionConfig>) -> BenchmarkRe
     }
 
     for _ in 0..config.warmup.batches {
-        run_batch(&client, &config, &data).await;
+        let _ = run_batch(&client, &config, &data).await;
     }
 
     let monitor = ResourceMonitor::spawn(config.measurement.metrics_interval);
     let mut iterations = Vec::new();
 
     for _ in 0..config.measurement.batches {
-        let start = Instant::now();
-        run_batch(&client, &config, &data).await;
-        let total_time = start.elapsed().as_secs_f64();
+        let total_time = run_batch(&client, &config, &data).await.as_secs_f64();
         let throughput_gbps =
             (config.batch.number_of_actions as f64 * config.action_config.object_size as f64 * 8.0)
                 / total_time
@@ -207,10 +205,11 @@ async fn setup_objects(client: &Client, config: &BenchmarkConfig<ActionConfig>, 
         .concurrency
         .unwrap_or(config.batch.number_of_actions);
     let sem = Arc::new(tokio::sync::Semaphore::new(concurrency));
+    let shared_data = bytes::Bytes::from(data.to_vec());
     let tasks: Vec<_> = (0..config.batch.number_of_actions)
         .map(|i| {
             let key = format!("{}{}", config.action_config.key_prefix, i);
-            let body = ByteStream::from(data.to_vec());
+            let body = ByteStream::from(shared_data.clone());
             let sem = sem.clone();
             let fut = client
                 .put_object()
@@ -228,7 +227,11 @@ async fn setup_objects(client: &Client, config: &BenchmarkConfig<ActionConfig>, 
     assert_all_ok(&results, "setup_objects", config.batch.number_of_actions);
 }
 
-async fn run_batch(client: &Client, config: &BenchmarkConfig<ActionConfig>, data: &[u8]) {
+async fn run_batch(
+    client: &Client,
+    config: &BenchmarkConfig<ActionConfig>,
+    data: &[u8],
+) -> std::time::Duration {
     let concurrency = config
         .batch
         .concurrency
@@ -236,45 +239,61 @@ async fn run_batch(client: &Client, config: &BenchmarkConfig<ActionConfig>, data
     let sem = Arc::new(tokio::sync::Semaphore::new(concurrency));
 
     if config.action == "upload" {
-        let tasks: Vec<_> = (0..config.batch.number_of_actions)
+        // Pre-build all requests before timing starts
+        let shared_data = bytes::Bytes::from(data.to_vec());
+        let futs: Vec<_> = (0..config.batch.number_of_actions)
             .map(|i| {
                 let key = format!("{}{}", config.action_config.key_prefix, i);
-                let body = ByteStream::from(data.to_vec());
-                let sem = sem.clone();
-                let fut = client
+                let body = ByteStream::from(shared_data.clone());
+                client
                     .put_object()
                     .bucket(&config.action_config.bucket_name)
                     .key(key)
                     .body(body)
-                    .send();
-                async move {
-                    let _permit = sem.acquire().await.expect("semaphore should not be closed");
-                    fut.await
-                }
+                    .send()
             })
             .collect();
-        let results = join_all(tasks).await;
-        assert_all_ok(&results, "upload", config.batch.number_of_actions);
+        let start = Instant::now();
+        let handles: Vec<_> = futs
+            .into_iter()
+            .map(|fut| {
+                let sem = sem.clone();
+                tokio::spawn(async move {
+                    let _permit = sem.acquire().await.expect("semaphore should not be closed");
+                    fut.await
+                })
+            })
+            .collect();
+        join_all(handles).await;
+        start.elapsed()
     } else {
-        let tasks: Vec<_> = (0..config.batch.number_of_actions)
+        // Pre-build all requests before timing starts
+        let futs: Vec<_> = (0..config.batch.number_of_actions)
             .map(|i| {
                 let key = format!("{}{}", config.action_config.key_prefix, i);
-                let sem = sem.clone();
-                let fut = client
+                client
                     .get_object()
                     .bucket(&config.action_config.bucket_name)
                     .key(key)
-                    .send();
-                async move {
+                    .send()
+            })
+            .collect();
+        let start = Instant::now();
+        let handles: Vec<_> = futs
+            .into_iter()
+            .map(|fut| {
+                let sem = sem.clone();
+                tokio::spawn(async move {
                     let _permit = sem.acquire().await.expect("semaphore should not be closed");
                     let resp = fut.await.expect("download request should succeed");
                     resp.body
                         .collect()
                         .await
                         .expect("download body read should succeed");
-                }
+                })
             })
             .collect();
-        join_all(tasks).await;
+        join_all(handles).await;
+        start.elapsed()
     }
 }


### PR DESCRIPTION
## Motivation and Context
[The S3 e2e benchmark](https://github.com/smithy-lang/smithy-rs/tree/main/aws/sdk/benchmarks/standardized-benches#e2e-benchmarks) was compared to other SDKs' counterparts with concurrency size 64. The Rust SDK reported ~1.6 Gbps for uploads and ~1.9 Gbps for downloads, which seemed low compared to
- `smithy-java` reporting 10.3 Gbps for uploads and 10.2 Gbps for downloads
- `.NET` reporting 6.9 Gbps for uploads and 8.9 Gbps for downloads.

## Description
Rust SDK showed sub-optimal throughput due to two issues in the benchmark harness:                                                                       
1. Input creation included in timing — `data.to_vec()` (256KiB × 10,000 = 2.5GB of copies) and request construction happened inside the measured region.
2. Single-threaded execution — `join_all` without `tokio::spawn` meant all 10,000 futures were polled on a single thread, not utilizing the multi-threaded tokio runtime. 

To address these, this PR                                                                                
- Moves request construction outside timing: Pre-build all request futures before `Instant::now()`, so only actual useful work is measured, e.g. serde, network I/O.
- Uses `tokio::spawn` per operation.
- Shares upload body via Bytes: Instead of cloning 256KiB per request (`data.to_vec()`), create one Bytes instance and let it be shared by operations. Reduces upload memory from ~2.9GB to ~340MB.
- Returns `Duration` from `run_batch`: Timing is captured inside the function to precisely bracket only the network execution phase.

## Testing
The analysis doc is to be updated for varying concurrency sizes but here are the updated results for S3 e2e benchmark with concurrency size 64.

Before:
  | SDK / Configuration | PutObject Gbps | PutObject p50 | PutObject Mem peak | GetObject Gbps | GetObject p50 | GetObject Mem peak |
  |---|---|---|---|---|---|---|
  | Rust @ 64 conc | 1.63 | — | 2916 MB | 1.90 | — | 316 MB |

After:
  | SDK / Configuration | PutObject Gbps | PutObject p50 | PutObject Mem peak | GetObject Gbps | GetObject p50 | GetObject Mem peak |
  |---|---|---|---|---|---|---|
  | Rust @ 64 conc | 10.5 | — | 340 MB | 10.3 | — | 290 MB |

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
