### PR TITLE
Use Bytes directly in Blob codegen paths

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -451,7 +451,7 @@ class RequestSerializerGenerator(
                 val memberName = symbolProvider.toMemberName(httpPayloadMember!!)
                 val bodyExpr =
                     when {
-                        isBlobPayload -> "payload.into_inner()"
+                        isBlobPayload -> "payload.into_bytes()"
                         isEnumPayload -> "payload.as_str().as_bytes().to_vec()"
                         else -> "payload.into_bytes()"
                     }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/RestJsonTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/RestJsonTest.kt
@@ -7,7 +7,11 @@ package software.amazon.smithy.rust.codegen.client.smithy.protocols
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.testModule
+import software.amazon.smithy.rust.codegen.core.testutil.tokioTest
 import kotlin.io.path.readText
 
 internal class RestJsonTest {
@@ -77,6 +81,30 @@ internal class RestJsonTest {
         }
         """.asSmithyModel()
 
+    private val blobPayloadModel =
+        """
+        ${'$'}version: "2"
+        namespace test
+
+        use aws.protocols#restJson1
+
+        @restJson1
+        service BlobPayloadService {
+            version: "2019-12-16",
+            operations: [PutBlob]
+        }
+
+        @http(uri: "/blob", method: "POST")
+        operation PutBlob {
+            input: PutBlobInput
+        }
+
+        structure PutBlobInput {
+            @httpPayload
+            data: Blob
+        }
+        """.asSmithyModel()
+
     @Test
     fun `generate a rest json service that compiles`() {
         val testDir = clientIntegrationTest(model) { _, _ -> }
@@ -94,5 +122,41 @@ internal class RestJsonTest {
         // even for empty structs, so no underscore prefix is needed.
         // This test passes without any code changes, proving RestJson immunity.
         clientIntegrationTest(inputUnionWithEmptyStructure) { _, _ -> }
+    }
+
+    @Test
+    fun `blob payload serialization reuses Bytes allocation`() {
+        clientIntegrationTest(blobPayloadModel) { context, rustCrate ->
+            rustCrate.testModule {
+                tokioTest("blob_payload_reuses_bytes") {
+                    rustTemplate(
+                        """
+                        let payload = ::bytes::Bytes::from_static(b"hello, world!");
+                        let payload_ptr = payload.as_ptr();
+                        let (http_client, rx) = #{capture_request}(#{None});
+                        let config = crate::Config::builder()
+                            .http_client(http_client)
+                            .endpoint_url("http://localhost:1234")
+                            .behavior_version_latest()
+                            .build();
+                        let client = crate::Client::from_conf(config);
+
+                        let _ = client
+                            .put_blob()
+                            .data(::aws_smithy_types::Blob::from_maybe_shared(payload))
+                            .send()
+                            .await;
+
+                        let request = rx.expect_request();
+                        let body = request.body().bytes().expect("in-memory request body");
+                        assert_eq!(b"hello, world!", body);
+                        assert_eq!(payload_ptr, body.as_ptr());
+                        """,
+                        *RuntimeType.preludeScope,
+                        "capture_request" to RuntimeType.captureRequest(context.runtimeConfig),
+                    )
+                }
+            }
+        }
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/HttpBoundProtocolPayloadGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/HttpBoundProtocolPayloadGenerator.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
@@ -66,6 +67,8 @@ class HttpBoundProtocolPayloadGenerator(
     private val smithyEventStream = RuntimeType.smithyEventStream(runtimeConfig)
     private val codegenScope =
         arrayOf(
+            "Blob" to RuntimeType.blob(runtimeConfig),
+            "Bytes" to RuntimeType.Bytes,
             "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
             "BuildError" to runtimeConfig.operationBuildError(),
             "SmithyHttp" to RuntimeType.smithyHttp(runtimeConfig),
@@ -308,11 +311,12 @@ class HttpBoundProtocolPayloadGenerator(
         val ref = if (payloadMetadata.takesOwnership) "" else "&"
         val serializer =
             protocolFunctions.serializeFn(member, fnNameSuffix = "http_payload") { fnName ->
+                val targetShape = model.expectShape(member.target)
                 val outputT =
-                    if (member.isStreaming(model)) {
-                        symbolProvider.toSymbol(member)
-                    } else {
-                        RuntimeType.ByteSlab.toSymbol()
+                    when {
+                        member.isStreaming(model) -> symbolProvider.toSymbol(member)
+                        targetShape is BlobShape -> RuntimeType.Bytes.toSymbol()
+                        else -> RuntimeType.ByteSlab.toSymbol()
                     }
                 rustBlockTemplate(
                     "pub fn $fnName(payload: $ref#{Member}) -> #{Result}<#{outputT}, #{BuildError}>",
@@ -332,9 +336,12 @@ class HttpBoundProtocolPayloadGenerator(
                             ")};",
                             *codegenScope,
                         ) {
-                            when (val targetShape = model.expectShape(member.target)) {
+                            when (targetShape) {
+                                // Return empty bytes.
+                                is BlobShape -> rustTemplate("#{Bytes}::new()", *codegenScope)
+
                                 // Return an empty `Vec<u8>`.
-                                is StringShape, is BlobShape, is DocumentShape ->
+                                is StringShape, is DocumentShape ->
                                     rust(
                                         """
                                         Vec::new()
@@ -379,8 +386,8 @@ class HttpBoundProtocolPayloadGenerator(
                     // Return the `ByteStream`.
                     rust(payloadName)
                 } else {
-                    // Convert the `Blob` into a `Vec<u8>` and return it.
-                    rust("$payloadName.into_inner()")
+                    // Convert the `Blob` into `Bytes` and return it.
+                    rustTemplate("#{Blob}::from($payloadName).into_bytes()", *codegenScope)
                 }
             }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
@@ -355,7 +355,7 @@ class EventStreamUnmarshallerGenerator(
             conditionalBlock("Some(", ")", member.isOptional) {
                 when (target) {
                     is BlobShape -> {
-                        rustTemplate("#{Blob}::new(message.payload().as_ref())", *codegenScope)
+                        rustTemplate("#{Blob}::from_maybe_shared(message.payload().clone())", *codegenScope)
                     }
 
                     is StringShape -> {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamErrorMarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamErrorMarshallerGenerator.kt
@@ -58,6 +58,7 @@ class EventStreamErrorMarshallerGenerator(
     private val errorsShape = unionShape.expectTrait<SyntheticEventStreamUnionTrait>()
     private val codegenScope =
         arrayOf(
+            "Bytes" to RuntimeType.Bytes,
             "MarshallMessage" to smithyEventStream.resolve("frame::MarshallMessage"),
             "Message" to smithyTypes.resolve("event_stream::Message"),
             "Header" to smithyTypes.resolve("event_stream::Header"),
@@ -129,7 +130,7 @@ class EventStreamErrorMarshallerGenerator(
                 rust("let mut headers = Vec::new();")
                 addStringHeader(":message-type", """"exception".into()""")
                 if (errorsShape.errorMembers.isEmpty()) {
-                    rust("let payload = Vec::new();")
+                    rustTemplate("let payload = #{Bytes}::new();", *codegenScope)
                 } else {
                     rustBlock("let payload = match _input") {
                         errorsShape.errorMembers.forEach { error ->
@@ -179,7 +180,7 @@ class EventStreamErrorMarshallerGenerator(
             val serializerFn = serializerGenerator.serverErrorSerializer(unionMember.target.toShapeId())
             renderMarshallEventPayload("inner", unionMember, eventStruct, serializerFn)
         } else {
-            rust("Vec::new()")
+            rustTemplate("#{Bytes}::new()", *codegenScope)
         }
     }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
@@ -64,6 +64,7 @@ open class EventStreamMarshallerGenerator(
     private val codegenScope =
         arrayOf(
             *preludeScope,
+            "Blob" to RuntimeType.blob(runtimeConfig),
             "Bytes" to RuntimeType.Bytes,
             "MarshallMessage" to smithyEventStream.resolve("frame::MarshallMessage"),
             "Message" to smithyTypes.resolve("event_stream::Message"),
@@ -248,7 +249,7 @@ open class EventStreamMarshallerGenerator(
                 }
             renderMarshallEventPayload(inner, unionMember, eventStruct, serializerFn)
         } else {
-            rust("Vec::new()")
+            rustTemplate("#{Bytes}::new()", *codegenScope)
         }
     }
 
@@ -291,7 +292,7 @@ open class EventStreamMarshallerGenerator(
             is ShortShape -> "Int16($inputName)"
             is IntegerShape -> "Int32($inputName)"
             is LongShape -> "Int64($inputName)"
-            is BlobShape -> "ByteArray($inputName.into_inner().into())"
+            is BlobShape -> "ByteArray(#{Blob}::from($inputName).into_bytes())"
             is EnumShape -> "String($inputName.to_string().into())"
             is StringShape -> "String($inputName.into())"
             is TimestampShape -> "Timestamp($inputName.into())"
@@ -306,21 +307,25 @@ open class EventStreamMarshallerGenerator(
     ) {
         val optional = symbolProvider.toSymbol(member).isOptional()
         if (target is BlobShape || target is StringShape) {
-            data class PayloadContext(val conversionFn: String, val contentType: String)
-
-            val ctx =
+            val contentType =
                 when (target) {
-                    is BlobShape -> PayloadContext("into_inner", "application/octet-stream")
-                    is StringShape -> PayloadContext("into_bytes", "text/plain")
+                    is BlobShape -> "application/octet-stream"
+                    is StringShape -> "text/plain"
                     else -> throw IllegalStateException("unreachable")
                 }
-            addStringHeader(":content-type", "${ctx.contentType.dq()}.into()")
+            addStringHeader(":content-type", "${contentType.dq()}.into()")
             handleOptional(
                 optional,
                 inputExpr,
                 "inner_payload",
-                { input -> rust("$input.${ctx.conversionFn}()") },
-                { rust("Vec::new()") },
+                { input ->
+                    when (target) {
+                        is BlobShape -> rustTemplate("#{Blob}::from($input).into_bytes()", *codegenScope)
+                        is StringShape -> rustTemplate("#{Bytes}::from($input.into_bytes())", *codegenScope)
+                        else -> throw IllegalStateException("unreachable")
+                    }
+                },
+                { rustTemplate("#{Bytes}::new()", *codegenScope) },
             )
         } else {
             addStringHeader(":content-type", "${payloadContentType.dq()}.into()")
@@ -340,7 +345,7 @@ open class EventStreamMarshallerGenerator(
                                 let mut ser = codec.create_serializer();
                                 #{ShapeSerializer}::write_struct(&mut *ser, #{Target}::SCHEMA, &$input)
                                     .map_err(|err| #{Error}::marshalling(format!("{err}")))?;
-                                #{PayloadSerializer}::finish_boxed(ser)
+                                #{Bytes}::from(#{PayloadSerializer}::finish_boxed(ser))
                             }
                             """,
                             "Target" to targetSymbol,
@@ -360,8 +365,10 @@ open class EventStreamMarshallerGenerator(
                 { input ->
                     rustTemplate(
                         """
-                        #{serializerFn}(&$input)
-                            .map_err(|err| #{Error}::marshalling(format!("{err}")))?
+                        #{Bytes}::from(
+                            #{serializerFn}(&$input)
+                                .map_err(|err| #{Error}::marshalling(format!("{err}")))?
+                        )
                         """,
                         "serializerFn" to serializerFn,
                         *codegenScope,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/EventStreamMarshallTestCases.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/EventStreamMarshallTestCases.kt
@@ -63,6 +63,8 @@ object EventStreamMarshallTestCases {
         unitTest("message_with_blob") {
             rustTemplate(
                 """
+                let payload = ::bytes::Bytes::from_static(b"hello, world!");
+                let payload_ptr = payload.as_ptr();
                 let event = TestStream::MessageWithBlob(
                     MessageWithBlob::builder().data(#{BlobInput:W}).build()
                 );
@@ -74,8 +76,9 @@ object EventStreamMarshallTestCases {
                 assert_eq!(&str_header("MessageWithBlob"), *headers.get(":event-type").unwrap());
                 assert_eq!(&str_header("application/octet-stream"), *headers.get(":content-type").unwrap());
                 assert_eq!(&b"hello, world!"[..], message.payload());
+                assert_eq!(payload_ptr, message.payload().as_ptr());
                 """,
-                "BlobInput" to builderInput("Blob::new(&b\"hello, world!\"[..])"),
+                "BlobInput" to builderInput("Blob::from_maybe_shared(payload)"),
             )
         }
 
@@ -160,6 +163,8 @@ object EventStreamMarshallTestCases {
         unitTest("message_with_headers") {
             rustTemplate(
                 """
+                let blob = ::bytes::Bytes::from_static(b"test");
+                let blob_ptr = blob.as_ptr();
                 let event = TestStream::MessageWithHeaders(MessageWithHeaders::builder()
                     .blob(#{BlobInput})
                     .boolean(#{BooleanInput})
@@ -186,8 +191,11 @@ object EventStreamMarshallTestCases {
                     .add_header(Header::new("string", HeaderValue::String("test".into())))
                     .add_header(Header::new("timestamp", HeaderValue::Timestamp(DateTime::from_secs(5))));
                 assert_eq!(expected_message, actual_message);
+                let headers = headers_to_map(actual_message.headers());
+                let actual_blob = headers.get("blob").unwrap().as_byte_array().unwrap();
+                assert_eq!(blob_ptr, actual_blob.as_ptr());
                 """,
-                "BlobInput" to builderInput("Blob::new(&b\"test\"[..])"),
+                "BlobInput" to builderInput("Blob::from_maybe_shared(blob)"),
                 "BooleanInput" to builderInput("true"),
                 "ByteInput" to builderInput("55i8"),
                 "IntInput" to builderInput("100_000i32"),


### PR DESCRIPTION
## Summary
- generate `Blob::into_bytes()` for non-streaming HTTP payloads and event-stream blob values
- preserve shared event-stream payload storage with `Blob::from_maybe_shared`
- keep event-stream payloads as `Bytes` through marshalling instead of converting through `Vec<u8>`
- verify allocation reuse in generated HTTP and event-stream paths with pointer-identity tests

Follow-up to #4758.

## Public API
The generated changes are confined to `pub(crate) mod protocol_serde`, private `mod event_stream_serde`, and internal request serialization expressions. No exported generated types or signatures change.

I generated matching SDKs from merged `main` and this branch for S3, Transcribe Streaming, STS, SSO, SSO OIDC, and SignIn. The complete generated-tree diff changed exactly two files: the private `event_stream_serde.rs` modules in S3 and Transcribe Streaming. No model types, builders, client methods, manifests, or other public files changed.

The changelog entry merged in #4758 already covers these protocol-path optimizations.

## Testing
- `./gradlew --no-daemon ktlint codegen-core:check codegen-client:check codegen-server:check codegen-client-test:check codegen-server-test:check`
- `./gradlew --no-daemon ktlint codegen-client:test --tests software.amazon.smithy.rust.codegen.client.smithy.protocols.RestJsonTest --tests software.amazon.smithy.rust.codegen.client.smithy.protocols.eventstream.ClientEventStreamMarshallerGeneratorTest codegen-server:test --tests software.amazon.smithy.rust.codegen.server.smithy.protocols.eventstream.ServerEventStreamMarshallerGeneratorTest`
- baseline-vs-branch focused SDK generation and full generated-tree comparison for the six services listed above

The focused tests assert pointer identity for non-streaming HTTP blob payloads, event-stream blob payloads, and event-stream blob headers.