### PR TITLE
Remove deprecated `multilingual` field from mdbook config

### DIFF
--- a/design/book.toml
+++ b/design/book.toml
@@ -2,7 +2,6 @@
 title = "Smithy Rust"
 authors = ["Russell Cohen", "aws-sdk-rust@amazon.com"]
 language = "en"
-multilingual = false
 src = "src"
 
 [rust]


### PR DESCRIPTION
## Motivation and Context
mdbook 0.5.3 now rejects the `multilingual` field in `book.toml`. This breaks the [GitHub Pages workflow](https://github.com/smithy-lang/smithy-rs/actions/runs/27452924916/job/81151746302).

The `multilingual` field was never functional; mdbook [never implemented](https://github.com/rust-lang/mdBook/pull/2775) multilingual support — and newer versions [reject it as an unknown field](https://github.com/rust-lang/mdBook/pull/2787).

## Description
Remove `multilingual = false` from `design/book.toml`.

## Testing
Per [README](https://github.com/smithy-lang/smithy-rs/blob/main/design/README.md), reproduced the error locally with mdbook 0.5.3, confirmed `mdbook build` succeeds after removal.
```
$ mdbook --version
mdbook v0.5.3

$ mdbook build
ERROR Invalid configuration file
        Caused by: TOML parse error at line 5, column 1
  | 
5 | multilingual = false
  | ^^^^^^^^^^^^
unknown field multilingual, expected one of title, authors, description, src, language, text-direction
```
After removing the line:
```
$ mdbook build
 INFO Book building has started
 INFO Running the html backend
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
