### PR TITLE
A collection of retry behavior fixes

### DIFF
--- a/.changelog/retry-adaptive-1-token-and-x-amz-retry-after.md
+++ b/.changelog/retry-adaptive-1-token-and-x-amz-retry-after.md
@@ -1,0 +1,14 @@
+---
+applies_to:
+- client
+authors:
+- ysaito1001
+references:
+- smithy-rs#4749
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix two retry-behavior bugs:
+- Under Retry Behavior 2.1, the adaptive client-side rate limiter now charges a uniform 1 token per send attempt (initial or retry). Pre-2.1 adaptive behavior is unchanged.
+- Honor the server-directed `x-amz-retry-after` header on responses that are retryable purely by HTTP status (e.g. a bare 500). This is enabled by a new `ClassifyRetry::classify_retry_v2`, which additionally receives the `RetryAction` accumulated by earlier-running classifiers and can refine it. It has a default implementation that delegates to `classify_retry`, so existing classifiers are unaffected.

--- a/.changelog/retry-adaptive-1-token-and-x-amz-retry-after.md
+++ b/.changelog/retry-adaptive-1-token-and-x-amz-retry-after.md
@@ -10,5 +10,5 @@ new_feature: false
 bug_fix: true
 ---
 Fix two retry-behavior bugs:
-- Under Retry Behavior 2.1, the adaptive client-side rate limiter now charges a uniform 1 token per send attempt (initial or retry). Pre-2.1 adaptive behavior is unchanged.
+- Under Retry Behavior 2.1, `adaptive` retry mode now acquires a client-side rate-limiter send token before every send, including retries. Previously a retry computed a rate-limiter delay but sent without acquiring a token, so the adaptive rate limiter under-throttled retried requests. Pre-2.1 adaptive behavior — still the default today, until 2.1 becomes the default (see [aws-sdk-rust#1431](https://github.com/awslabs/aws-sdk-rust/discussions/1431)) — is unchanged.
 - Honor the server-directed `x-amz-retry-after` header on responses that are retryable purely by HTTP status (e.g. a bare 500). This is enabled by a new `ClassifyRetry::classify_retry_v2`, which additionally receives the `RetryAction` accumulated by earlier-running classifiers and can refine it. It has a default implementation that delegates to `classify_retry`, so existing classifiers are unaffected.

--- a/.changelog/sts-retry-idp-communication-error.md
+++ b/.changelog/sts-retry-idp-communication-error.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#4749
+breaking: false
+new_feature: false
+bug_fix: true
+---
+STS clients now retry the `IDPCommunicationError` error code on all operations, not just those that model the `IDPCommunicationErrorException` shape.

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -19,7 +19,7 @@ import software.amazon.smithy.rustsdk.customize.RemoveDefaultsDecorator
 import software.amazon.smithy.rustsdk.customize.Sigv4aAuthTraitBackfillDecorator
 import software.amazon.smithy.rustsdk.customize.apigateway.ApiGatewayDecorator
 import software.amazon.smithy.rustsdk.customize.applyDecorators
-import software.amazon.smithy.rustsdk.customize.applyExceptFor
+import software.amazon.smithy.rustsdk.customize.applyExceptForNamespaces
 import software.amazon.smithy.rustsdk.customize.dsql.DsqlDecorator
 import software.amazon.smithy.rustsdk.customize.dynamodb.DynamoDbDecorator
 import software.amazon.smithy.rustsdk.customize.ec2.Ec2Decorator
@@ -82,11 +82,15 @@ val DECORATORS: List<ClientCodegenDecorator> =
             // TODO(https://github.com/smithy-lang/smithy-rs/issues/3863): Comment in once the issue has been resolved
             // SmokeTestsDecorator(),
         ),
-        // S3 needs `AwsErrorCodeClassifier` to handle an `InternalError` as a transient error. We need to customize
-        // that behavior for S3 in a way that does not conflict with the globally applied `RetryClassifierDecorator`.
-        // Therefore, that decorator is applied to all but S3, and S3 customizes the creation of `AwsErrorCodeClassifier`
-        // accordingly (see https://github.com/smithy-lang/smithy-rs/pull/3699).
-        RetryClassifierDecorator().applyExceptFor("com.amazonaws.s3#AmazonS3"),
+        // S3 and STS both customize `AwsErrorCodeClassifier` (S3 to treat `InternalError` as a
+        // transient error, STS to treat `IDPCommunicationError` as one for all operations). We need
+        // to customize that behavior in a way that does not conflict with the globally applied
+        // `RetryClassifierDecorator`. Therefore, that decorator is applied to all but S3 and STS,
+        // and each customizes the creation of `AwsErrorCodeClassifier` accordingly.
+        RetryClassifierDecorator().applyExceptForNamespaces(
+            "com.amazonaws.s3",
+            "com.amazonaws.sts",
+        ),
         // Service specific decorators
         ApiGatewayDecorator().onlyApplyTo("com.amazonaws.apigateway#BackplaneControlService"),
         DsqlDecorator().onlyApplyTo("com.amazonaws.dsql#DSQL"),
@@ -106,7 +110,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
             AwsChunkedContentEncodingDecorator(),
         ),
         S3ControlDecorator().onlyApplyTo("com.amazonaws.s3control#AWSS3ControlServiceV20180820"),
-        STSDecorator().onlyApplyTo("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
+        STSDecorator().onlyApplyToNamespace("com.amazonaws.sts"),
         SSODecorator().onlyApplyTo("com.amazonaws.sso#SWBPortalService"),
         TimestreamDecorator().onlyApplyTo("com.amazonaws.timestreamwrite#Timestream_20181101"),
         TimestreamDecorator().onlyApplyTo("com.amazonaws.timestreamquery#Timestream_20181101"),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/ServiceSpecificDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/ServiceSpecificDecorator.kt
@@ -40,13 +40,32 @@ fun ClientCodegenDecorator.onlyApplyToList(serviceIds: List<String>): List<Clien
         }
     }
 
-/** Apply this decorator to all services but the one identified by ID */
-fun ClientCodegenDecorator.applyExceptFor(serviceId: String): List<ClientCodegenDecorator> =
-    listOf(
+/** Apply this decorator to all services except those identified by the given IDs */
+fun ClientCodegenDecorator.applyExceptFor(vararg serviceIds: String): List<ClientCodegenDecorator> {
+    val excluded = serviceIds.map { ShapeId.from(it) }.toSet()
+    return listOf(
         ConditionalDecorator(this) { _, serviceShapeId ->
-            serviceShapeId != ShapeId.from(serviceId)
+            serviceShapeId !in excluded
         },
     )
+}
+
+/**
+ * Apply this decorator to all services except those in the given namespaces.
+ *
+ * Like [onlyApplyToNamespace], matching on the namespace rather than the exact shape ID keeps the
+ * exclusion stable across service API version bumps, which are encoded in the service shape name
+ * (e.g. `AWSSecurityTokenServiceV20110615`). Exactly one service is defined per model file, so the
+ * namespace uniquely identifies the excluded service.
+ */
+fun ClientCodegenDecorator.applyExceptForNamespaces(vararg namespaces: String): List<ClientCodegenDecorator> {
+    val excluded = namespaces.toSet()
+    return listOf(
+        ConditionalDecorator(this) { _, serviceShapeId ->
+            serviceShapeId?.toShapeId()?.namespace !in excluded
+        },
+    )
+}
 
 /** Apply the given decorators only to this service ID */
 fun String.applyDecorators(vararg decorators: ClientCodegenDecorator): List<ClientCodegenDecorator> =

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/sts/STSDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/sts/STSDecorator.kt
@@ -5,6 +5,7 @@
 package software.amazon.smithy.rustsdk.customize.sts
 
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
@@ -13,10 +14,18 @@ import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.RetryableTrait
 import software.amazon.smithy.model.traits.SensitiveTrait
 import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationSection
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.letIf
+import software.amazon.smithy.rustsdk.AwsRuntimeType
 import java.util.logging.Logger
 
 class STSDecorator : ClientCodegenDecorator {
@@ -46,4 +55,48 @@ class STSDecorator : ClientCodegenDecorator {
                 (shape as StructureShape).toBuilder().addTrait(SensitiveTrait()).build()
             }
         }
+
+    override fun operationCustomizations(
+        codegenContext: ClientCodegenContext,
+        operation: OperationShape,
+        baseCustomizations: List<OperationCustomization>,
+    ): List<OperationCustomization> =
+        baseCustomizations +
+            object : OperationCustomization() {
+                private val runtimeConfig = codegenContext.runtimeConfig
+                private val symbolProvider = codegenContext.symbolProvider
+
+                override fun section(section: OperationSection): Writable =
+                    writable {
+                        when (section) {
+                            // STS clients must treat `IDPCommunicationError` as a transient error
+                            // for ALL operations, not only those that model the
+                            // `IDPCommunicationErrorException` shape (which the @retryable trait
+                            // above already covers). Classify it by error code so every STS
+                            // operation retries it.
+                            is OperationSection.RetryClassifiers -> {
+                                section.registerRetryClassifier(this) {
+                                    rustTemplate(
+                                        """
+                                        #{AwsErrorCodeClassifier}::<#{OperationError}>::builder().transient_errors({
+                                            let mut transient_errors: Vec<&'static str> = #{TRANSIENT_ERRORS}.into();
+                                            transient_errors.push("IDPCommunicationError");
+                                            #{Cow}::Owned(transient_errors)
+                                            }).build()""",
+                                        "AwsErrorCodeClassifier" to
+                                            AwsRuntimeType.awsRuntime(runtimeConfig)
+                                                .resolve("retries::classifiers::AwsErrorCodeClassifier"),
+                                        "Cow" to RuntimeType.Cow,
+                                        "OperationError" to symbolProvider.symbolForOperationError(operation),
+                                        "TRANSIENT_ERRORS" to
+                                            AwsRuntimeType.awsRuntime(runtimeConfig)
+                                                .resolve("retries::classifiers::TRANSIENT_ERRORS"),
+                                    )
+                                }
+                            }
+
+                            else -> {}
+                        }
+                    }
+            }
 }

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "lru",
  "ring",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "arbitrary",
  "aws-credential-types",
@@ -139,7 +139,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -210,7 +210,7 @@ dependencies = [
  "crc-fast",
  "hex",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "md-5",
  "pin-project-lite",
@@ -239,7 +239,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -307,7 +307,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -360,7 +360,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -470,9 +470,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytes-utils"
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -731,18 +731,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -1194,14 +1194,14 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.3"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -1497,9 +1497,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1527,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1794,9 +1794,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -2243,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
@@ -2395,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2420,7 +2420,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2603,9 +2603,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2879,18 +2879,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"

--- a/aws/rust-runtime/aws-runtime/src/retries/classifiers.rs
+++ b/aws/rust-runtime/aws-runtime/src/retries/classifiers.rs
@@ -14,6 +14,17 @@ use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::marker::PhantomData;
 
+/// Parse the AWS-specific `x-amz-retry-after` response header (milliseconds) into
+/// a [`Duration`](std::time::Duration). Returns `None` when the header is absent
+/// or does not parse as an integer, in which case the SDK falls back to
+/// exponential backoff.
+fn retry_after_from_ctx(ctx: &InterceptorContext) -> Option<std::time::Duration> {
+    ctx.response()
+        .and_then(|res| res.headers().get("x-amz-retry-after"))
+        .and_then(|header| header.parse::<u64>().ok())
+        .map(std::time::Duration::from_millis)
+}
+
 /// AWS error codes that represent throttling errors.
 pub const THROTTLING_ERRORS: &[&str] = &[
     "Throttling",
@@ -110,11 +121,7 @@ where
             Some(Err(err)) => err,
         };
 
-        let retry_after = ctx
-            .response()
-            .and_then(|res| res.headers().get("x-amz-retry-after"))
-            .and_then(|header| header.parse::<u64>().ok())
-            .map(std::time::Duration::from_millis);
+        let retry_after = retry_after_from_ctx(ctx);
 
         let error_code = OrchestratorError::as_operation_error(error)
             .and_then(|err| err.downcast_ref::<E>())
@@ -135,10 +142,41 @@ where
             }
         };
 
-        debug_assert!(
-            retry_after.is_none(),
-            "retry_after should be None if the error wasn't an identifiable AWS error"
-        );
+        RetryAction::NoActionIndicated
+    }
+
+    fn classify_retry_v2(&self, ctx: &InterceptorContext, previous: &RetryAction) -> RetryAction {
+        // First, run our own error-code-based classification. When it
+        // recognizes an AWS error code it already attaches x-amz-retry-after,
+        // so that result stands unchanged.
+        let own = self.classify_retry(ctx);
+        if own != RetryAction::NoActionIndicated {
+            return own;
+        }
+
+        // No modeled error code matched. Per the Retry Behavior 2.1 spec,
+        // x-amz-retry-after MUST be incorporated into the backoff for ANY
+        // retryable error -- including transient errors classified purely by
+        // HTTP status (e.g. a bare 500) by HttpStatusCodeClassifier, which
+        // cannot read this AWS-specific header. If an earlier-running
+        // classifier already marked the response retryable but without an
+        // explicit delay, tuck the server-directed delay into that verdict,
+        // preserving the upstream error kind. The header alone does not make a
+        // response retryable, so we only refine an already-retryable `previous`;
+        // an unparsable header leaves retry_after as None and the request falls
+        // back to exponential backoff.
+        if let RetryAction::RetryIndicated(RetryReason::RetryableError {
+            kind,
+            retry_after: None,
+        }) = previous
+        {
+            if let Some(retry_after) = retry_after_from_ctx(ctx) {
+                return RetryAction::RetryIndicated(RetryReason::RetryableError {
+                    kind: *kind,
+                    retry_after: Some(retry_after),
+                });
+            }
+        }
 
         RetryAction::NoActionIndicated
     }
@@ -265,6 +303,167 @@ mod test {
         assert_eq!(
             policy.classify_retry(&ctx),
             RetryAction::retryable_error(ErrorKind::ThrottlingError)
+        );
+    }
+
+    /// Build a context whose response optionally carries an `x-amz-retry-after`
+    /// header (whose value is a count of **milliseconds**) and whose error
+    /// optionally carries an error code (`None` models a bare response with no
+    /// identifiable AWS error code, e.g. an unparsable 5xx).
+    fn ctx_with(
+        retry_after_header_millis: Option<&str>,
+        error_code: Option<&'static str>,
+    ) -> InterceptorContext {
+        let mut builder = http_1x::Response::builder();
+        if let Some(millis) = retry_after_header_millis {
+            builder = builder.header("x-amz-retry-after", millis);
+        }
+        let res = builder.body("nope").unwrap().map(SdkBody::from);
+
+        let err = match error_code {
+            Some(code) => ErrorMetadata::builder().code(code).build(),
+            None => ErrorMetadata::builder().build(),
+        };
+
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_response(res.try_into().unwrap());
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(err))));
+        ctx
+    }
+
+    // The headline scenario: a bare 5xx with no identifiable AWS error code that
+    // an earlier classifier (`HttpStatusCodeClassifier`) marked transient.
+    // `classify_retry_v2` attaches the server-directed delay from
+    // `x-amz-retry-after`, which that earlier classifier cannot read. The header
+    // is a count of milliseconds, so 5000ms == 5s. The clamping
+    // to `[t_i, 5 + t_i]` happens later in the backoff strategy, so the
+    // classifier stores the raw parsed duration.
+    #[test]
+    fn classify_retry_v2_attaches_server_delay_on_bare_5xx() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+        // No error code -> this classifier's own classification is `NoActionIndicated`.
+        let ctx = ctx_with(Some("5000"), None);
+
+        let previous = RetryAction::transient_error();
+        assert_eq!(
+            policy.classify_retry_v2(&ctx, &previous),
+            RetryAction::retryable_error_with_explicit_delay(
+                ErrorKind::TransientError,
+                Duration::from_secs(5)
+            ),
+        );
+    }
+
+    // Same refinement occurs when there is an error code that this classifier
+    // simply doesn't recognize ("InternalError" is not in its throttling/transient
+    // lists), so its own classification is still `NoActionIndicated`.
+    #[test]
+    fn classify_retry_v2_attaches_server_delay_on_unrecognized_error_code() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+        let ctx = ctx_with(Some("5000"), Some("InternalError"));
+
+        let previous = RetryAction::transient_error();
+        assert_eq!(
+            policy.classify_retry_v2(&ctx, &previous),
+            RetryAction::retryable_error_with_explicit_delay(
+                ErrorKind::TransientError,
+                Duration::from_secs(5)
+            ),
+        );
+    }
+
+    // The `kind` of the previous (already-retryable) verdict must be preserved
+    // when the server-directed delay is tucked in.
+    #[test]
+    fn classify_retry_v2_preserves_previous_kind() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+        let ctx = ctx_with(Some("2500"), None);
+
+        let previous = RetryAction::retryable_error(ErrorKind::ServerError);
+        assert_eq!(
+            policy.classify_retry_v2(&ctx, &previous),
+            RetryAction::retryable_error_with_explicit_delay(
+                ErrorKind::ServerError,
+                Duration::from_millis(2500)
+            ),
+        );
+    }
+
+    // When this classifier recognizes the error code itself, its own verdict
+    // (which already attaches `x-amz-retry-after`) stands unchanged, regardless
+    // of what an earlier classifier decided. `SlowDown` is a
+    // throttling error (not transient).
+    #[test]
+    fn classify_retry_v2_prefers_own_error_code_verdict() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+        let ctx = ctx_with(Some("5000"), Some("SlowDown"));
+
+        // Even with a `previous` transient verdict, the modeled throttling code wins.
+        let previous = RetryAction::transient_error();
+        assert_eq!(
+            policy.classify_retry_v2(&ctx, &previous),
+            RetryAction::retryable_error_with_explicit_delay(
+                ErrorKind::ThrottlingError,
+                Duration::from_secs(5)
+            ),
+        );
+    }
+
+    // The header alone must not make a response retryable: if no earlier
+    // classifier marked the response retryable, `classify_retry_v2` indicates no
+    // action even when `x-amz-retry-after` is present.
+    #[test]
+    fn classify_retry_v2_ignores_header_without_retryable_previous() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+        let ctx = ctx_with(Some("5000"), None);
+
+        assert_eq!(
+            policy.classify_retry_v2(&ctx, &RetryAction::NoActionIndicated),
+            RetryAction::NoActionIndicated,
+        );
+    }
+
+    // When the previous verdict already carries an explicit delay, the
+    // refinement branch (which only matches `retry_after: None`) is skipped and
+    // this classifier abstains by returning `NoActionIndicated`. Abstaining is
+    // precisely how it avoids overriding the existing delay: in
+    // `run_classifiers_on_ctx`, a `NoActionIndicated` result is a no-op that
+    // leaves the accumulated verdict (here, the `Some(1s)` delay) untouched.
+    // That end-to-end preservation is exercised in the aws-smithy-runtime
+    // `run_classifiers_on_ctx` test.
+    #[test]
+    fn classify_retry_v2_abstains_when_previous_has_explicit_delay() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+        let ctx = ctx_with(Some("5000"), None);
+
+        let previous = RetryAction::retryable_error_with_explicit_delay(
+            ErrorKind::TransientError,
+            Duration::from_secs(1),
+        );
+        assert_eq!(
+            policy.classify_retry_v2(&ctx, &previous),
+            RetryAction::NoActionIndicated,
+        );
+    }
+
+    // Invalid values in `x-amz-retry-after` must be ignored (fall
+    // back to exponential backoff). With no header, or an unparsable one, an
+    // already-retryable `previous` is left as-is (this classifier returns
+    // `NoActionIndicated`).
+    #[test]
+    fn classify_retry_v2_falls_back_without_valid_header() {
+        let policy = AwsErrorCodeClassifier::<ErrorMetadata>::new();
+
+        let previous = RetryAction::transient_error();
+        // Absent header.
+        assert_eq!(
+            policy.classify_retry_v2(&ctx_with(None, None), &previous),
+            RetryAction::NoActionIndicated,
+        );
+        // Unparsable header.
+        assert_eq!(
+            policy.classify_retry_v2(&ctx_with(Some("invalid"), None), &previous),
+            RetryAction::NoActionIndicated,
         );
     }
 }

--- a/aws/sdk/integration-tests/dynamodb/tests/retries-with-client-rate-limiting.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/retries-with-client-rate-limiting.rs
@@ -204,16 +204,20 @@ async fn test_adaptive_retries_with_throttling_errors() {
     )
     .await;
 
-    // Retry 2.1: throttling still uses 1s base, rate limiter behavior unchanged
+    // Retry 2.1: throttling errors now charge only 1 token against the adaptive
+    // rate limiter (vs. the legacy 10-token RetryTimeout cost), so the
+    // rate-limiter-induced delay is far smaller. op1 drops to 4s and op2 only
+    // adds ~0.86s of rate-limiter backoff (cumulative ~4.862s) rather than the
+    // legacy ~10s.
     adaptive_retries_with_throttling(
         BehaviorVersion::latest(),
         base_config.with_retry_spec(
             RetrySpec::v2_1().with_non_throttling_initial_backoff(Duration::from_millis(25)),
         ),
         "throttle_v2_1",
-        Duration::from_secs(38),
-        Duration::from_secs(47),
-        Duration::from_secs(49),
+        Duration::from_secs(4),
+        Duration::from_millis(4700),
+        Duration::from_millis(5000),
     )
     .await;
 }

--- a/aws/sdk/integration-tests/dynamodb/tests/retries-with-client-rate-limiting.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/retries-with-client-rate-limiting.rs
@@ -206,9 +206,10 @@ async fn test_adaptive_retries_with_throttling_errors() {
 
     // Retry 2.1: throttling errors now charge only 1 token against the adaptive
     // rate limiter (vs. the legacy 10-token RetryTimeout cost), so the
-    // rate-limiter-induced delay is far smaller. op1 drops to 4s and op2 only
-    // adds ~0.86s of rate-limiter backoff (cumulative ~4.862s) rather than the
-    // legacy ~10s.
+    // rate-limiter-induced delay is far smaller than legacy (~48s). Each retry
+    // now actually acquires (and pays for) a send token before sending, so op1's
+    // throttling retries pace op2 slightly: op1 is 4s and the cumulative op2
+    // total is ~5.15s.
     adaptive_retries_with_throttling(
         BehaviorVersion::latest(),
         base_config.with_retry_spec(
@@ -216,8 +217,8 @@ async fn test_adaptive_retries_with_throttling_errors() {
         ),
         "throttle_v2_1",
         Duration::from_secs(4),
-        Duration::from_millis(4700),
         Duration::from_millis(5000),
+        Duration::from_millis(5300),
     )
     .await;
 }

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -12,10 +12,11 @@ publish = false
 
 [dev-dependencies]
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
-aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts", features = ["behavior-version-latest"] }
+aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts", features = ["behavior-version-latest", "test-util"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-runtime = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime", features = ["client"] }
 aws-smithy-http-client = { path = "../../build/aws-sdk/sdk/aws-smithy-http-client", features = ["test-util"] }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
+http-1x = { package = "http", version = "1" }
 tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/sts/tests/retry_idp_comms_err.rs
+++ b/aws/sdk/integration-tests/sts/tests/retry_idp_comms_err.rs
@@ -4,6 +4,9 @@
  */
 
 use aws_sdk_sts as sts;
+use aws_sdk_sts::config::retry::RetryConfig;
+use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
+use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::error::ErrorMetadata;
 use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind};
 use sts::operation::assume_role_with_web_identity::AssumeRoleWithWebIdentityError;
@@ -26,5 +29,83 @@ async fn idp_comms_err_retryable() {
         Some(ErrorKind::ServerError),
         error.retryable_error_kind(),
         "IdpCommunicationErrorException should be a retryable server error"
+    );
+}
+
+fn req() -> http_1x::Request<SdkBody> {
+    http_1x::Request::builder()
+        .body(SdkBody::from("request"))
+        .unwrap()
+}
+
+// An `awsQuery` STS error response carrying the given error code with a
+// non-retryable HTTP status (400). Using a 400 ensures any retry is caused by
+// error-code classification, not by the HTTP status code classifier.
+fn sts_error(code: &str) -> http_1x::Response<SdkBody> {
+    let body = format!(
+        r#"<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+    <Error>
+        <Type>Sender</Type>
+        <Code>{code}</Code>
+        <Message>test</Message>
+    </Error>
+    <RequestId>req-id</RequestId>
+</ErrorResponse>"#
+    );
+    http_1x::Response::builder()
+        .status(400)
+        .body(SdkBody::from(body))
+        .unwrap()
+}
+
+// Drives `GetCallerIdentity` (which does NOT model `IDPCommunicationErrorException`)
+// against three identical error responses and returns the number of attempts the
+// client actually made.
+async fn attempts_for_error_code(code: &'static str) -> usize {
+    let http_client = StaticReplayClient::new(vec![
+        ReplayEvent::new(req(), sts_error(code)),
+        ReplayEvent::new(req(), sts_error(code)),
+        ReplayEvent::new(req(), sts_error(code)),
+    ]);
+    let conf = sts::Config::builder()
+        .http_client(http_client.clone())
+        .retry_config(RetryConfig::standard().with_max_attempts(3))
+        .with_test_defaults_v2()
+        .build();
+    let client = sts::Client::from_conf(conf);
+
+    let _ = client
+        .get_caller_identity()
+        .send()
+        .await
+        .expect_err("the mocked response is an error");
+
+    http_client.actual_requests().count()
+}
+
+// Unlike `idp_comms_err_retryable` above (which covers the *modeled*
+// `IDPCommunicationErrorException` on `AssumeRoleWithWebIdentity` via the
+// `@retryable` trait), this exercises the `IDPCommunicationError` *error code* on
+// `GetCallerIdentity`, which does NOT model that exception. The only thing that
+// makes it retryable is the by-error-code classifier that STS registers for every
+// operation, so the client must use all 3 attempts.
+#[tokio::test]
+async fn idp_communication_error_retried_on_operation_that_does_not_model_it() {
+    assert_eq!(
+        attempts_for_error_code("IDPCommunicationError").await,
+        3,
+        "IDPCommunicationError should be retried on all STS operations"
+    );
+}
+
+// Control: an unrelated, non-retryable error code makes exactly one attempt,
+// confirming the retry above is specific to `IDPCommunicationError` and not a
+// blanket retry of every error.
+#[tokio::test]
+async fn unrelated_error_code_is_not_retried() {
+    assert_eq!(
+        attempts_for_error_code("ValidationError").await,
+        1,
+        "a non-retryable error code should not be retried"
     );
 }

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -340,6 +340,17 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-async"
 version = "1.3.0"
 dependencies = [
  "futures-util",
@@ -350,25 +361,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-async"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "aws-smithy-cbor"
 version = "0.61.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d37cd9b566efa38233b081038602e92f5b54c87f270b7f5922f6e33c6b4d"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.12.3",
  "aws-smithy-schema 0.1.0",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.5.0",
  "minicbor",
  "num-bigint",
 ]
@@ -377,7 +377,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.1",
  "criterion",
@@ -396,7 +396,7 @@ dependencies = [
  "crc-fast",
  "hex",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "md-5 0.11.0",
  "pin-project-lite",
@@ -412,14 +412,14 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "bytes",
  "bytes-utils",
  "flate2",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "pretty_assertions",
@@ -431,7 +431,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -462,8 +462,8 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-types 1.5.0",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -483,14 +483,14 @@ version = "0.64.0"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "bytes",
  "bytes-utils",
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
  "percent-encoding",
@@ -507,7 +507,7 @@ version = "1.2.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "base64 0.22.1",
  "bytes",
@@ -516,7 +516,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
  "hyper 1.10.1",
@@ -526,7 +526,7 @@ dependencies = [
  "indexmap 2.14.0",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.42",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.4",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -551,8 +551,8 @@ dependencies = [
  "aws-smithy-cbor 0.61.10",
  "aws-smithy-http 0.62.6",
  "aws-smithy-json 0.61.9",
- "aws-smithy-runtime-api 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-types 1.5.0",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -579,17 +579,17 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "aws-smithy-xml 0.62.0",
  "bytes",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
- "lambda_http 1.3.0",
+ "lambda_http 1.2.1",
  "mime",
  "nom",
  "pin-project-lite",
@@ -617,7 +617,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "hyper 0.14.32",
  "hyper 1.10.1",
  "metrique",
@@ -685,14 +685,14 @@ version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
 dependencies = [
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.5.0",
 ]
 
 [[package]]
 name = "aws-smithy-json"
 version = "0.63.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.1",
  "proptest",
@@ -706,7 +706,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.64.0",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "bytes",
  "bytes-utils",
@@ -731,7 +731,7 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "aws-smithy-xml 0.62.0",
  "bytes",
@@ -761,7 +761,7 @@ dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "http 1.4.2",
  "tokio",
@@ -771,7 +771,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.3.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "serial_test",
 ]
 
@@ -795,7 +795,7 @@ name = "aws-smithy-protocol-test"
 version = "0.64.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -812,7 +812,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.1",
  "aws-smithy-xml 0.62.0",
@@ -829,7 +829,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.1",
  "bytes",
@@ -838,7 +838,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
  "pin-project-lite",
@@ -852,7 +852,24 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.13.0"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+dependencies = [
+ "aws-smithy-async 1.2.14",
+ "aws-smithy-runtime-api-macros 1.0.0",
+ "aws-smithy-types 1.5.0",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-runtime-api-macros 1.1.0",
@@ -868,25 +885,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-runtime-api"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
-dependencies = [
- "aws-smithy-async 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-runtime-api-macros 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes",
- "http 0.2.12",
- "http 1.4.2",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.1.0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -896,8 +898,6 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api-macros"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,8 +910,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.12.3",
+ "aws-smithy-types 1.5.0",
  "http 1.4.2",
 ]
 
@@ -919,9 +919,36 @@ dependencies = [
 name = "aws-smithy-schema"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 0.14.32",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -938,7 +965,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
  "itoa",
@@ -947,7 +974,7 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "proptest",
- "rand 0.8.7",
+ "rand 0.8.6",
  "ryu",
  "serde",
  "serde_json",
@@ -955,33 +982,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-util",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.1.0",
- "http-body-util",
- "hyper 0.14.32",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
  "tokio-util",
 ]
 
@@ -1001,7 +1001,7 @@ name = "aws-smithy-wasm"
 version = "0.2.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "http-body-util",
  "sync_wrapper",
@@ -1022,7 +1022,7 @@ name = "aws-smithy-xml"
 version = "0.62.0"
 dependencies = [
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.1",
  "base64 0.13.1",
@@ -1055,7 +1055,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-serde 2.1.1",
  "query_map",
  "serde",
@@ -1191,9 +1191,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1450,7 +1450,7 @@ dependencies = [
  "crc",
  "digest 0.10.7",
  "rustversion",
- "spin 0.10.1",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -1508,18 +1508,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1527,27 +1527,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1738,7 +1738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2126,7 +2126,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.5",
+ "rand 0.9.4",
  "ring 0.17.14",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2148,7 +2148,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.5",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -2200,14 +2200,14 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2294,7 +2294,7 @@ dependencies = [
  "futures-core",
  "h2 0.4.15",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2329,7 +2329,7 @@ dependencies = [
  "http 1.4.2",
  "hyper 1.10.1",
  "hyper-util",
- "rustls 0.23.42",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2347,13 +2347,13 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -2511,7 +2511,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.13.0",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.1",
  "aws-smithy-xml 0.62.0",
@@ -2521,7 +2521,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "md-5 0.10.6",
  "percent-encoding",
@@ -2557,7 +2557,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -2578,7 +2578,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2636,11 +2636,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.35"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -2690,19 +2690,19 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69eb3117d123f471f7d2b5d02b5afe150f54f9f7cff3264e578c9dd03675ad9"
+checksum = "9f7f1395a7854d32e6f0c366448740dceb2e1bcb90bbbbf2785152e0ca3283e0"
 dependencies = [
  "aws_lambda_events 1.2.0",
  "bytes",
  "encoding_rs",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
- "lambda_runtime 1.3.0",
+ "lambda_runtime 1.2.1",
  "mime",
  "percent-encoding",
  "pin-project-lite",
@@ -2739,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484647f147899f866a7b5db6aaa1671e943f89f4be76e2a383c96b1b27058294"
+checksum = "4de91395937cd37777dce2c98ed95060a6fbd7dfaefb7ae3cc5fec84bb8379d0"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -2751,7 +2751,7 @@ dependencies = [
  "http-body-util",
  "http-serde 2.1.1",
  "hyper 1.10.1",
- "lambda_runtime_api_client 1.1.0",
+ "lambda_runtime_api_client 1.0.3",
  "pin-project",
  "serde",
  "serde_json",
@@ -2776,15 +2776,15 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "1.1.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92e6500e47d17c1ffd3e6ad3ca224bb86382fc8b63414f6f20b1b2d98dfb7cf"
+checksum = "b5e9ffa99f1e87b21d42ac98fe7eac55f4cfb9ed14677a64a7dab4d8f44399a4"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
@@ -2885,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.3"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -2923,7 +2923,7 @@ dependencies = [
  "ordered-float",
  "quanta",
  "radix_trie",
- "rand 0.9.5",
+ "rand 0.9.4",
  "rand_xoshiro",
  "rapidhash",
  "sketches-ddsketch",
@@ -2973,18 +2973,18 @@ dependencies = [
 
 [[package]]
 name = "metrique-service-metrics"
-version = "0.1.23"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ee17caa35f83b730a83c8fa8f7a9aaa61a0becc7a71feb5bfb854bc75440d7"
+checksum = "93045b7f5c8b998946b715de07523b1c6d81932512c5c27590bf73328aaf3832"
 dependencies = [
  "metrique-writer",
 ]
 
 [[package]]
 name = "metrique-timesource"
-version = "0.1.10"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faca4e4480069ff02b1763b3b79f5cec7e8628e24d9dc5b6073f53d2577a4d9"
+checksum = "d607939211e4eaaa8cd35394fa5e57faffb7390d0ac513b39992edcaf3cc526c"
 
 [[package]]
 name = "metrique-writer"
@@ -3000,7 +3000,7 @@ dependencies = [
  "metrique-core",
  "metrique-writer-core",
  "metrique-writer-macro",
- "rand 0.9.5",
+ "rand 0.9.4",
  "smallvec",
  "tokio",
  "tracing",
@@ -3032,7 +3032,7 @@ dependencies = [
  "itoa",
  "metrique-writer",
  "metrique-writer-core",
- "rand 0.9.5",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "smallvec",
@@ -3041,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-macro"
-version = "0.1.10"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eef190f855405b9df4166ee0495925162fb2a7985bac62c6ae44f40061fac00"
+checksum = "5891f02fdba5bd734992ea074502934344e4138525bf299ee4984f16160c3e6e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3095,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3151,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3261,7 +3261,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.7",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -3493,7 +3493,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.5",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3658,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3669,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3679,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3752,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.5.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
 dependencies = [
  "rustversion",
 ]
@@ -3811,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3823,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3890,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -3904,7 +3904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3921,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4010,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -4034,9 +4034,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.40"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76c77f8c280a581031ad88f8bc09c18581b11d785f530025d135dd22c03b9e"
+checksum = "d7e9f6ebf37b1fcc2ef03b7d46a0ab8209bad2622060cf1c40011e97d866ec6f"
 dependencies = [
  "errno",
  "hex",
@@ -4061,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.40"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce900e83d6cb0dee6623e6e0c955ce1973ad2994ce76c5ed577e27fa564cb82b"
+checksum = "ad635286a83358b8cce8c6a40e7fc8621c02bab9b3d3433fd91c002bb311ec21"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -4072,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-tokio"
-version = "0.3.40"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4e29d385fec73b3b85c4c353dbe30cb84477c43270236d13278eb1e4f4387e"
+checksum = "83cdcee2f7fdf66f0f044d968c5faf14eebc2659735f96781f7b4b869b5bb46b"
 dependencies = [
  "errno",
  "libc",
@@ -4317,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.10"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -4351,9 +4351,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4367,9 +4367,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "stable_deref_trait"
@@ -4502,7 +4502,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4562,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
@@ -4621,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4660,7 +4660,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4692,7 +4692,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -4789,7 +4789,7 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tokio",
  "tower-layer",
@@ -4999,13 +4999,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.2",
+ "rand 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -5017,9 +5017,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.13.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version_check"
@@ -5175,7 +5175,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5327,7 +5327,7 @@ dependencies = [
  "bytes",
  "futures-lite 1.13.0",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "pin-project-lite",
@@ -5394,18 +5394,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.13.0"
+version = "1.14.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/retries/classifiers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/retries/classifiers.rs
@@ -248,7 +248,27 @@ impl Default for RetryClassifierPriority {
 pub trait ClassifyRetry: Send + Sync + fmt::Debug {
     /// Run this classifier on the [`InterceptorContext`] to determine if the previous request
     /// should be retried. Returns a [`RetryAction`].
+    ///
+    /// Prefer implementing [`classify_retry_v2`](ClassifyRetry::classify_retry_v2) when a
+    /// classifier needs the [`RetryAction`] accumulated by earlier-running classifiers (e.g. to
+    /// refine an already-retryable verdict). This method has no access to that cumulative verdict;
+    /// it remains the required building block that `classify_retry_v2` delegates to by default.
     fn classify_retry(&self, ctx: &InterceptorContext) -> RetryAction;
+
+    /// Run this classifier with awareness of the [`RetryAction`] accumulated by
+    /// earlier-running (lower-priority) classifiers. `previous` is the running
+    /// result of classification so far ([`RetryAction::NoActionIndicated`] until
+    /// some classifier sets one).
+    ///
+    /// The default implementation ignores `previous` and delegates to
+    /// [`classify_retry`](ClassifyRetry::classify_retry), so existing classifiers
+    /// are unaffected. Override this to refine a verdict produced by an
+    /// earlier-running classifier — for example, to attach a server-directed
+    /// delay to an already-retryable response.
+    fn classify_retry_v2(&self, ctx: &InterceptorContext, previous: &RetryAction) -> RetryAction {
+        let _ = previous;
+        self.classify_retry(ctx)
+    }
 
     /// The name of this retry classifier.
     ///
@@ -289,6 +309,10 @@ impl ClassifyRetry for SharedRetryClassifier {
         self.0.classify_retry(ctx)
     }
 
+    fn classify_retry_v2(&self, ctx: &InterceptorContext, previous: &RetryAction) -> RetryAction {
+        self.0.classify_retry_v2(ctx, previous)
+    }
+
     fn name(&self) -> &'static str {
         self.0.name()
     }
@@ -325,7 +349,7 @@ impl ValidateConfig for SharedRetryClassifier {
 #[cfg(test)]
 mod tests {
     use super::{ClassifyRetry, RetryAction, RetryClassifierPriority, SharedRetryClassifier};
-    use crate::client::interceptors::context::InterceptorContext;
+    use crate::client::interceptors::context::{Input, InterceptorContext};
 
     #[test]
     fn test_preset_priorities() {
@@ -493,5 +517,86 @@ mod tests {
             ],
             actual
         );
+    }
+
+    fn test_ctx() -> InterceptorContext {
+        InterceptorContext::new(Input::erase("input"))
+    }
+
+    // A classifier that only implements `classify_retry`, returning a fixed
+    // verdict and ignoring the context.
+    #[derive(Debug)]
+    struct FixedClassifier(RetryAction);
+
+    impl ClassifyRetry for FixedClassifier {
+        fn classify_retry(&self, _ctx: &InterceptorContext) -> RetryAction {
+            self.0.clone()
+        }
+
+        fn name(&self) -> &'static str {
+            "fixed"
+        }
+    }
+
+    // The default `classify_retry_v2` implementation must ignore `previous` and
+    // delegate to `classify_retry`, so classifiers that don't override it are
+    // unaffected by the newer signature.
+    #[test]
+    fn default_classify_retry_v2_delegates_and_ignores_previous() {
+        let ctx = test_ctx();
+        let classifier = FixedClassifier(RetryAction::transient_error());
+
+        // Regardless of what `previous` is, the result matches `classify_retry`.
+        for previous in [
+            RetryAction::NoActionIndicated,
+            RetryAction::RetryForbidden,
+            RetryAction::throttling_error(),
+        ] {
+            assert_eq!(
+                classifier.classify_retry_v2(&ctx, &previous),
+                classifier.classify_retry(&ctx),
+            );
+        }
+    }
+
+    // A classifier whose `classify_retry_v2` behaves observably differently from
+    // its `classify_retry`: it echoes back the `previous` verdict.
+    #[derive(Debug)]
+    struct PreviousEchoClassifier;
+
+    impl ClassifyRetry for PreviousEchoClassifier {
+        fn classify_retry(&self, _ctx: &InterceptorContext) -> RetryAction {
+            RetryAction::NoActionIndicated
+        }
+
+        fn classify_retry_v2(
+            &self,
+            _ctx: &InterceptorContext,
+            previous: &RetryAction,
+        ) -> RetryAction {
+            previous.clone()
+        }
+
+        fn name(&self) -> &'static str {
+            "previous-echo"
+        }
+    }
+
+    // `SharedRetryClassifier` must forward `classify_retry_v2` to the wrapped
+    // classifier's override rather than falling back to `classify_retry`.
+    #[test]
+    fn shared_classifier_forwards_classify_retry_v2_to_inner() {
+        let ctx = test_ctx();
+        let shared = SharedRetryClassifier::new(PreviousEchoClassifier);
+
+        // If forwarding were (incorrectly) routed to `classify_retry`, this
+        // would be `NoActionIndicated` instead of the echoed `previous`.
+        assert_eq!(
+            shared.classify_retry_v2(&ctx, &RetryAction::throttling_error()),
+            RetryAction::throttling_error(),
+        );
+
+        // The plain `classify_retry` path remains unaffected.
+        assert_eq!(shared.classify_retry(&ctx), RetryAction::NoActionIndicated);
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -31,7 +31,7 @@ use aws_smithy_runtime_api::client::ser_de::{
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
 use aws_smithy_types::config_bag::ConfigBag;
-use aws_smithy_types::retry::{MergeRetryConfig, RetryConfig};
+use aws_smithy_types::retry::{MergeRetryConfig, RetryConfig, RetrySpec};
 use aws_smithy_types::timeout::{MergeTimeoutConfig, TimeoutConfig};
 use endpoints::apply_endpoint;
 use std::mem;
@@ -325,6 +325,15 @@ async fn try_op(
             debug!("delaying for {delay:?}");
             sleep.await;
         }
+        // Acquire an adaptive-rate-limiter send token before each retry send
+        // (the initial attempt acquired its token above). This is a no-op
+        // unless the client is in adaptive mode under Retry Behavior 2.1 -- see
+        // `acquire_adaptive_send_token`.
+        if i > 1 {
+            halt_on_err!([ctx] => acquire_adaptive_send_token(cfg, runtime_components)
+                .await
+                .map_err(OrchestratorError::other));
+        }
         let attempt_timeout_config =
             MaybeTimeoutConfig::new(runtime_components, cfg, TimeoutKind::OperationAttempt);
         trace!(attempt_timeout_config = ?attempt_timeout_config);
@@ -374,6 +383,51 @@ async fn try_op(
                 )));
                 retry_delay = Some((delay, sleep_impl.sleep(delay)));
                 continue;
+            }
+        }
+    }
+}
+
+// Acquires one send token from the adaptive client-side rate limiter before a
+// retry send, mirroring the Retry Behavior 2.1 spec's `GetSendToken()` step,
+// which charges one token per attempt (the initial attempt is charged earlier,
+// in `try_op`'s send loop).
+//
+// This is meaningful only in `adaptive` retry mode under Retry Behavior 2.1, and
+// is a deliberate no-op otherwise:
+//   - non-adaptive modes (`standard`/`legacy`) have no rate limiter, so the
+//     retry strategy OKs the send immediately; and
+//   - pre-2.1 adaptive folds the limiter delay into the retry backoff instead
+//     (see `check_rate_limiter_for_delay`), so it is left untouched here.
+//
+// When the bucket has no capacity, the strategy returns a delay instead of
+// charging the token. We sleep that delay and then re-acquire, so capacity is
+// re-checked after the wait and is never driven negative -- concurrent attempts
+// may have drained the bucket while we waited, and it must stay >= 0.
+async fn acquire_adaptive_send_token(
+    cfg: &ConfigBag,
+    runtime_components: &RuntimeComponents,
+) -> Result<(), BoxError> {
+    let is_v2_1 = cfg
+        .load::<RetryConfig>()
+        .and_then(|rc| rc.retry_spec())
+        .is_some_and(|s| s.is_at_least(RetrySpec::V2_1));
+    if !is_v2_1 {
+        return Ok(());
+    }
+    let retry_strategy = runtime_components.retry_strategy();
+    loop {
+        match retry_strategy.should_attempt_initial_request(runtime_components, cfg)? {
+            // `GetSendToken` only gates on rate-limiter capacity; it never
+            // forbids the send, so both `Yes` and `No` mean "proceed".
+            ShouldAttempt::Yes | ShouldAttempt::No => return Ok(()),
+            ShouldAttempt::YesAfterDelay(delay) => {
+                let sleep_impl = runtime_components.sleep_impl().ok_or(
+                    "the retry strategy requested a delay before sending a retry, \
+                     but no 'async sleep' implementation was set",
+                )?;
+                debug!("adaptive rate limiter delayed a retry send by {delay:?}");
+                sleep_impl.sleep(delay).await;
             }
         }
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/classifiers.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/classifiers.rs
@@ -177,8 +177,9 @@ impl ClassifyRetry for HttpStatusCodeClassifier {
 }
 
 /// Given an iterator of retry classifiers and an interceptor context, run retry classifiers on the
-/// context. Each classifier is passed the classification result from the previous classifier (the
-/// 'root' classifier is passed `None`.)
+/// context. Each classifier is passed the [`RetryAction`] accumulated by the previously-run
+/// classifiers (the first classifier is passed [`RetryAction::NoActionIndicated`]) via
+/// [`ClassifyRetry::classify_retry_v2`], so a later classifier may refine an earlier verdict.
 pub fn run_classifiers_on_ctx(
     classifiers: impl Iterator<Item = SharedRetryClassifier>,
     ctx: &InterceptorContext,
@@ -187,7 +188,7 @@ pub fn run_classifiers_on_ctx(
     let mut result = RetryAction::NoActionIndicated;
 
     for classifier in classifiers {
-        let new_result = classifier.classify_retry(ctx);
+        let new_result = classifier.classify_retry_v2(ctx, &result);
 
         // If the result is `NoActionIndicated`, continue to the next classifier
         // without overriding any previously-set result.
@@ -220,12 +221,15 @@ mod test {
     };
     use aws_smithy_runtime_api::client::interceptors::context::{Error, Input, InterceptorContext};
     use aws_smithy_runtime_api::client::orchestrator::OrchestratorError;
-    use aws_smithy_runtime_api::client::retries::classifiers::{ClassifyRetry, RetryAction};
+    use aws_smithy_runtime_api::client::retries::classifiers::{
+        ClassifyRetry, RetryAction, RetryReason, SharedRetryClassifier,
+    };
     use aws_smithy_types::body::SdkBody;
     use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind};
     use std::fmt;
+    use std::time::Duration;
 
-    use super::TransientErrorClassifier;
+    use super::{run_classifiers_on_ctx, TransientErrorClassifier};
 
     #[derive(Debug, PartialEq, Eq, Clone)]
     struct UnmodeledError;
@@ -315,5 +319,120 @@ mod test {
             "I am a timeout error".into(),
         )));
         assert_eq!(policy.classify_retry(&ctx), RetryAction::transient_error(),);
+    }
+
+    // A classifier that returns a fixed verdict from `classify_retry` (and thus,
+    // via the default impl, from `classify_retry_v2`).
+    #[derive(Debug)]
+    struct StaticClassifier {
+        name: &'static str,
+        action: RetryAction,
+    }
+
+    impl ClassifyRetry for StaticClassifier {
+        fn classify_retry(&self, _ctx: &InterceptorContext) -> RetryAction {
+            self.action.clone()
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    // A classifier that refines an already-retryable verdict by attaching a
+    // fixed delay, mimicking how `AwsErrorCodeClassifier` tucks an
+    // `x-amz-retry-after` delay into a verdict produced by an earlier-running
+    // classifier. It only refines a retryable `previous` that has no delay yet;
+    // otherwise it abstains with `NoActionIndicated`.
+    #[derive(Debug)]
+    struct DelayRefiningClassifier;
+
+    impl ClassifyRetry for DelayRefiningClassifier {
+        fn classify_retry(&self, _ctx: &InterceptorContext) -> RetryAction {
+            RetryAction::NoActionIndicated
+        }
+
+        fn classify_retry_v2(
+            &self,
+            _ctx: &InterceptorContext,
+            previous: &RetryAction,
+        ) -> RetryAction {
+            if let RetryAction::RetryIndicated(RetryReason::RetryableError {
+                kind,
+                retry_after: None,
+            }) = previous
+            {
+                RetryAction::retryable_error_with_explicit_delay(*kind, Duration::from_secs(5))
+            } else {
+                RetryAction::NoActionIndicated
+            }
+        }
+
+        fn name(&self) -> &'static str {
+            "delay-refining"
+        }
+    }
+
+    // `run_classifiers_on_ctx` passes each classifier the verdict accumulated by
+    // the previously-run classifiers via `classify_retry_v2`, so a later
+    // classifier can refine an earlier one's verdict (attaching a delay here).
+    #[test]
+    fn run_classifiers_on_ctx_lets_later_classifier_refine_earlier_verdict() {
+        let ctx = InterceptorContext::new(Input::doesnt_matter());
+        let classifiers = vec![
+            SharedRetryClassifier::new(StaticClassifier {
+                name: "transient",
+                action: RetryAction::transient_error(),
+            }),
+            SharedRetryClassifier::new(DelayRefiningClassifier),
+        ];
+
+        assert_eq!(
+            run_classifiers_on_ctx(classifiers.into_iter(), &ctx),
+            RetryAction::retryable_error_with_explicit_delay(
+                ErrorKind::TransientError,
+                Duration::from_secs(5),
+            ),
+        );
+    }
+
+    // The refining classifier must not fabricate a retry on its own: if no
+    // earlier classifier marked the response retryable, the refinement abstains
+    // and the overall result is `NoActionIndicated`. This matches the behavior
+    // of other SDKs (e.g. Java v2), where `x-amz-retry-after` only supplies a
+    // backoff delay for an already-retryable error and never forces a retry.
+    #[test]
+    fn run_classifiers_on_ctx_refiner_does_not_fabricate_retry() {
+        let ctx = InterceptorContext::new(Input::doesnt_matter());
+        let classifiers = vec![SharedRetryClassifier::new(DelayRefiningClassifier)];
+
+        assert_eq!(
+            run_classifiers_on_ctx(classifiers.into_iter(), &ctx),
+            RetryAction::NoActionIndicated,
+        );
+    }
+
+    // When the refining classifier abstains (returns `NoActionIndicated` because
+    // the earlier verdict already carries a delay), `run_classifiers_on_ctx`
+    // preserves that earlier verdict rather than clobbering it.
+    #[test]
+    fn run_classifiers_on_ctx_preserves_earlier_verdict_when_refiner_abstains() {
+        let ctx = InterceptorContext::new(Input::doesnt_matter());
+        let already_delayed = RetryAction::retryable_error_with_explicit_delay(
+            ErrorKind::TransientError,
+            Duration::from_secs(1),
+        );
+        let classifiers = vec![
+            SharedRetryClassifier::new(StaticClassifier {
+                name: "already-delayed",
+                action: already_delayed.clone(),
+            }),
+            SharedRetryClassifier::new(DelayRefiningClassifier),
+        ];
+
+        assert_eq!(
+            run_classifiers_on_ctx(classifiers.into_iter(), &ctx),
+            already_delayed,
+        );
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/client_rate_limiter.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/client_rate_limiter.rs
@@ -119,15 +119,26 @@ impl ClientRateLimiter {
 
         if amount > it.current_capacity {
             let sleep_time = (amount - it.current_capacity) / it.fill_rate;
-            debug!(
-                amount,
-                it.current_capacity,
-                it.fill_rate,
-                sleep_time,
-                "client rate limiter delayed a request"
-            );
-            // Capacity unchanged; caller sleeps and re-acquires.
-            Err(Duration::from_secs_f64(sleep_time))
+            let dur = Duration::from_secs_f64(sleep_time);
+            if dur.is_zero() {
+                // Shortfall is sub-nanosecond (float boundary). Returning Err(0ns)
+                // makes the orchestrator's re-acquire loop spin: sleep(0) never
+                // advances the clock, so capacity never grows and we'd re-check
+                // forever. Treat it as available and grant, clamping to keep
+                // capacity >= 0 (preserving the never-negative invariant).
+                it.current_capacity = (it.current_capacity - amount).max(0.0);
+                Ok(())
+            } else {
+                debug!(
+                    amount,
+                    it.current_capacity,
+                    it.fill_rate,
+                    sleep_time,
+                    "client rate limiter delayed a request"
+                );
+                // Capacity unchanged; caller sleeps and re-acquires.
+                Err(dur)
+            }
         } else {
             it.current_capacity -= amount;
             Ok(())
@@ -415,7 +426,7 @@ impl ClientRateLimiterBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{cubic_throttle, ClientRateLimiter};
+    use super::{cubic_throttle, ClientRateLimiter, INITIAL_REQUEST_COST};
     use crate::client::retries::client_rate_limiter::RequestReason;
     use approx::assert_relative_eq;
     use aws_smithy_async::rt::sleep::AsyncSleep;
@@ -805,6 +816,41 @@ mod tests {
 
         let inner = rate_limiter.inner.lock().unwrap();
         assert_relative_eq!(inner.current_capacity, 0.0, epsilon = 0.01);
+    }
+
+    #[tokio::test]
+    async fn test_sub_nanosecond_shortfall_grants_instead_of_returning_zero_delay() {
+        let rate_limiter = ClientRateLimiter::builder()
+            .time_of_last_throttle(0.0)
+            .previous_time_bucket(0.0)
+            .build();
+        rate_limiter.update_rate_limiter(0.0, true); // enable throttling
+
+        // Force capacity infinitesimally below the InitialRequest cost so the
+        // computed wait (shortfall / fill_rate) rounds below 1ns. Pin
+        // `last_timestamp` so the acquire below refills ~nothing.
+        {
+            let mut inner = rate_limiter.inner.lock().unwrap();
+            inner.current_capacity = INITIAL_REQUEST_COST - 1e-12;
+            inner.last_timestamp = Some(0.5);
+        }
+
+        // Previously this returned `Err(0ns)`, which spins the orchestrator's
+        // re-acquire loop (sleep(0) never advances capacity). It must now grant.
+        let result =
+            rate_limiter.acquire_permission_to_send_a_request(0.5, RequestReason::InitialRequest);
+        assert!(
+            result.is_ok(),
+            "a sub-nanosecond shortfall must grant, not return Err(0ns)"
+        );
+
+        // Capacity must remain non-negative (the #4632 invariant).
+        let inner = rate_limiter.inner.lock().unwrap();
+        assert!(
+            inner.current_capacity >= 0.0,
+            "capacity must not go negative, was {}",
+            inner.current_capacity
+        );
     }
 
     // This test is only testing that we don't fail basic math and panic. It does include an

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -336,20 +336,21 @@ fn check_rate_limiter_for_delay(
     kind: ErrorKind,
 ) -> Option<Duration> {
     if let Some(crl) = StandardRetryStrategy::adaptive_retry_rate_limiter(runtime_components, cfg) {
-        // Retry Behavior 2.1: the adaptive client-side rate limiter is a
-        // requests-per-second limiter, so per the spec it charges a uniform
-        // 1 token per send attempt (same as an initial request). The legacy
-        // 5/10-token retry costs, charged against a cold-start capacity
-        // floored at MIN_CAPACITY (1.0), deadlocked retries and starved
-        // throughput. Scope this to V2.1 so pre-2.1 adaptive behavior is
-        // unchanged.
+        // Retry Behavior 2.1 acquires one adaptive send token per attempt in the
+        // orchestrator's send loop (GetSendToken: sleep-then-re-acquire, so
+        // capacity is never driven negative). The rate limiter therefore must
+        // NOT also fold an acquire delay into the retry backoff here; the
+        // x-amz-retry-after / exponential backoff is applied on its own below.
+        // Pre-2.1 keeps the legacy behavior of folding the acquire delay (with
+        // the 5/10-token retry costs) into the backoff.
         let is_v2_1 = cfg
             .load::<RetryConfig>()
             .and_then(|rc| rc.retry_spec())
             .is_some_and(|s| s.is_at_least(RetrySpec::V2_1));
-        let retry_reason = if is_v2_1 {
-            RequestReason::InitialRequest
-        } else if kind == ErrorKind::ThrottlingError {
+        if is_v2_1 {
+            return None;
+        }
+        let retry_reason = if kind == ErrorKind::ThrottlingError {
             RequestReason::RetryTimeout
         } else {
             RequestReason::Retry

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -235,7 +235,7 @@ impl RetryStrategy for StandardRetryStrategy {
         let classifier_result = run_classifiers_on_ctx(retry_classifiers, ctx);
 
         // (adaptive only): update fill rate
-        // NOTE: SEP indicates doing bookkeeping before asking if we should retry. We need to know if
+        // NOTE: the retry spec indicates doing bookkeeping before asking if we should retry. We need to know if
         // the error was a throttling error though to do adaptive retry bookkeeping so we take
         // advantage of that information being available via the classifier result
         let error_kind = error_kind(&classifier_result);
@@ -336,7 +336,20 @@ fn check_rate_limiter_for_delay(
     kind: ErrorKind,
 ) -> Option<Duration> {
     if let Some(crl) = StandardRetryStrategy::adaptive_retry_rate_limiter(runtime_components, cfg) {
-        let retry_reason = if kind == ErrorKind::ThrottlingError {
+        // Retry Behavior 2.1: the adaptive client-side rate limiter is a
+        // requests-per-second limiter, so per the spec it charges a uniform
+        // 1 token per send attempt (same as an initial request). The legacy
+        // 5/10-token retry costs, charged against a cold-start capacity
+        // floored at MIN_CAPACITY (1.0), deadlocked retries and starved
+        // throughput. Scope this to V2.1 so pre-2.1 adaptive behavior is
+        // unchanged.
+        let is_v2_1 = cfg
+            .load::<RetryConfig>()
+            .and_then(|rc| rc.retry_spec())
+            .is_some_and(|s| s.is_at_least(RetrySpec::V2_1));
+        let retry_reason = if is_v2_1 {
+            RequestReason::InitialRequest
+        } else if kind == ErrorKind::ThrottlingError {
             RequestReason::RetryTimeout
         } else {
             RequestReason::Retry


### PR DESCRIPTION
## Motivation and Context
Internal testing surfaced several retry bugs that diverged from the Retry Behavior 2.1 specification. This PR collects a set of retry-behavior correctness fixes — one specific to 2.1 adaptive rate limiting, and others addressing latent bugs in the original retry implementation.

## Description
The PR includes three independent retry-behavior fixes:
1. **Acquire the adaptive send token per send under v2.1.** ([commit](https://github.com/smithy-lang/smithy-rs/pull/4749/commits/a0ba816194171ae3dee4192484b44c9d5331235f), [commit](https://github.com/smithy-lang/smithy-rs/pull/4749/commits/f6ee0055d162496d375b7a9d475fa29d5c1e86b3))
Under Retry Behavior 2.1, every send (initial and each retry) now acquires one send token (`GetSendToken`) in the orchestrator's attempt loop. Previously a retry computed a rate-limiter delay but sent without acquiring, so it never paid the token. Scoped to v2.1; pre-2.1 unchanged.

2. **Honor `x-amz-retry-after` on bare 5xx.** ([commit](https://github.com/smithy-lang/smithy-rs/pull/4749/commits/e444f4f904b3f7ee283786eb123a62abb7a1072b))
Adds `ClassifyRetry::classify_retry_v2`, which additionally receives the `RetryAction` accumulated by earlier-running classifiers. Passing each classifier the prior classification result was originally designed in [the retry classifier customization RFC](https://smithy-lang.github.io/smithy-rs/design/rfcs/rfc0038_retry_classifier_customization.html#the-retryclassifier-trait) but was never actually implemented. `run_classifiers_on_ctx` now threads that verdict through so `AwsErrorCodeClassifier` can attach the server-directed `x-amz-retry-after` delay to a response already classified retryable purely by HTTP status (e.g. a bare 500 from `HttpStatusCodeClassifier`, which cannot read this AWS-specific header). `classify_retry_v2` has a default delegating to `classify_retry`, making this an additive, non-breaking change.

3. **Retry `IDPCommunicationError` on all STS operations.** ([commit](https://github.com/smithy-lang/smithy-rs/pull/4749/commits/17527b99d96e2508f2268b9429e341906ebd9ad4))
`STSDecorator` now registers an `AwsErrorCodeClassifier` treating `IDPCommunicationError` as transient for every STS operation, not just those modeling `IDPCommunicationErrorException`.

## Testing
- Updated the DynamoDB adaptive client-rate-limiting integration test for the 1-token cost.
- Unit tests for `classify_retry_v2` across `aws-runtime`, `aws-smithy-runtime-api`, and `aws-smithy-runtime` (delay attachment, `kind` preservation, error-code precedence, no fabricated retries, header fallback, default delegation, and `run_classifiers_on_ctx` threading).
- End-to-end STS integration test (`retry_idp_comms_err.rs`) proving `IDPCommunicationError` is retried on `GetCallerIdentity` (which does not model `IDPCommunicationErrorException`), with a non-retryable control.
-  Adaptive rate limiter: new `client_rate_limiter` unit test that a sub-nanosecond required wait grants (no re-acquire spin) and keeps capacity ≥ 0; the DynamoDB adaptive-throttling integration test would hang due to `0ns` re-acquire spin.
- The internal tests that originally surfaced these retry bugs now pass.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
