### PR TITLE
Raise Metrique minimums

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-smithy-http-server 0.65.10",
  "aws-smithy-http-server 0.67.0",
@@ -2349,7 +2349,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -2927,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdfd0c9954a916c5e1db230cc7593569858afec7744cebfd0fbef45de7b07c7"
+checksum = "d6737991308ea171744eac9bb26885d6caa0b747d3cca72f7a69f38e689a1886"
 dependencies = [
  "itoa",
  "metrique-core",
@@ -2945,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56ef332b47a4d2dc14209bf9ce4334682dd2fec43a4b84e5ed063bf2f4ea29a"
+checksum = "8bd60ab3f5d8e13e36aa1d1dd9cc4920012dd21a25bd7311ae3c39810648e068"
 dependencies = [
  "itertools 0.14.0",
  "metrique-writer-core",
@@ -2955,12 +2955,13 @@ dependencies = [
 
 [[package]]
 name = "metrique-macro"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403c61cd847b11680ae6cf1feb384cbe06e412e4dc221f1e16ccf48038d190bb"
+checksum = "6512443e1f72c1faa670da0e7cc347dbdd6f17b8e97c3a10d0de56365887f18d"
 dependencies = [
  "Inflector",
  "darling",
+ "metrique-core",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2983,9 +2984,9 @@ checksum = "d607939211e4eaaa8cd35394fa5e57faffb7390d0ac513b39992edcaf3cc526c"
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9e23184d81616fcdfcdc5768e14c2bca765096094d08e7895259fe658378e4"
+checksum = "124326a2ac4c4f61562fa4d071735a1c463f9ba0317d1564f75dc01313dc12d7"
 dependencies = [
  "ahash",
  "crossbeam-queue",
@@ -3004,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23421d85733c0182613b32f32094080e07cd5e98be5893f1cd3baf7eed16c4d0"
+checksum = "55b5bbb6d88bde29f6ed74a574cbe49e51ea0c36cccc7e63eee2040db5675b15"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -3016,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fca512de7ed9e29644950426fe3810016fb8f8e478a779fffc33d45b9e9b4e"
+checksum = "48324410658d3fbb08b9d8c863ebfc9e1e2460f24f192b4b826eaee5fa874a80"
 dependencies = [
  "bit-set",
  "dtoa",

--- a/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-metrics"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",
@@ -20,9 +20,9 @@ http = "1.3.1"
 http-body = "1.0.1"
 hyper = "1.6.0"
 futures = "0.3"
-metrique = "0.1.17"
-metrique-core = "0.1.15"
-metrique-writer = "0.1.17"
+metrique = "0.1.27"
+metrique-core = "0.1.22"
+metrique-writer = "0.1.24"
 pin-project-lite = "0.2.14"
 thiserror = "2"
 tower = "0.4.13"
@@ -43,7 +43,7 @@ aws-smithy-legacy-http-server = { path = "../aws-smithy-legacy-http-server", opt
 
 [dev-dependencies]
 tracing-appender = "0.2"
-metrique-writer-format-emf = "0.1.16"
+metrique-writer-format-emf = "0.1.23"
 
 [features]
 aws-smithy-http-server-065 = [


### PR DESCRIPTION
This PR fixes the repo-wide `check-rust-runtimes` CI failure in the minimal-versions step.

The failing command is `cargo minimal-versions check --direct --all-features`, which resolves `metrique-macro v0.1.18` together with the old lower bound `metrique-core v0.1.15` from `aws-smithy-http-server-metrics`.

That combination fails to compile with `error[E0433]: failed to resolve: could not find Styles in metrique_core` / `error[E0433]: cannot find Styles in metrique_core`.

Changing only `rust-runtime/Cargo.lock` is not enough for this CI path because minimal-version resolution uses the dependency lower bounds from `Cargo.toml`.

This PR raises the Metrique family minimums in `rust-runtime/aws-smithy-http-server-metrics/Cargo.toml`, bumps `aws-smithy-http-server-metrics` from `0.2.0` to `0.2.1`, and updates `rust-runtime/Cargo.lock` to match.

Validation: `runtime-versioner audit` passed during commit, and the normal pre-push hook completed with `[pre-push] all runtime CI checks passed.`