### PR TITLE
Fix DynamoDB integ test missing `test-util` on `aws-config`

### DIFF
--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
@@ -167,6 +167,7 @@ class DynamoDbTestDependencies(private val runtimeConfig: RuntimeConfig) : LibRs
     override fun section(section: LibRsSection): Writable =
         writable {
             addDependency(Approx)
+            addDependency(awsConfig(runtimeConfig).toDevDependency().withFeature("test-util"))
             // Used by `tests/protocol-swap.rs` to plug `AwsRestXmlProtocol`
             // into a JSON-RPC service to demonstrate runtime protocol selection
             // (the Serialization-Schema-Decoupling SEP's goal 2).

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.20
+codegenVersion=0.1.21


### PR DESCRIPTION
## Motivation and Context
Follow-up to https://github.com/smithy-lang/smithy-rs/pull/4730. Fixes the `Check for semver hazards` CI failure:
```
[7](https://github.com/smithy-lang/smithy-rs/actions/runs/28969878954/job/85963248456#step:4:2085)
error[E0599]: no method named `env` found for struct `ConfigLoader` in the current scope
   --> sdk/dynamodb/tests/ignore_configured_endpoint_urls.rs:146:10
    |
141 |       let sdk_config = aws_config::defaults(aws_sdk_dynamodb::config::BehaviorVersion::latest())
    |  ______________________-
142 | |         .http_client(http_client)
143 | |         .test_credentials()
144 | |         .region(aws_sdk_dynamodb::config::Region::new("us-east-1"))
145 | |         .endpoint_url("http://programmatic-endpoint:8080")
146 | |         .env(Env::from_slice(&[
    | |         -^^^ private field, not a method
    | |_________|
    |
```

## Description
PR #4730 added `ignore_configured_endpoint_urls.rs` to the DynamoDB integration tests, which uses `ConfigLoader::env()` — a method gated behind `#[cfg(any(test, feature = "test-util"))]`. The integration-test workspace's `Cargo.toml` was correctly updated to enable `test-util` on `aws-config`, but [`IntegrationTestDependencies.kt`](https://github.com/smithy-lang/smithy-rs/tree/main/aws/sdk/integration-tests#adding-dependencies-to-tests) was not, so the generated `sdk/dynamodb/Cargo.toml` was missing `aws-config` with `test-util`. No customer or release impact.
  
Other CI checks (`check-aws-sdk-*`) pass because they use the integration-test workspace which correctly enables `test-util`. `Check for semver hazards` is the one that runs `cargo test --all-features` directly on the generated SDK crate.
  
## Testing
- Reproduced the failure locally on `main`: generated the DynamoDB SDK, ran `cargo test --all-features` on the generated `sdk/dynamodb` crate, and confirmed the error
- Verified the fix on this branch: regenerated the SDK, re-run integ tests, and confirmed they passed.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
