### PR TITLE
Make blanket From impls concrete to fix E0119 (time 0.3.48)

### DIFF
--- a/.changelog/fix-candisable-blanket-from-impl.md
+++ b/.changelog/fix-candisable-blanket-from-impl.md
@@ -1,0 +1,14 @@
+---
+applies_to:
+- client
+- server
+- aws-sdk-rust
+authors:
+- vcjana
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Make `CanDisable`'s `From` impl in `aws-smithy-types` concrete (`From<Duration>`) instead of a blanket `impl<T> From<T>`. The blanket impl could clash with `From` impls from other crates and break the build with `error[E0119]` on a routine dependency bump (it surfaced via `time 0.3.48`).

--- a/.changelog/fix-candisable-blanket-from-impl.md
+++ b/.changelog/fix-candisable-blanket-from-impl.md
@@ -12,3 +12,5 @@ bug_fix: true
 ---
 
 Make `CanDisable`'s `From` impl in `aws-smithy-types` concrete (`From<Duration>`) instead of a blanket `impl<T> From<T>`. The blanket impl could clash with `From` impls from other crates and break the build with `error[E0119]` on a routine dependency bump (it surfaced via `time 0.3.48`).
+
+Additionally, constrain the `time` dependency to `<0.3.48` in `aws-smithy-types`. `time 0.3.48` introduced an E0119 coherence regression (<https://github.com/time-rs/time/issues/783>) that breaks any crate with a blanket `From` impl when `time` is in its dependency graph. Constraining `time` forces resolution to the last-good `0.3.47` across all build paths. Relax this bound once `time 0.3.49` ships.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -441,6 +441,7 @@ fun Project.registerDowngradeFor(
                     "libfuzzer-sys" to "0.4.7", // TODO(https://github.com/rust-fuzz/libfuzzer/issues/126)
                     "crc-fast" to "1.9.0", // TODO(https://github.com/smithy-lang/smithy-rs/issues/3981)
                     "serde_json" to "1.0.146", // TODO(https://github.com/serde-rs/json/issues/1309)
+                    "time" to "0.3.47", // TODO(https://github.com/time-rs/time/issues/783): 0.3.48 has an E0119 regression; remove once 0.3.49 ships
                 )
 
             crateNameToLastKnownWorkingVersions.forEach { (crate, version) ->

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.61.10"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "criterion",
  "minicbor 2.2.2",
  "num-bigint",
@@ -385,7 +385,7 @@ name = "aws-smithy-checksums"
 version = "0.64.8"
 dependencies = [
  "aws-smithy-http 0.63.6",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "bytes-utils",
  "crc-fast",
@@ -408,7 +408,7 @@ name = "aws-smithy-compression"
 version = "0.1.6"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -437,7 +437,7 @@ name = "aws-smithy-eventstream"
 version = "0.60.21"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -479,7 +479,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -503,7 +503,7 @@ dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-protocol-test",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "base64 0.22.1",
  "bytes",
  "h2 0.3.27",
@@ -575,7 +575,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.7",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -642,7 +642,7 @@ dependencies = [
  "aws-smithy-http 0.63.6",
  "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http-server",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures",
@@ -689,7 +689,7 @@ version = "0.62.7"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "proptest",
  "serde_json",
 ]
@@ -702,7 +702,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -727,7 +727,7 @@ dependencies = [
  "aws-smithy-json 0.62.7",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -757,7 +757,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "http 1.4.2",
  "tokio",
 ]
@@ -807,7 +807,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.60.15"
 dependencies = [
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "urlencoding",
 ]
 
@@ -822,7 +822,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "fastrand 2.4.1",
  "futures-util",
@@ -863,7 +863,7 @@ version = "1.12.3"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api-macros",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "bytes",
  "http 0.2.12",
  "http 1.4.2",
@@ -888,7 +888,7 @@ name = "aws-smithy-schema"
 version = "0.1.0"
 dependencies = [
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "http 1.4.2",
 ]
 
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -958,7 +958,7 @@ name = "aws-smithy-types-convert"
 version = "0.60.14"
 dependencies = [
  "aws-smithy-async 1.2.14",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "chrono",
  "futures-core",
  "time",
@@ -970,7 +970,7 @@ version = "0.1.11"
 dependencies = [
  "aws-smithy-async 1.2.14",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "http-body-util",
  "sync_wrapper",
  "wstd",
@@ -2503,7 +2503,7 @@ dependencies = [
  "aws-smithy-json 0.62.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.12.3",
- "aws-smithy-types 1.5.0",
+ "aws-smithy-types 1.5.1",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "fastrand 2.4.1",

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -46,7 +46,9 @@ num-integer = "0.1.46"
 pin-project-lite = "0.2.14"
 pin-utils = "0.1.0"
 ryu = "1.0.22"
-time = { version = "0.3.4", features = ["parsing"] }
+# Upper bound excludes the broken 0.3.48, which has an E0119 coherence regression
+# (https://github.com/time-rs/time/issues/783). Relax to "0.3.4" once 0.3.49 ships.
+time = { version = ">=0.3.4, <0.3.48", features = ["parsing"] }
 
 # ByteStream internals
 futures-core = { version = "0.3.31", optional = true }

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/timeout.rs
+++ b/rust-runtime/aws-smithy-types/src/timeout.rs
@@ -46,8 +46,10 @@ impl<T> CanDisable<T> {
     }
 }
 
-impl<T> From<T> for CanDisable<T> {
-    fn from(value: T) -> Self {
+// Keep this concrete (not a blanket `impl<T> From<T>`): a blanket impl can clash with
+// `From` impls from other crates and break the build (E0119) on a dependency bump.
+impl From<Duration> for CanDisable<Duration> {
+    fn from(value: Duration) -> Self {
         Self::Set(value)
     }
 }


### PR DESCRIPTION
Closes #4698.

## Motivation and Context

time 0.3.48 added impl From<T> for <T as ModifierValue>::Type (time-rs/time#783), which conflicts with any 
local blanket impl<T> From<T> and breaks the build with E0119:

```
error[E0119]: conflicting implementations of trait `From<...HourBase>`
   = note: conflicting implementation in crate `time`
```

smithy-rs has several such blanket impls, so it breaks wherever time resolves fresh to 0.3.48 (generated SDK build, TLS job, etc.).

## Description

Fix at the dependency layer instead of narrowing every blanket impl (whack-a-mole + public-API breaks):

- **Constrain time to `<0.3.48`** in aws-smithy-types. Everything routes through it, so cargo's version 
intersection forces time `0.3.47` across all build paths (and it's copied verbatim into the generated SDK).
- **Defense in depth:** pin time →` 0.3.47` in the broken-dependency map in aws/sdk/build.gradle.kts.
- **Hygiene:** make the private CanDisable blanket concrete (From<Duration>).

No public API changes.

## Testing

- cargo update -p time holds at 0.3.47 (not 0.3.48) in both workspaces.
- E2E:` ./gradlew :aws:sdk:assemble`; generated aws-smithy-types/Cargo.toml carries the bound; in the generated SDK, cargo check -p aws-smithy-runtime-api compiles with no E0119.
- cargo fmt --check, runtime-versioner audit, sdk-lints pass.
- **Check PR semver compliance fails as a false positive:** cargo-semver-checks builds the main baseline, which predates the constraint and can't compile against time 0.3.48. Not an API break (only private  CanDisable changed); resolves once this lands on main or time 0.3.49 ships.

## Checklist

- [x] Changelog entry added for client/server (applies_to).
- [x] Changelog entry added for aws-sdk-rust.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this 
contribution, under the terms of your choice.