### PR TITLE
feat(client): Add `pool_max_idle_per_host` setter to HTTP client builders

### DIFF
--- a/.changelog/add-pool-max-idle-per-host-setter.md
+++ b/.changelog/add-pool-max-idle-per-host-setter.md
@@ -1,0 +1,11 @@
+---
+applies_to: ["client", "aws-sdk-rust"]
+authors: ["jasgin"]
+references: []
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add `pool_max_idle_per_host` setter to HTTP client `Builder` and `ConnectorBuilder`,
+exposing hyper's `pool_max_idle_per_host` setting to control the maximum number of idle
+connections kept alive per host.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.2.0"
+version = "1.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.3.0"
+version = "1.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -111,6 +111,7 @@ pub struct ConnectorBuilder<Tls = TlsUnset> {
     sleep_impl: Option<SharedAsyncSleep>,
     client_builder: Option<hyper_util::client::legacy::Builder>,
     pool_idle_timeout: Option<Option<Duration>>,
+    pool_max_idle_per_host: Option<usize>,
     enable_tcp_nodelay: bool,
     interface: Option<String>,
     proxy_config: Option<proxy::ProxyConfig>,
@@ -125,6 +126,7 @@ impl<Tls: Default> Default for ConnectorBuilder<Tls> {
             sleep_impl: None,
             client_builder: None,
             pool_idle_timeout: None,
+            pool_max_idle_per_host: None,
             // Curated default: TCP_NODELAY on. Without it, Nagle's algorithm
             // can hold a small write while earlier data is unacknowledged. On
             // request shapes emitted as multiple sub-MSS writes, this can add
@@ -163,6 +165,7 @@ impl ConnectorBuilder<TlsUnset> {
             interface: self.interface,
             proxy_config: self.proxy_config,
             pool_idle_timeout: self.pool_idle_timeout,
+            pool_max_idle_per_host: self.pool_max_idle_per_host,
             tls: TlsProviderSelected {
                 provider,
                 context: TlsContext::default(),
@@ -212,9 +215,9 @@ impl<Any> ConnectorBuilder<Any> {
         C::Future: Unpin + Send + 'static,
         C::Error: Into<BoxError>,
     {
-        let client_builder = self
-            .client_builder
-            .unwrap_or_else(|| new_tokio_hyper_builder(self.pool_idle_timeout));
+        let client_builder = self.client_builder.unwrap_or_else(|| {
+            new_tokio_hyper_builder(self.pool_idle_timeout, self.pool_max_idle_per_host)
+        });
         let sleep_impl = self.sleep_impl.or_else(default_async_sleep);
         let (connect_timeout, read_timeout) = self
             .connector_settings
@@ -428,6 +431,41 @@ impl<Any> ConnectorBuilder<Any> {
         self
     }
 
+    /// Sets the maximum number of idle pooled connections allowed per host.
+    ///
+    /// Default is determined by the underlying hyper client, which is currently no limit
+    /// (`usize::MAX`) - see [hyper_util::client::legacy::Builder::pool_max_idle_per_host].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "rustls-aws-lc")]
+    /// # {
+    /// use aws_smithy_http_client::{Connector, tls};
+    ///
+    /// let connector = Connector::builder()
+    ///     .pool_max_idle_per_host(70)
+    ///     .tls_provider(tls::Provider::Rustls(tls::rustls_provider::CryptoMode::AwsLc))
+    ///     .build();
+    /// # }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn pool_max_idle_per_host(mut self, val: usize) -> Self {
+        self.pool_max_idle_per_host = Some(val);
+        self
+    }
+
+    /// Sets the maximum number of idle pooled connections allowed per host.
+    ///
+    /// Pass `None` to use the hyper default (currently no limit, `usize::MAX`) - see
+    /// [hyper_util::client::legacy::Builder::pool_max_idle_per_host].
+    ///
+    /// This is the mutable version of [`pool_max_idle_per_host`](Self::pool_max_idle_per_host).
+    pub fn set_pool_max_idle_per_host(&mut self, val: Option<usize>) -> &mut Self {
+        self.pool_max_idle_per_host = val;
+        self
+    }
+
     /// Override the Hyper client [`Builder`](hyper_util::client::legacy::Builder) used to construct this client.
     ///
     /// This enables changing settings like forcing HTTP2 and modifying other default client behavior.
@@ -498,6 +536,7 @@ fn extract_smithy_connection(capture_conn: &CaptureConnection) -> Option<Connect
 
 fn new_tokio_hyper_builder(
     pool_idle_timeout: Option<Option<Duration>>,
+    pool_max_idle_per_host: Option<usize>,
 ) -> hyper_util::client::legacy::Builder {
     let mut builder = hyper_util::client::legacy::Builder::new(TokioExecutor::new());
     // Explicitly setting the pool_timer is required for connection timeouts to work.
@@ -505,6 +544,10 @@ fn new_tokio_hyper_builder(
 
     if let Some(pool_idle_timeout) = pool_idle_timeout {
         builder.pool_idle_timeout(pool_idle_timeout);
+    }
+
+    if let Some(max_idle) = pool_max_idle_per_host {
+        builder.pool_max_idle_per_host(max_idle);
     }
 
     builder
@@ -762,6 +805,7 @@ where
 pub struct Builder<Tls = TlsUnset> {
     client_builder: Option<hyper_util::client::legacy::Builder>,
     pool_idle_timeout: Option<Option<Duration>>,
+    pool_max_idle_per_host: Option<usize>,
     #[allow(unused)]
     tls_provider: Tls,
 }
@@ -843,6 +887,7 @@ cfg_tls! {
             build_with_conn_fn(
                 self.client_builder,
                 self.pool_idle_timeout,
+                self.pool_max_idle_per_host,
                 move |client_builder, settings, runtime_components| {
                     let builder = new_conn_builder(client_builder, settings, runtime_components)
                         .tls_provider(self.tls_provider.provider.clone())
@@ -860,6 +905,7 @@ cfg_tls! {
             build_with_conn_fn(
                 self.client_builder,
                 self.pool_idle_timeout,
+                self.pool_max_idle_per_host,
                 move |client_builder, settings, runtime_components| {
                     let builder = new_conn_builder(client_builder, settings, runtime_components)
                         .tls_provider(self.tls_provider.provider.clone())
@@ -935,6 +981,41 @@ impl<Any> Builder<Any> {
         self.pool_idle_timeout = val;
         self
     }
+
+    /// Sets the maximum number of idle pooled connections allowed per host.
+    ///
+    /// Default is determined by the underlying hyper client, which is currently no limit
+    /// (`usize::MAX`) - see [hyper_util::client::legacy::Builder::pool_max_idle_per_host].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "rustls-aws-lc")]
+    /// # {
+    /// use aws_smithy_http_client::{Builder, tls};
+    ///
+    /// let client = Builder::new()
+    ///     .pool_max_idle_per_host(70)
+    ///     .tls_provider(tls::Provider::Rustls(tls::rustls_provider::CryptoMode::AwsLc))
+    ///     .build_https();
+    /// # }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn pool_max_idle_per_host(mut self, val: usize) -> Self {
+        self.pool_max_idle_per_host = Some(val);
+        self
+    }
+
+    /// Sets the maximum number of idle pooled connections allowed per host.
+    ///
+    /// Pass `None` to use the hyper default (currently no limit, `usize::MAX`) - see
+    /// [hyper_util::client::legacy::Builder::pool_max_idle_per_host].
+    ///
+    /// This is the mutable version of [`pool_max_idle_per_host`](Self::pool_max_idle_per_host).
+    pub fn set_pool_max_idle_per_host(&mut self, val: Option<usize>) -> &mut Self {
+        self.pool_max_idle_per_host = val;
+        self
+    }
 }
 
 impl Builder<TlsUnset> {
@@ -955,6 +1036,7 @@ impl Builder<TlsUnset> {
         build_with_conn_fn(
             self.client_builder,
             self.pool_idle_timeout,
+            self.pool_max_idle_per_host,
             move |_builder, settings, runtime_components| {
                 connector_fn(settings, runtime_components)
             },
@@ -967,6 +1049,7 @@ impl Builder<TlsUnset> {
         build_with_conn_fn(
             self.client_builder,
             self.pool_idle_timeout,
+            self.pool_max_idle_per_host,
             move |client_builder, settings, runtime_components| {
                 let builder = new_conn_builder(client_builder, settings, runtime_components);
                 builder.build_http()
@@ -979,6 +1062,7 @@ impl Builder<TlsUnset> {
         Builder {
             client_builder: self.client_builder,
             pool_idle_timeout: self.pool_idle_timeout,
+            pool_max_idle_per_host: self.pool_max_idle_per_host,
             tls_provider: TlsProviderSelected {
                 provider,
                 context: TlsContext::default(),
@@ -990,6 +1074,7 @@ impl Builder<TlsUnset> {
 pub(crate) fn build_with_conn_fn<F>(
     client_builder: Option<hyper_util::client::legacy::Builder>,
     pool_idle_timeout: Option<Option<Duration>>,
+    pool_max_idle_per_host: Option<usize>,
     connector_fn: F,
 ) -> SharedHttpClient
 where
@@ -1002,8 +1087,8 @@ where
         + Sync
         + 'static,
 {
-    let client_builder =
-        client_builder.unwrap_or_else(|| new_tokio_hyper_builder(pool_idle_timeout));
+    let client_builder = client_builder
+        .unwrap_or_else(|| new_tokio_hyper_builder(pool_idle_timeout, pool_max_idle_per_host));
     SharedHttpClient::new(HyperClient {
         connector_cache: RwLock::new(HashMap::new()),
         client_builder,
@@ -1015,6 +1100,7 @@ where
 pub(crate) fn build_with_tcp_conn_fn<C, F>(
     client_builder: Option<hyper_util::client::legacy::Builder>,
     pool_idle_timeout: Option<Option<Duration>>,
+    pool_max_idle_per_host: Option<usize>,
     tcp_connector_fn: F,
 ) -> SharedHttpClient
 where
@@ -1029,6 +1115,7 @@ where
     build_with_conn_fn(
         client_builder,
         pool_idle_timeout,
+        pool_max_idle_per_host,
         move |client_builder, settings, runtime_components| {
             let builder = new_conn_builder(client_builder, settings, runtime_components);
             builder.wrap_connector(tcp_connector_fn())
@@ -1072,7 +1159,7 @@ mod test {
     async fn connector_selection() {
         // Create a client that increments a count every time it creates a new Connector
         let creation_count = Arc::new(AtomicU32::new(0));
-        let http_client = build_with_tcp_conn_fn(None, None, {
+        let http_client = build_with_tcp_conn_fn(None, None, None, {
             let count = creation_count.clone();
             move || {
                 count.fetch_add(1, Ordering::Relaxed);

--- a/rust-runtime/aws-smithy-http-client/src/test_util/never.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/never.rs
@@ -131,7 +131,7 @@ mod hyper1_support {
         /// Convert this connector into a usable HTTP client for testing
         #[doc(hidden)]
         pub fn into_client(self) -> SharedHttpClient {
-            crate::client::build_with_tcp_conn_fn(None, None, NeverTcpConnector::new)
+            crate::client::build_with_tcp_conn_fn(None, None, None, NeverTcpConnector::new)
         }
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/test_util/wire.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/wire.rs
@@ -335,7 +335,7 @@ impl WireMockServer {
     /// **Note**: This must be used in tandem with [`Self::dns_resolver`]
     pub fn http_client(&self) -> SharedHttpClient {
         let resolver = self.dns_resolver();
-        crate::client::build_with_tcp_conn_fn(None, None, move || {
+        crate::client::build_with_tcp_conn_fn(None, None, None, move || {
             hyper_util::client::legacy::connect::HttpConnector::new_with_resolver(
                 resolver.clone().0,
             )


### PR DESCRIPTION
https://github.com/smithy-lang/smithy-rs/issues/4759

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Expose hyper's pool_max_idle_per_host setting on both ConnectorBuilder and Builder, allowing users to limit the number of idle connections kept alive per host. This unblocks migrations from the legacy client.

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
