### PR TITLE
Update Jmespath shape traversal codegen to support keys() on union shapes

### DIFF
--- a/.changelog/jmespath-keys-union-support.md
+++ b/.changelog/jmespath-keys-union-support.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- client
+authors:
+- mark-creamer-amazon
+references: ["smithy-rs#4726"]
+breaking: false
+new_feature: true
+bug_fix: false
+---
+
+Add `keys()` JMESPath function support for union shapes in waiter matchers. This enables waiters to match on the active variant of a union using `keys(unionField)` with the `allStringEquals` or `anyStringEquals` comparators.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
@@ -35,6 +35,7 @@ import software.amazon.smithy.model.shapes.NumberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
@@ -58,6 +59,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.orNull
+import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 import java.text.NumberFormat
 
 /**
@@ -88,7 +90,7 @@ sealed class TraversedShape {
             shape: Shape,
         ): TraversedShape =
             when {
-                shape is MapShape || shape is StructureShape -> Object(shape)
+                shape is MapShape || shape is StructureShape || shape is UnionShape -> Object(shape)
                 shape is CollectionShape -> Array(shape, from(model, model.expectShape(shape.member.target)))
                 shape is BooleanShape -> Bool(shape)
                 shape is EnumShape || shape.hasTrait<EnumTrait>() -> Enum(shape)
@@ -504,8 +506,22 @@ class RustJmespathShapeTraversalGenerator(
                                     rust("let $ident = ${arg.identifier}.keys().map(Clone::clone).collect::<Vec<String>>();")
                                 }
 
+                                is UnionShape -> {
+                                    // A union serializes as a single-key JSON object.
+                                    // Generate a match that returns the active variant name.
+                                    val unionSym = symbolProvider.toSymbol(outputShape)
+                                    val matchArms = outputShape.allMembers.keys.joinToString("\n") { memberName ->
+                                        val variantName = memberName.toPascalCase()
+                                        "${unionSym.rustType().render()}::$variantName(_) => ${memberName.dq()}.to_string(),"
+                                    }
+                                    rust("""let $ident = vec![match ${arg.identifier} {
+                                        |$matchArms
+                                        |_ => "unknown".to_string(),
+                                        |}];""".trimMargin())
+                                }
+
                                 else ->
-                                    throw UnsupportedJmesPathException("The shape type for an input to the keys function must be a struct or a map, got ${outputShape?.type}")
+                                    throw UnsupportedJmesPathException("The shape type for an input to the keys function must be a struct, map, or union, got ${outputShape?.type}")
                             }
                         },
                 )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt
@@ -510,14 +510,19 @@ class RustJmespathShapeTraversalGenerator(
                                     // A union serializes as a single-key JSON object.
                                     // Generate a match that returns the active variant name.
                                     val unionSym = symbolProvider.toSymbol(outputShape)
-                                    val matchArms = outputShape.allMembers.keys.joinToString("\n") { memberName ->
-                                        val variantName = memberName.toPascalCase()
-                                        "${unionSym.rustType().render()}::$variantName(_) => ${memberName.dq()}.to_string(),"
-                                    }
-                                    rust("""let $ident = vec![match ${arg.identifier} {
-                                        |$matchArms
-                                        |_ => "unknown".to_string(),
-                                        |}];""".trimMargin())
+
+                                    val matchArms =
+                                        outputShape.allMembers.keys.joinToString("\n") { memberName ->
+                                            val variantName = memberName.toPascalCase()
+                                            "${unionSym.rustType().render()}::$variantName(_) => ${memberName.dq()}.to_string(),"
+                                        }
+                                    rust(
+                                        """let $ident = vec![match ${arg.identifier} {
+                                         |$matchArms
+                                         |_ => "unknown".to_string(),
+                                        |}];
+                                        """.trimMargin(),
+                                    )
                                 }
 
                                 else ->

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGeneratorTest.kt
@@ -51,6 +51,8 @@ class RustJmespathShapeTraversalGeneratorTest {
         val enum = symbolProvider.toSymbol(model.lookup<Shape>("test#Enum"))
         val struct = symbolProvider.toSymbol(model.lookup<Shape>("test#Struct"))
         val subStruct = symbolProvider.toSymbol(model.lookup<Shape>("test#SubStruct"))
+        val status = symbolProvider.toSymbol(model.lookup<Shape>("test#Status"))
+        val statusDone = symbolProvider.toSymbol(model.lookup<Shape>("test#StatusDone"))
         val traversalContext = TraversalContext(retainOption = false)
 
         val testInputDataFn: RuntimeType
@@ -137,6 +139,7 @@ class RustJmespathShapeTraversalGeneratorTest {
                                     .structs("foo", #{Struct}::builder().required_integer(2).integer(5).strings("maps_foo_struct_strings1").build().unwrap())
                                     .structs("bar", #{Struct}::builder().required_integer(3).primitives(primitives).integer(7).build().unwrap())
                                     .build())
+                                .status(#{Status}::Done(#{StatusDone}::builder().message("completed").build()))
                                 .build()
                         }
                         """,
@@ -147,6 +150,8 @@ class RustJmespathShapeTraversalGeneratorTest {
                         "Enum" to enum,
                         "Struct" to struct,
                         "SubStruct" to subStruct,
+                        "Status" to status,
+                        "StatusDone" to statusDone,
                     )
                 }
         }
@@ -481,6 +486,13 @@ class RustJmespathShapeTraversalGeneratorTest {
                     "assert!(result.contains(&\"bar\".to_string()));",
             ),
         )
+        test(
+            "keys_union", "keys(status)",
+            simple(
+                "assert_eq!(1, result.len());" +
+                    "assert_eq!(\"done\".to_string(), result[0]);",
+            ),
+        )
 
         invalid("length()", "Length function takes exactly one argument")
         invalid("length(primitives.integer)", "Argument to `length` function")
@@ -691,7 +703,20 @@ class RustJmespathShapeTraversalGeneratorTest {
             primitives: EntityPrimitives,
             lists: EntityLists,
             maps: EntityMaps,
+            status: Status,
         }
+
+        union Status {
+            pending: StatusPending,
+            running: StatusRunning,
+            done: StatusDone,
+            failed: StatusFailed,
+        }
+
+        structure StatusPending {}
+        structure StatusRunning {}
+        structure StatusDone { message: String }
+        structure StatusFailed { reason: String }
 
         structure EntityPrimitives {
             boolean: Boolean,


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This change enables a waiter case that is currently not supported. Services may contain async job status information in union variant name instead of a direct field in a structure. For example,

```
@output
structure GetAsyncJobResultsOutput {
    @required
    results: JobResults
    ...
}

union JobResults {
    pending: StatusPending,
    running: StatusRunning,
    done: StatusComplete,
    failed: StatusFailed,
}
```

The gap is that as far as I see, there are no JMESPath [expressions](https://jmespath.org/specification.html) currently expressible that are compatible with the supported [comparators](https://smithy.io/2.0/additional-specs/waiters.html#pathcomparator-enum) that allow us to resolve against the union variant name, which in the above case contains the job status information we'd use for the waiter [matcher](https://smithy.io/2.0/additional-specs/waiters.html#waiter-matcher).

The alternative to this change would be for the above service adding a redundant, direct `status` field in the response `structure`.

## Description
<!--- Describe your changes in detail -->

Since union shapes are serialized as objects, we _could_ naturally enough implement the [keys()](https://jmespath.org/specification.html#keys) JMESPath operation for `UnionShape` to help expose what union variant is being used. Then this would unblock the waiter use case and enable us to do the following:

```
@waitable(
    JobComplete: {
        documentation: "Wait until the async job completes"
        acceptors: [
            {
                state: "success"
                matcher: {
                    output: {
                        path: "keys(results)"
                        expected: "done"
                        comparator: "allStringEquals"
                    }
                }
            }
            {
                state: "failure"
                matcher: {
                    output: {
                        path: "keys(results)"
                        expected: "failed"
                        comparator: "allStringEquals"
                    }
                }
            }
            {
                state: "retry"
                matcher: {
                    output: {
                        path: "keys(results)"
                        expected: "pending"
                        comparator: "allStringEquals"
                    }
                }
            }
            {
                state: "retry"
                matcher: {
                    output: {
                        path: "keys(results)"
                        expected: "running"
                        comparator: "allStringEquals"
                    }
                }
            }
        ]
    }
)
operation GetAsyncJobResults {
    input: GetAsyncJobResultsInput
    output: GetAsyncJobResultsOutput
    errors: [
        ValidationException,
        ResourceNotFoundException,
        ThrottlingException,
        InternalServerException
    ]
}
```

This change
* Maps the `UnionShape` as an `Object` in the `TraversalShape`. Previously using a union in a JMESPath expression for the waiter would result in a `UnsupportedJmesPathException`
* Added `keys` support on unions by creating a one element `vec![]`, matching against the generated Rust enum to get the active variant name. If no variant matches, resolves to `vec!["unknown"]`

The current [RustJmespathShapeTraversalGenerator](https://github.com/smithy-lang/smithy-rs/blob/main/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGenerator.kt) also implements [length](https://jmespath.org/specification.html#length) and [contains](https://jmespath.org/specification.html#contains), but this change leaves those alone for `UnionShape`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Ran `./gradlew test` and confirmed tests succeeded locally
* Added tests to `codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/waiters/RustJmespathShapeTraversalGeneratorTest.kt`
  * Checking that the result of `keys` on a union is a 1 member list
* Tested end to end locally with an existing service under the above scheme. Confirmed it worked as expected
  * Confirmed that no `DANGER` warning was generated upon Smithy model build
  ```
    // Start a job
    let start_resp = client
        .start_async_job()
        ...
        .send()
        .await?;

    let job_id = start_resp.job_id();
    println!("Started job: {job_id}");

    // Use the waiter to poll until completion
    let final_poll = client
        .wait_until_job_complete()
        .job_id(job_id)
        .wait(Duration::from_secs(300))
        .await?;

    let output = final_poll.into_result()?;
    println!("Job completed!");
    println!("Results: {:?}", output.results());
  ```

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
