### PR TITLE
Fix semver hazards aws-config test feature

### DIFF
--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -35,7 +35,12 @@ for sdk in aws-sdk-rust/sdk/*; do
     if ls "$sdk/tests" | grep -v '^endpoint_tests\.rs$'; then
       echo -e "${C_YELLOW}# Testing ${sdk}...${C_RESET}"
       pushd "$sdk" &>/dev/null
-      cargo test --all-features
+      cargo_test_args=(--all-features)
+      if grep -q 'aws-config' Cargo.toml; then
+        # Some checked-out SDK release tests call aws_config::ConfigLoader test APIs.
+        cargo_test_args+=(--features aws-config/test-util)
+      fi
+      cargo test "${cargo_test_args[@]}"
       popd &>/dev/null
     fi
  fi


### PR DESCRIPTION
This fixes the `Check for semver hazards` CI fallout in the patched `aws-sdk-rust` release tests.

The failing test is `sdk/dynamodb/tests/ignore_configured_endpoint_urls.rs`, which calls `aws_config::defaults(...).env(...)`.

CI fails with `error[E0599]: no method named env found for struct ConfigLoader in the current scope` because the semver-hazards harness runs `cargo test --all-features` without enabling `aws-config/test-util`.

`ConfigLoader::env` is a test utility API, so the harness now enables `--features aws-config/test-util` when testing SDK crates that depend on `aws-config`.

Validation: `bash -n tools/ci-scripts/check-semver-hazards`, `git diff --check`, and `cargo metadata --manifest-path aws/sdk/build/aws-sdk/sdk/dynamodb/Cargo.toml --features aws-config/test-util --no-deps --format-version 1` passed locally.