### PR TITLE
Pin badssl.com to pre-Ubuntu 24.04 commit

### DIFF
--- a/.github/workflows/ci-tls.yml
+++ b/.github/workflows/ci-tls.yml
@@ -56,6 +56,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: chromium/badssl.com
+        # TODO(smithy-rs#4687): Remove this pin once we upgrade OpenSSL to support @SECLEVEL=0
+        ref: 6e53ae0859e678724d54eb4f64f839174c9b82e3
         path: ./badssl.com
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Motivation and Context
Upstream commit bfc80f7 (https://github.com/chromium/badssl.com/commit/bfc80f7c2bf0873e2fdc9ba79f38a5afd93570fb) (Jun 1, 2026) added `@SECLEVEL=0` to nginx `ssl_ciphers` directives, which is not recognized by the OpenSSL 1.0.2g we build from source in `new-badssl-dockerfile`.
This causes `nginx -t` to fail with `SSL_CIPHER_PROCESS_RULESTR:invalid command`.


## Description
Pin `chromium/badssl.com` checkout to commit `6e53ae0` (pre-Ubuntu 24.04 upgrade) to fix the TLS CI build.

Opened  #4687 as a follow-up.

## Testing
- CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
