### PR TITLE
Lift patch-only version restriction on `aws-smithy-eventstream`

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 dependencies = [
  "aws-smithy-types",
  "bytes",

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -263,7 +263,8 @@ impl Sign for SigV4Signer {
         #[cfg(feature = "event-stream")]
         {
             use crate::auth::sigv4::SigV4MessageSigner;
-            use aws_smithy_eventstream::frame::DeferredSignerSender;
+            use aws_smithy_eventstream::frame::SignMessage;
+            use aws_smithy_types::event_stream::DeferredSignerSender;
 
             if let Some(signer_sender) = config_bag.load::<DeferredSignerSender>() {
                 let time_source = runtime_components.time_source().unwrap_or_default();
@@ -282,7 +283,7 @@ impl Sign for SigV4Signer {
                         name,
                         time_source,
                         (),
-                    )) as _)
+                    )) as Box<dyn SignMessage + Send + Sync>)
                     .expect("failed to send deferred signer");
             }
         }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamMarshallerGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamMarshallerGeneratorTest.kt
@@ -269,7 +269,7 @@ class ClientEventStreamMarshallerGeneratorTest {
                                 ) -> Result<(), BoxError> {
                                     if let Some(signer_sender) = cfg.load::<DeferredSignerSender>() {
                                         signer_sender
-                                            .send(Box::new(TestSigner))
+                                            .send(Box::new(TestSigner) as Box<dyn SignMessage + Send + Sync>)
                                             .expect("failed to send test signer");
                                     }
                                     Ok(())

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 dependencies = [
  "arbitrary",
  "aws-smithy-types 1.5.0",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.61.10"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "criterion",
  "minicbor 2.2.2",
  "num-bigint",
@@ -385,7 +385,7 @@ name = "aws-smithy-checksums"
 version = "0.64.8"
 dependencies = [
  "aws-smithy-http 0.63.6",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
  "crc-fast",
@@ -408,7 +408,7 @@ name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -437,7 +437,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.20"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -479,7 +479,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -503,7 +503,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "base64 0.22.1",
  "bytes",
  "h2 0.3.27",
@@ -575,7 +575,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.7",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -642,7 +642,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http-server",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures",
@@ -689,7 +689,7 @@ version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "proptest",
  "serde_json",
 ]
@@ -702,7 +702,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -727,7 +727,7 @@ dependencies = [
  "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -757,7 +757,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "http 1.4.0",
  "tokio",
 ]
@@ -807,7 +807,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.15"
 dependencies = [
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "urlencoding",
 ]
 
@@ -822,7 +822,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "fastrand 2.4.1",
  "futures-util",
@@ -863,7 +863,7 @@ version = "1.12.3"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api-macros",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "http 0.2.12",
  "http 1.4.0",
@@ -888,7 +888,7 @@ name = "aws-smithy-schema"
 version = "0.1.0"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "http 1.4.0",
 ]
 
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -958,7 +958,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.14"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "chrono",
  "futures-core",
  "time",
@@ -970,7 +970,7 @@ version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "http-body-util",
  "sync_wrapper",
  "wstd",
@@ -2503,7 +2503,7 @@ dependencies = [
  "aws-smithy-json 0.62.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.5.0",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "fastrand 2.4.1",

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-eventstream"
-# <IMPORTANT> Only patch releases can be made to this runtime crate until https://github.com/smithy-lang/smithy-rs/issues/3370 is resolved
-version = "0.60.20"
+# <IMPORTANT> Only patch releases can be made to this runtime crate until 0.60.21 is published on crates.io
+version = "0.60.21"
 # </IMPORTANT>
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -13,7 +13,6 @@ use aws_smithy_types::event_stream::{DeferredSignerReceiver, Header, HeaderValue
 use aws_smithy_types::str_bytes::StrBytes;
 use aws_smithy_types::DateTime;
 use bytes::{Buf, BufMut};
-use std::error::Error as StdError;
 use std::fmt;
 use std::mem::size_of;
 
@@ -34,18 +33,7 @@ pub(crate) const TYPE_STRING: u8 = 7;
 pub(crate) const TYPE_TIMESTAMP: u8 = 8;
 pub(crate) const TYPE_UUID: u8 = 9;
 
-pub type SignMessageError = Box<dyn StdError + Send + Sync + 'static>;
-
-/// Signs an Event Stream message.
-pub trait SignMessage: fmt::Debug {
-    fn sign(&mut self, message: Message) -> Result<Message, SignMessageError>;
-
-    /// SigV4 requires an empty last signed message to be sent.
-    /// Other protocols do not require one.
-    /// Return `Some(_)` to send a signed last empty message, before completing the stream.
-    /// Return `None` to not send one and terminate the stream immediately.
-    fn sign_empty(&mut self) -> Option<Result<Message, SignMessageError>>;
-}
+pub use aws_smithy_types::event_stream::{SignMessage, SignMessageError};
 
 /// Deferred event stream signer to allow a signer to be wired up later.
 ///

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -8,15 +8,14 @@
 use crate::buf::count::CountBuf;
 use crate::buf::crc::{CrcBuf, CrcBufMut};
 use crate::error::{Error, ErrorKind};
-use aws_smithy_types::config_bag::{Storable, StoreReplace};
-use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
+pub use aws_smithy_types::event_stream::DeferredSignerSender;
+use aws_smithy_types::event_stream::{DeferredSignerReceiver, Header, HeaderValue, Message};
 use aws_smithy_types::str_bytes::StrBytes;
 use aws_smithy_types::DateTime;
 use bytes::{Buf, BufMut};
 use std::error::Error as StdError;
 use std::fmt;
 use std::mem::size_of;
-use std::sync::{mpsc, Mutex};
 
 const PRELUDE_LENGTH_BYTES: u32 = 3 * size_of::<u32>() as u32;
 const PRELUDE_LENGTH_BYTES_USIZE: usize = PRELUDE_LENGTH_BYTES as usize;
@@ -48,30 +47,6 @@ pub trait SignMessage: fmt::Debug {
     fn sign_empty(&mut self) -> Option<Result<Message, SignMessageError>>;
 }
 
-/// A sender that gets placed in the request config to wire up an event stream signer after signing.
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct DeferredSignerSender(Mutex<mpsc::Sender<Box<dyn SignMessage + Send + Sync>>>);
-
-impl DeferredSignerSender {
-    /// Creates a new `DeferredSignerSender`
-    fn new(tx: mpsc::Sender<Box<dyn SignMessage + Send + Sync>>) -> Self {
-        Self(Mutex::new(tx))
-    }
-
-    /// Sends a signer on the channel
-    pub fn send(
-        &self,
-        signer: Box<dyn SignMessage + Send + Sync>,
-    ) -> Result<(), mpsc::SendError<Box<dyn SignMessage + Send + Sync>>> {
-        self.0.lock().unwrap().send(signer)
-    }
-}
-
-impl Storable for DeferredSignerSender {
-    type Storer = StoreReplace<Self>;
-}
-
 /// Deferred event stream signer to allow a signer to be wired up later.
 ///
 /// HTTP request signing takes place after serialization, and the event stream
@@ -89,19 +64,19 @@ impl Storable for DeferredSignerSender {
 /// for the remainder of the operation.
 #[derive(Debug)]
 pub struct DeferredSigner {
-    rx: Option<Mutex<mpsc::Receiver<Box<dyn SignMessage + Send + Sync>>>>,
+    rx: Option<DeferredSignerReceiver>,
     signer: Option<Box<dyn SignMessage + Send + Sync>>,
 }
 
 impl DeferredSigner {
     pub fn new() -> (Self, DeferredSignerSender) {
-        let (tx, rx) = mpsc::channel();
+        let (rx, sender) = DeferredSignerSender::new();
         (
             Self {
-                rx: Some(Mutex::new(rx)),
+                rx: Some(rx),
                 signer: None,
             },
-            DeferredSignerSender::new(tx),
+            sender,
         )
     }
 
@@ -114,17 +89,10 @@ impl DeferredSigner {
                 self.rx
                     .take()
                     .expect("only taken once")
-                    .lock()
-                    .unwrap()
-                    .try_recv()
-                    .ok()
-                    // TODO(enableNewSmithyRuntimeCleanup): When the middleware implementation is removed,
-                    // this should panic rather than default to the `NoOpSigner`. The reason it defaults
-                    // is because middleware-based generic clients don't have any default middleware,
-                    // so there is no way to send a `NoOpSigner` by default when there is no other
-                    // auth scheme. The orchestrator auth setup is a lot more robust and will make
-                    // this problem trivial.
-                    .unwrap_or_else(|| Box::new(NoOpSigner {}) as _),
+                    .recv::<Box<dyn SignMessage + Send + Sync>>()
+                    // Fall back to NoOpSigner when no signer is sent (e.g., server-side
+                    // event streams or tests that don't configure signing).
+                    .unwrap_or_else(|_| Box::new(NoOpSigner {}) as _),
             );
             self.acquire()
         }
@@ -780,7 +748,9 @@ mod deferred_signer_tests {
 
         let (mut signer, sender) = check_send_sync(DeferredSigner::new());
 
-        sender.send(Box::<TestSigner>::default()).expect("success");
+        sender
+            .send(Box::<TestSigner>::default() as Box<dyn SignMessage + Send + Sync>)
+            .expect("success");
 
         let message = signer.sign(Message::new(Bytes::new())).expect("success");
         assert_eq!(1, message.headers()[0].value().as_int32().unwrap());

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/event_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/event_stream.rs
@@ -5,8 +5,12 @@
 
 //! Types relevant to event stream serialization/deserialization
 
+use crate::config_bag::{Storable, StoreReplace};
 use crate::str_bytes::StrBytes;
 use bytes::Bytes;
+use std::any::Any;
+use std::fmt;
+use std::sync::{mpsc, Mutex};
 
 mod value {
     use crate::str_bytes::StrBytes;
@@ -200,4 +204,110 @@ impl RawMessage {
     pub fn invalid(bytes: Option<Bytes>) -> Self {
         Self::Invalid(bytes)
     }
+}
+
+/// Error returned when sending a deferred signer fails.
+#[derive(Debug)]
+pub struct DeferredSignerSendError {
+    kind: DeferredSignerSendErrorKind,
+}
+
+#[derive(Debug)]
+enum DeferredSignerSendErrorKind {
+    Closed,
+}
+
+impl fmt::Display for DeferredSignerSendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            DeferredSignerSendErrorKind::Closed => f.write_str("receiver was dropped"),
+        }
+    }
+}
+
+impl std::error::Error for DeferredSignerSendError {}
+
+/// Error returned when receiving a deferred signer fails.
+#[derive(Debug)]
+pub struct DeferredSignerRecvError {
+    kind: DeferredSignerRecvErrorKind,
+}
+
+#[derive(Debug)]
+enum DeferredSignerRecvErrorKind {
+    NoSigner,
+}
+
+impl fmt::Display for DeferredSignerRecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            DeferredSignerRecvErrorKind::NoSigner => f.write_str("no signer was available"),
+        }
+    }
+}
+
+impl std::error::Error for DeferredSignerRecvError {}
+
+/// Receiver half of the deferred signer channel.
+///
+/// Held internally by a deferred signer implementation to receive the concrete
+/// signer once it becomes available after HTTP request signing.
+#[derive(Debug)]
+pub struct DeferredSignerReceiver {
+    rx: Mutex<Option<mpsc::Receiver<Box<dyn Any + Send + Sync>>>>,
+}
+
+impl DeferredSignerReceiver {
+    /// Receives the value sent by the corresponding [`DeferredSignerSender`].
+    ///
+    /// This consumes the receiver's channel on first call. Subsequent calls will
+    /// return an error.
+    pub fn recv<T: Send + Sync + 'static>(&self) -> Result<T, DeferredSignerRecvError> {
+        let mut rx = self.rx.lock().unwrap();
+        rx.take()
+            .and_then(|r| r.try_recv().ok())
+            .and_then(|any| any.downcast::<T>().ok())
+            .map(|b| *b)
+            .ok_or(DeferredSignerRecvError {
+                kind: DeferredSignerRecvErrorKind::NoSigner,
+            })
+    }
+}
+
+/// Sender for wiring up an event stream message signer after HTTP request signing.
+///
+/// During serialization, a [`DeferredSignerSender`] is placed in the config bag.
+/// After HTTP signing completes, the auth scheme retrieves it and sends the
+/// concrete signer implementation through the channel.
+#[derive(Debug)]
+pub struct DeferredSignerSender {
+    tx: Mutex<mpsc::Sender<Box<dyn Any + Send + Sync>>>,
+}
+
+impl DeferredSignerSender {
+    /// Creates a new sender/receiver pair.
+    pub fn new() -> (DeferredSignerReceiver, Self) {
+        let (tx, rx) = mpsc::channel();
+        (
+            DeferredSignerReceiver {
+                rx: Mutex::new(Some(rx)),
+            },
+            Self { tx: Mutex::new(tx) },
+        )
+    }
+
+    /// Sends a value through the channel.
+    pub fn send<T: Send + Sync + 'static>(&self, value: T) -> Result<(), DeferredSignerSendError> {
+        self.tx
+            .lock()
+            .unwrap()
+            .send(Box::new(value))
+            .map_err(|_| DeferredSignerSendError {
+                kind: DeferredSignerSendErrorKind::Closed,
+            })
+    }
+}
+
+impl Storable for DeferredSignerSender {
+    type Storer = StoreReplace<Self>;
 }

--- a/rust-runtime/aws-smithy-types/src/event_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/event_stream.rs
@@ -311,3 +311,18 @@ impl DeferredSignerSender {
 impl Storable for DeferredSignerSender {
     type Storer = StoreReplace<Self>;
 }
+
+/// An error that occurs when signing an Event Stream message.
+pub type SignMessageError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Signs an Event Stream message.
+pub trait SignMessage: fmt::Debug {
+    /// Signs a message, returning the signed version.
+    fn sign(&mut self, message: Message) -> Result<Message, SignMessageError>;
+
+    /// SigV4 requires an empty last signed message to be sent.
+    /// Other protocols do not require one.
+    /// Return `Some(_)` to send a signed last empty message, before completing the stream.
+    /// Return `None` to not send one and terminate the stream immediately.
+    fn sign_empty(&mut self) -> Option<Result<Message, SignMessageError>>;
+}


### PR DESCRIPTION
## Motivation and Context
https://github.com/smithy-lang/smithy-rs/issues/3370

## Description
This PR lifts the restriction that `aws-smithy-eventstream` can only receive patch version bumps in `Cargo.toml`, which has prevented the crate from receiving minor version bumps, let alone becoming stable.

The root cause is that `DeferredSignerSender`, a type stored in `ConfigBag`, is defined in `aws-smithy-eventstream` (an unstable 0.x crate). If the crate receives a minor bump (e.g., 0.60 → 0.61), Cargo treats these as semver-incompatible for 0.x crates and allows both to coexist in the dependency graph. Since `ConfigBag` uses `TypeId` for lookups, the old version's type differs from the new version's type, causing silent lookup failures that break event stream signing.

The fix moves `DeferredSignerSender` and the `SignMessage` trait to `aws-smithy-types` (a stable 1.x crate). This is the only place in the crate hierarchy that avoids circular dependencies (and already has an `event_stream` module).

Changes:
- `aws-smithy-types` (bumped to 1.5.0): Add `DeferredSignerSender`, `DeferredSignerReceiver`, `SignMessage`, and associated error types to the existing `event_stream` module.
- `aws-smithy-eventstream` (bumped to 0.60.21, still a patch version bump): Remove old `DeferredSignerSender` definition, re-export from `aws-smithy-types`. Adapt `DeferredSigner` to use `DeferredSignerReceiver`.
- `aws-runtime` (bumped to 1.7.5): Import `DeferredSignerSender` from `aws-smithy-types` instead of `aws-smithy-eventstream`.
- Remove the "only patch releases" restriction comment from `aws-smithy-eventstream/Cargo.toml`.

~**Note on `send` method signature change**: The `send` method on `DeferredSignerSender` previously took `Box<dyn SignMessage + Send + Sync>` directly. Since moving the `SignMessage` trait to `aws-smithy-types` requires stabilizing the trait, the new `send` is generic (`send<T: Send + Sync + 'static>`) with the value type-erased internally via `Box<dyn Any>`. This changes the method signature, but `send` is only called internally by `aws-runtime`; verified this via internal code search and public GitHub search. An alternative would be to also move `SignMessage` to `aws-smithy-types` to preserve the `send` method signature, but at the cost of committing to stabilizing the trait.~ 

## Testing
- CI
  - `cargo-semver-checks` reports `struct_missing` for `DeferredSignerSender` in `aws-smithy-eventstream` — this is expected, and the struct is replaced by a re-export from `aws-smithy-types` at the same path; the tool does not follow cross-crate re-exports of types.
- Manual standalone test (uncommitted) that reproduces the hazard and verifies the fix

<details>
<summary>Standalone test crate details</summary>

The test simulates two versions of `aws-smithy-eventstream` coexisting in a dependency graph — an SDK on 0.60.x and that on 0.61.0. It stores a `DeferredSignerSender` via the "old" eventstream and loads it via `aws-smithy-types` (as the new runtime would).

**Setup**:
```
$ cd semver-test
# Bump local eventstream to 0.61.0 to simulate a future minor bump
$ sed -i '' 's/0.60.21/0.61.0/' ../rust-runtime/aws-smithy-eventstream/Cargo.toml
# Create fake-0.60.21/ — a copy of the fixed eventstream at version 0.60.21
# (simulates what old SDKs resolve to after cargo update picks up the fix)
$ cp -r ../rust-runtime/aws-smithy-eventstream ./fake-0.60.21
$ sed -i '' 's/0.61.0/0.60.21/' ./fake-0.60.21/Cargo.toml
```

`semver-test/src/main.rs` (shared by both cases):
```
use aws_smithy_types::config_bag::{ConfigBag, Layer};
use aws_smithy_types::event_stream::DeferredSignerSender;

fn main() { 
    // "Old SDK" stores DeferredSignerSender via eventstream
    let (_signer, sender) = aws_smithy_eventstream_old::frame::DeferredSigner::new();
    let mut layer = Layer::new("test");
    layer.store_put(sender);
    let bag = ConfigBag::of_layers(vec![layer]);

    // "New runtime" loads via aws-smithy-types directly
    let loaded = bag.load::<DeferredSignerSender>();
    assert!(loaded.is_some(), "SEMVER HAZARD: TypeId mismatch!");
    println!("SUCCESS: DeferredSignerSender survives across eventstream version boundary!");
}
```

**Step 1: Reproduce the hazard (before fix)**

Uses crates.io's 0.60.20 as the "old" dep — this version defines its own `DeferredSignerSender`:
```
[dependencies]
aws-smithy-eventstream-old = { package = "aws-smithy-eventstream", version = "0.60.20" }
# Local eventstream at 0.61.0 (simulates the minor bump)
aws-smithy-eventstream-new = { package = "aws-smithy-eventstream", path = "../rust-runtime/aws-smithy-eventstream" } 
aws-smithy-types = { path = "../rust-runtime/aws-smithy-types" } 

[patch.crates-io]
# Unifies aws-smithy-types — simulates 1.5.0 published on crates.io
aws-smithy-types = { path = "../rust-runtime/aws-smithy-types" } 
```
```
$ cargo run
SEMVER HAZARD: TypeId mismatch!
```

**Step 2: Verify the fix (simulating after 0.60.21 published)**
Uses fake-0.60.21/ as the "old" dep — same fixed code, just at version 0.60.21 (uses `DeferredSignerSender` from `aws-smithy-types`):

```
[dependencies]
aws-smithy-eventstream-old = { package = "aws-smithy-eventstream", path = "./fake-0.60.21" }
# Local eventstream at 0.61.0 (simulates the minor bump)
aws-smithy-eventstream-new = { package = "aws-smithy-eventstream", path = "../rust-runtime/aws-smithy-eventstream" }
aws-smithy-types = { path = "../rust-runtime/aws-smithy-types" }

# No [patch.crates-io] needed — all deps are local paths, single aws-smithy-types resolved naturally
```

```  
$ cargo run
SUCCESS: DeferredSignerSender survives across eventstream version boundary!
```
  
**Revert after testing:**
`$ sed -i '' 's/0.61.0/0.60.21/' ../rust-runtime/aws-smithy-eventstream/Cargo.toml`


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
