### PR TITLE
Fix paginator codegen for required outputToken members

### DIFF
--- a/.changelog/fix-paginator-required-output-token.md
+++ b/.changelog/fix-paginator-required-output-token.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- vcjana
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Fix paginator codegen for operations whose `@paginated` `outputToken` targets a `@required` member. Previously, the generated `src/lens.rs` borrowing accessor emitted a direct field access (`input.field`) instead of a reference (`&input.field`) for required members, causing a type mismatch (`Option<&String>` vs `String`).

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/NestedAccessorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/NestedAccessorGenerator.kt
@@ -104,7 +104,11 @@ class NestedAccessorGenerator(private val codegenContext: CodegenContext) {
                         )
                     }
                 } else {
-                    rust("let input = input.${symbolProvider.toMemberName(head)};")
+                    if (reference) {
+                        rust("let input = &input.${symbolProvider.toMemberName(head)};")
+                    } else {
+                        rust("let input = input.${symbolProvider.toMemberName(head)};")
+                    }
                 }
                 // Note: although _this_ function is recursive, it generates a series of `if let` statements with early returns.
                 generateBody(path.drop(1), reference)(this)

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGeneratorTest.kt
@@ -86,6 +86,57 @@ internal class PaginatorGeneratorTest {
         }
     }
 
+    // Regression: when a @paginated operation's top-level outputToken targets a @required member,
+    // the borrowing lens accessor in src/lens.rs previously moved the owned value instead of
+    // borrowing it, producing Option<String> where Option<&String> is expected.
+    @Test
+    fun `paginators with required top-level outputToken compile`() {
+        val requiredTokenModel =
+            """
+            namespace test
+            use aws.protocols#awsJson1_1
+
+            @awsJson1_1
+            service TestService {
+                operations: [ListThings]
+            }
+
+            @readonly
+            @optionalAuth
+            @paginated(inputToken: "nextToken", outputToken: "nextToken",
+                       pageSize: "maxResults", items: "thingSummaries")
+            operation ListThings {
+                input: ListThingsInput,
+                output: ListThingsOutput
+            }
+
+            structure ListThingsInput {
+                maxResults: Integer,
+                nextToken: String
+            }
+
+            structure ListThingsOutput {
+                @required
+                nextToken: String,
+
+                @required
+                thingSummaries: StringList
+            }
+
+            list StringList {
+                member: String
+            }
+            // disableValidation: Smithy's paginated-trait lint flags a @required outputToken; we intentionally model it that way to exercise the codegen path.
+            """.asSmithyModel(disableValidation = true)
+
+        clientIntegrationTest(requiredTokenModel) { clientCodegenContext, rustCrate ->
+            rustCrate.integrationTest("paginators_required_top_level_token") {
+                Attribute.AllowUnusedImports.render(this)
+                rust("use ${clientCodegenContext.moduleUseName()}::operation::list_things::paginator::ListThingsPaginator;")
+            }
+        }
+    }
+
     @Test
     fun `isTruncated paginators compile`() {
         // Adding IsTruncated trait to the output shape


### PR DESCRIPTION
## Motivation and Context
Paginators don't compile when an operation's `@paginated` `outputToken` points at a `@required` member. The generated lens accessor in `src/lens.rs` moves the field out of a borrowed struct instead of borrowing it, so it returns an owned `String` where the signature promises `&String`:

```
error[E0308]: mismatched types
   |     ::std::option::Option::Some(input)
   |     expected `&String`, found `String`
```

This has been latent for a while — it only became reachable once smithy-lang/smithy#2983 relaxed pagination validation (ERROR → DANGER) for a required `outputToken`, which landed here via #4647 (Smithy 1.69.0). Before that, such models couldn't get past validation, so codegen never had to handle them.

## Description
The output-token lens is a *borrowing* accessor — it takes `&Output` and returns `Option<&T>`. `NestedAccessorGenerator` walks the token path and, for optional members, correctly matches on a reference. For non-optional (`@required`) members, though, it just did `let input = input.field;`, moving the value regardless of whether the accessor was meant to borrow. The base case then wraps that in `Some(input)`, giving `Option<String>` instead of `Option<&String>`. Required members aren't `Option`-wrapped under CLIENT nullability, so they fell straight into this branch — which nothing had exercised until now.

The fix is small: when generating a borrowing accessor, take a reference (`&input.field`) for required members too. The owned accessor path is left alone.

## Testing
- Added a `PaginatorGeneratorTest` case with a top-level `@required` output token. It fails to compile on `main` and passes with the fix; the rest of the suite stays green.
- Generated and compiled a full SDK from a model that uses a required paginated output token — `E0308` without the fix, clean build with it.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
