### PR TITLE
Store Blob contents in Bytes

### DIFF
--- a/.changelog/4758.md
+++ b/.changelog/4758.md
@@ -1,0 +1,14 @@
+---
+applies_to:
+- client
+- server
+- aws-sdk-rust
+authors:
+- rcoh
+references:
+- smithy-rs#4758
+breaking: false
+new_feature: true
+bug_fix: false
+---
+`Blob` now stores its contents as `Bytes` and provides `from_maybe_shared` and `into_bytes` methods to avoid copies in `Bytes`-based protocol paths.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "a615d37cd9b566efa38233b081038602e92f5b54c87f270b7f5922f6e33c6b4d"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-schema 0.1.0",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.6.1",
  "minicbor",
  "num-bigint",
 ]
@@ -379,7 +379,7 @@ version = "0.62.0"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "criterion",
  "minicbor",
  "num-bigint",
@@ -390,7 +390,7 @@ name = "aws-smithy-checksums"
 version = "0.65.0"
 dependencies = [
  "aws-smithy-http 0.64.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
  "crc-fast",
@@ -413,7 +413,7 @@ name = "aws-smithy-compression"
 version = "0.2.0"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
  "flate2",
@@ -439,10 +439,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 dependencies = [
  "arbitrary",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
  "crc32fast",
@@ -463,7 +463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.6.1",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -484,7 +484,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -508,7 +508,7 @@ dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "base64 0.22.1",
  "bytes",
  "h2 0.3.27",
@@ -552,7 +552,7 @@ dependencies = [
  "aws-smithy-http 0.62.6",
  "aws-smithy-json 0.61.9",
  "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.6.1",
  "aws-smithy-xml 0.60.15",
  "bytes",
  "futures-util",
@@ -580,7 +580,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "bytes",
  "futures-util",
@@ -647,7 +647,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http-server",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "bytes",
  "futures",
@@ -685,7 +685,7 @@ version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
 dependencies = [
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.6.1",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ version = "0.63.0"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "proptest",
  "serde_json",
 ]
@@ -707,7 +707,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.64.0",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -732,7 +732,7 @@ dependencies = [
  "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "bytes",
  "futures-util",
@@ -762,7 +762,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "http 1.4.2",
  "tokio",
 ]
@@ -814,7 +814,7 @@ version = "0.62.0"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "criterion",
  "urlencoding",
@@ -831,7 +831,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "fastrand 2.5.0",
  "futures-util",
@@ -856,7 +856,7 @@ version = "1.14.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-runtime-api-macros 1.1.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "bytes",
  "http 0.2.12",
  "http 1.4.2",
@@ -875,7 +875,7 @@ checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-smithy-runtime-api-macros 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.6.1",
  "bytes",
  "http 0.2.12",
  "http 1.4.2",
@@ -911,7 +911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aws-smithy-types 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-types 1.6.1",
  "http 1.4.2",
 ]
 
@@ -920,13 +920,40 @@ name = "aws-smithy-schema"
 version = "0.2.0"
 dependencies = [
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "http 1.4.2",
 ]
 
 [[package]]
 name = "aws-smithy-types"
 version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 0.14.32",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.2"
 dependencies = [
  "base64 0.13.1",
  "base64-simd",
@@ -959,38 +986,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.1.0",
- "http-body-util",
- "hyper 0.14.32",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "aws-smithy-types-convert"
 version = "0.61.1"
 dependencies = [
  "aws-smithy-async 1.3.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "chrono",
  "futures-core",
  "time",
@@ -1002,7 +1002,7 @@ version = "0.2.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-runtime-api 1.14.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "http-body-util",
  "sync_wrapper",
  "wstd",
@@ -1024,7 +1024,7 @@ dependencies = [
  "aws-smithy-protocol-test",
  "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "base64 0.13.1",
  "proptest",
  "xmlparser",
@@ -2512,7 +2512,7 @@ dependencies = [
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.2.0",
- "aws-smithy-types 1.6.1",
+ "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "bytes",
  "fastrand 2.5.0",

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Event stream logic for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-eventstream/src/smithy.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/smithy.rs
@@ -32,7 +32,7 @@ expect_shape_fn!(fn expect_byte[Byte] -> i8 { value -> *value });
 expect_shape_fn!(fn expect_int16[Int16] -> i16 { value -> *value });
 expect_shape_fn!(fn expect_int32[Int32] -> i32 { value -> *value });
 expect_shape_fn!(fn expect_int64[Int64] -> i64 { value -> *value });
-expect_shape_fn!(fn expect_byte_array[ByteArray] -> Blob { bytes -> Blob::new(bytes.as_ref()) });
+expect_shape_fn!(fn expect_byte_array[ByteArray] -> Blob { bytes -> Blob::from_maybe_shared(bytes.clone()) });
 expect_shape_fn!(fn expect_string[String] -> String { value -> value.as_str().into() });
 expect_shape_fn!(fn expect_timestamp[Timestamp] -> DateTime { value -> *value });
 

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/rust-runtime/aws-smithy-types/src/blob.rs
+++ b/rust-runtime/aws-smithy-types/src/blob.rs
@@ -3,25 +3,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use bytes::Bytes;
+use std::any::Any;
+
 /// Binary Blob Type
 ///
 /// Blobs represent protocol-agnostic binary content.
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct Blob {
-    inner: Vec<u8>,
+    inner: Bytes,
 }
 
 impl Blob {
     /// Creates a new blob from the given `input`.
     pub fn new<T: Into<Vec<u8>>>(input: T) -> Self {
         Blob {
-            inner: input.into(),
+            inner: input.into().into(),
         }
+    }
+
+    /// Creates a new blob, reusing an existing shared allocation when possible.
+    pub fn from_maybe_shared<T: AsRef<[u8]> + 'static>(input: T) -> Self {
+        let mut input = Some(input);
+        let inner =
+            if let Some(bytes) = (&mut input as &mut dyn Any).downcast_mut::<Option<Bytes>>() {
+                bytes.take().expect("input is present")
+            } else {
+                Bytes::copy_from_slice(input.as_ref().expect("input is present").as_ref())
+            };
+        Blob { inner }
+    }
+
+    /// Consumes the `Blob` and returns its contents as `Bytes`.
+    pub fn into_bytes(self) -> Bytes {
+        self.inner
     }
 
     /// Consumes the `Blob` and returns a `Vec<u8>` with its contents.
     pub fn into_inner(self) -> Vec<u8> {
-        self.inner
+        self.inner.into()
     }
 }
 
@@ -85,7 +105,7 @@ mod serde_deserialize {
             E: serde::de::Error,
         {
             match crate::base64::decode(v) {
-                Ok(inner) => Ok(Blob { inner }),
+                Ok(inner) => Ok(Blob::from(inner)),
                 Err(e) => Err(E::custom(e)),
             }
         }
@@ -102,7 +122,7 @@ mod serde_deserialize {
         where
             E: serde::de::Error,
         {
-            Ok(Blob { inner: v })
+            Ok(Blob::from(v))
         }
     }
 
@@ -123,6 +143,7 @@ mod serde_deserialize {
 #[cfg(test)]
 mod test {
     use crate::Blob;
+    use bytes::Bytes;
 
     #[test]
     fn blob_conversion() {
@@ -137,6 +158,25 @@ mod test {
         let blob2: Blob = my_vec.into();
         let vec2: Vec<u8> = blob2.into();
         assert_eq!(orig_vec, vec2);
+    }
+
+    #[test]
+    fn blob_reuses_bytes() {
+        let bytes = Bytes::from_static(b"some shared bytes");
+        let original_ptr = bytes.as_ptr();
+
+        let blob = Blob::from_maybe_shared(bytes);
+        let bytes = blob.into_bytes();
+
+        assert_eq!(original_ptr, bytes.as_ptr());
+    }
+
+    #[test]
+    fn blob_new_accepts_borrowed_data() {
+        let bytes = vec![1, 2, 3];
+        let blob = Blob::new(bytes.as_slice());
+
+        assert_eq!(bytes, blob.as_ref());
     }
 }
 
@@ -160,7 +200,7 @@ mod test_serde {
         let aws_in_base64 = r#"{"blob":"QVdT"}"#;
         let for_test = ForTest {
             blob: Blob {
-                inner: vec![b'A', b'W', b'S'],
+                inner: vec![b'A', b'W', b'S'].into(),
             },
         };
         assert_eq!(for_test, serde_json::from_str(aws_in_base64).unwrap());
@@ -174,7 +214,7 @@ mod test_serde {
 
         let for_test = ForTest {
             blob: Blob {
-                inner: vec![b'A', b'W', b'S'],
+                inner: vec![b'A', b'W', b'S'].into(),
             },
         };
         let mut buf = vec![];


### PR DESCRIPTION
## Motivation and Context

Smithy protocol paths commonly carry binary payloads as `bytes::Bytes`, but `Blob` stored a `Vec<u8>`. Moving data between those types introduced avoidable copies and allocation conversions.

## Description

- Store `Blob` contents internally as `Bytes` while preserving the existing `Blob::new<T: Into<Vec<u8>>>` and `into_inner() -> Vec<u8>` APIs.
- Add `Blob::from_maybe_shared<T: AsRef<[u8]> + 'static>`, which downcasts and reuses an incoming `Bytes` allocation without naming `Bytes` in the constructor signature.
- Add `Blob::into_bytes()` for consumers that can retain the shared representation.
- Use the shared representation when converting event-stream byte arrays into blobs.

## Testing

- `RUSTFLAGS='--cfg aws_sdk_unstable' cargo test -p aws-smithy-types --all-features`
- `cargo test -p aws-smithy-eventstream`
- `cargo check --workspace --all-targets` in `rust-runtime`
- `cargo clippy --workspace --all-targets -- -D warnings` in `rust-runtime`
- `cargo fmt --all -- --check`

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._