### PR TITLE
Bump MSRV to 1.94.1

### DIFF
--- a/.changelog/msrv-1-94-1.md
+++ b/.changelog/msrv-1-94-1.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client", "server", "aws-sdk-rust"]
+authors: ["ysaito1001"]
+references: ["smithy-rs#4692"]
+breaking: true
+new_feature: false
+bug_fix: false
+---
+Upgrade MSRV to Rust 1.94.1.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ on:
         required: false
 
 env:
-  rust_version: 1.91.1
+  rust_version: 1.94.1
   rust_toolchain_components: clippy,rustfmt
   ENCRYPTED_DOCKER_PASSWORD: ${{ secrets.ENCRYPTED_DOCKER_PASSWORD }}
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
@@ -412,8 +412,8 @@ jobs:
       run: |
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
         # Install the pinned toolchain from rust-toolchain.toml and add musl target
-        rustup toolchain install 1.91.1
-        rustup target add aarch64-unknown-linux-musl wasm32-wasip2 --toolchain 1.91.1
+        rustup toolchain install 1.94.1
+        rustup target add aarch64-unknown-linux-musl wasm32-wasip2 --toolchain 1.94.1
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.91.1
+  rust_version: 1.94.1
 
 name: Claim unpublished crate names on crates.io
 run-name: ${{ github.workflow }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ on:
 name: Update GitHub Pages
 
 env:
-  rust_version: 1.91.1
+  rust_version: 1.94.1
 
 # Allow only one doc pages build to run at a time for the entire smithy-rs repo
 concurrency:

--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -159,8 +159,8 @@ jobs:
       run: |
         export RUST_STABLE_VERSION="$(rustc --version | cut -d' ' -f2)"
         # Install the pinned toolchain from rust-toolchain.toml and add musl target
-        rustup toolchain install 1.91.1
-        rustup target add aarch64-unknown-linux-musl wasm32-wasip2 --toolchain 1.91.1
+        rustup toolchain install 1.94.1
+        rustup target add aarch64-unknown-linux-musl wasm32-wasip2 --toolchain 1.94.1
         ./smithy-rs/tools/ci-scripts/run-canary \
           ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }} \
           ${{ steps.creds.outputs.aws-access-key-id }} \

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -35,7 +35,7 @@ env:
   apt_dependencies: libssl-dev gnuplot jq
   java_version: 17
   rust_toolchain_components: clippy,rustfmt
-  rust_nightly_version: nightly-2025-10-18
+  rust_nightly_version: nightly-2026-03-20
   ENCRYPTED_DOCKER_PASSWORD: ${{ secrets.ENCRYPTED_DOCKER_PASSWORD }}
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.91.1
+  rust_version: 1.94.1
 
 name: Release smithy-rs
 on:

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "arbitrary",
  "aws-credential-types",

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.8.18"
+version = "1.9.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",
@@ -10,7 +10,7 @@ edition = "2021"
 exclude = ["test-data/*", "integration-tests/*"]
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 behavior-version-latest = []

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Types for AWS SDK credentials."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 hardcoded-credentials = []

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 http-1x = ["aws-smithy-runtime-api/http-1x"]

--- a/aws/rust-runtime/aws-runtime-api/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime-api/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-runtime-api"
-version = "1.1.12"
+version = "1.2.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This isn't intended to be used directly."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.8.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 event-stream = ["dep:aws-smithy-eventstream", "aws-sigv4/sign-eventstream"]

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "David Barsky <me@davidbarsky.com>"]
 description = "SigV4 signer for HTTP requests and Event Stream messages."
 edition = "2021"
 exclude = ["aws-sig-v4-test-suite/*"]
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 default = ["sign-http", "http1"]

--- a/aws/rust-runtime/aws-sigv4/src/date_time.rs
+++ b/aws/rust-runtime/aws-sigv4/src/date_time.rs
@@ -96,7 +96,7 @@ mod tests {
     use time::format_description::well_known::Rfc3339;
 
     // TODO(https://github.com/smithy-lang/smithy-rs/issues/1857)
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
+    #[cfg(not(any(target_arch = "powerpc", target_arch = "x86", target_os = "windows")))]
     #[test]
     fn date_format() {
         let time: SystemTime = OffsetDateTime::parse("2039-02-04T23:01:09.104Z", &Rfc3339)
@@ -110,7 +110,7 @@ mod tests {
     }
 
     // TODO(https://github.com/smithy-lang/smithy-rs/issues/1857)
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
+    #[cfg(not(any(target_arch = "powerpc", target_arch = "x86", target_os = "windows")))]
     #[test]
     fn date_time_format() {
         let time: SystemTime = OffsetDateTime::parse("2039-02-04T23:01:09.104Z", &Rfc3339)

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-types"
-version = "1.3.16"
+version = "1.4.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "Cross-service types for the AWS SDK."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 # This feature is to be used only for doc comments

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -478,9 +478,9 @@ class ServerProtocolTestGenerator(
                 val sanitizedBody = escape(body.replace("\u000c", "\\u{000c}")).dq()
 
                 val encodedBodyTemplate = """
-                #{Bytes}::copy_from_slice(
-                    &#{decode_body_data}($sanitizedBody.as_bytes(), #{MediaType}::from(${(bodyMediaType ?: "unknown").dq()}))
-                )
+                    #{Bytes}::copy_from_slice(
+                        &#{decode_body_data}($sanitizedBody.as_bytes(), #{MediaType}::from(${(bodyMediaType ?: "unknown").dq()}))
+                    )
                 """
 
                 requestBodyConstructor(encodedBodyTemplate, needsSync)
@@ -490,8 +490,8 @@ class ServerProtocolTestGenerator(
 
         rustTemplate(
             """
-             .body(#{BodyCode}).unwrap();
-             """,
+            .body(#{BodyCode}).unwrap();
+            """,
             *codegenScope,
             "BodyCode" to bodyCode,
         )
@@ -605,14 +605,19 @@ class ServerProtocolTestGenerator(
             let (sender, mut receiver) = #{Tokio}::sync::mpsc::channel(1);
             let config = crate::service::${serviceName}Config::builder().build();
             let service = crate::service::$serviceName::builder::<#{BodyType}, _, _, _>(config)
-                .$operationName(move |input: $inputT| {
-                    let sender = sender.clone();
-                    async move {
-                        let result = { #{Body:W} };
-                        sender.send(()).await.expect("receiver dropped early");
-                        result
+                .$operationName(
+                    // Rust 1.94+ flags the moved `sender` as "value captured is never read"
+                    // since `send()` only borrows it.
+                    ##[allow(unused_assignments)]
+                    move |input: $inputT| {
+                        let sender = sender.clone();
+                        async move {
+                            let result = { #{Body:W} };
+                            sender.send(()).await.expect("receiver dropped early");
+                            result
+                        }
                     }
-                })
+                )
                 .build_unchecked();
             let http_response = #{Tower}::ServiceExt::oneshot(service, http_request)
                 .await

--- a/design/src/server/anatomy.md
+++ b/design/src/server/anatomy.md
@@ -187,7 +187,7 @@ let operation = GetPokemonSpecies::from_handler(get_pokemon_service);
 
 Alternatively, `from_service` constructor:
 
-```rust
+```rust,ignore
 # extern crate pokemon_service_server_sdk;
 # extern crate aws_smithy_http_server;
 # extern crate tower;
@@ -230,7 +230,7 @@ To summarize a _model service_ constructed can be constructed from a `Handler` o
 
 A [Smithy protocol](https://awslabs.github.io/smithy/2.0/spec/protocol-traits.html#serialization-and-protocol-traits) specifies the serialization/deserialization scheme - how a HTTP request is transformed into a modelled input and a modelled output to a HTTP response. The is formalized using the [`FromRequest`](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromRequest.html) and [`IntoResponse`](https://github.com/smithy-lang/smithy-rs/blob/4c5cbc39384f0d949d7693eb87b5853fe72629cd/rust-runtime/aws-smithy-http-server/src/response.rs#L40-L44) traits:
 
-```rust
+```rust,ignore
 # extern crate aws_smithy_http_server;
 # extern crate http;
 # use aws_smithy_http_server::body::BoxBody;
@@ -357,7 +357,7 @@ Different protocols supported by Smithy enjoy different routing mechanisms, for 
 
 Despite their differences, all routing mechanisms satisfy a common interface. This is formalized using the [Router](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/routing/trait.Router.html) trait:
 
-```rust
+```rust,ignore
 # extern crate aws_smithy_http_server;
 # extern crate http;
 /// An interface for retrieving an inner [`Service`] given a [`http::Request`].
@@ -673,7 +673,7 @@ stateDiagram-v2
 
 An additional omitted detail is that we provide an "escape hatch" allowing `Handler`s and `OperationService`s to accept data that isn't modelled. In addition to accepting `Op::Input` they can accept additional arguments which implement the [`FromParts`](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/request/trait.FromParts.html) trait:
 
-```rust
+```rust,ignore
 # extern crate aws_smithy_http_server;
 # extern crate http;
 # use http::request::Parts;
@@ -709,7 +709,7 @@ pub struct Parts {
 
 This is commonly used to access types stored within [`Extensions`](https://docs.rs/http/0.2.8/http/struct.Extensions.html) which have been inserted by a middleware. An `Extension` struct implements `FromParts` to support this use case:
 
-```rust
+```rust,ignore
 # extern crate aws_smithy_http_server;
 # extern crate http;
 # extern crate thiserror;

--- a/design/src/server/middleware.md
+++ b/design/src/server/middleware.md
@@ -49,7 +49,7 @@ The `Service` trait can be thought of as an asynchronous function from a request
 
 Middleware in `tower` typically conforms to the following pattern, a `Service` implementation of the form
 
-```rust
+```rust,ignore
 pub struct NewService<S> {
     inner: S,
     /* auxillary data */

--- a/examples/pokemon-service/Cargo.toml
+++ b/examples/pokemon-service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 authors = ["Smithy-rs Server Team <smithy-rs-server@amazon.com>"]
 description = "A smithy Rust service to retrieve information about Pokémon."
-rust-version = "1.88"
+rust-version = "1.94.1"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.19
+codegenVersion=0.1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.91.1
+rust.msrv=1.94.1
 # To enable debug, swap out the two lines below.
 # When changing this value, be sure to run `./gradlew --stop` to kill the Gradle daemon.
 # org.gradle.jvmargs=-Xmx1024M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5006

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-cbor"
-version = "0.61.10"
+version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-schema",
  "aws-smithy-types 1.5.0",
  "criterion",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.65.0"
 dependencies = [
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-compression"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-dns"
-version = "0.1.12"
+version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.21"
+version = "0.60.22"
 dependencies = [
  "arbitrary",
  "aws-smithy-types 1.5.0",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-experimental"
-version = "0.2.4"
+version = "0.3.0"
 
 [[package]]
 name = "aws-smithy-http"
@@ -474,11 +474,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
@@ -498,11 +498,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.13"
+version = "1.2.0"
 dependencies = [
- "aws-smithy-async 1.2.14",
+ "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "base64 0.22.1",
  "bytes",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.66.5"
+version = "0.67.0"
 dependencies = [
- "aws-smithy-cbor 0.61.10",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.7",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-cbor 0.62.0",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
- "aws-smithy-xml 0.60.15",
+ "aws-smithy-xml 0.61.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -602,10 +602,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aws-smithy-http-server 0.65.10",
- "aws-smithy-http-server 0.66.5",
+ "aws-smithy-http-server 0.67.0",
  "aws-smithy-http-server-metrics-macro",
  "aws-smithy-legacy-http-server",
  "futures",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics-macro"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -637,13 +637,13 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-python"
-version = "0.67.1"
+version = "0.68.0"
 dependencies = [
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.7",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http-server",
  "aws-smithy-types 1.5.0",
- "aws-smithy-xml 0.60.15",
+ "aws-smithy-xml 0.61.1",
  "bytes",
  "futures",
  "futures-util",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-schema",
  "aws-smithy-types 1.5.0",
  "proptest",
@@ -696,12 +696,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-legacy-http"
-version = "0.62.15"
+version = "0.63.0"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
@@ -721,14 +721,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-legacy-http-server"
-version = "0.65.15"
+version = "0.66.0"
 dependencies = [
- "aws-smithy-cbor 0.61.10",
- "aws-smithy-json 0.62.7",
+ "aws-smithy-cbor 0.62.0",
+ "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
- "aws-smithy-xml 0.60.15",
+ "aws-smithy-xml 0.61.1",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -751,12 +751,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-mocks"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
- "aws-smithy-async 1.2.14",
+ "aws-smithy-async 1.3.0",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "http 1.4.0",
  "tokio",
@@ -764,15 +764,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "serial_test",
 ]
 
 [[package]]
 name = "aws-smithy-observability-otel"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "async-global-executor",
  "async-task",
@@ -787,10 +787,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.63.14"
+version = "0.64.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.61.1"
 dependencies = [
  "aws-smithy-types 1.5.0",
  "urlencoding",
@@ -813,14 +813,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.0"
 dependencies = [
  "approx",
- "aws-smithy-async 1.2.14",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-async 1.3.0",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-schema",
  "aws-smithy-types 1.5.0",
  "bytes",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.13.0"
 dependencies = [
- "aws-smithy-async 1.2.14",
+ "aws-smithy-async 1.3.0",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types 1.5.0",
  "bytes",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "http 1.4.0",
 ]
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types-convert"
-version = "0.60.14"
+version = "0.61.1"
 dependencies = [
- "aws-smithy-async 1.2.14",
+ "aws-smithy-async 1.3.0",
  "aws-smithy-types 1.5.0",
  "chrono",
  "futures-core",
@@ -966,10 +966,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-wasm"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
- "aws-smithy-async 1.2.14",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-async 1.3.0",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
  "http-body-util",
  "sync_wrapper",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.61.1"
 dependencies = [
  "aws-smithy-protocol-test",
  "base64 0.13.1",
@@ -2497,14 +2497,14 @@ dependencies = [
 name = "inlineable"
 version = "0.1.0"
 dependencies = [
- "aws-smithy-cbor 0.61.10",
+ "aws-smithy-cbor 0.62.0",
  "aws-smithy-compression",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.7",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-runtime-api 1.13.0",
  "aws-smithy-types 1.5.0",
- "aws-smithy-xml 0.60.15",
+ "aws-smithy-xml 0.61.1",
  "bytes",
  "fastrand 2.4.1",
  "futures-util",

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Async runtime agnostic abstractions for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 rt-tokio = ["tokio/time"]

--- a/rust-runtime/aws-smithy-cbor/Cargo.toml
+++ b/rust-runtime/aws-smithy-cbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-cbor"
-version = "0.61.10"
+version = "0.62.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "David Pérez <d@vidp.dev>",
@@ -9,7 +9,7 @@ description = "CBOR utilities for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies.minicbor]
 version = "2.2.1"

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.65.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",
@@ -9,7 +9,7 @@ description = "Checksum calculation and verification callbacks"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-runtime/aws-smithy-compression/Cargo.toml
+++ b/rust-runtime/aws-smithy-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-compression"
-version = "0.1.6"
+version = "0.2.0"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Zelda Hessler <zhessler@amazon.com>",
@@ -9,7 +9,7 @@ description = "Request compression for smithy clients."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-runtime/aws-smithy-dns/Cargo.toml
+++ b/rust-runtime/aws-smithy-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-dns"
-version = "0.1.12"
+version = "0.2.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]
@@ -8,7 +8,7 @@ description = "DNS resolvers for smithy-rs"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 
 [features]

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "aws-smithy-eventstream"
-# <IMPORTANT> Only patch releases can be made to this runtime crate until 0.60.21 is published on crates.io
-version = "0.60.21"
-# </IMPORTANT>
+# TODO(smithy-rs#4691): once it's released in aws-sdk-rust, bump to 0.61.1 before merging to main
+version = "0.60.22"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 derive-arbitrary = ["dep:arbitrary", "dep:derive_arbitrary", "arbitrary?/derive"]

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -69,10 +69,7 @@ impl DeferredSigner {
     }
 
     fn acquire(&mut self) -> &mut (dyn SignMessage + Send + Sync) {
-        // Can't use `if let Some(signer) = &mut self.signer` because the borrow checker isn't smart enough
-        if self.signer.is_some() {
-            self.signer.as_mut().unwrap().as_mut()
-        } else {
+        if self.signer.is_none() {
             self.signer = Some(
                 self.rx
                     .take()
@@ -82,8 +79,8 @@ impl DeferredSigner {
                     // event streams or tests that don't configure signing).
                     .unwrap_or_else(|_| Box::new(NoOpSigner {}) as _),
             );
-            self.acquire()
         }
+        self.signer.as_mut().unwrap().as_mut()
     }
 }
 

--- a/rust-runtime/aws-smithy-experimental/Cargo.toml
+++ b/rust-runtime/aws-smithy-experimental/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-experimental"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Experiments for the smithy-rs ecosystem"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 crypto-ring = []

--- a/rust-runtime/aws-smithy-fuzz/Cargo.toml
+++ b/rust-runtime/aws-smithy-fuzz/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 [package]
 name = "aws-smithy-fuzz"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Fuzzing utilities for smithy-rs servers"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 afl = "0.15.10"

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,11 +2,11 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.1.13"
+version = "1.2.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 hyper-014 = [

--- a/rust-runtime/aws-smithy-http-server-metrics-macro/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics-macro/Cargo.toml
@@ -3,7 +3,7 @@ proc-macro = true
 
 [package]
 name = "aws-smithy-http-server-metrics-macro"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",
@@ -12,7 +12,7 @@ description = "Server metrics via metrique integration."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 syn = { version = "2.0.114", features = ["full"] }

--- a/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-metrics"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",
@@ -9,7 +9,7 @@ description = "Server metrics via metrique integration."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-http-server = { path = "../aws-smithy-http-server", features = [

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.67.1"
+version = "0.68.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ description = """
 Python server runtime for Smithy Rust Server Framework.
 """
 publish = true
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-http = { path = "../aws-smithy-http" }

--- a/rust-runtime/aws-smithy-http-server-typescript/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-typescript"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ description = """
 Typescript server runtime for Smithy Rust Server Framework.
 """
 publish = false
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.66.5"
+version = "0.67.0"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ description = """
 Server runtime for Smithy Rust Server Framework.
 """
 publish = true
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 default = []

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",
@@ -9,7 +9,7 @@ description = "Smithy HTTP logic for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 event-stream = ["aws-smithy-eventstream"]

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client"] }

--- a/rust-runtime/aws-smithy-legacy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-legacy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-legacy-http-server"
-version = "0.65.15"
+version = "0.66.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ description = """
 Legacy server runtime for Smithy Rust Server Framework, providing compatibility for code generated with http 0.x and hyper 0.x dependencies.
 """
 publish = true
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 aws-lambda = ["dep:lambda_http"]

--- a/rust-runtime/aws-smithy-legacy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-legacy-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-legacy-http"
-version = "0.62.15"
+version = "0.63.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",
@@ -9,7 +9,7 @@ description = "Smithy HTTP-0x logic for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 event-stream = ["aws-smithy-eventstream", "aws-smithy-http/event-stream"]

--- a/rust-runtime/aws-smithy-mocks/Cargo.toml
+++ b/rust-runtime/aws-smithy-mocks/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-mocks"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Testing utilities for smithy-rs generated clients"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types" }

--- a/rust-runtime/aws-smithy-observability-otel/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability-otel"
-version = "0.1.11"
+version = "0.2.0"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]
@@ -8,7 +8,7 @@ description = "Smithy OpenTelemetry observability implementation."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-observability = { path = "../aws-smithy-observability" }

--- a/rust-runtime/aws-smithy-observability/Cargo.toml
+++ b/rust-runtime/aws-smithy-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
 ]
@@ -8,7 +8,7 @@ description = "Smithy observability implementation."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api" }

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-protocol-test"
-version = "0.63.14"
+version = "0.64.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "A collection of library functions to validate HTTP requests against Smithy protocol tests."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 default = ["http-02x"]

--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.61.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "AWSQuery and EC2Query Smithy protocol logic for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"] }

--- a/rust-runtime/aws-smithy-runtime-api-macros/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api-macros/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Proc macros for aws-smithy-runtime-api."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.0"
+rust-version = "1.94.1"
 
 [lib]
 proc-macro = true

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.13.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-runtime/aws-smithy-schema/Cargo.toml
+++ b/rust-runtime/aws-smithy-schema/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "aws-smithy-schema"
-version = "0.1.0"
+# Note: bumping minor (0.1 -> 0.2) for an MSRV update causes semver hazards
+# because aws-config depends on ^0.1. Use patch bumps until stable is released.
+version = "0.1.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Schema types for the smithy-rs ecosystem"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["client"] }

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-types-convert"
-version = "0.60.14"
+version = "0.61.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Conversion of types from aws-smithy-types to other libraries."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 convert-chrono = ["aws-smithy-types", "chrono"]

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -9,7 +9,7 @@ description = "Types for smithy-rs codegen."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 byte-stream-poll-next = []

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -392,9 +392,6 @@ mod test {
     use crate::date_time::Format;
     use crate::DateTime;
     use proptest::proptest;
-    use std::time::SystemTime;
-    use time::format_description::well_known::Rfc3339;
-    use time::OffsetDateTime;
 
     #[test]
     fn test_display_date_time() {
@@ -621,9 +618,12 @@ mod test {
     }
 
     // TODO(https://github.com/smithy-lang/smithy-rs/issues/1857)
-    #[cfg(not(any(target_arch = "powerpc", target_arch = "x86")))]
+    #[cfg(not(any(target_arch = "powerpc", target_arch = "x86", target_os = "windows")))]
     #[test]
     fn system_time_conversions() {
+        use std::time::SystemTime;
+        use time::format_description::well_known::Rfc3339;
+        use time::OffsetDateTime;
         // Check agreement
         let date_time = DateTime::from_str("1000-01-02T01:23:10.123Z", Format::DateTime).unwrap();
         let off_date_time = OffsetDateTime::parse("1000-01-02T01:23:10.123Z", &Rfc3339).unwrap();

--- a/rust-runtime/aws-smithy-wasm/Cargo.toml
+++ b/rust-runtime/aws-smithy-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-wasm"
-version = "0.1.11"
+version = "0.2.0"
 authors = [
   "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
   "Eduardo Rodrigues <16357187+eduardomourar@users.noreply.github.com>",
@@ -10,7 +10,7 @@ description = "Smithy WebAssembly wasip2 configuration for smithy-rs."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }

--- a/rust-runtime/aws-smithy-xml/Cargo.toml
+++ b/rust-runtime/aws-smithy-xml/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.61.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 description = "XML parsing logic for Smithy protocols."
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [dependencies]
 xmlparser = "0.13.5"

--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -10,7 +10,7 @@ are to allow this crate to be compilable and testable in isolation, no client co
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/smithy-lang/smithy-rs"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 
 [features]
 # this allows the tests to be excluded from downstream crates to keep dependencies / test times reasonable (e.g. no proptests)

--- a/rust-runtime/inlineable/src/endpoint_lib/coalesce.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/coalesce.rs
@@ -99,7 +99,6 @@ pub(crate) use coalesce;
 
 #[cfg(test)]
 mod test {
-    use super::*;
 
     #[test]
     fn base_cases() {

--- a/rust-runtime/inlineable/src/endpoint_lib/ite.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/ite.rs
@@ -101,7 +101,6 @@ pub(crate) use ite;
 
 #[cfg(test)]
 mod test {
-    use super::*;
 
     #[test]
     fn base_cases() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.94.1"

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -7,7 +7,7 @@
 
 ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2023
 ARG rust_stable_version=1.94.1
-ARG rust_nightly_version=nightly-2025-10-18
+ARG rust_nightly_version=nightly-2026-03-20
 
 FROM ${base_image} AS bare_base_image
 RUN yum -y updateinfo && yum clean all && rm -rf /var/cache/yum
@@ -84,6 +84,7 @@ RUN yum -y install --allowerasing \
     rustup component add clippy; \
     rustup toolchain install ${rust_nightly_version} --component clippy; \
     rustup target add x86_64-unknown-linux-musl; \
+    rustup target add aarch64-unknown-linux-musl; \
     rustup target add wasm32-unknown-unknown; \
     rustup target add wasm32-wasip1; \
     rustup target add wasm32-wasip2; \
@@ -129,7 +130,7 @@ ARG cargo_deny_version=0.16.4
 ARG cargo_udeps_version=0.1.56
 ARG cargo_hack_version=0.6.27
 ARG cargo_minimal_versions_version=0.1.27
-ARG cargo_check_external_types_version=0.4.0
+ARG cargo_check_external_types_version=0.5.0
 ARG maturin_version=1.5.1
 ARG wasm_pack_version=0.13.1
 ARG cargo_wasmtime_version=38.0.4

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -6,7 +6,7 @@
 # This is the base Docker build image used by CI
 
 ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2023
-ARG rust_stable_version=1.91.1
+ARG rust_stable_version=1.94.1
 ARG rust_nightly_version=nightly-2025-10-18
 
 FROM ${base_image} AS bare_base_image

--- a/tools/ci-build/smithy-rs-tool-common/src/retry.rs
+++ b/tools/ci-build/smithy-rs-tool-common/src/retry.rs
@@ -6,7 +6,7 @@
 use std::error::Error;
 use std::error::Error as StdError;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::info;
 
 pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 


### PR DESCRIPTION
## Motivation and Context
Upgrade the MSRV to 1.94.1. Per [feedback from a customer](https://github.com/smithy-lang/smithy-rs/issues/4578), this PR bumps minor versions across crates, regardless of whether stable or unstable.

## Description
The following is a list of CI failures addressed during the MSRV upgrade:

### Compiler lint fixes
- `unused_imports` in `coalesce.rs` / `ite.rs` — Removed `use super::*` from test modules. Rust 1.94 correctly identifies that macros re-exported with pub(crate) use are already in scope without an explicit import.
```
  error: unused import: `super`
     --> sdk/s3/src/endpoint_lib/coalesce.rs:103:9
```
- `clippy::unnecessary_unwrap` in `aws-smithy-eventstream` — Restructured `acquire()` to use early-return pattern instead of `is_some()/unwrap()`.
```
  error: called `unwrap` on `self.signer` after checking its variant with `is_some`
     --> aws-smithy-eventstream/src/frame.rs:111:13
```
- `unused_assignments` in generated server protocol tests — Rust 1.94 flags the moved sender in async closures as "value captured is never read" since `send()` only borrows it. Fixed by placing `#[allow(unused_assignments)]` on the closure expression.
```
error: value captured by `sender` is never read
     --> rest_json/rust-server-codegen/src/operation.rs:45822:37
      |
45822 | ...                   sender.send(()).await.expect("receiver dropped early");
      |                       ^^^^^^
      |
      = help: did you mean to capture by reference instead?

```
- `unused_imports` in `retry.rs` — Removed unused `error` from tracing import.
```
  error: unused import: `error`
   --> smithy-rs-tool-common/src/retry.rs:9:15
```
- `unused_imports` on Windows — Moved `SystemTime`, `Rfc3339`, and `OffsetDateTime` imports inside cfg-gated test functions so they're only compiled when the test is active.
```
  error: unused import: `time::format_description::well_known::Rfc3339`
     --> aws-smithy-types\src\date_time\mod.rs:396:9
```

### Test fixes
- `system_time_conversions` / `date_format` / `date_time_format` panics on Windows — Added `target_os = "windows"` to cfg exclusions. The `time` crate's `SystemTime::from(OffsetDateTime)` panics for pre-1601 dates on Windows because `SystemTime` is backed by `FILETIME` (epoch 1601). The test oracle panics while constructing the expected value; our production code handles this correctly via `checked_sub` → `Err`.
```
  thread 'date_time::test::system_time_conversions' panicked at std\src\time.rs:712:31:
  overflow when subtracting duration from instant
```

### CI/tooling updates
- Dockerfile — added `aarch64-unknown-linux-musl` target, bumped `cargo-check-external-types` to 0.5.0.
- `ci.yml` / `manual-canary.yml` — Updated hardcoded toolchain from 1.91.1 to 1.94.1 for the aarch64 canary jobs.
```
  error[E0463]: can't find crate for core
    = note: the aarch64-unknown-linux-musl target may not be installed
```
- `pull-request-bot.yml` — Updated `rust_nightly_version` to nightly-2026-03-20.

### Design book doctests
- Marked 6 code blocks in `design/src/server/anatomy.md` and `middleware.md` as `rust,ignore`. The shared `target-dir` in `.cargo/config.toml` causes both `http 0.2` and `http 1.x` rlibs to exist in `target/debug/deps/`, making `extern crate http` ambiguous.
```
  error[E0464]: multiple candidates for rlib dependency http found
     --> /tmp/mdbook-J98CBh/server/anatomy.md:677:1
      = note: candidate #1: target/debug/deps/libhttp-3d1c53169010d178.rlib
      = note: candidate #2: target/debug/deps/libhttp-654580366553cb9a.rlib
```

### Semver/version bumps
- `aws-smithy-schema` — Changed from 0.1.0 to 0.1.1. A minor bump on a 0.x crate is semver-incompatible with `^0.1` required by released `aws-config`, causing the semver hazards check to fail. When we ship schema serde, we make `aws-smithy-schema` 1.x, after which we can bump minor for MSRV upgrades.
```
  error[E0308]: mismatched types
     --> aws-config-1.8.18/src/lib.rs:999:34
  note: there are multiple different versions of crate aws_smithy_schema in the dependency graph
```

## Testing
- CI

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
