### PR TITLE
Fix f64/f32 default value literal codegen

### DIFF
--- a/.changelog/fix-f64-default-value-literal-codegen.md
+++ b/.changelog/fix-f64-default-value-literal-codegen.md
@@ -1,0 +1,15 @@
+---
+applies_to:
+- client
+- server
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#4729
+breaking: false
+new_feature: false
+bug_fix: true
+---
+
+Fix codegen emitting integer literals for f64/f32 non-zero default value comparisons in serializers. When a Smithy model specifies a non-zero `@default` on a Double or Float member using a JSON integer (e.g., `1` instead of `1.0`), the generated "skip if default" check produced `if value != 1` which fails to compile in Rust. The fix appends `_f64`/`_f32` type suffixes to the rendered default value.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -835,6 +835,16 @@ class RustWriter private constructor(
                                     block(variable)
                                 }
 
+                            is FloatShape ->
+                                rustBlock("if ${variable.asValue()} != ${default}_f32") {
+                                    block(variable)
+                                }
+
+                            is DoubleShape ->
+                                rustBlock("if ${variable.asValue()} != ${default}_f64") {
+                                    block(variable)
+                                }
+
                             else ->
                                 rustBlock("if ${variable.asValue()} != $default") {
                                     block(variable)


### PR DESCRIPTION
## Motivation and Context
When a Smithy model specifies a non-zero @default value for a double or float member using a JSON integer literal (e.g., `"smithy.api#default": 1` instead of `1.0`), the generated code fails to compile, e.g.
```
12 |     if input.temperature != 1 {
   |                          ^^ no implementation for `f64 == {integer}`
```

## Description
In `RustWriter.kt's ifNotNumberOrBoolDefault`, the `NonZeroDefault` branch used `Node.printJson()` to render the default value, which preserves the JSON integer representation verbatim (e.g., 1). This produced invalid Rust like `if input.temperature != 1` where `temperature` is `f64` like above.

The fix adds `FloatShape` and `DoubleShape` cases to the `NonZeroDefault` branch, appending`_f32` or `_f64` type suffixes to the default literal.
```
// Before (compile error: can't compare f64 with {integer})
if input.temperature != 1 { 

// After
if input.temperature != 1_f64 { 
```

## Testing
- CI
- A service model that failed to compile due to this bug now compiles

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
