### PR TITLE
fix: Avoid stack overflow in JSON parsing

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",

--- a/aws/sdk/benchmarks/sdk-perf/Cargo.lock
+++ b/aws/sdk/benchmarks/sdk-perf/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -572,7 +572,7 @@ version = "0.66.5"
 dependencies = [
  "aws-smithy-cbor 0.61.9",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
@@ -639,7 +639,7 @@ name = "aws-smithy-http-server-python"
 version = "0.67.1"
 dependencies = [
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http-server",
  "aws-smithy-types 1.4.9",
  "aws-smithy-xml 0.60.15",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
@@ -723,7 +723,7 @@ name = "aws-smithy-legacy-http-server"
 version = "0.65.15"
 dependencies = [
  "aws-smithy-cbor 0.61.9",
- "aws-smithy-json 0.62.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",
@@ -2499,7 +2499,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.9",
  "aws-smithy-compression",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-types 1.4.9",

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-json/fuzz/Cargo.lock
+++ b/rust-runtime/aws-smithy-json/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-schema"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -358,21 +358,36 @@ pub fn skip_to_end<'a>(
     skip_inner(1, tokens)
 }
 
+/// Maximum nesting depth allowed while skipping a JSON value.
+const MAX_SKIP_DEPTH: usize = 512;
+
 fn skip_inner<'a>(
-    depth: isize,
+    initial_depth: usize,
     tokens: &mut impl Iterator<Item = Result<Token<'a>, Error>>,
 ) -> Result<(), Error> {
+    let mut depth = initial_depth;
     loop {
         match tokens.next().transpose()? {
             Some(Token::StartObject { .. }) | Some(Token::StartArray { .. }) => {
-                skip_inner(depth + 1, tokens)?;
-                if depth == 0 {
-                    break;
+                depth = depth.checked_add(1).ok_or_else(|| {
+                    Error::custom("exceeded max recursion depth while skipping value")
+                })?;
+                if depth > MAX_SKIP_DEPTH {
+                    return Err(Error::custom(
+                        "exceeded max recursion depth while skipping value",
+                    ));
                 }
             }
             Some(Token::EndObject { .. }) | Some(Token::EndArray { .. }) => {
                 debug_assert!(depth > 0);
-                break;
+                // The token iterator validates matching braces, so reaching
+                // this branch with depth == 0 indicates a bug upstream rather
+                // than untrusted input. Saturate to avoid underflow in
+                // release builds.
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    break;
+                }
             }
             Some(Token::ValueNull { .. })
             | Some(Token::ValueBool { .. })
@@ -383,7 +398,7 @@ fn skip_inner<'a>(
                 }
             }
             Some(Token::ObjectKey { .. }) => {}
-            _ => return Err(Error::custom("expected value")),
+            None => return Err(Error::custom("expected value")),
         }
     }
     Ok(())
@@ -559,6 +574,87 @@ pub mod test {
             tokens.next(),
             Some(Ok(Token::ValueBool { value: true, .. }))
         ))
+    }
+
+    /// Regression test for unbounded recursion in `skip_inner`.
+    ///
+    /// The previous implementation recursed once per nested container. A payload
+    /// consisting of hundreds of thousands of `[` characters therefore recursed
+    /// deeply enough to overflow the default thread stack. With the iterative
+    /// implementation we instead return a bounded depth-limit error.
+    #[test]
+    fn skip_deeply_nested_returns_depth_error() {
+        // Far deeper than MAX_SKIP_DEPTH, and far deeper than a typical
+        // thread stack can tolerate with a recursive implementation
+        // (~8 bytes per recursion would blow 8 MiB at ~1M frames, and the
+        // real frame cost is much larger than that in debug builds).
+        let depth = 200_000;
+        let mut payload = Vec::with_capacity(depth * 2);
+        payload.extend(std::iter::repeat_n(b'[', depth));
+        payload.extend(std::iter::repeat_n(b']', depth));
+
+        let mut tokens = json_token_iter(&payload);
+        let err = skip_value(&mut tokens).expect_err("should hit the depth limit");
+        match err.kind {
+            ErrorKind::Custom { message, .. } => {
+                assert!(
+                    message.contains("exceeded max recursion depth"),
+                    "unexpected error message: {message}"
+                );
+            }
+            other => panic!("expected Custom depth-limit error, got {other:?}"),
+        }
+    }
+
+    /// The same scenario as [`skip_deeply_nested_returns_depth_error`], but run
+    /// on a thread with a very small stack. The previous recursive
+    /// implementation would stack-overflow here (aborting the process).
+    /// The iterative implementation uses O(1) stack so this completes with a
+    /// normal error return value.
+    #[test]
+    fn skip_deeply_nested_does_not_overflow_stack() {
+        // 256 KiB — too small for hundreds of thousands of recursive frames,
+        // plenty for the iterative implementation.
+        const SMALL_STACK: usize = 256 * 1024;
+
+        let handle = std::thread::Builder::new()
+            .stack_size(SMALL_STACK)
+            .spawn(|| {
+                let depth = 200_000;
+                let mut payload = Vec::with_capacity(depth * 2);
+                payload.extend(std::iter::repeat_n(b'[', depth));
+                payload.extend(std::iter::repeat_n(b']', depth));
+
+                let mut tokens = json_token_iter(&payload);
+                // We don't care about the exact result here (it will be a
+                // depth-limit error); we only care that the thread returns
+                // rather than aborting the process via stack overflow.
+                let _ = skip_value(&mut tokens);
+            })
+            .expect("failed to spawn small-stack thread");
+
+        handle
+            .join()
+            .expect("skip_value overflowed a 256KiB stack — recursion is unbounded");
+    }
+
+    /// Nesting below the depth limit should still succeed, demonstrating that
+    /// the iterative implementation preserves the happy path behaviour.
+    #[test]
+    fn skip_modestly_nested_still_works() {
+        // Below MAX_SKIP_DEPTH (256).
+        let depth = 100;
+        let mut payload = Vec::with_capacity(depth * 2 + 5);
+        payload.extend(std::iter::repeat_n(b'[', depth));
+        payload.extend(std::iter::repeat_n(b']', depth));
+        payload.extend_from_slice(b" true");
+
+        let mut tokens = json_token_iter(&payload);
+        skip_value(&mut tokens).expect("nesting below limit should parse");
+        assert!(matches!(
+            tokens.next(),
+            Some(Ok(Token::ValueBool { value: true, .. }))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation and Context
Certain JSON inputs can lead to stack overflow

## Description
Change all JSON code paths to avoid unbounded recursion

## Testing
Unit tests


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
