### PR TITLE
CI speedup

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -12,6 +12,14 @@ inputs:
   action-arguments:
     description: Arguments to pass to the action
     required: false
+  # A filesystem/cache-safe identifier for this leg, used for the artifact name and the Rust
+  # cache key. Defaults to `action`. Set this when several matrix legs share the same `action`
+  # but pass different `action-arguments` (e.g. partitioned check-aws-config), so they don't
+  # collide on one artifact name / cache key. Must contain no slashes or spaces.
+  label:
+    description: Unique slug for artifact name and cache key; defaults to action
+    required: false
+    default: ''
   use_cache:
     description: Whether to use the gradle cache
     type: boolean
@@ -34,7 +42,11 @@ runs:
        # Pinned to the commit hash of v2.7.3
   - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:
-      shared-key: ${{ runner.os }}-${{ github.job }}
+      # Include the action name so each matrix leg gets its own cache entry. Keying only on
+      # `github.job` made all legs of a matrix job (e.g. the 8 `test-sdk` legs, which compile
+      # different crate sets) contend for one write-once key, so most legs restored a stale or
+      # cold cache. Per-action keys give each leg its own warm target.
+      shared-key: ${{ runner.os }}-${{ github.job }}-${{ inputs.label != '' && inputs.label || inputs.action }}
       workspaces: |
         . smithy-rs-target
   - name: Download all artifacts
@@ -68,14 +80,16 @@ runs:
      # This runs the commands from the matrix strategy
   - name: Run ${{ inputs.action }}
     shell: bash
+    env:
+      ARTIFACT_LABEL: ${{ inputs.label != '' && inputs.label || inputs.action }}
     run: |
       ./smithy-rs/tools/ci-build/ci-action ${{ inputs.action }} ${{ inputs.action-arguments}}
-      tar cfz artifacts-${{ inputs.action }}.tar.gz -C artifacts .
+      tar cfz "artifacts-${ARTIFACT_LABEL}.tar.gz" -C artifacts .
   - name: Upload artifacts
     uses: actions/upload-artifact@v4
     with:
-      name: artifacts-${{ inputs.action }}
-      path: artifacts-${{ inputs.action }}.tar.gz
+      name: artifacts-${{ inputs.label != '' && inputs.label || inputs.action }}
+      path: artifacts-${{ inputs.label != '' && inputs.label || inputs.action }}.tar.gz
       if-no-files-found: error
       retention-days: 3
       overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
         - action: check-core-codegen-unit-tests
           runner: smithy_ubuntu-latest_8-core
         - action: check-rust-runtimes
+          action-arguments: rust-runtime
+          label: check-rust-runtimes-smithy
+          runner: smithy_ubuntu-latest_8-core
+          fetch-depth: 0
+        - action: check-rust-runtimes
+          action-arguments: aws/rust-runtime
+          label: check-rust-runtimes-aws
           runner: smithy_ubuntu-latest_8-core
           fetch-depth: 0
         - action: check-sdk-codegen-unit-tests
@@ -138,6 +145,8 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: ${{ matrix.test.action }}
+        action-arguments: ${{ matrix.test.action-arguments }}
+        label: ${{ matrix.test.label }}
 
   # Separate from the main checks above because it uses aws-sdk-rust from GitHub
   check-semver-hazards:
@@ -174,7 +183,29 @@ jobs:
       matrix:
         # These correspond to scripts in tools/ci-scripts that will be run in the Docker build image
         test:
+        # `check-aws-config` is split into a one-time `base` leg plus 4 parallel `featureset`
+        # legs that shard the expensive `cargo hack` feature-powersets via `--partition i/4`.
+        # The union runs exactly the same checks as the old single leg (see tools/ci-scripts/
+        # check-aws-config), but as 5 parallel legs instead of one ~28-minute serial job.
         - action: check-aws-config
+          action-arguments: base
+          label: check-aws-config-base
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 1/4
+          label: check-aws-config-featureset-1
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 2/4
+          label: check-aws-config-featureset-2
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 3/4
+          label: check-aws-config-featureset-3
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 4/4
+          label: check-aws-config-featureset-4
           runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-canary
           runner: smithy_ubuntu-latest_8-core
@@ -200,6 +231,8 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: ${{ matrix.test.action }}
+        action-arguments: ${{ matrix.test.action-arguments }}
+        label: ${{ matrix.test.label }}
 
   test-rust-windows:
     name: Rust Tests on Windows

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -8,53 +8,76 @@ C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
 set -eux
+
+# Selects which portion of the aws-config checks to run. Splitting the work lets CI run the
+# expensive `cargo hack` feature-powersets as several parallel matrix legs instead of one
+# ~28-minute serial job. The union of `base` + every `featureset <i/N>` runs exactly the same
+# commands as `all`.
+#   all                  - everything (default; local dev and any non-matrix caller)
+#   base                 - the one-time checks (clippy/test/doc/minimal-versions/external-types/
+#                          tree/each-feature/wasm), i.e. everything except the two powersets
+#   featureset [i/N]     - only the two `cargo hack` feature-powerset passes, optionally sharded
+#                          to partition i of N via `cargo hack --partition`
+MODE="${1:-all}"
+PARTITION="${2:-}"
+
 cd smithy-rs
 
 # Make aws-config (which depends on generated services) available to additional checks
 mkdir -p aws/sdk/build
 mv ../aws-sdk-smoketest aws/sdk/build/aws-sdk
 
-echo -e "${C_YELLOW}# Testing aws-config...${C_RESET}"
+echo -e "${C_YELLOW}# Testing aws-config (mode=${MODE}${PARTITION:+, partition=${PARTITION}})...${C_RESET}"
 pushd "aws/rust-runtime/aws-config" &>/dev/null
 
-echo "${C_YELLOW}## Running 'cargo clippy'${C_RESET}"
-cargo clippy --all-features
+if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
+    echo "${C_YELLOW}## Running 'cargo clippy'${C_RESET}"
+    cargo clippy --all-features
 
-echo "${C_YELLOW}## Running 'cargo test'${C_RESET}"
-cargo test --all-features
+    echo "${C_YELLOW}## Running 'cargo test'${C_RESET}"
+    cargo test --all-features
 
-echo "${C_YELLOW}## Running 'cargo doc'${C_RESET}"
-cargo doc --no-deps --document-private-items --all-features
+    echo "${C_YELLOW}## Running 'cargo doc'${C_RESET}"
+    cargo doc --no-deps --document-private-items --all-features
 
-echo "${C_YELLOW}## Running 'cargo minimal-versions check'${C_RESET}"
-cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --all-features
+    echo "${C_YELLOW}## Running 'cargo minimal-versions check'${C_RESET}"
+    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --all-features
 
-echo "${C_YELLOW}## Checking for external types in public API${C_RESET}"
-cargo "+${RUST_NIGHTLY_VERSION:-nightly}" check-external-types --all-features --config external-types.toml
+    echo "${C_YELLOW}## Checking for external types in public API${C_RESET}"
+    cargo "+${RUST_NIGHTLY_VERSION:-nightly}" check-external-types --all-features --config external-types.toml
 
-echo "${C_YELLOW}## Checking for duplicate dependency versions in the normal dependency graph with all features enabled${C_RESET}"
-cargo tree -d --edges normal --all-features
+    echo "${C_YELLOW}## Checking for duplicate dependency versions in the normal dependency graph with all features enabled${C_RESET}"
+    cargo tree -d --edges normal --all-features
 
-# the crate has `allow-compilation` which needs to be deprecated
+    echo "${C_YELLOW}## Testing each feature in isolation${C_RESET}"
+    # these features are missed by the powerset check because they are grouped
+    cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls,default-https-client --exclude-no-default-features
 
-echo "${C_YELLOW}## Checking every combination of features${C_RESET}"
-cargo hack check --feature-powerset --exclude-all-features --exclude-features allow-compilation
+    echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasip2 targets${C_RESET}"
+    cargo check --target wasm32-unknown-unknown --no-default-features
+    cargo check --target wasm32-wasip2 --no-default-features
 
-echo "${C_YELLOW}## Testing each feature in isolation${C_RESET}"
-# these features are missed by the following check because they are grouped
-cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls,default-https-client --exclude-no-default-features
+    # TODO(https://github.com/smithy-lang/smithy-rs/issues/2499): Uncomment the following once aws-config tests compile for WASM
+    # echo "${C_YELLOW}## Testing the wasm32-unknown-unknown and wasm32-wasip1 targets${C_RESET}"
+    # wasm-pack test --node -- --no-default-features
+    # cargo test --target wasm32-wasip1 --no-default-features
+fi
 
-# This check will check other individual features and no-default-features
-# grouping these features because they don't interact
-cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client
+if [[ "${MODE}" == "all" || "${MODE}" == "featureset" ]]; then
+    # `--partition i/N` shards the powerset across N legs; empty PARTITION runs the full set.
+    partition_arg=()
+    if [[ -n "${PARTITION}" ]]; then
+        partition_arg=(--partition "${PARTITION}")
+    fi
 
-echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasip2 targets${C_RESET}"
-cargo check --target wasm32-unknown-unknown --no-default-features
-cargo check --target wasm32-wasip2 --no-default-features
+    # the crate has `allow-compilation` which needs to be deprecated
+    echo "${C_YELLOW}## Checking every combination of features${C_RESET}"
+    cargo hack check --feature-powerset --exclude-all-features --exclude-features allow-compilation "${partition_arg[@]}"
 
-# TODO(https://github.com/smithy-lang/smithy-rs/issues/2499): Uncomment the following once aws-config tests compile for WASM
-# echo "${C_YELLOW}## Testing the wasm32-unknown-unknown and wasm32-wasip1 targets${C_RESET}"
-# wasm-pack test --node -- --no-default-features
-# cargo test --target wasm32-wasip1 --no-default-features
+    # This check will check other individual features and no-default-features
+    # grouping these features because they don't interact
+    echo "${C_YELLOW}## Testing feature powerset (grouped)${C_RESET}"
+    cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client "${partition_arg[@]}"
+fi
 
 popd &>/dev/null

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -13,6 +13,15 @@ set -eux
 
 : "$RUST_NIGHTLY_VERSION"
 
+# Optional first argument selects a single runtime workspace to check, so CI can run
+# `rust-runtime` and `aws/rust-runtime` as two parallel matrix legs instead of one serial job.
+# With no argument, both are checked (local dev and any non-matrix caller).
+if [[ $# -gt 0 ]]; then
+    runtime_paths=("$1")
+else
+    runtime_paths=("rust-runtime" "aws/rust-runtime")
+fi
+
 cd smithy-rs
 
 echo -e "# ${C_YELLOW}Auditing runtime crate version numbers...${C_RESET}"
@@ -31,9 +40,7 @@ fi
 # Array to collect MSRV mismatches
 msrv_mismatches=()
 
-for runtime_path in \
-    "rust-runtime" \
-    "aws/rust-runtime"
+for runtime_path in "${runtime_paths[@]}"
 do
     echo -e "# ${C_YELLOW}Testing ${runtime_path}...${C_RESET}"
     pushd "${runtime_path}" &>/dev/null


### PR DESCRIPTION
Parallelizes `check-aws-config` (base + 4 `cargo hack --partition` legs) and `check-rust-runtimes` (per-workspace legs) to cut CI wall-clock. Same checks, run in parallel.

> **⚠️ DO NOT MERGE** — draft opened to measure CI timing only.