### PR TITLE
flex checksum validated result + response extensions

### DIFF
--- a/.changelog/response-checksum-validation-outcome.md
+++ b/.changelog/response-checksum-validation-outcome.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- aajtodd
+references: []
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Response checksum validation results are now recorded on operation outputs. After consuming a response body, call `output.extensions().get::<aws_smithy_checksums::body::validate::ResponseChecksumValidationResult>()` to learn whether the body was validated against a checksum and, if so, which algorithm was used.

--- a/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/HttpChecksumTest.kt
+++ b/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/HttpChecksumTest.kt
@@ -429,13 +429,38 @@ internal class HttpChecksumTest {
                         .validation_mode($moduleName::types::ValidationMode::Enabled)
                         .send()
                         .await;
-                    assert!(res.is_ok())
+                    let output = res.expect("response checksum should validate");
+
+                    // The validation outcome is recorded onto the output's extensions. For this
+                    // (non-streaming) operation the orchestrator reads the response body to
+                    // completion before deserialization even though the output models no body
+                    // member, so the `ChecksumBody` has already reached EOF and resolved the
+                    // outcome by the time `send()` returns.
+                    use #{ProvideExtensions};
+                    let outcome = #{ProvideExtensions}::extensions(&output)
+                        .get::<#{ResponseChecksumValidationResult}>()
+                        .expect("validation result handle is attached to the output")
+                        .outcome();
+                    assert_eq!(
+                        outcome,
+                        #{Some}(#{ValidationOutcome}::Validated {
+                            algorithm: "$algoLower".parse::<#{ChecksumAlgorithm}>().unwrap(),
+                        }),
+                    );
                 }
                 """,
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
                 "http_1x" to CargoDependency.Http1x.toType(),
+                "ProvideExtensions" to
+                    RuntimeType.smithyTypes(rc).resolve("extensions::ProvideExtensions"),
+                "ResponseChecksumValidationResult" to
+                    RuntimeType.smithyChecksums(rc).resolve("body::validate::ResponseChecksumValidationResult"),
+                "ValidationOutcome" to
+                    RuntimeType.smithyChecksums(rc).resolve("body::validate::ValidationOutcome"),
+                "ChecksumAlgorithm" to
+                    RuntimeType.smithyChecksums(rc).resolve("ChecksumAlgorithm"),
             )
         }
     }
@@ -702,11 +727,58 @@ internal class HttpChecksumTest {
                     assert!(sdk_metrics.contains(&"c"));
                     assert!(!sdk_metrics.contains(&"b"));
                 }
+
+                // When validation is enabled but the response carries no checksum header for any
+                // supported algorithm, the operation still succeeds and the recorded validation
+                // outcome is `NotValidated { NoChecksum }`. (As above, the orchestrator reads the
+                // response body to completion for this non-streaming operation, so the outcome is
+                // resolved by the time `send()` returns.)
+                ##[::tokio::test]
+                async fn response_no_checksum_header_is_not_validated() {
+                    let (http_client, _rx) = #{capture_request}(Some(
+                        #{http_1x}::Response::builder()
+                            .body(SdkBody::from("Hello world"))
+                            .unwrap(),
+                    ));
+                    let config = $moduleName::Config::builder()
+                        .region(Region::from_static("doesntmatter"))
+                        .with_test_defaults()
+                        .http_client(http_client)
+                        .build();
+
+                    let client = $moduleName::Client::from_conf(config);
+                    let output = client
+                        .http_checksum_operation()
+                        .body(Blob::new(b"Doesn't matter."))
+                        .validation_mode($moduleName::types::ValidationMode::Enabled)
+                        .send()
+                        .await
+                        .expect("request should succeed when no checksum header is present");
+
+                    let outcome = #{ProvideExtensions}::extensions(&output)
+                        .get::<#{ResponseChecksumValidationResult}>()
+                        .expect("validation result handle is attached to the output")
+                        .outcome();
+                    assert_eq!(
+                        outcome,
+                        #{Some}(#{ValidationOutcome}::NotValidated {
+                            reason: #{NotValidatedReason}::NoChecksum,
+                        }),
+                    );
+                }
                 """,
                 *preludeScope,
                 "tokio" to CargoDependency.Tokio.toType(),
                 "capture_request" to RuntimeType.captureRequest(rc),
                 "http_1x" to CargoDependency.Http1x.toType(),
+                "ProvideExtensions" to
+                    RuntimeType.smithyTypes(rc).resolve("extensions::ProvideExtensions"),
+                "ResponseChecksumValidationResult" to
+                    RuntimeType.smithyChecksums(rc).resolve("body::validate::ResponseChecksumValidationResult"),
+                "ValidationOutcome" to
+                    RuntimeType.smithyChecksums(rc).resolve("body::validate::ValidationOutcome"),
+                "NotValidatedReason" to
+                    RuntimeType.smithyChecksums(rc).resolve("body::validate::NotValidatedReason"),
             )
         }
     }

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.64.9"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
@@ -7,6 +7,9 @@
 
 //! Interceptor for handling Smithy `@httpChecksum` response checksumming
 
+use aws_smithy_checksums::body::validate::{
+    NotValidatedReason, ResponseChecksumValidationResult, ValidationOutcome,
+};
 use aws_smithy_checksums::ChecksumAlgorithm;
 use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
 use aws_smithy_runtime_api::box_error::BoxError;
@@ -19,6 +22,7 @@ use aws_smithy_runtime_api::http::Headers;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::checksum_config::ResponseChecksumValidation;
 use aws_smithy_types::config_bag::{ConfigBag, Layer, Storable, StoreReplace};
+use aws_smithy_types::extensions::Extensions;
 use std::{fmt, mem};
 
 #[derive(Debug)]
@@ -133,22 +137,43 @@ where
         };
 
         if validation_enabled {
+            // Install a handle so the operation output can carry the validation outcome. The
+            // outcome is filled below (immediately for the no-validation paths) or by the wrapped
+            // body on clean EOF (for the validated path). The handle is placed into the shared
+            // `Extensions` in the config bag; the generated deserializer lifts that `Extensions`
+            // onto the operation output.
+            let validation_result = ResponseChecksumValidationResult::new();
+            let mut extensions = cfg.load::<Extensions>().cloned().unwrap_or_default();
+            extensions.insert(validation_result.clone());
+            cfg.interceptor_state().store_put(extensions);
+
             let response = context.response_mut();
-            let maybe_checksum_headers = check_headers_for_precalculated_checksum(
+            match check_headers_for_precalculated_checksum(
                 response.headers(),
                 self.response_algorithms,
-            );
+            ) {
+                PrecalculatedChecksum::Found(checksum_algorithm, precalculated_checksum) => {
+                    let mut body = SdkBody::taken();
+                    mem::swap(&mut body, response.body_mut());
 
-            if let Some((checksum_algorithm, precalculated_checksum)) = maybe_checksum_headers {
-                let mut body = SdkBody::taken();
-                mem::swap(&mut body, response.body_mut());
-
-                let mut body = wrap_body_with_checksum_validator(
-                    body,
-                    checksum_algorithm,
-                    precalculated_checksum,
-                );
-                mem::swap(&mut body, response.body_mut());
+                    let mut body = wrap_body_with_checksum_validator(
+                        body,
+                        checksum_algorithm,
+                        precalculated_checksum,
+                        validation_result,
+                    );
+                    mem::swap(&mut body, response.body_mut());
+                }
+                PrecalculatedChecksum::PartLevelChecksum => {
+                    validation_result.set(ValidationOutcome::NotValidated {
+                        reason: NotValidatedReason::PartLevelChecksum,
+                    });
+                }
+                PrecalculatedChecksum::None => {
+                    validation_result.set(ValidationOutcome::NotValidated {
+                        reason: NotValidatedReason::NoChecksum,
+                    });
+                }
             }
         }
 
@@ -156,23 +181,38 @@ where
     }
 }
 
-/// Given an `SdkBody`, a `aws_smithy_checksums::ChecksumAlgorithm`, and a pre-calculated checksum,
-/// return an `SdkBody` where the body will processed with the checksum algorithm and checked
-/// against the pre-calculated checksum.
+/// Given an `SdkBody`, a `aws_smithy_checksums::ChecksumAlgorithm`, a pre-calculated checksum, and
+/// a [`ResponseChecksumValidationResult`] handle, return an `SdkBody` where the body will be
+/// processed with the checksum algorithm and checked against the pre-calculated checksum. On clean
+/// end-of-stream the handle is populated with `Validated { algorithm }`.
 pub(crate) fn wrap_body_with_checksum_validator(
     body: SdkBody,
     checksum_algorithm: ChecksumAlgorithm,
     precalculated_checksum: bytes::Bytes,
+    validation_result: ResponseChecksumValidationResult,
 ) -> SdkBody {
     use aws_smithy_checksums::body::validate;
 
     body.map(move |body: SdkBody| {
-        SdkBody::from_body_1_x(validate::ChecksumBody::new(
-            body,
-            checksum_algorithm.into_impl(),
-            precalculated_checksum.clone(),
-        ))
+        SdkBody::from_body_1_x(
+            validate::ChecksumBody::new(
+                body,
+                checksum_algorithm.into_impl(),
+                precalculated_checksum.clone(),
+            )
+            .with_validation_result(validation_result.clone(), checksum_algorithm),
+        )
     })
+}
+
+/// The result of scanning response headers for a usable precalculated checksum.
+pub(crate) enum PrecalculatedChecksum {
+    /// A usable checksum header was found.
+    Found(ChecksumAlgorithm, bytes::Bytes),
+    /// A checksum header was present but is a part-level (composite) checksum the SDK can't validate.
+    PartLevelChecksum,
+    /// No checksum header was present for any supported algorithm.
+    None,
 }
 
 /// Given a `HeaderMap`, extract any checksum included in the headers as `Some(Bytes)`.
@@ -181,7 +221,7 @@ pub(crate) fn wrap_body_with_checksum_validator(
 pub(crate) fn check_headers_for_precalculated_checksum(
     headers: &Headers,
     response_algorithms: &[&str],
-) -> Option<(ChecksumAlgorithm, bytes::Bytes)> {
+) -> PrecalculatedChecksum {
     let checksum_algorithms_to_check =
         aws_smithy_checksums::http::CHECKSUM_ALGORITHMS_IN_PRIORITY_ORDER
             .into_iter()
@@ -212,7 +252,7 @@ pub(crate) fn check_headers_for_precalculated_checksum(
                       "This checksum is a part-level checksum which can't be validated by the Rust SDK. Disable checksum validation for this request to fix this warning.",
                   );
 
-                return None;
+                return PrecalculatedChecksum::PartLevelChecksum;
             }
 
             let precalculated_checksum = match aws_smithy_types::base64::decode(
@@ -221,15 +261,15 @@ pub(crate) fn check_headers_for_precalculated_checksum(
                 Ok(decoded_checksum) => decoded_checksum.into(),
                 Err(_) => {
                     tracing::error!("Checksum received from server could not be base64 decoded. No checksum validation will be performed.");
-                    return None;
+                    return PrecalculatedChecksum::None;
                 }
             };
 
-            return Some((checksum_algorithm, precalculated_checksum));
+            return PrecalculatedChecksum::Found(checksum_algorithm, precalculated_checksum);
         }
     }
 
-    None
+    PrecalculatedChecksum::None
 }
 
 fn is_part_level_checksum(checksum: &str) -> bool {
@@ -280,6 +320,7 @@ mod tests {
                 sdk_body,
                 checksum_algorithm,
                 precalculated_checksum.clone(),
+                aws_smithy_checksums::body::validate::ResponseChecksumValidationResult::new(),
             )
         });
 

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -21,6 +21,7 @@ aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", 
 aws-runtime = { path = "../../build/aws-sdk/sdk/aws-runtime", features = ["test-util"] }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", features = ["test-util", "behavior-version-latest"] }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["test-util", "rt-tokio"] }
+aws-smithy-checksums = { path = "../../build/aws-sdk/sdk/aws-smithy-checksums" }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol-test" }
 aws-smithy-runtime = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime", features = ["test-util"] }

--- a/aws/sdk/integration-tests/s3/tests/checksums.rs
+++ b/aws/sdk/integration-tests/s3/tests/checksums.rs
@@ -131,6 +131,40 @@ async fn test_crc32_checksum_on_streaming_response() {
     assert_eq!(body, "Hello world");
 }
 
+// GetObject is a streaming operation: the response body is handed to the caller rather than read
+// by the orchestrator, so the validation outcome is only resolved once the caller drains the body.
+// The outcome rides on the output's extensions.
+#[tokio::test]
+async fn test_validation_outcome_recorded_on_streaming_output() {
+    use aws_sdk_s3::operation::ProvideExtensions;
+    use aws_smithy_checksums::body::validate::{
+        ResponseChecksumValidationResult, ValidationOutcome,
+    };
+    use aws_smithy_checksums::ChecksumAlgorithm;
+
+    let res = test_checksum_on_streaming_response("x-amz-checksum-crc32", "i9aeUg==").await;
+
+    let validation = res
+        .extensions()
+        .get::<ResponseChecksumValidationResult>()
+        .expect("validation result handle is attached to the output")
+        .clone();
+
+    // Body has not been consumed yet, so the outcome is unresolved.
+    assert_eq!(validation.outcome(), None);
+
+    let body = collect_body_into_string(res.body.into_inner()).await;
+    assert_eq!(body, "Hello world");
+
+    // Draining the body drives validation to completion.
+    assert_eq!(
+        validation.outcome(),
+        Some(ValidationOutcome::Validated {
+            algorithm: ChecksumAlgorithm::Crc32,
+        }),
+    );
+}
+
 #[tokio::test]
 async fn test_crc32c_checksum_on_streaming_response() {
     let res = test_checksum_on_streaming_response("x-amz-checksum-crc32c", "crUfeA==").await;

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpConn
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdempotencyTokenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.LongPollingOperationDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.NoAuthDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.customizations.OutputExtensionsDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.SchemaDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.SensitiveOutputDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.StaticSdkFeatureTrackerDecorator
@@ -74,6 +75,7 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
                 HttpConnectorConfigDecorator(),
                 SensitiveOutputDecorator(),
                 SchemaDecorator(),
+                OutputExtensionsDecorator(),
                 IdempotencyTokenDecorator(),
                 LongPollingOperationDecorator(),
                 StalledStreamProtectionDecorator(),

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecorator.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.customizations
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.core.rustlang.InlineDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderSection
+import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureSection
+import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticOutputTrait
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+
+/**
+ * Adds an [`Extensions`] type-map to every operation output, accessible through the
+ * `ProvideExtensions` trait. Extensions carry auxiliary data attached during request
+ * processing (for example response checksum validation results) that is not part of a
+ * modeled shape.
+ *
+ * The field is held in an inlined `EqIgnore` wrapper so it does not participate in the
+ * output's derived `PartialEq` (`Extensions` has no meaningful equality), while the
+ * output keeps its blanket derives.
+ *
+ * This decorator only provides the container and accessor. Population is the
+ * responsibility of feature-specific decorators, which contribute a `MutateOutput`
+ * customization that reads from the config bag and calls `_insert_extension`.
+ */
+class OutputExtensionsDecorator : ClientCodegenDecorator {
+    override val name: String = "OutputExtensions"
+    override val order: Byte = 0
+
+    private fun extensionsType(codegenContext: ClientCodegenContext): RuntimeType =
+        RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("extensions::Extensions")
+
+    private fun provideExtensionsTrait(codegenContext: ClientCodegenContext): RuntimeType =
+        RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("extensions::ProvideExtensions")
+
+    private fun eqIgnore(codegenContext: ClientCodegenContext): RuntimeType =
+        RuntimeType.forInlineDependency(
+            InlineDependency.forRustFile(
+                RustModule.pubCrate("eq_ignore", parent = ClientRustModule.root),
+                "/inlineable/src/eq_ignore.rs",
+            ),
+        ).resolve("EqIgnore")
+
+    override fun structureCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<StructureCustomization>,
+    ): List<StructureCustomization> = baseCustomizations + OutputExtensionsStructureCustomization(codegenContext)
+
+    override fun builderCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<BuilderCustomization>,
+    ): List<BuilderCustomization> = baseCustomizations + OutputExtensionsBuilderCustomization(codegenContext)
+
+    override fun extras(
+        codegenContext: ClientCodegenContext,
+        rustCrate: RustCrate,
+    ) {
+        rustCrate.withModule(ClientRustModule.Operation) {
+            // Re-export ProvideExtensions in the generated crate.
+            rust("pub use #T;", provideExtensionsTrait(codegenContext))
+        }
+    }
+
+    private inner class OutputExtensionsStructureCustomization(
+        private val codegenContext: ClientCodegenContext,
+    ) : StructureCustomization() {
+        override fun section(section: StructureSection): Writable =
+            writable {
+                if (!section.shape.hasTrait<SyntheticOutputTrait>()) {
+                    return@writable
+                }
+                when (section) {
+                    is StructureSection.AdditionalFields -> {
+                        rustTemplate(
+                            "_extensions: #{EqIgnore}<#{Extensions}>,",
+                            "EqIgnore" to eqIgnore(codegenContext),
+                            "Extensions" to extensionsType(codegenContext),
+                        )
+                    }
+
+                    is StructureSection.AdditionalTraitImpls -> {
+                        rustTemplate(
+                            """
+                            impl #{ProvideExtensions} for ${section.structName} {
+                                fn extensions(&self) -> &#{Extensions} {
+                                    self._extensions.get()
+                                }
+                            }
+                            """,
+                            "ProvideExtensions" to provideExtensionsTrait(codegenContext),
+                            "Extensions" to extensionsType(codegenContext),
+                        )
+                    }
+
+                    is StructureSection.AdditionalDebugFields -> {
+                        rust("""${section.formatterName}.field("_extensions", &self._extensions);""")
+                    }
+                }
+            }
+    }
+
+    private inner class OutputExtensionsBuilderCustomization(
+        private val codegenContext: ClientCodegenContext,
+    ) : BuilderCustomization() {
+        override fun section(section: BuilderSection): Writable =
+            writable {
+                if (!section.shape.hasTrait<SyntheticOutputTrait>()) {
+                    return@writable
+                }
+                when (section) {
+                    is BuilderSection.AdditionalFields -> {
+                        rustTemplate(
+                            "_extensions: #{EqIgnore}<#{Extensions}>,",
+                            "EqIgnore" to eqIgnore(codegenContext),
+                            "Extensions" to extensionsType(codegenContext),
+                        )
+                    }
+
+                    is BuilderSection.AdditionalMethods -> {
+                        rust(
+                            """
+                            ##[allow(dead_code)]
+                            pub(crate) fn _insert_extension<T: ::std::any::Any + ::std::clone::Clone + ::std::fmt::Debug + ::std::marker::Send + ::std::marker::Sync + 'static>(
+                                mut self,
+                                value: T,
+                            ) -> Self {
+                                self._extensions.get_mut().insert(value);
+                                self
+                            }
+                            """,
+                        )
+                    }
+
+                    is BuilderSection.AdditionalDebugFields -> {
+                        rust("""${section.formatterName}.field("_extensions", &self._extensions);""")
+                    }
+
+                    is BuilderSection.AdditionalFieldsInBuild -> {
+                        rust("_extensions: self._extensions,")
+                    }
+                }
+            }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecorator.kt
@@ -141,21 +141,6 @@ class OutputExtensionsDecorator : ClientCodegenDecorator {
                         )
                     }
 
-                    is BuilderSection.AdditionalMethods -> {
-                        rust(
-                            """
-                            ##[allow(dead_code)]
-                            pub(crate) fn _insert_extension<T: ::std::any::Any + ::std::clone::Clone + ::std::fmt::Debug + ::std::marker::Send + ::std::marker::Sync + 'static>(
-                                mut self,
-                                value: T,
-                            ) -> Self {
-                                self._extensions.get_mut().insert(value);
-                                self
-                            }
-                            """,
-                        )
-                    }
-
                     is BuilderSection.AdditionalDebugFields -> {
                         rust("""${section.formatterName}.field("_extensions", &self._extensions);""")
                     }
@@ -163,6 +148,8 @@ class OutputExtensionsDecorator : ClientCodegenDecorator {
                     is BuilderSection.AdditionalFieldsInBuild -> {
                         rust("_extensions: self._extensions,")
                     }
+
+                    else -> {}
                 }
             }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecorator.kt
@@ -33,9 +33,10 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
  * output's derived `PartialEq` (`Extensions` has no meaningful equality), while the
  * output keeps its blanket derives.
  *
- * This decorator only provides the container and accessor. Population is the
- * responsibility of feature-specific decorators, which contribute a `MutateOutput`
- * customization that reads from the config bag and calls `_insert_extension`.
+ * This decorator only provides the container and accessor. Population is generic: the
+ * generated response deserializer lifts the `Extensions` accumulated in the config bag
+ * onto the output via `_set_extensions`. Feature-specific interceptors contribute by
+ * inserting their typed handles into the config-bag `Extensions`.
  */
 class OutputExtensionsDecorator : ClientCodegenDecorator {
     override val name: String = "OutputExtensions"
@@ -98,6 +99,16 @@ class OutputExtensionsDecorator : ClientCodegenDecorator {
                             impl #{ProvideExtensions} for ${section.structName} {
                                 fn extensions(&self) -> &#{Extensions} {
                                     self._extensions.get()
+                                }
+                            }
+
+                            impl ${section.structName} {
+                                /// Replaces this output's extensions. Used by the generated response
+                                /// deserializer to lift extensions accumulated in the config bag onto
+                                /// the output.
+                                ##[allow(dead_code)]
+                                pub(crate) fn _set_extensions(&mut self, extensions: #{Extensions}) {
+                                    *self._extensions.get_mut() = extensions;
                                 }
                             }
                             """,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCus
 import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationSection
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
@@ -179,13 +180,14 @@ class ResponseDeserializerGenerator(
                     #{Ok}(output)
                 })();
 
-                #{Some}(#{type_erase_result}(result))
+                #{Some}(#{type_erase_result}(#{lift_extensions}))
             }
             """,
             *codegenScope,
             "ConcreteOutput" to outputSymbol,
             "E" to errorSymbol,
             "ByteStream" to RuntimeType.byteStream(runtimeConfig),
+            "lift_extensions" to liftExtensions("result"),
             "BeforeParseResponse" to
                 writable {
                     writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response", "force_error", body = null))
@@ -274,7 +276,7 @@ class ResponseDeserializerGenerator(
                     #{Ok}(output)
                 })();
 
-                #{Some}(#{type_erase_result}(result))
+                #{Some}(#{type_erase_result}(#{lift_extensions}))
             }
             """,
             *codegenScope,
@@ -284,6 +286,7 @@ class ResponseDeserializerGenerator(
             "EventReceiver" to RuntimeType.eventReceiver(runtimeConfig),
             "Receiver" to RuntimeType.eventStreamReceiver(runtimeConfig),
             "unmarshaller" to unmarshallerCtor,
+            "lift_extensions" to liftExtensions("result"),
             "MutateOutput" to
                 writable {
                     writeCustomizations(
@@ -312,7 +315,7 @@ class ResponseDeserializerGenerator(
         val successCode = httpBindingResolver.httpTrait(operationShape).code
         rustTemplate(
             """
-            fn deserialize_streaming(&self, response: &mut #{HttpResponse}) -> #{Option}<#{OutputOrError}> {
+            fn deserialize_streaming_with_config(&self, response: &mut #{HttpResponse}, _cfg: &#{ConfigBag}) -> #{Option}<#{OutputOrError}> {
                 ##[allow(unused_mut)]
                 let mut force_error = false;
                 #{BeforeParseResponse}
@@ -321,17 +324,43 @@ class ResponseDeserializerGenerator(
                 if (!response.status().is_success() && response.status().as_u16() != $successCode) || force_error {
                     return #{None};
                 }
-                #{Some}(#{type_erase_result}(#{parse_streaming_response}(response)))
+                let result = #{parse_streaming_response}(response);
+                #{Some}(#{type_erase_result}(#{lift_extensions}))
             }
             """,
             *codegenScope,
             "parse_streaming_response" to parserGenerator.parseStreamingResponseFn(operationShape, customizations),
+            "lift_extensions" to liftExtensions("result"),
             "BeforeParseResponse" to
                 writable {
                     writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response", "force_error", body = null))
                 },
         )
     }
+
+    /**
+     * Lifts the [`Extensions`] accumulated in the config bag (by interceptors) onto a concrete
+     * operation output, before it is type-erased. Produces an expression of the same
+     * `Result<ConcreteOutput, E>` type as [resultExpr], with the output's extensions replaced.
+     *
+     * `_cfg` and [resultExpr] must be in scope. Relies on the synthetic `_set_extensions`
+     * inherent method present on every operation output (see `OutputExtensionsDecorator`).
+     */
+    private fun liftExtensions(resultExpr: String): Writable =
+        writable {
+            rustTemplate(
+                """
+                $resultExpr.map(|mut output| {
+                    if let #{Some}(extensions) = _cfg.load::<#{Extensions}>() {
+                        output._set_extensions(extensions.clone());
+                    }
+                    output
+                })
+                """,
+                *preludeScope,
+                "Extensions" to RuntimeType.smithyTypes(runtimeConfig).resolve("extensions::Extensions"),
+            )
+        }
 
     private fun RustWriter.deserializeStreamingError(
         operationShape: OperationShape,
@@ -413,18 +442,22 @@ class ResponseDeserializerGenerator(
                 let mut deser = protocol.deserialize_response(response, $operationName::OUTPUT_SCHEMA, _cfg)
                     .map_err(|e| #{OrchestratorError}::other(#{BoxError}::from(e)))?;
                 let body = response.body().bytes().expect("body loaded");
-                let output = #{ConcreteOutput}::deserialize_with_response(
+                let mut output = #{ConcreteOutput}::deserialize_with_response(
                     &mut *deser,
                     response.headers(),
                     response.status().into(),
                     body,
                 ).map_err(|e| #{OrchestratorError}::other(#{BoxError}::from(e)))?;
+                if let #{Some}(extensions) = _cfg.load::<#{Extensions}>() {
+                    output._set_extensions(extensions.clone());
+                }
                 #{Ok}(#{Output}::erase(output))
             }
             """,
             *codegenScope,
             "BoxError" to RuntimeType.boxError(runtimeConfig),
             "ConcreteOutput" to outputSymbol,
+            "Extensions" to RuntimeType.smithyTypes(runtimeConfig).resolve("extensions::Extensions"),
         )
     }
 
@@ -550,11 +583,12 @@ class ResponseDeserializerGenerator(
             } else {
                 #{parse_response}(status, headers, body)
             };
-            #{type_erase_result}(parse_result)
+            #{type_erase_result}(#{lift_extensions})
             """,
             *codegenScope,
             "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
             "parse_response" to parserGenerator.parseResponseFn(operationShape, customizations),
+            "lift_extensions" to liftExtensions("parse_result"),
             "BeforeParseResponse" to
                 writable {
                     writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response", "force_error", "body"))

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/OutputExtensionsDecoratorTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.customizations
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+
+class OutputExtensionsDecoratorTest {
+    private fun codegenScope(runtimeConfig: RuntimeConfig): Array<Pair<String, Any>> =
+        arrayOf(
+            "capture_request" to RuntimeType.captureRequest(runtimeConfig),
+            "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
+            "ProvideExtensions" to
+                RuntimeType.smithyTypes(runtimeConfig).resolve("extensions::ProvideExtensions"),
+            "http_1x" to software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency.Http1x.toType(),
+        )
+
+    private val model =
+        """
+        namespace com.example
+        use aws.protocols#awsJson1_0
+        @awsJson1_0
+        service HelloService {
+            operations: [SayHello],
+            version: "1"
+        }
+        @optionalAuth
+        operation SayHello { output: TestOutput }
+
+        structure TestOutput {
+           message: String,
+        }
+        """.asSmithyModel()
+
+    @Test
+    fun `operation output exposes empty extensions by default`() {
+        clientIntegrationTest(model) { codegenContext, rustCrate ->
+            rustCrate.integrationTest("output_extensions") {
+                val moduleName = codegenContext.moduleUseName()
+                Attribute.TokioTest.render(this)
+                rustTemplate(
+                    """
+                    async fn output_has_extensions_accessor() {
+                        let (http_client, _r) = #{capture_request}(Some(
+                            #{http_1x}::Response::builder()
+                                .status(200)
+                                .body(#{SdkBody}::from("{}"))
+                                .unwrap(),
+                        ));
+
+                        let config = $moduleName::Config::builder()
+                            .endpoint_url("http://localhost:1234")
+                            .http_client(http_client.clone())
+                            .build();
+                        let client = $moduleName::Client::from_conf(config);
+                        let out = client.say_hello().send().await.expect("success");
+
+                        // The `ProvideExtensions` trait is implemented for the output,
+                        // and is empty when nothing populated it.
+                        use #{ProvideExtensions};
+                        assert!(out.extensions().is_empty());
+                    }
+                    """,
+                    *codegenScope(codegenContext.runtimeConfig),
+                )
+            }
+        }
+    }
+}

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.61.10"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "criterion",
  "minicbor 2.2.2",
  "num-bigint",
@@ -382,10 +382,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.64.9"
 dependencies = [
  "aws-smithy-http 0.63.6",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "bytes-utils",
  "crc-fast",
@@ -408,7 +408,7 @@ name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -437,7 +437,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.20"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -479,7 +479,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -503,7 +503,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "base64 0.22.1",
  "bytes",
  "h2 0.3.27",
@@ -575,7 +575,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.7",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -642,7 +642,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http-server",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures",
@@ -689,7 +689,7 @@ version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "proptest",
  "serde_json",
 ]
@@ -702,7 +702,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -727,7 +727,7 @@ dependencies = [
  "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -757,7 +757,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "http 1.4.0",
  "tokio",
 ]
@@ -807,7 +807,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.15"
 dependencies = [
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "urlencoding",
 ]
 
@@ -822,7 +822,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "fastrand 2.4.1",
  "futures-util",
@@ -863,7 +863,7 @@ version = "1.12.3"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api-macros",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "bytes",
  "http 0.2.12",
  "http 1.4.0",
@@ -888,7 +888,7 @@ name = "aws-smithy-schema"
 version = "0.1.0"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "http 1.4.0",
 ]
 
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -958,7 +958,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.14"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "chrono",
  "futures-core",
  "time",
@@ -970,7 +970,7 @@ version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "http-body-util",
  "sync_wrapper",
  "wstd",
@@ -2503,7 +2503,7 @@ dependencies = [
  "aws-smithy-json 0.62.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.4.9",
+ "aws-smithy-types 1.4.10",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "fastrand 2.4.1",

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.64.9"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Zelda Hessler <zhessler@amazon.com>",

--- a/rust-runtime/aws-smithy-checksums/src/body/validate.rs
+++ b/rust-runtime/aws-smithy-checksums/src/body/validate.rs
@@ -7,6 +7,7 @@
 //! error if it doesn't match.
 
 use crate::http::HttpChecksum;
+use crate::ChecksumAlgorithm;
 
 use aws_smithy_types::body::SdkBody;
 
@@ -15,7 +16,70 @@ use pin_project_lite::pin_project;
 
 use std::fmt::Display;
 use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
+
+/// Whether a response body was validated against a checksum, and with which algorithm.
+///
+/// A checksum *mismatch* is not represented here: a mismatch surfaces as an error while reading
+/// the body. This type distinguishes a body that was validated and matched from one that was not
+/// validated, and records why validation did not happen.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ValidationOutcome {
+    /// The response body was validated against a checksum and matched.
+    Validated {
+        /// The algorithm used to validate the response body.
+        algorithm: ChecksumAlgorithm,
+    },
+    /// The response body was not validated.
+    NotValidated {
+        /// Why validation did not happen.
+        reason: NotValidatedReason,
+    },
+}
+
+/// The reason response checksum validation did not occur.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NotValidatedReason {
+    /// The response carried no checksum header for any supported algorithm.
+    NoChecksum,
+    /// The response checksum was a part-level (composite, `<base64>-<N>`) checksum, which the
+    /// SDK cannot validate against the response bytes.
+    PartLevelChecksum,
+}
+
+/// A shared, late-populated handle to a response's [`ValidationOutcome`].
+///
+/// Response checksum validation runs lazily as the response body is consumed, after the operation
+/// has already returned its output. This handle is installed before body consumption and filled
+/// when the body reaches end-of-stream, so a caller holding it can learn the outcome once the body
+/// has been fully read. Until then, [`outcome`](Self::outcome) returns `None`.
+///
+/// The handle is cheap to clone (it is reference-counted) and is the value stored on an operation
+/// output's extensions.
+#[derive(Clone, Debug, Default)]
+pub struct ResponseChecksumValidationResult(Arc<OnceLock<ValidationOutcome>>);
+
+impl ResponseChecksumValidationResult {
+    /// Create a new, unpopulated handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the validation outcome, or `None` if the response body has not yet been fully
+    /// consumed (validation is only resolved at end-of-stream).
+    pub fn outcome(&self) -> Option<ValidationOutcome> {
+        self.0.get().cloned()
+    }
+
+    /// Record the validation outcome. The first write wins; subsequent writes are ignored (the
+    /// outcome for a given response is resolved exactly once).
+    pub fn set(&self, outcome: ValidationOutcome) {
+        let _ = self.0.set(outcome);
+    }
+}
 
 pin_project! {
     /// A body-wrapper that will calculate the `InnerBody`'s checksum and emit an error if it
@@ -25,6 +89,8 @@ pin_project! {
         inner: InnerBody,
         checksum: Option<Box<dyn HttpChecksum>>,
         precalculated_checksum: Bytes,
+        // When present, the validation outcome is recorded into this handle on clean EOF.
+        validation_result: Option<(ResponseChecksumValidationResult, ChecksumAlgorithm)>,
     }
 }
 
@@ -40,7 +106,20 @@ impl ChecksumBody<SdkBody> {
             inner: body,
             checksum: Some(checksum),
             precalculated_checksum,
+            validation_result: None,
         }
+    }
+
+    /// Attach a [`ResponseChecksumValidationResult`] handle that will be populated with
+    /// `Validated { algorithm }` when the body is fully read and the checksum matches. On a
+    /// mismatch the handle is left unset (the mismatch surfaces as a body error instead).
+    pub fn with_validation_result(
+        mut self,
+        result: ResponseChecksumValidationResult,
+        algorithm: ChecksumAlgorithm,
+    ) -> Self {
+        self.validation_result = Some((result, algorithm));
+        self
     }
 
     fn poll_inner(
@@ -84,6 +163,11 @@ impl ChecksumBody<SdkBody> {
 
                 let actual_checksum = checksum.finalize();
                 if *this.precalculated_checksum == actual_checksum {
+                    // Record a positive validation outcome (if a handle is attached) now that the
+                    // whole body has been read and matched.
+                    if let Some((result, algorithm)) = this.validation_result.take() {
+                        result.set(ValidationOutcome::Validated { algorithm });
+                    }
                     Poll::Ready(None)
                 } else {
                     // So many parens it's starting to look like LISP
@@ -204,5 +288,57 @@ mod tests {
             .expect("Doesn't cause IO errors");
         // Verify data is complete and unaltered
         assert_eq!(input_text, output_text);
+    }
+
+    #[tokio::test]
+    async fn test_validation_result_populated_on_match() {
+        use crate::body::validate::{ResponseChecksumValidationResult, ValidationOutcome};
+
+        let input_text = "This is some test text for an SdkBody";
+        let actual_checksum = calculate_crc32_checksum(input_text);
+        let http_checksum = "crc32".parse::<ChecksumAlgorithm>().unwrap().into_impl();
+        let result = ResponseChecksumValidationResult::new();
+        let mut body = ChecksumBody::new(SdkBody::from(input_text), http_checksum, actual_checksum)
+            .with_validation_result(result.clone(), ChecksumAlgorithm::Crc32);
+
+        // Outcome is unresolved until the body is fully drained.
+        assert_eq!(result.outcome(), None);
+
+        while let Some(buf) = body.frame().await {
+            let _ = buf.unwrap();
+        }
+
+        assert_eq!(
+            result.outcome(),
+            Some(ValidationOutcome::Validated {
+                algorithm: ChecksumAlgorithm::Crc32
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validation_result_unset_on_mismatch() {
+        use crate::body::validate::ResponseChecksumValidationResult;
+
+        let input_text = "This is some test text for an SdkBody";
+        let non_matching_checksum = Bytes::copy_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        let http_checksum = "crc32".parse::<ChecksumAlgorithm>().unwrap().into_impl();
+        let result = ResponseChecksumValidationResult::new();
+        let mut body = ChecksumBody::new(
+            SdkBody::from(input_text),
+            http_checksum,
+            non_matching_checksum,
+        )
+        .with_validation_result(result.clone(), ChecksumAlgorithm::Crc32);
+
+        // Drain until the mismatch error surfaces.
+        while let Some(data) = body.frame().await {
+            if data.is_err() {
+                break;
+            }
+        }
+
+        // A mismatch leaves the outcome unset (it surfaces as a body error, not a verdict).
+        assert_eq!(result.outcome(), None);
     }
 }

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.4.10"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/extensions.rs
+++ b/rust-runtime/aws-smithy-types/src/extensions.rs
@@ -1,0 +1,218 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! A type-erased map of extensions, keyed by type.
+//!
+//! [`Extensions`] stores at most one value of any given type, retrieved by that
+//! type. It is used to carry auxiliary data that is derived during request
+//! processing but is not part of a modeled shape, for example the outcome of
+//! response checksum validation or per-request telemetry.
+
+use crate::type_erasure::TypeErasedBox;
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::{BuildHasherDefault, Hasher};
+
+/// A hasher for `TypeId`s that does no work.
+///
+/// A `TypeId` is already a well-distributed hash produced by the compiler, so
+/// the map can use its `u64` directly instead of hashing it again.
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("TypeId calls write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+type AnyMap = HashMap<TypeId, TypeErasedBox, BuildHasherDefault<IdHasher>>;
+
+/// A type-erased map of extensions, keyed by type.
+///
+/// Holds at most one value of any given type. Inserting a second value of the
+/// same type replaces the first. Stored values must be `Clone` so that
+/// `Extensions` itself is `Clone`.
+///
+/// ```
+/// use aws_smithy_types::extensions::Extensions;
+///
+/// #[derive(Clone, Debug, PartialEq)]
+/// struct Marker(u32);
+///
+/// let mut ext = Extensions::new();
+/// assert_eq!(ext.insert(Marker(1)), None);
+/// assert_eq!(ext.get::<Marker>(), Some(&Marker(1)));
+/// // Inserting the same type again returns the previous value.
+/// assert_eq!(ext.insert(Marker(2)), Some(Marker(1)));
+/// assert_eq!(ext.get::<Marker>(), Some(&Marker(2)));
+/// ```
+// An empty `HashMap` is three words; boxing keeps an unused `Extensions` to a
+// single word, since most values never carry any extensions.
+#[derive(Default)]
+pub struct Extensions {
+    map: Option<Box<AnyMap>>,
+}
+
+impl Clone for Extensions {
+    fn clone(&self) -> Self {
+        // Every value is inserted through `insert`, which requires `Clone` and
+        // stores a cloneable `TypeErasedBox`, so `try_clone` always succeeds.
+        let map = self.map.as_ref().map(|m| {
+            let cloned: AnyMap = m
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        *k,
+                        v.try_clone()
+                            .expect("values are cloneable via Extensions::insert"),
+                    )
+                })
+                .collect();
+            Box::new(cloned)
+        });
+        Self { map }
+    }
+}
+
+impl Extensions {
+    /// Create an empty [`Extensions`].
+    pub fn new() -> Self {
+        Self { map: None }
+    }
+
+    /// Insert a value into the map, returning the previous value of the same
+    /// type if one was present.
+    pub fn insert<T: Any + Clone + fmt::Debug + Send + Sync + 'static>(
+        &mut self,
+        value: T,
+    ) -> Option<T> {
+        self.map
+            .get_or_insert_with(Box::default)
+            .insert(TypeId::of::<T>(), TypeErasedBox::new_with_clone(value))
+            .and_then(|prev| prev.downcast::<T>().ok().map(|b| *b))
+    }
+
+    /// Get a reference to the value of type `T`, if present.
+    pub fn get<T: Any + fmt::Debug + Send + Sync + 'static>(&self) -> Option<&T> {
+        self.map
+            .as_ref()?
+            .get(&TypeId::of::<T>())
+            .and_then(|b| b.downcast_ref())
+    }
+
+    /// Get a mutable reference to the value of type `T`, if present.
+    pub fn get_mut<T: Any + fmt::Debug + Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.map
+            .as_mut()?
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|b| b.downcast_mut())
+    }
+
+    /// Remove the value of type `T`, returning it if present.
+    pub fn remove<T: Any + fmt::Debug + Send + Sync + 'static>(&mut self) -> Option<T> {
+        self.map
+            .as_mut()?
+            .remove(&TypeId::of::<T>())
+            .and_then(|b| b.downcast::<T>().ok().map(|b| *b))
+    }
+
+    /// Returns `true` if no extensions are present.
+    pub fn is_empty(&self) -> bool {
+        self.map.as_ref().is_none_or(|m| m.is_empty())
+    }
+
+    /// Returns the number of extensions present.
+    pub fn len(&self) -> usize {
+        self.map.as_ref().map_or(0, |m| m.len())
+    }
+}
+
+impl fmt::Debug for Extensions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Extensions")
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+/// Provides access to the [`Extensions`] carried by a type.
+///
+/// Implemented by generated operation outputs so callers can read auxiliary
+/// data attached during request processing (for example response checksum
+/// validation results) without it being part of a modeled shape.
+pub trait ProvideExtensions {
+    /// Returns the extensions attached to this value.
+    fn extensions(&self) -> &Extensions;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Extensions;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct A(u32);
+    #[derive(Clone, Debug, PartialEq)]
+    struct B(String);
+
+    #[test]
+    fn insert_get_remove() {
+        let mut ext = Extensions::new();
+        assert!(ext.is_empty());
+
+        assert_eq!(ext.insert(A(1)), None);
+        assert_eq!(ext.insert(B("x".to_string())), None);
+        assert_eq!(ext.len(), 2);
+
+        assert_eq!(ext.get::<A>(), Some(&A(1)));
+        assert_eq!(ext.get::<B>(), Some(&B("x".to_string())));
+
+        // Replacing returns the prior value of that type.
+        assert_eq!(ext.insert(A(2)), Some(A(1)));
+        assert_eq!(ext.get::<A>(), Some(&A(2)));
+        assert_eq!(ext.len(), 2);
+
+        assert_eq!(ext.remove::<A>(), Some(A(2)));
+        assert_eq!(ext.get::<A>(), None);
+        assert_eq!(ext.len(), 1);
+    }
+
+    #[test]
+    fn get_mut() {
+        let mut ext = Extensions::new();
+        ext.insert(A(1));
+        if let Some(a) = ext.get_mut::<A>() {
+            a.0 = 9;
+        }
+        assert_eq!(ext.get::<A>(), Some(&A(9)));
+    }
+
+    #[test]
+    fn missing_type_is_none() {
+        let ext = Extensions::new();
+        assert_eq!(ext.get::<A>(), None);
+    }
+
+    #[test]
+    fn clone_is_independent() {
+        let mut ext = Extensions::new();
+        ext.insert(A(1));
+        let mut cloned = ext.clone();
+        cloned.insert(A(2));
+        assert_eq!(ext.get::<A>(), Some(&A(1)));
+        assert_eq!(cloned.get::<A>(), Some(&A(2)));
+    }
+}

--- a/rust-runtime/aws-smithy-types/src/extensions.rs
+++ b/rust-runtime/aws-smithy-types/src/extensions.rs
@@ -159,6 +159,10 @@ pub trait ProvideExtensions {
     fn extensions(&self) -> &Extensions;
 }
 
+impl crate::config_bag::Storable for Extensions {
+    type Storer = crate::config_bag::StoreReplace<Self>;
+}
+
 #[cfg(test)]
 mod tests {
     use super::Extensions;

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -28,6 +28,7 @@ pub mod date_time;
 pub mod endpoint;
 pub mod error;
 pub mod event_stream;
+pub mod extensions;
 pub mod primitive;
 pub mod retry;
 pub mod timeout;

--- a/rust-runtime/inlineable/src/eq_ignore.rs
+++ b/rust-runtime/inlineable/src/eq_ignore.rs
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! A field wrapper that excludes its value from a struct's equality.
+
+use std::fmt;
+
+/// Wraps a value that is carried on a struct but must not participate in the
+/// struct's equality.
+///
+/// Two `EqIgnore<T>` always compare equal regardless of their contents, so a
+/// `#[derive(PartialEq)]` struct can hold a value whose type is not (or should
+/// not be) `PartialEq` without that value affecting the meaning of `==` over the
+/// struct's other fields. This is used to carry out-of-band runtime metadata
+/// (for example an `Extensions` type-map) on generated operation outputs.
+#[derive(Clone, Default)]
+pub(crate) struct EqIgnore<T>(pub(crate) T);
+
+impl<T> EqIgnore<T> {
+    /// Borrow the wrapped value.
+    #[allow(dead_code)]
+    pub(crate) fn get(&self) -> &T {
+        &self.0
+    }
+
+    /// Mutably borrow the wrapped value.
+    #[allow(dead_code)]
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> PartialEq for EqIgnore<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for EqIgnore<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EqIgnore;
+
+    #[test]
+    fn always_equal_regardless_of_contents() {
+        assert_eq!(EqIgnore(1), EqIgnore(2));
+        assert_eq!(EqIgnore("a"), EqIgnore("b"));
+    }
+
+    #[test]
+    fn enclosing_struct_ignores_the_field() {
+        #[derive(PartialEq, Debug)]
+        struct S {
+            modeled: u32,
+            ignored: EqIgnore<u32>,
+        }
+        // Equal modeled field, different ignored field -> equal.
+        assert_eq!(
+            S {
+                modeled: 1,
+                ignored: EqIgnore(10)
+            },
+            S {
+                modeled: 1,
+                ignored: EqIgnore(20)
+            },
+        );
+        // Different modeled field -> not equal.
+        assert_ne!(
+            S {
+                modeled: 1,
+                ignored: EqIgnore(10)
+            },
+            S {
+                modeled: 2,
+                ignored: EqIgnore(10)
+            },
+        );
+    }
+
+    #[test]
+    fn get_and_get_mut() {
+        let mut e = EqIgnore(5);
+        assert_eq!(*e.get(), 5);
+        *e.get_mut() = 9;
+        assert_eq!(*e.get(), 9);
+    }
+}

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -18,6 +18,8 @@ mod client_idempotency_token;
 mod constrained;
 #[allow(dead_code)]
 mod ec2_query_errors;
+#[allow(dead_code)]
+mod eq_ignore;
 #[allow(unused)]
 mod event_receiver;
 #[allow(dead_code)]


### PR DESCRIPTION
## Motivation and Context

The SDK validates response checksums, but a caller has no way to learn whether validation actually happened or which algorithm was used. Validation runs lazily inside the response body as it is consumed: a match completes silently at end-of-stream, and a mismatch surfaces as a body error. There is no caller-observable signal for "this response was validated with CRC32," and "the body reached EOF cleanly" is ambiguous — it means either validated-and-matched or never-validated (no checksum header, or a part-level checksum the SDK skips).

This change makes the validation outcome observable on the operation output. It also introduces a generic mechanism — an `Extensions` type-map on every output, populated from the config bag during deserialization — that future features (for example per-request telemetry) can reuse to attach auxiliary, non-modeled data to an output.

## Description

A caller reads the outcome from the output's extensions after consuming the response body:

```rust
use aws_sdk_s3::operation::ProvideExtensions;
use aws_smithy_checksums::body::validate::{ResponseChecksumValidationResult, ValidationOutcome};

let output = client.get_object().bucket(b).key(k).checksum_mode(ChecksumMode::Enabled).send().await?;
let validation = output.extensions().get::<ResponseChecksumValidationResult>().cloned();

// drive validation to completion by consuming the body
while let Some(chunk) = output.body.next().await { /* ... */ }

match validation.and_then(|v| v.outcome()) {
    Some(ValidationOutcome::Validated { algorithm }) => { /* validated with `algorithm` */ }
    Some(ValidationOutcome::NotValidated { reason }) => { /* not validated, see `reason` */ }
    None => { /* body not yet fully consumed */ }
}
```

The design separates a generic extensions mechanism from the checksum-specific consumer.

**Generic: `Extensions` on every output.** A new `aws_smithy_types::extensions::Extensions` is a type-erased map (over the existing `TypeErasedBox`) exposed through a `ProvideExtensions` trait. Every generated operation output carries one, in an inlined `EqIgnore` wrapper so it does not participate in the output's derived `PartialEq` (`Extensions` has no meaningful equality) while the output keeps its blanket derives. Population is generic: interceptors accumulate an `Extensions` in the config bag, and the generated response deserializer lifts it onto the output via a synthetic `_set_extensions` before the output is type-erased. This lift is rendered uniformly across every deserializer path and is not checksum-aware.

**Consumer: response checksum validation.** `aws-smithy-checksums` gains `ValidationOutcome`, `NotValidatedReason`, and `ResponseChecksumValidationResult` — a cheaply-cloneable handle over a shared cell. `ChecksumBody` records `Validated { algorithm }` into the handle on a clean end-of-stream (a mismatch stays a body error and leaves the cell unset). The response checksum interceptor creates the handle, wraps the body with it, and inserts it into the config-bag `Extensions`; on the paths where it does not wrap the body it records `NotValidated { NoChecksum }` or `NotValidated { PartLevelChecksum }` directly.

Because validation is consume-time, the timing of the observable outcome follows the body:

- For non-streaming operations the orchestrator reads the body to completion before deserialization, so the outcome is resolved by the time `send()` returns.
- For streaming operations (for example `GetObject`) the body is handed to the caller, so the outcome resolves once the caller drains it.

### How to review

Commit-by-commit:

1. [`define extensions type`](aca503b8d) — the generic substrate: `Extensions` + `ProvideExtensions` in `aws-smithy-types`, the inlined `EqIgnore` wrapper, and `OutputExtensionsDecorator` adding the field, accessor, and `_set_extensions` to every output. Standalone codegen test proves an output exposes `extensions()`.
2. [`wire checksum validation into output extensions and add tests`](79fcafb17) — the consumer and the lift: the validation-outcome types and `ChecksumBody` cell-write in `aws-smithy-checksums`, the interceptor writing the handle into the config-bag `Extensions`, `Storable for Extensions`, and the generic lift in `ResponseDeserializerGenerator`. `HttpChecksumTest` asserts the outcome for all algorithms.
3. [`add additional tests`](fe4695316) — the changelog entry and an `aws-sdk-s3` integration test proving the lazy streaming outcome on a real `GetObject` (unresolved before the body is drained, `Validated` after).

### Notable details

- The legacy streaming deserializer was switched from the deprecated `deserialize_streaming` to `deserialize_streaming_with_config` so the config bag is in scope for the lift. This affects every legacy-path streaming operation, which is why the change is rendered uniformly rather than gated to checksum operations.
- `Extensions` is intentionally not `PartialEq`; the `EqIgnore` wrapper is inlined into generated crates rather than added to the stable `aws-smithy-types` API.
- `aws-smithy-checksums` and `aws-smithy-types` patch versions are bumped.

## Testing

- `HttpChecksumTest` (codegen): asserts `Validated { algorithm }` on the output extensions for CRC32, CRC32C, CRC64NVME, SHA1, and SHA256, plus a no-checksum-header case asserting `NotValidated { NoChecksum }`. The existing mismatch test (surfacing as an error) is unchanged.
- `OutputExtensionsDecoratorTest` (codegen): a generated output exposes `extensions()`.
- `aws-smithy-checksums` unit tests: the handle is `Validated` on a clean read and left unset on a mismatch.
- `aws-sdk-s3` integration test (`test_validation_outcome_recorded_on_streaming_output`): on a streaming `GetObject`, the outcome is `None` before the body is drained and `Validated { Crc32 }` after.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
