### PR TITLE
CI speedup

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -12,10 +12,8 @@ inputs:
   action-arguments:
     description: Arguments to pass to the action
     required: false
-  # A filesystem/cache-safe identifier for this leg, used for the artifact name and the Rust
-  # cache key. Defaults to `action`. Set this when several matrix legs share the same `action`
-  # but pass different `action-arguments` (e.g. partitioned check-aws-config), so they don't
-  # collide on one artifact name / cache key. Must contain no slashes or spaces.
+  # Cache-safe slug for the artifact name and cache key (no slashes/spaces); defaults to `action`.
+  # Set it when legs share an `action` but differ by `action-arguments`, so they don't collide.
   label:
     description: Unique slug for artifact name and cache key; defaults to action
     required: false
@@ -42,10 +40,7 @@ runs:
        # Pinned to the commit hash of v2.7.3
   - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:
-      # Include the action name so each matrix leg gets its own cache entry. Keying only on
-      # `github.job` made all legs of a matrix job (e.g. the 8 `test-sdk` legs, which compile
-      # different crate sets) contend for one write-once key, so most legs restored a stale or
-      # cold cache. Per-action keys give each leg its own warm target.
+      # Per-leg key: keying only on `github.job` made a job's matrix legs contend for one cache
       shared-key: ${{ runner.os }}-${{ github.job }}-${{ inputs.label != '' && inputs.label || inputs.action }}
       workspaces: |
         . smithy-rs-target

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -37,6 +37,15 @@ runs:
       key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/caches/**/*', 'gradle/wrapper/**/*') }}
       restore-keys: |
         ${{ runner.os }}-gradle-
+  # Cargo registry (index + downloaded crate sources) shared across containerized legs. ci-action
+  # seeds this from the image's baked-in registry on a miss, so a cold cache never regresses.
+  - name: Cargo registry cache
+    uses: actions/cache@v4
+    with:
+      path: cargo-registry
+      key: ${{ runner.os }}-cargo-registry-${{ hashFiles('smithy-rs/**/Cargo.lock') }}
+      restore-keys: |
+        ${{ runner.os }}-cargo-registry-
        # Pinned to the commit hash of v2.7.3
   - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -12,6 +12,14 @@ inputs:
   action-arguments:
     description: Arguments to pass to the action
     required: false
+  # A filesystem/cache-safe identifier for this leg, used for the artifact name and the Rust
+  # cache key. Defaults to `action`. Set this when several matrix legs share the same `action`
+  # but pass different `action-arguments` (e.g. partitioned check-aws-config), so they don't
+  # collide on one artifact name / cache key. Must contain no slashes or spaces.
+  label:
+    description: Unique slug for artifact name and cache key; defaults to action
+    required: false
+    default: ''
   use_cache:
     description: Whether to use the gradle cache
     type: boolean
@@ -34,7 +42,11 @@ runs:
        # Pinned to the commit hash of v2.7.3
   - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
     with:
-      shared-key: ${{ runner.os }}-${{ github.job }}
+      # Include the action name so each matrix leg gets its own cache entry. Keying only on
+      # `github.job` made all legs of a matrix job (e.g. the 8 `test-sdk` legs, which compile
+      # different crate sets) contend for one write-once key, so most legs restored a stale or
+      # cold cache. Per-action keys give each leg its own warm target.
+      shared-key: ${{ runner.os }}-${{ github.job }}-${{ inputs.label != '' && inputs.label || inputs.action }}
       workspaces: |
         . smithy-rs-target
   - name: Download all artifacts
@@ -68,14 +80,16 @@ runs:
      # This runs the commands from the matrix strategy
   - name: Run ${{ inputs.action }}
     shell: bash
+    env:
+      ARTIFACT_LABEL: ${{ inputs.label != '' && inputs.label || inputs.action }}
     run: |
       ./smithy-rs/tools/ci-build/ci-action ${{ inputs.action }} ${{ inputs.action-arguments}}
-      tar cfz artifacts-${{ inputs.action }}.tar.gz -C artifacts .
+      tar cfz "artifacts-${ARTIFACT_LABEL}.tar.gz" -C artifacts .
   - name: Upload artifacts
     uses: actions/upload-artifact@v4
     with:
-      name: artifacts-${{ inputs.action }}
-      path: artifacts-${{ inputs.action }}.tar.gz
+      name: artifacts-${{ inputs.label != '' && inputs.label || inputs.action }}
+      path: artifacts-${{ inputs.label != '' && inputs.label || inputs.action }}.tar.gz
       if-no-files-found: error
       retention-days: 3
       overwrite: true

--- a/.github/scripts/acquire-build-image
+++ b/.github/scripts/acquire-build-image
@@ -17,6 +17,9 @@ AWS_ACCOUNT_ID="686190543447"
 AWS_REGION="us-west-2"
 ECR_REPOSITORY="smithy-rs-build-image"
 REMOTE_BASE_IMAGE_NAME = f"{AWS_ACCOUNT_ID}.dkr.ecr.{AWS_REGION}.amazonaws.com/{ECR_REPOSITORY}"
+# Public mirror of the build image. Fork PRs can't authenticate to ECR, but this is public so
+# they can pull it anonymously instead of rebuilding the image from scratch (~45m).
+GHCR_BASE_IMAGE_NAME = "ghcr.io/smithy-lang/smithy-rs-build-image"
 LOCAL_BASE_IMAGE_NAME = "smithy-rs-base-image"
 LOCAL_TAG = "local"
 
@@ -231,20 +234,32 @@ def acquire_build_image(context=Context.default(), shell=Shell()):
             else:
                 announce("Failed to pull remote image, which can happen if it doesn't exist.")
 
-            if not context.allow_local_build:
-                announce("Local build turned off by ALLOW_LOCAL_BUILD env var. Aborting.")
-                return 1
+            # Before falling back to an expensive local build (the fork-PR case, where ECR auth
+            # is unavailable), try the public GHCR mirror. It's public, so a fork PR can pull it
+            # anonymously -- no credentials needed. On success, tag it as the local base image
+            # and fall through to the shared build-image step below.
+            announce("Attempting to pull the public GHCR image...")
+            ghcr_result = docker_pull_with_retry(shell, GHCR_BASE_IMAGE_NAME, context.image_tag)
+            if ghcr_result == DockerPullResult.SUCCESS:
+                announce("Successfully pulled the public GHCR image!")
+                shell.docker_tag(GHCR_BASE_IMAGE_NAME, context.image_tag, LOCAL_BASE_IMAGE_NAME, context.image_tag)
+            else:
+                announce("GHCR image unavailable; a local build is required.")
 
-            announce("Building a new image locally.")
-            shell.docker_build_base_image(context.image_tag, context.docker_image_path)
+                if not context.allow_local_build:
+                    announce("Local build turned off by ALLOW_LOCAL_BUILD env var. Aborting.")
+                    return 1
 
-            if context.github_actions:
-                announce("Saving base image for use in later jobs...")
-                shell.docker_save(
-                    LOCAL_BASE_IMAGE_NAME,
-                    context.image_tag,
-                    context.start_path + "/smithy-rs-base-image"
-                )
+                announce("Building a new image locally.")
+                shell.docker_build_base_image(context.image_tag, context.docker_image_path)
+
+                if context.github_actions:
+                    announce("Saving base image for use in later jobs...")
+                    shell.docker_save(
+                        LOCAL_BASE_IMAGE_NAME,
+                        context.image_tag,
+                        context.start_path + "/smithy-rs-base-image"
+                    )
         else:
             announce("Successfully pulled remote image!")
             shell.docker_tag(REMOTE_BASE_IMAGE_NAME, context.image_tag, LOCAL_BASE_IMAGE_NAME, context.image_tag)
@@ -300,7 +315,12 @@ class SelfTest(unittest.TestCase):
 
     def test_docker_login(self):
         shell = self.mock_shell()
+        shell.platform.return_value = Platform.X86_64
+        # ECR then GHCR both miss; we only care that docker_login was called for ECR auth
+        shell.docker_image_exists_locally.side_effect = [False]
+        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND, DockerPullResult.NOT_FOUND]
         acquire_build_image(self.test_context(
+            allow_local_build=True,
             encrypted_docker_password="jA0ECQMCvYU/JxsX3g/70j0BxbLLW8QaFWWb/DqY9gPhTuEN/xdYVxaoDnV6Fha+lAWdT7xN0qZr5DHPBalLfVvvM1SEXRBI8qnfXyGI",
             docker_passphrase="secret"), shell)
         shell.docker_login.assert_called_with("payload")
@@ -443,9 +463,10 @@ class SelfTest(unittest.TestCase):
     def test_image_local_build(self):
         context = self.test_context(allow_local_build=True)
         shell = self.mock_shell()
-        shell.platform.side_effect = [Platform.X86_64]
+        shell.platform.return_value = Platform.X86_64
         shell.docker_image_exists_locally.side_effect = [False]
-        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND]
+        # First pull is ECR (not found), second is the GHCR fallback (also not found) -> local build
+        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND, DockerPullResult.NOT_FOUND]
 
         self.assertEqual(0, acquire_build_image(context, shell))
         shell.docker_image_exists_locally.assert_called_once()
@@ -464,7 +485,8 @@ class SelfTest(unittest.TestCase):
     def test_image_local_build_architecture_mismatch(self):
         context = self.test_context(allow_local_build=True)
         shell = self.mock_shell()
-        shell.platform.side_effect = [Platform.ARM_64]
+        # ARM short-circuits both the ECR and GHCR pulls to a mismatch -> local build
+        shell.platform.return_value = Platform.ARM_64
         shell.docker_image_exists_locally.side_effect = [False]
 
         self.assertEqual(0, acquire_build_image(context, shell))
@@ -483,9 +505,10 @@ class SelfTest(unittest.TestCase):
     def test_image_local_build_github_actions(self):
         context = self.test_context(allow_local_build=True, github_actions=True)
         shell = self.mock_shell()
-        shell.platform.side_effect = [Platform.X86_64]
+        shell.platform.return_value = Platform.X86_64
         shell.docker_image_exists_locally.side_effect = [False]
-        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND]
+        # ECR not found, then GHCR fallback not found -> local build
+        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND, DockerPullResult.NOT_FOUND]
 
         self.assertEqual(0, acquire_build_image(context, shell))
         shell.docker_image_exists_locally.assert_called_once()
@@ -506,9 +529,10 @@ class SelfTest(unittest.TestCase):
     def test_image_fail_local_build_disabled(self):
         context = self.test_context(allow_local_build=False)
         shell = self.mock_shell()
-        shell.platform.side_effect = [Platform.X86_64]
+        shell.platform.return_value = Platform.X86_64
         shell.docker_image_exists_locally.side_effect = [False]
-        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND]
+        # ECR miss, then GHCR fallback miss; local build disabled -> fail
+        shell.docker_pull.side_effect = [DockerPullResult.NOT_FOUND, DockerPullResult.NOT_FOUND]
 
         self.assertEqual(1, acquire_build_image(context, shell))
         shell.docker_image_exists_locally.assert_called_once()
@@ -534,6 +558,28 @@ class SelfTest(unittest.TestCase):
         shell.docker_save.assert_not_called()
         shell.docker_tag.assert_has_calls([
             call(REMOTE_BASE_IMAGE_NAME, "someimagetag", LOCAL_BASE_IMAGE_NAME, "someimagetag"),
+            call(LOCAL_BASE_IMAGE_NAME, "someimagetag", LOCAL_BASE_IMAGE_NAME, LOCAL_TAG)
+        ])
+        shell.docker_build_build_image.assert_called_with("123", "/tmp/test/tools-path/ci-build")
+
+    # When:
+    #  - the base image doesn't exist locally
+    #  - ECR pull fails (the fork-PR case: no ECR auth), but the public GHCR image exists
+    #  - local builds are disabled
+    # It should: pull from GHCR, tag it, and NOT build locally
+    def test_pull_ghcr_fallback(self):
+        context = self.test_context(allow_local_build=False)
+        shell = self.mock_shell()
+        shell.platform.return_value = Platform.X86_64
+        shell.docker_image_exists_locally.side_effect = [False]
+        # ECR unauthenticated (fork), then GHCR succeeds
+        shell.docker_pull.side_effect = [DockerPullResult.UNAUTHENTICATED, DockerPullResult.SUCCESS]
+
+        self.assertEqual(0, acquire_build_image(context, shell))
+        shell.docker_build_base_image.assert_not_called()
+        shell.docker_save.assert_not_called()
+        shell.docker_tag.assert_has_calls([
+            call(GHCR_BASE_IMAGE_NAME, "someimagetag", LOCAL_BASE_IMAGE_NAME, "someimagetag"),
             call(LOCAL_BASE_IMAGE_NAME, "someimagetag", LOCAL_BASE_IMAGE_NAME, LOCAL_TAG)
         ])
         shell.docker_build_build_image.assert_called_with("123", "/tmp/test/tools-path/ci-build")

--- a/.github/scripts/acquire-build-image
+++ b/.github/scripts/acquire-build-image
@@ -234,10 +234,8 @@ def acquire_build_image(context=Context.default(), shell=Shell()):
             else:
                 announce("Failed to pull remote image, which can happen if it doesn't exist.")
 
-            # Before falling back to an expensive local build (the fork-PR case, where ECR auth
-            # is unavailable), try the public GHCR mirror. It's public, so a fork PR can pull it
-            # anonymously -- no credentials needed. On success, tag it as the local base image
-            # and fall through to the shared build-image step below.
+            # Try the public GHCR mirror before an expensive local build. This is the fork-PR case:
+            # no ECR auth, but GHCR is public so it can be pulled anonymously.
             announce("Attempting to pull the public GHCR image...")
             ghcr_result = docker_pull_with_retry(shell, GHCR_BASE_IMAGE_NAME, context.image_tag)
             if ghcr_result == DockerPullResult.SUCCESS:
@@ -562,11 +560,7 @@ class SelfTest(unittest.TestCase):
         ])
         shell.docker_build_build_image.assert_called_with("123", "/tmp/test/tools-path/ci-build")
 
-    # When:
-    #  - the base image doesn't exist locally
-    #  - ECR pull fails (the fork-PR case: no ECR auth), but the public GHCR image exists
-    #  - local builds are disabled
-    # It should: pull from GHCR, tag it, and NOT build locally
+    # It should: when ECR pull fails (the fork case) but the GHCR image exists, pull from GHCR and NOT build locally
     def test_pull_ghcr_fallback(self):
         context = self.test_context(allow_local_build=False)
         shell = self.mock_shell()

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -66,15 +66,47 @@ jobs:
         ./.github/scripts/upload-build-image.sh $IMAGE_TAG
     # Mirror the image to public GHCR so fork PRs (which can't authenticate to ECR) can pull it
     # anonymously instead of rebuilding it from scratch. Uses the built-in GITHUB_TOKEN.
+    #
+    # `continue-on-error` because this job is a required check and ECR (the path every
+    # non-fork build depends on) has already succeeded by this point. The mirror is a
+    # best-effort optimization for forks: if it fails, forks fall back to building the image
+    # locally, which is slow but correct. Letting it fail the job would take main's CI down
+    # for a fork-only speedup — the exact tradeoff this step is not worth.
     - name: Mirror image to public GHCR
+      continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        set -euo pipefail
         IMAGE_TAG="ci-$(./.github/scripts/docker-image-hash)"
         echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
         GHCR_IMAGE="ghcr.io/smithy-lang/smithy-rs-build-image:${IMAGE_TAG}"
         docker tag "smithy-rs-base-image:${IMAGE_TAG}" "${GHCR_IMAGE}"
         docker push "${GHCR_IMAGE}"
+        # A newly-created GHCR package is PRIVATE by default, and there is no REST endpoint to
+        # change package visibility — it has to be done once, by hand, in the org's package
+        # settings. Until that happens the anonymous pull on the fork path gets a 403 and
+        # silently falls back to a local build, so check it here rather than letting a green
+        # run imply fork PRs are fixed.
+        #
+        # Note this has to go through the registry's token endpoint: GHCR's /v2/ API answers
+        # 401 without a token even for public packages, so an unauthenticated request can't
+        # distinguish public from private. An *anonymous* token, however, is only granted pull
+        # scope on a public package, so 200-vs-403 with that token is the real signal.
+        GHCR_REPO="${{ github.repository_owner }}/smithy-rs-build-image"
+        # The token endpoint answers 403 for a private or absent package, so tolerate a failed
+        # request and an empty body here; the `if` below treats an empty token as "not public".
+        ANON_TOKEN="$(
+          curl -fsSL "https://ghcr.io/token?scope=repository:${GHCR_REPO}:pull&service=ghcr.io" 2>/dev/null \
+            | sed -n 's/.*"token":"\([^"]*\)".*/\1/p' || true
+        )"
+        if [[ -n "${ANON_TOKEN}" ]] && curl -fsSL -o /dev/null \
+            -H "Authorization: Bearer ${ANON_TOKEN}" \
+            "https://ghcr.io/v2/${GHCR_REPO}/tags/list"; then
+          echo "GHCR package is anonymously pullable; fork PRs can use the mirror."
+        else
+          echo "::warning::GHCR package ${GHCR_REPO} is not anonymously pullable (likely still private). Make it public in the org's package settings, or fork PRs will keep rebuilding the image (~45m)."
+        fi
 
   # Run the shared CI after a Docker build image has been uploaded to ECR
   ci:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -32,6 +32,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Needed to push the build image to the public GHCR mirror that fork PRs pull from
+      packages: write
     steps:
     - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - name: Checkout
@@ -62,6 +64,17 @@ jobs:
         pwd
         IMAGE_TAG="ci-$(./.github/scripts/docker-image-hash)"
         ./.github/scripts/upload-build-image.sh $IMAGE_TAG
+    # Mirror the image to public GHCR so fork PRs (which can't authenticate to ECR) can pull it
+    # anonymously instead of rebuilding it from scratch. Uses the built-in GITHUB_TOKEN.
+    - name: Mirror image to public GHCR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        IMAGE_TAG="ci-$(./.github/scripts/docker-image-hash)"
+        echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        GHCR_IMAGE="ghcr.io/smithy-lang/smithy-rs-build-image:${IMAGE_TAG}"
+        docker tag "smithy-rs-base-image:${IMAGE_TAG}" "${GHCR_IMAGE}"
+        docker push "${GHCR_IMAGE}"
 
   # Run the shared CI after a Docker build image has been uploaded to ECR
   ci:

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -1,0 +1,230 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow runs CI for GitHub merge queue entries.
+#
+# Why this is a separate workflow rather than another trigger on `ci-pr.yml`: every job in
+# `ci-pr.yml` is gated on `github.event.pull_request.head.repo.full_name`, and a `merge_group`
+# event carries no `pull_request` object at all, so all of those jobs would silently skip. The
+# jobs here are the same shape as `ci-pr.yml`'s, minus the ones that only make sense on a real
+# pull request (the PR bot and the canary, which post PR comments and need an issue number).
+#
+# A merge-queue entry is a temporary `gh-readonly-queue/<base>/...` branch owned by this repo
+# containing `main` + the already-queued PRs + this one, so unlike a fork PR it can read repo
+# secrets and pull the build image from ECR.
+name: CI (merge queue)
+on:
+  merge_group:
+    # `checks_requested` is the only useful activity type: it fires when GitHub has created the
+    # merge-queue branch and wants status checks reported against it.
+    types: [checks_requested]
+
+# Each queue entry is a distinct commit that must be tested on its own, so entries must not
+# cancel each other. Key on the merge-group ref rather than the base branch.
+concurrency:
+  group: ci-merge-queue-${{ github.event.merge_group.head_ref || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  # Mirrors `ci-pr.yml`'s job of the same name: stash an ECR login password so the containerized
+  # jobs in `ci.yml` can pull the build image.
+  save-docker-login-token:
+    name: Save a docker login token
+    timeout-minutes: 10
+    outputs:
+      docker-login-password: ${{ steps.set-token.outputs.docker-login-password }}
+    permissions:
+      id-token: write
+      contents: read
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - name: Attempt to load a docker login password
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}
+        role-session-name: GitHubActions
+        aws-region: us-west-2
+    - name: Save the docker login password to the output
+      id: set-token
+      run: |
+        ENCRYPTED_PAYLOAD=$(
+          gpg --symmetric --batch --passphrase "${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}" --output - <(aws ecr get-login-password --region us-west-2) | base64 -w0
+        )
+        echo "docker-login-password=$ENCRYPTED_PAYLOAD" >> $GITHUB_OUTPUT
+
+  acquire-base-image:
+    name: Acquire Base Image
+    timeout-minutes: 90
+    needs: save-docker-login-token
+    runs-on: smithy_ubuntu-latest_8-core
+    env:
+      ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
+      DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+    - uses: ./smithy-rs/.github/actions/free-disk-space
+    - name: Acquire base image
+      id: acquire
+      env:
+        DOCKER_BUILDKIT: 1
+      run: ./smithy-rs/.github/scripts/acquire-build-image
+    - name: Acquire credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.SMITHY_RS_ECR_PUSH_ROLE_ARN }}
+        role-session-name: GitHubActions
+        aws-region: us-west-2
+    - name: Upload image
+      run: |
+        IMAGE_TAG="ci-$(./smithy-rs/.github/scripts/docker-image-hash)"
+        ./smithy-rs/.github/scripts/upload-build-image.sh $IMAGE_TAG
+
+  # NOTE: `run_canary` is deliberately left at its default (true). It is tempting to pass `false`
+  # here — the canary is already covered on the PR and on `main` after merge — but in `ci.yml`
+  # `run_canary: false` is the *fork* signal: it enables the
+  # `ask-maintainer-to-run-pr-bot-and-canary` job, which unconditionally `exit 1`s to tell fork
+  # authors to ask a maintainer. Passing `false` here would therefore fail every queue entry.
+  # Decoupling "skip the canary" from "this is a fork" is a separate change to `ci.yml`.
+  ci:
+    needs:
+    - save-docker-login-token
+    - acquire-base-image
+    uses: ./.github/workflows/ci.yml
+    secrets:
+      ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
+      DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
+      CANARY_GITHUB_ACTIONS_ROLE_ARN: ${{ secrets.CANARY_GITHUB_ACTIONS_ROLE_ARN }}
+      CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME: ${{ secrets.CANARY_STACK_CDK_OUTPUTS_BUCKET_NAME }}
+
+  # `ci-pr.yml` reads the base revision from `github.event.pull_request.base.sha`, which does not
+  # exist for a merge-group event. The equivalent here is `github.event.merge_group.base_sha`: the
+  # commit the queue branch was built on top of (`main` plus any earlier entries), which is the
+  # right baseline — a queue entry must be semver-compatible with what it will actually merge into.
+  #
+  # The `breaking-change` label lives on the pull request, and a merge-group event doesn't name
+  # one, so it's looked up from the commits in the queue branch. If any queued PR carries the
+  # label, failures are downgraded to warnings for the whole entry, matching the PR behavior.
+  semver-checks:
+    name: Check PR semver compliance
+    permissions:
+      pull-requests: read
+      contents: read
+    runs-on: smithy_ubuntu-latest_8-core
+    timeout-minutes: 30
+    needs:
+    - save-docker-login-token
+    - acquire-base-image
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+        fetch-depth: 0
+    - name: Get merge queue info
+      id: check-breaking-label
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // `base_sha` is the merge group's parent commit and `head_sha` is the merge group
+          // itself; both are required fields of the `merge_group` payload. `base_sha` is the
+          // right semver baseline: a queue entry must be compatible with what it will actually
+          // merge into, which is `main` plus any entries queued ahead of it — not the base
+          // branch as it looked when the pull request was opened.
+          const mg = context.payload.merge_group;
+          const baseSha = mg.base_sha;
+          const headSha = mg.head_sha;
+          // Guard anyway: passing an empty baseline through to `check-semver` would compare
+          // against the wrong tree and could pass silently, so fail loudly instead.
+          if (!baseSha || !headSha) {
+            core.setFailed(`merge_group payload missing base_sha/head_sha: ${JSON.stringify(mg)}`);
+            return;
+          }
+          // Find the pull requests bundled into this queue entry so their labels and changed
+          // files can be inspected. Default to running the check (and to not downgrading
+          // failures) if anything here is unavailable.
+          let isBreaking = false;
+          let runSemver = true;
+          try {
+            const commits = await github.paginate(github.rest.repos.compareCommitsWithBasehead, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${baseSha}...${headSha}`,
+            }, (response) => response.data.commits ?? []);
+            const prNumbers = new Set();
+            for (const commit of commits) {
+              const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: commit.sha,
+              });
+              for (const pr of associated.data) {
+                prNumbers.add(pr.number);
+              }
+            }
+            // Semver can only change if the generated SDK's public API can: runtime crates
+            // (copied into the SDK) or codegen sources. Skip the check only when every changed
+            // file across every queued PR is inert (docs, changelog, CI config).
+            //
+            // Markdown only counts as inert outside the runtime crates: files under
+            // rust-runtime/ and aws/rust-runtime/ can be pulled into crate docs with
+            // `#[doc = include_str!(...)]`, which is part of the public API surface
+            // `cargo-semver-checks` inspects.
+            const inert = /^(design\/|docs\/|\.github\/|\.changelog\/|CHANGELOG\.md$|[^/]+\.md$)/;
+            const labels = [];
+            let sawNonInert = false;
+            for (const number of prNumbers) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: number,
+              });
+              labels.push(...pr.data.labels.map(l => l.name));
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: number,
+              });
+              if (files.some(f => !inert.test(f.filename))) {
+                sawNonInert = true;
+              }
+            }
+            isBreaking = labels.includes("breaking-change");
+            // Only skip when at least one PR was actually inspected; an empty set means the
+            // lookup found nothing and the check should still run.
+            runSemver = prNumbers.size === 0 ? true : sawNonInert;
+          } catch (e) {
+            core.warning(`merge queue lookup failed, running semver checks anyway: ${e}`);
+          }
+          const data = { baseSha, isBreaking, runSemver };
+          console.log("data:", data);
+          return data;
+    - name: Run semver check
+      # Only run when the queue entry touches something that could change a crate's public API
+      if: fromJSON(steps.check-breaking-label.outputs.result).runSemver
+      env:
+        ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
+        DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
+      uses: ./smithy-rs/.github/actions/docker-build
+      with:
+        action: check-semver
+        action-arguments: ${{ fromJSON(steps.check-breaking-label.outputs.result).baseSha }} ${{ fromJSON(steps.check-breaking-label.outputs.result).isBreaking }}
+    - name: Print help message
+      if: failure()
+      run: echo "::error::This pull request either contains breaking changes, or has cross-crate changes that may be backwards compatible, but that cargo-semver-checks cannot verify. Please scrutinize the change for backwards compatibility."

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -151,13 +151,26 @@ jobs:
           });
           const labels = response.data.labels.map(l => l.name);
           const isBreaking = labels.includes("breaking-change");
+          // Semver can only change if the generated SDK's public API can: runtime crates (copied
+          // into the SDK) or codegen sources. Skip the check when every changed file is inert
+          // (docs, changelog, CI config), which can't affect any crate's API.
+          const files = await github.paginate(github.rest.pulls.listFiles, {
+            pull_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const inert = /^(design\/|\.github\/|\.changelog\/|CHANGELOG|.*\.md$)/;
+          const runSemver = files.some(f => !inert.test(f.filename));
           const data = {
             labels,
-            isBreaking
+            isBreaking,
+            runSemver
           };
           console.log("data:", data);
           return data;
     - name: Run semver check
+      # Only run when the PR touches something that could change a crate's public API (see above)
+      if: fromJSON(steps.check-breaking-label.outputs.result).runSemver
       env:
         ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
         DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -159,7 +159,10 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
           });
-          const inert = /^(design\/|\.github\/|\.changelog\/|CHANGELOG|.*\.md$)/;
+          // Markdown only counts as inert outside the runtime crates: files under rust-runtime/ and
+          // aws/rust-runtime/ can be pulled into crate docs with `#[doc = include_str!(...)]`, which
+          // is part of the public API surface `cargo-semver-checks` inspects.
+          const inert = /^(design\/|docs\/|\.github\/|\.changelog\/|CHANGELOG\.md$|[^/]+\.md$)/;
           const runSemver = files.some(f => !inert.test(f.filename));
           const data = {
             labels,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,11 @@ jobs:
           }
           // Runtime jobs only exercise the runtime crates, so skip when every changed file is inert
           // (docs, changelog, CI config, design). Default to running on any error.
-          const inert = /^(design\/|\.github\/|\.changelog\/|CHANGELOG|.*\.md$)/;
+          //
+          // Markdown only counts as inert outside the runtime crates: files under rust-runtime/ and
+          // aws/rust-runtime/ can be pulled into crate docs with `#[doc = include_str!(...)]`, so
+          // editing them can break `cargo doc -D warnings` and must still run the checks.
+          const inert = /^(design\/|docs\/|\.github\/|\.changelog\/|CHANGELOG\.md$|[^/]+\.md$)/;
           try {
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,19 @@ jobs:
       fail-fast: false
       matrix:
         test:
+        # check-only-aws-sdk-services `cargo check`s ~300 service crates; shard it across parallel
+        # legs. See ci-scripts/check-only-aws-sdk-services.
         - action: check-only-aws-sdk-services
+          action-arguments: 1/3
+          label: check-only-aws-sdk-services-1
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-only-aws-sdk-services
+          action-arguments: 2/3
+          label: check-only-aws-sdk-services-2
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-only-aws-sdk-services
+          action-arguments: 3/3
+          label: check-only-aws-sdk-services-3
           runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-cargo-deny
           runner: smithy_ubuntu-latest_8-core
@@ -317,6 +329,8 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: ${{ matrix.test.action }}
+        action-arguments: ${{ matrix.test.action-arguments }}
+        label: ${{ matrix.test.label }}
 
   test-rust-windows:
     name: Rust Tests on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,42 @@ env:
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
 
 jobs:
+  # Detects whether a pull request changes anything that could affect the runtime crates, so the
+  # runtime-only jobs (Windows, exotic platforms) can skip their expensive steps on PRs that only
+  # touch docs/CI/changelog. Outputs `rust=true` for any non-PR event (push, schedule) and on any
+  # error, so those cases always run the full checks.
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.detect.outputs.rust }}
+    steps:
+    - name: Detect Rust changes
+      id: detect
+      uses: actions/github-script@v7
+      with:
+        script: |
+          if (context.eventName !== 'pull_request') {
+            core.setOutput('rust', 'true');
+            return;
+          }
+          // Runtime jobs only exercise the runtime crates, so skip when every changed file is inert
+          // (docs, changelog, CI config, design). Default to running on any error.
+          const inert = /^(design\/|\.github\/|\.changelog\/|CHANGELOG|.*\.md$)/;
+          try {
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const rust = files.some(f => !inert.test(f.filename));
+            core.setOutput('rust', rust ? 'true' : 'false');
+          } catch (e) {
+            core.warning(`change detection failed, running checks anyway: ${e}`);
+            core.setOutput('rust', 'true');
+          }
+
   # Generates the artifacts most test-sdk legs need: the ~23-service smoketest SDK and the release
   # bundle. The full ~300-service SDK is generated separately in `generate-full` so that the legs
   # that only need the smoketest SDK don't wait on it.
@@ -284,6 +320,7 @@ jobs:
 
   test-rust-windows:
     name: Rust Tests on Windows
+    needs: detect-changes
     runs-on: windows-latest
     timeout-minutes: 30
     env:
@@ -297,19 +334,24 @@ jobs:
         ref: ${{ inputs.git_ref }}
       # Pinned to the commit hash of v2.7.3
     - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
+      if: needs.detect-changes.outputs.rust == 'true'
       with:
         shared-key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
         workspaces: |
           .
           tools
     - uses: dtolnay/rust-toolchain@master
+      if: needs.detect-changes.outputs.rust == 'true'
       with:
         toolchain: ${{ env.rust_version }}
         components: ${{ env.rust_toolchain_components }}
       # To fix OpenSSL not found on Windows: https://github.com/sfackler/rust-openssl/issues/1542
-    - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-    - run: vcpkg install openssl:x64-windows-static-md
+    - if: needs.detect-changes.outputs.rust == 'true'
+      run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - if: needs.detect-changes.outputs.rust == 'true'
+      run: vcpkg install openssl:x64-windows-static-md
     - name: Run tests
+      if: needs.detect-changes.outputs.rust == 'true'
       shell: bash
       run: tools/ci-scripts/test-windows.sh
 
@@ -319,6 +361,7 @@ jobs:
   # complicated setup involving architecture emulation.
   test-exotic-platform-support:
     name: Exotic platform support
+    needs: detect-changes
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -362,12 +405,14 @@ jobs:
         ref: ${{ inputs.git_ref }}
       # Pinned to the commit hash of v2.7.3
     - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
+      if: needs.detect-changes.outputs.rust == 'true'
       with:
         shared-key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ matrix.target }}
         workspaces: |
           .
           tools
     - uses: dtolnay/rust-toolchain@master
+      if: needs.detect-changes.outputs.rust == 'true'
       with:
         toolchain: ${{ env.rust_version }}
         components: ${{ env.rust_toolchain_components }}
@@ -376,13 +421,14 @@ jobs:
       run: |
         echo "OPENSSL_LIB_DIR=/usr/lib/i386-linux-gnu" >> $GITHUB_ENV
         echo "OPENSSL_INCLUDE_DIR=/usr/include/i386-linux-gnu" >> $GITHUB_ENV
-      if: matrix.target == 'i686-unknown-linux-gnu'
+      if: needs.detect-changes.outputs.rust == 'true' && matrix.target == 'i686-unknown-linux-gnu'
     - name: Sets OpenSSL env vars on ppc and ppc64
       run: |
         echo "OPENSSL_DIR=/openssl" >> $GITHUB_ENV
-      if: matrix.target != 'i686-unknown-linux-gnu'
+      if: needs.detect-changes.outputs.rust == 'true' && matrix.target != 'i686-unknown-linux-gnu'
     - name: Configure cross
       shell: bash
+      if: needs.detect-changes.outputs.rust == 'true'
       # configure and cross compile openssl locally on ppc and ppc64 to be able to run aws-smithy-client tests.
       # since cross dropped support for openssl, we use the build script from version 0.16.
       run: |
@@ -406,15 +452,19 @@ jobs:
         passthrough = ["OPENSSL_DIR"]
         EOF
     - name: Build Smithy-rs rust-runtime crates
+      if: needs.detect-changes.outputs.rust == 'true'
       shell: bash
       run: cross build -vv --target ${{ matrix.target }} --manifest-path "rust-runtime/Cargo.toml" ${{ matrix.build_smithy_rs_exclude }} --workspace ${{ matrix.build_smithy_rs_features }}
     - name: Build AWS rust-runtime crates
+      if: needs.detect-changes.outputs.rust == 'true'
       shell: bash
       run: cross build -vv --target ${{ matrix.target }} --manifest-path "aws/rust-runtime/Cargo.toml" ${{ matrix.build_aws_exclude }} --workspace
     - name: Test Smithy-rs rust-runtime crates
+      if: needs.detect-changes.outputs.rust == 'true'
       shell: bash
       run: cross test --target ${{ matrix.target }} --manifest-path "rust-runtime/Cargo.toml" ${{ matrix.test_smithy_rs_exclude }} --workspace ${{ matrix.test_smithy_rs_features }}
     - name: Test AWS rust-runtime crates
+      if: needs.detect-changes.outputs.rust == 'true'
       shell: bash
       run: cross test --target ${{ matrix.target }} --manifest-path "aws/rust-runtime/Cargo.toml" ${{ matrix.test_aws_exclude }} --workspace ${{ matrix.test_aws_features }}
 
@@ -518,6 +568,7 @@ jobs:
   # the myriad of test matrix combinations into GitHub's protected branch rules
   require-all:
     needs:
+    - detect-changes
     - generate
     - generate-full
     - test-codegen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,10 @@ jobs:
           runner: smithy_ubuntu-latest_8-core
         - action: check-codegen-version
           runner: smithy_ubuntu-latest_8-core
+        # Guards that the check-aws-config feature-powerset partitioning is a complete, disjoint
+        # cover (see tools/ci-scripts/check-aws-config-partition-coverage). Cheap; no generated SDK.
+        - action: check-aws-config-partition-coverage
+          runner: smithy_ubuntu-latest_8-core
     steps:
     - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,9 +155,17 @@ jobs:
           runner: smithy_ubuntu-latest_8-core
         - action: check-core-codegen-unit-tests
           runner: smithy_ubuntu-latest_8-core
+        # The rust-runtime workspace is split by phase: the whole-workspace passes (clippy, nextest,
+        # doc, minimal-versions) and the slower per-crate `additional-ci` feature-combination tests
+        # run as parallel legs. aws/rust-runtime is small enough to stay a single leg.
         - action: check-rust-runtimes
-          action-arguments: rust-runtime
+          action-arguments: rust-runtime workspace
           label: check-rust-runtimes-smithy
+          runner: smithy_ubuntu-latest_8-core
+          fetch-depth: 0
+        - action: check-rust-runtimes
+          action-arguments: rust-runtime additional
+          label: check-rust-runtimes-smithy-additional
           runner: smithy_ubuntu-latest_8-core
           fetch-depth: 0
         - action: check-rust-runtimes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
         - action: check-core-codegen-unit-tests
           runner: smithy_ubuntu-latest_8-core
         - action: check-rust-runtimes
+          action-arguments: rust-runtime
+          label: check-rust-runtimes-smithy
+          runner: smithy_ubuntu-latest_8-core
+          fetch-depth: 0
+        - action: check-rust-runtimes
+          action-arguments: aws/rust-runtime
+          label: check-rust-runtimes-aws
           runner: smithy_ubuntu-latest_8-core
           fetch-depth: 0
         - action: check-sdk-codegen-unit-tests
@@ -138,6 +145,8 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: ${{ matrix.test.action }}
+        action-arguments: ${{ matrix.test.action-arguments }}
+        label: ${{ matrix.test.label }}
 
   # Separate from the main checks above because it uses aws-sdk-rust from GitHub
   check-semver-hazards:
@@ -174,7 +183,29 @@ jobs:
       matrix:
         # These correspond to scripts in tools/ci-scripts that will be run in the Docker build image
         test:
+        # `check-aws-config` is split into a one-time `base` leg plus 4 parallel `featureset`
+        # legs that shard the expensive `cargo hack` feature-powersets via `--partition i/4`.
+        # The union runs exactly the same checks as the old single leg (see tools/ci-scripts/
+        # check-aws-config), but as 5 parallel legs instead of one ~28-minute serial job.
         - action: check-aws-config
+          action-arguments: base
+          label: check-aws-config-base
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 1/4
+          label: check-aws-config-featureset-1
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 2/4
+          label: check-aws-config-featureset-2
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 3/4
+          label: check-aws-config-featureset-3
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-config
+          action-arguments: featureset 4/4
+          label: check-aws-config-featureset-4
           runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-canary
           runner: smithy_ubuntu-latest_8-core
@@ -200,6 +231,8 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: ${{ matrix.test.action }}
+        action-arguments: ${{ matrix.test.action-arguments }}
+        label: ${{ matrix.test.label }}
 
   test-rust-windows:
     name: Rust Tests on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,16 @@ jobs:
           runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-canary
           runner: smithy_ubuntu-latest_8-core
+        # Split by phase into parallel legs: doc/clippy (+ integration-test check) and
+        # udeps/external-types. The phases use different toolchains and don't share compiled
+        # artifacts, so this adds no extra compilation.
         - action: check-aws-sdk-smoketest-docs-clippy-udeps
+          action-arguments: docs
+          label: check-aws-sdk-smoketest-docs
+          runner: smithy_ubuntu-latest_16-core
+        - action: check-aws-sdk-smoketest-docs-clippy-udeps
+          action-arguments: types
+          label: check-aws-sdk-smoketest-types
           runner: smithy_ubuntu-latest_16-core
         - action: check-aws-sdk-smoketest-unit-tests
           runner: smithy_ubuntu-latest_8-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,9 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTDOCFLAGS: -D warnings
       RUSTFLAGS: -D warnings
+      # Point vcpkg's binary cache at a stable path we can persist across runs. Without this it
+      # defaults to the runner's ephemeral home dir, so the OpenSSL build (~6 min) repeats every run.
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg-cache
     steps:
     - uses: actions/checkout@v4
       with:
@@ -368,8 +371,19 @@ jobs:
         toolchain: ${{ env.rust_version }}
         components: ${{ env.rust_toolchain_components }}
       # To fix OpenSSL not found on Windows: https://github.com/sfackler/rust-openssl/issues/1542
+    # Restore the prebuilt OpenSSL binary so `vcpkg install` below is a cache hit instead of a
+    # ~6 min from-source build. Keyed on the package spec so a version bump busts the cache.
+    - name: Cache vcpkg OpenSSL
+      if: needs.detect-changes.outputs.rust == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\vcpkg-cache
+        key: ${{ runner.os }}-vcpkg-openssl-x64-windows-static-md
     - if: needs.detect-changes.outputs.rust == 'true'
       run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - if: needs.detect-changes.outputs.rust == 'true'
+      # vcpkg requires the binary cache directory to exist before it will write to it
+      run: New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE
     - if: needs.detect-changes.outputs.rust == 'true'
       run: vcpkg install openssl:x64-windows-static-md
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
   # Test the code generator and other parts (styles and lints) that don't require
   # code to have already been generated in order to run.
   test-codegen:
-    name: Test Codegen
+    # `label || action` keeps matrix leg names readable instead of GitHub's auto-generated tuple
+    name: Test Codegen / ${{ matrix.test.label || matrix.test.action }}
     runs-on: ${{ matrix.test.runner }}
     timeout-minutes: 35
     # To avoid repeating setup boilerplate, we have the actual test commands
@@ -133,8 +134,7 @@ jobs:
           runner: smithy_ubuntu-latest_8-core
         - action: check-codegen-version
           runner: smithy_ubuntu-latest_8-core
-        # Guards that the check-aws-config feature-powerset partitioning is a complete, disjoint
-        # cover (see tools/ci-scripts/check-aws-config-partition-coverage). Cheap; no generated SDK.
+        # Guards that the check-aws-config --partition legs cover the whole powerset (cheap; no SDK)
         - action: check-aws-config-partition-coverage
           runner: smithy_ubuntu-latest_8-core
     steps:
@@ -176,7 +176,8 @@ jobs:
   # Test all the things that require generated code. Note: the Rust runtimes require codegen
   # to be checked since `aws-config` depends on the generated STS client.
   test-sdk:
-    name: Test the SDK
+    # `label || action` keeps matrix leg names readable instead of GitHub's auto-generated tuple
+    name: Test the SDK / ${{ matrix.test.label || matrix.test.action }}
     needs: generate
     runs-on: ${{ matrix.test.runner }}
     timeout-minutes: 45
@@ -187,10 +188,8 @@ jobs:
       matrix:
         # These correspond to scripts in tools/ci-scripts that will be run in the Docker build image
         test:
-        # `check-aws-config` is split into a one-time `base` leg plus 4 parallel `featureset`
-        # legs that shard the expensive `cargo hack` feature-powersets via `--partition i/4`.
-        # The union runs exactly the same checks as the old single leg (see tools/ci-scripts/
-        # check-aws-config), but as 5 parallel legs instead of one ~28-minute serial job.
+        # check-aws-config split into a `base` leg + 4 `--partition` featureset legs; the union
+        # runs the same checks as the old single leg, but in parallel. See ci-scripts/check-aws-config.
         - action: check-aws-config
           action-arguments: base
           label: check-aws-config-base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ env:
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
 
 jobs:
-  # The `generate` job runs scripts that produce artifacts that are required by the `test` job,
-  # and also runs some checks/lints so that those are run sooner rather than later.
+  # Generates the artifacts most test-sdk legs need: the ~23-service smoketest SDK and the release
+  # bundle. The full ~300-service SDK is generated separately in `generate-full` so that the legs
+  # that only need the smoketest SDK don't wait on it.
   generate:
     name: Generate
     timeout-minutes: 30
@@ -52,7 +53,6 @@ jobs:
       matrix:
         # These correspond to scripts in tools/ci-scripts that will be run in the Docker build image
         actions:
-        - action: generate-aws-sdk
         - action: generate-aws-sdk-smoketest
         - action: generate-smithy-rs-release
     steps:
@@ -73,6 +73,29 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: ${{ matrix.actions.action }}
+
+  # Generates the full ~300-service SDK, which is slower than the smoketest SDK and only consumed by
+  # the `test-sdk-full` legs (check-only-aws-sdk-services, check-aws-sdk-cargo-deny) and canary. Kept
+  # off the critical path of the smoketest-only test legs.
+  generate-full:
+    name: Generate / full-sdk
+    timeout-minutes: 30
+    runs-on: smithy_ubuntu-latest_8-core
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+        ref: ${{ inputs.git_ref }}
+    # The models from aws-sdk-rust are needed to generate the full SDK for CI
+    - uses: actions/checkout@v4
+      with:
+        repository: awslabs/aws-sdk-rust
+        path: aws-sdk-rust
+    - name: Run generate-aws-sdk
+      uses: ./smithy-rs/.github/actions/docker-build
+      with:
+        action: generate-aws-sdk
 
   # Test the code generator and other parts (styles and lints) that don't require
   # code to have already been generated in order to run.
@@ -212,10 +235,6 @@ jobs:
           runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-canary
           runner: smithy_ubuntu-latest_8-core
-        - action: check-aws-sdk-cargo-deny
-          runner: smithy_ubuntu-latest_8-core
-        - action: check-only-aws-sdk-services
-          runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-smoketest-docs-clippy-udeps
           runner: smithy_ubuntu-latest_16-core
         - action: check-aws-sdk-smoketest-unit-tests
@@ -236,6 +255,32 @@ jobs:
         action: ${{ matrix.test.action }}
         action-arguments: ${{ matrix.test.action-arguments }}
         label: ${{ matrix.test.label }}
+
+  # The SDK checks that consume the full ~300-service SDK, split out so they wait on `generate-full`
+  # while the smoketest-only legs above start as soon as the faster `generate` finishes.
+  test-sdk-full:
+    name: Test the SDK / ${{ matrix.test.label || matrix.test.action }}
+    needs: generate-full
+    runs-on: ${{ matrix.test.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+        - action: check-only-aws-sdk-services
+          runner: smithy_ubuntu-latest_8-core
+        - action: check-aws-sdk-cargo-deny
+          runner: smithy_ubuntu-latest_8-core
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+        ref: ${{ inputs.git_ref }}
+    - name: Run ${{ matrix.test.action }}
+      uses: ./smithy-rs/.github/actions/docker-build
+      with:
+        action: ${{ matrix.test.action }}
 
   test-rust-windows:
     name: Rust Tests on Windows
@@ -382,7 +427,7 @@ jobs:
   canary:
     name: Canary
     if: ${{ inputs.run_canary }}
-    needs: generate
+    needs: generate-full
     runs-on: smithy_ubuntu-latest_8-core
     timeout-minutes: 30
     permissions:
@@ -412,7 +457,7 @@ jobs:
   canary-arm:
     name: Canary (aarch64)
     if: ${{ inputs.run_canary }}
-    needs: generate
+    needs: generate-full
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     permissions:
@@ -474,9 +519,11 @@ jobs:
   require-all:
     needs:
     - generate
+    - generate-full
     - test-codegen
     - check-semver-hazards
     - test-sdk
+    - test-sdk-full
     - test-rust-windows
     - test-exotic-platform-support
     # Run this job even if its dependency jobs fail

--- a/rust-runtime/.config/nextest.toml
+++ b/rust-runtime/.config/nextest.toml
@@ -1,0 +1,9 @@
+# cargo-nextest configuration for the smithy-rs runtime workspace.
+#
+# The experimental `aws-smithy-http-server-python` crate uses custom test harnesses
+# (`harness = false`) for `middleware_tests` and `python_tests`. nextest discovers tests by
+# invoking each binary with `--list --format terse`, which those custom harnesses don't support,
+# so it errors. Exclude them from the default nextest run -- they continue to run under
+# `cargo test` (and this crate is already excluded from exotic-platform CI as experimental).
+[profile.default]
+default-filter = "not binary(=middleware_tests) and not binary(=python_tests)"

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -138,8 +138,10 @@ ARG cargo_component_version=0.20.0
 ARG cargo_semver_checks_version=0.46.0
 ARG cargo_mdbook_version=0.4.37
 ARG cargo_mdbook_mermaid_version=0.13.0
+ARG cargo_nextest_version=0.9.140
 ARG rust_nightly_version
 RUN cargo install cargo-deny --locked --version ${cargo_deny_version} && \
+    cargo install cargo-nextest --locked --version ${cargo_nextest_version} && \
     cargo +${rust_nightly_version} install cargo-udeps --locked --version ${cargo_udeps_version} && \
     cargo install cargo-hack --locked --version ${cargo_hack_version} && \
     cargo install cargo-minimal-versions --locked --version ${cargo_minimal_versions_version} && \

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -128,7 +128,7 @@ RUN cargo install --locked --path tools/ci-build/changelogger && \
 FROM install_rust AS cargo_tools
 ARG cargo_deny_version=0.16.4
 ARG cargo_udeps_version=0.1.56
-ARG cargo_hack_version=0.6.27
+ARG cargo_hack_version=0.6.31
 ARG cargo_minimal_versions_version=0.1.27
 ARG cargo_check_external_types_version=0.5.0
 ARG maturin_version=1.5.1

--- a/tools/ci-build/build.docker-compose.yml
+++ b/tools/ci-build/build.docker-compose.yml
@@ -18,4 +18,10 @@ services:
     - type: bind
       source: ${GRADLE_CACHE_PATH}
       target: /home/build/.gradle
+    # Persist the cargo registry (index + downloaded crate sources) across CI runs so containerized
+    # legs don't re-download dependencies. CARGO_HOME lives in the image, so ci-action seeds this
+    # host dir from the image's baked-in registry on a cold cache to avoid hiding it.
+    - type: bind
+      source: ${CARGO_REGISTRY_PATH}
+      target: /opt/cargo/registry
     command: [/bin/bash, -c, --, sleep infinity]

--- a/tools/ci-build/ci-action
+++ b/tools/ci-build/ci-action
@@ -53,12 +53,19 @@ export GROUP_ID
 export GRADLE_CACHE_PATH="${START_PATH}/gradle"
 
 # Cargo registry cache. On a cold cache the host dir is empty; seed it from the image's baked-in
-# registry first, otherwise the bind mount would hide it and force a full re-download.
+# registry first, otherwise the bind mount would hide it and force a full re-download. Run the seed
+# as the invoking user so the copied files stay readable on the host for the cache upload, and let a
+# copy failure surface rather than leaving a half-seeded registry behind.
 export CARGO_REGISTRY_PATH="${START_PATH}/cargo-registry"
 mkdir -p "${CARGO_REGISTRY_PATH}"
 if [[ -z "$(ls -A "${CARGO_REGISTRY_PATH}" 2>/dev/null)" ]]; then
-    docker run --rm --entrypoint sh -v "${CARGO_REGISTRY_PATH}:/seed" smithy-rs-build-image:latest \
-        -c 'cp -a /opt/cargo/registry/. /seed/ 2>/dev/null || true'
+    if ! docker run --rm --entrypoint sh --user "${USER_ID}:${GROUP_ID}" \
+        -v "${CARGO_REGISTRY_PATH}:/seed" smithy-rs-build-image:latest \
+        -c 'cp -a /opt/cargo/registry/. /seed/'; then
+        echo "failed to seed the cargo registry cache; starting from an empty one"
+        rm -rf "${CARGO_REGISTRY_PATH}"
+        mkdir -p "${CARGO_REGISTRY_PATH}"
+    fi
 fi
 
 docker compose -f build.docker-compose.yml up -d

--- a/tools/ci-build/ci-action
+++ b/tools/ci-build/ci-action
@@ -51,6 +51,16 @@ GROUP_ID="$(id -g)"
 export USER_ID
 export GROUP_ID
 export GRADLE_CACHE_PATH="${START_PATH}/gradle"
+
+# Cargo registry cache. On a cold cache the host dir is empty; seed it from the image's baked-in
+# registry first, otherwise the bind mount would hide it and force a full re-download.
+export CARGO_REGISTRY_PATH="${START_PATH}/cargo-registry"
+mkdir -p "${CARGO_REGISTRY_PATH}"
+if [[ -z "$(ls -A "${CARGO_REGISTRY_PATH}" 2>/dev/null)" ]]; then
+    docker run --rm --entrypoint sh -v "${CARGO_REGISTRY_PATH}:/seed" smithy-rs-build-image:latest \
+        -c 'cp -a /opt/cargo/registry/. /seed/ 2>/dev/null || true'
+fi
+
 docker compose -f build.docker-compose.yml up -d
 if [[ "${ACTION_NAME}" == "--shell" ]]; then
     docker compose -f build.docker-compose.yml exec smithy-rs-build /bin/bash

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -27,8 +27,10 @@ if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
     echo "${C_YELLOW}## Running 'cargo clippy'${C_RESET}"
     cargo clippy --all-features
 
-    echo "${C_YELLOW}## Running 'cargo test'${C_RESET}"
-    cargo test --all-features
+    echo "${C_YELLOW}## Running 'cargo nextest run'${C_RESET}"
+    cargo nextest run --all-features
+    # nextest does not run doctests, so run them separately to keep coverage
+    cargo test --all-features --doc
 
     echo "${C_YELLOW}## Running 'cargo doc'${C_RESET}"
     cargo doc --no-deps --document-private-items --all-features

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -9,15 +9,8 @@ C_RESET='\033[0m'
 
 set -eux
 
-# Selects which portion of the aws-config checks to run. Splitting the work lets CI run the
-# expensive `cargo hack` feature-powersets as several parallel matrix legs instead of one
-# ~28-minute serial job. The union of `base` + every `featureset <i/N>` runs exactly the same
-# commands as `all`.
-#   all                  - everything (default; local dev and any non-matrix caller)
-#   base                 - the one-time checks (clippy/test/doc/minimal-versions/external-types/
-#                          tree/each-feature/wasm), i.e. everything except the two powersets
-#   featureset [i/N]     - only the two `cargo hack` feature-powerset passes, optionally sharded
-#                          to partition i of N via `cargo hack --partition`
+# Which checks to run so CI can parallelize the powersets: `all` (default), `base` (everything
+# except the powersets), or `featureset [i/N]` (only the powersets, optionally partitioned).
 MODE="${1:-all}"
 PARTITION="${2:-}"
 
@@ -64,10 +57,8 @@ if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
 fi
 
 if [[ "${MODE}" == "all" || "${MODE}" == "featureset" ]]; then
-    # `--partition M/N` shards the powerset across N legs (requires cargo-hack >= 0.6.31).
-    # NOTE: `--partition` is a cargo-hack flag and MUST come before the `check`/`test`
-    # subcommand, otherwise it is forwarded to cargo and fails with "unexpected argument".
-    # Empty PARTITION runs the full set.
+    # `--partition M/N` shards the powerset (needs cargo-hack >= 0.6.31) and MUST come before the
+    # subcommand, else it's forwarded to cargo and fails. Empty PARTITION runs the full set.
     partition_arg=()
     if [[ -n "${PARTITION}" ]]; then
         partition_arg=(--partition "${PARTITION}")

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -8,53 +8,76 @@ C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
 set -eux
+
+# Selects which portion of the aws-config checks to run. Splitting the work lets CI run the
+# expensive `cargo hack` feature-powersets as several parallel matrix legs instead of one
+# ~28-minute serial job. The union of `base` + every `featureset <i/N>` runs exactly the same
+# commands as `all`.
+#   all                  - everything (default; local dev and any non-matrix caller)
+#   base                 - the one-time checks (clippy/test/doc/minimal-versions/external-types/
+#                          tree/each-feature/wasm), i.e. everything except the two powersets
+#   featureset [i/N]     - only the two `cargo hack` feature-powerset passes, optionally sharded
+#                          to partition i of N via `cargo hack --partition`
+MODE="${1:-all}"
+PARTITION="${2:-}"
+
 cd smithy-rs
 
 # Make aws-config (which depends on generated services) available to additional checks
 mkdir -p aws/sdk/build
 mv ../aws-sdk-smoketest aws/sdk/build/aws-sdk
 
-echo -e "${C_YELLOW}# Testing aws-config...${C_RESET}"
+echo -e "${C_YELLOW}# Testing aws-config (mode=${MODE}${PARTITION:+, partition=${PARTITION}})...${C_RESET}"
 pushd "aws/rust-runtime/aws-config" &>/dev/null
 
-echo "${C_YELLOW}## Running 'cargo clippy'${C_RESET}"
-cargo clippy --all-features
+if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
+    echo "${C_YELLOW}## Running 'cargo clippy'${C_RESET}"
+    cargo clippy --all-features
 
-echo "${C_YELLOW}## Running 'cargo test'${C_RESET}"
-cargo test --all-features
+    echo "${C_YELLOW}## Running 'cargo test'${C_RESET}"
+    cargo test --all-features
 
-echo "${C_YELLOW}## Running 'cargo doc'${C_RESET}"
-cargo doc --no-deps --document-private-items --all-features
+    echo "${C_YELLOW}## Running 'cargo doc'${C_RESET}"
+    cargo doc --no-deps --document-private-items --all-features
 
-echo "${C_YELLOW}## Running 'cargo minimal-versions check'${C_RESET}"
-cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --all-features
+    echo "${C_YELLOW}## Running 'cargo minimal-versions check'${C_RESET}"
+    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --all-features
 
-echo "${C_YELLOW}## Checking for external types in public API${C_RESET}"
-cargo "+${RUST_NIGHTLY_VERSION:-nightly}" check-external-types --all-features --config external-types.toml
+    echo "${C_YELLOW}## Checking for external types in public API${C_RESET}"
+    cargo "+${RUST_NIGHTLY_VERSION:-nightly}" check-external-types --all-features --config external-types.toml
 
-echo "${C_YELLOW}## Checking for duplicate dependency versions in the normal dependency graph with all features enabled${C_RESET}"
-cargo tree -d --edges normal --all-features
+    echo "${C_YELLOW}## Checking for duplicate dependency versions in the normal dependency graph with all features enabled${C_RESET}"
+    cargo tree -d --edges normal --all-features
 
-# the crate has `allow-compilation` which needs to be deprecated
+    echo "${C_YELLOW}## Testing each feature in isolation${C_RESET}"
+    # these features are missed by the powerset check because they are grouped
+    cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls,default-https-client --exclude-no-default-features
 
-echo "${C_YELLOW}## Checking every combination of features${C_RESET}"
-cargo hack check --feature-powerset --exclude-all-features --exclude-features allow-compilation
+    echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasip2 targets${C_RESET}"
+    cargo check --target wasm32-unknown-unknown --no-default-features
+    cargo check --target wasm32-wasip2 --no-default-features
 
-echo "${C_YELLOW}## Testing each feature in isolation${C_RESET}"
-# these features are missed by the following check because they are grouped
-cargo hack test --each-feature --include-features rt-tokio,client-hyper,rustls,default-https-client --exclude-no-default-features
+    # TODO(https://github.com/smithy-lang/smithy-rs/issues/2499): Uncomment the following once aws-config tests compile for WASM
+    # echo "${C_YELLOW}## Testing the wasm32-unknown-unknown and wasm32-wasip1 targets${C_RESET}"
+    # wasm-pack test --node -- --no-default-features
+    # cargo test --target wasm32-wasip1 --no-default-features
+fi
 
-# This check will check other individual features and no-default-features
-# grouping these features because they don't interact
-cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client
+if [[ "${MODE}" == "all" || "${MODE}" == "featureset" ]]; then
+    # `--partition i/N` shards the powerset across N legs; empty PARTITION runs the full set.
+    partition_arg=()
+    if [[ -n "${PARTITION}" ]]; then
+        partition_arg=(--partition "${PARTITION}")
+    fi
 
-echo "${C_YELLOW}## Checking the wasm32-unknown-unknown and wasm32-wasip2 targets${C_RESET}"
-cargo check --target wasm32-unknown-unknown --no-default-features
-cargo check --target wasm32-wasip2 --no-default-features
+    # the crate has `allow-compilation` which needs to be deprecated
+    echo "${C_YELLOW}## Checking every combination of features${C_RESET}"
+    cargo hack check --feature-powerset --exclude-all-features --exclude-features allow-compilation "${partition_arg[@]}"
 
-# TODO(https://github.com/smithy-lang/smithy-rs/issues/2499): Uncomment the following once aws-config tests compile for WASM
-# echo "${C_YELLOW}## Testing the wasm32-unknown-unknown and wasm32-wasip1 targets${C_RESET}"
-# wasm-pack test --node -- --no-default-features
-# cargo test --target wasm32-wasip1 --no-default-features
+    # This check will check other individual features and no-default-features
+    # grouping these features because they don't interact
+    echo "${C_YELLOW}## Testing feature powerset (grouped)${C_RESET}"
+    cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client "${partition_arg[@]}"
+fi
 
 popd &>/dev/null

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -28,7 +28,7 @@ if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
     cargo clippy --all-features
 
     echo "${C_YELLOW}## Running 'cargo nextest run'${C_RESET}"
-    cargo nextest run --all-features
+    cargo nextest run --no-tests=pass --all-features
     # nextest does not run doctests, so run them separately to keep coverage
     cargo test --all-features --doc
 

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -62,7 +62,7 @@ if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
 fi
 
 if [[ "${MODE}" == "all" || "${MODE}" == "featureset" ]]; then
-    # `--partition M/N` shards the powerset (needs cargo-hack >= 0.6.31) and MUST come before the
+    # `--partition M/N` shards the powerset (needs cargo-hack >= 0.6.31) and must come before the
     # subcommand, else it's forwarded to cargo and fails. Empty PARTITION runs the full set.
     partition_arg=()
     if [[ -n "${PARTITION}" ]]; then

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -7,6 +7,9 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib-doctest-helper.sh"
+
 set -eux
 
 # Which checks to run so CI can parallelize the powersets: `all` (default), `base` (everything
@@ -29,8 +32,8 @@ if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
 
     echo "${C_YELLOW}## Running 'cargo nextest run'${C_RESET}"
     cargo nextest run --no-tests=pass --all-features
-    # nextest does not run doctests, so run them separately to keep coverage
-    cargo test --all-features --doc
+    # nextest does not run doctests, so run them separately (only where a lib target exists)
+    run_doctests_if_lib ""
 
     echo "${C_YELLOW}## Running 'cargo doc'${C_RESET}"
     cargo doc --no-deps --document-private-items --all-features

--- a/tools/ci-scripts/check-aws-config
+++ b/tools/ci-scripts/check-aws-config
@@ -64,7 +64,10 @@ if [[ "${MODE}" == "all" || "${MODE}" == "base" ]]; then
 fi
 
 if [[ "${MODE}" == "all" || "${MODE}" == "featureset" ]]; then
-    # `--partition i/N` shards the powerset across N legs; empty PARTITION runs the full set.
+    # `--partition M/N` shards the powerset across N legs (requires cargo-hack >= 0.6.31).
+    # NOTE: `--partition` is a cargo-hack flag and MUST come before the `check`/`test`
+    # subcommand, otherwise it is forwarded to cargo and fails with "unexpected argument".
+    # Empty PARTITION runs the full set.
     partition_arg=()
     if [[ -n "${PARTITION}" ]]; then
         partition_arg=(--partition "${PARTITION}")
@@ -72,12 +75,12 @@ if [[ "${MODE}" == "all" || "${MODE}" == "featureset" ]]; then
 
     # the crate has `allow-compilation` which needs to be deprecated
     echo "${C_YELLOW}## Checking every combination of features${C_RESET}"
-    cargo hack check --feature-powerset --exclude-all-features --exclude-features allow-compilation "${partition_arg[@]}"
+    cargo hack "${partition_arg[@]}" check --feature-powerset --exclude-all-features --exclude-features allow-compilation
 
     # This check will check other individual features and no-default-features
     # grouping these features because they don't interact
     echo "${C_YELLOW}## Testing feature powerset (grouped)${C_RESET}"
-    cargo hack test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client "${partition_arg[@]}"
+    cargo hack "${partition_arg[@]}" test --feature-powerset --exclude-all-features --exclude-features allow-compilation --group-features rt-tokio,client-hyper,rustls,default-https-client
 fi
 
 popd &>/dev/null

--- a/tools/ci-scripts/check-aws-config-partition-coverage
+++ b/tools/ci-scripts/check-aws-config-partition-coverage
@@ -3,11 +3,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Checks that the check-aws-config `--partition` legs cover the full feature powerset exactly
-# once, so partitioning can't silently drop coverage. Cheap; no generated SDK needed.
+# Checks that the check-aws-config `--partition` legs cover the feature powerset exactly once, so
+# partitioning can't drop coverage. Cheap; no generated SDK needed.
 
-C_RED='\033[1;31m'
-C_GREEN='\033[1;32m'
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
@@ -15,24 +13,21 @@ set -euo pipefail
 cd smithy-rs
 
 N="${1:-4}"   # number of partitions; keep in sync with the check-aws-config matrix in ci.yml
-# A crate that builds standalone (no generated SDK needed) so this test can run in test-codegen.
+# A crate that builds standalone (no generated SDK needed) so this can run in test-codegen.
 PROBE_DIR="rust-runtime/aws-smithy-types"
 
 echo -e "${C_YELLOW}# Guarding check-aws-config partition coverage (N=${N})...${C_RESET}"
 
-# cargo-hack must support --partition (missing before 0.6.31)
+# --partition was added in cargo-hack 0.6.31
 if ! cargo hack --help 2>&1 | grep -q -- '--partition'; then
-    echo -e "${C_RED}FAIL: installed cargo-hack has no --partition flag (needs >= 0.6.31).${C_RESET}"
-    cargo hack --version || true
-    exit 1
+    echo "ERROR: installed cargo-hack has no --partition flag (needs >= 0.6.31)" && cargo hack --version && exit 1
 fi
 echo "cargo-hack supports --partition: $(cargo hack --version)"
 
-# Check the partitions are a complete, disjoint cover of the powerset
 pushd "${PROBE_DIR}" &>/dev/null
 
-# cargo-hack prints `info: running ... (k/TOTAL)` for combos IN the partition and
-# `info: skipping ... (k/TOTAL)` for combos NOT in it. --depth 1 keeps the set tiny and fast.
+# cargo-hack logs `info: running ... (k/TOTAL)` for combos in the partition and `info: skipping`
+# for the rest. --depth 1 keeps the set small and fast.
 HACK_ARGS=(check --feature-powerset --exclude-all-features --depth 1)
 
 total_run=0
@@ -40,38 +35,36 @@ union_file="$(mktemp)"
 TOTAL=""
 for (( i=1; i<=N; i++ )); do
     log="$(mktemp)"
-    # --partition MUST precede the subcommand, or it is forwarded to cargo and errors.
+    # --partition must precede the subcommand, or it's forwarded to cargo and errors
     cargo hack --partition "${i}/${N}" "${HACK_ARGS[@]}" >"${log}" 2>&1 || {
-        echo -e "${C_RED}FAIL: partition ${i}/${N} invocation errored:${C_RESET}"; cat "${log}"; exit 1; }
+        echo "ERROR: partition ${i}/${N} invocation errored:" && cat "${log}" && exit 1; }
 
-    # `|| true`: a partition may run or skip zero combos, and grep exits 1 on no match under `set -e`
+    # `|| true` since grep exits 1 on no match under `set -e`
     ran="$(grep -c 'info: running '  "${log}" || true)"
     skipped="$(grep -c 'info: skipping ' "${log}" || true)"
     seen=$(( ran + skipped ))
     echo "  partition ${i}/${N}: ran=${ran} skipped=${skipped} (accounted ${seen})"
 
-    # Every partition sees the same full set as its denominator.
+    # Every partition sees the same full set as its denominator
     if [[ -z "${TOTAL}" ]]; then TOTAL="${seen}"; fi
     if [[ "${seen}" -ne "${TOTAL}" ]]; then
-        echo -e "${C_RED}FAIL: partition ${i}/${N} accounted ${seen}, expected ${TOTAL}.${C_RESET}"; exit 1
+        echo "ERROR: partition ${i}/${N} accounted ${seen}, expected ${TOTAL}" && exit 1
     fi
 
     (grep 'info: running ' "${log}" || true) | sed -E 's/.*running .(cargo[^`]*). on.*/\1/' >>"${union_file}"
     total_run=$(( total_run + ran ))
 done
 
-# Completeness: the partitions together run the whole set.
+# Completeness: the partitions together run the whole set
 if [[ "${total_run}" -ne "${TOTAL}" ]]; then
-    echo -e "${C_RED}FAIL: partitions ran ${total_run} combinations but the full set is ${TOTAL} — coverage lost.${C_RESET}"
-    exit 1
+    echo "ERROR: partitions ran ${total_run} combinations but the full set is ${TOTAL} -- coverage lost" && exit 1
 fi
 
-# Disjointness: no combination runs in more than one partition.
+# Disjointness: no combination runs in more than one partition
 distinct="$(sort -u "${union_file}" | wc -l | tr -d ' ')"
 if [[ "${distinct}" -ne "${TOTAL}" ]]; then
-    echo -e "${C_RED}FAIL: partitions overlap — ${total_run} runs but ${distinct} distinct combinations.${C_RESET}"
-    exit 1
+    echo "ERROR: partitions overlap -- ${total_run} runs but ${distinct} distinct combinations" && exit 1
 fi
 
 popd &>/dev/null
-echo -e "${C_GREEN}PASS: ${N} partitions are a complete, disjoint cover of all ${TOTAL} combinations.${C_RESET}"
+echo -e "${C_YELLOW}# ${N} partitions are a complete, disjoint cover of all ${TOTAL} combinations${C_RESET}"

--- a/tools/ci-scripts/check-aws-config-partition-coverage
+++ b/tools/ci-scripts/check-aws-config-partition-coverage
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Guards the `check-aws-config` feature-powerset partitioning (see tools/ci-scripts/
+# check-aws-config, MODE=featureset). Splitting the powerset across N `cargo hack --partition`
+# legs is only safe if the legs form a COMPLETE and DISJOINT cover of the full powerset — every
+# feature combination runs in exactly one leg, none dropped, none duplicated. If that breaks
+# (a cargo-hack without `--partition`, the flag in the wrong position so it is silently ignored,
+# or an upstream behavior change), coverage would shrink while CI stayed green.
+#
+# This regression bit us once: cargo-hack 0.6.27 has no `--partition` flag (added in 0.6.31),
+# so the featureset legs errored with "unexpected argument '--partition'". This test would have
+# caught that at near-zero cost.
+#
+# It runs two cheap assertions, neither of which needs the generated SDK:
+#   1. The installed cargo-hack actually supports `--partition` (the exact regression above).
+#   2. Partitioning is a complete, disjoint cover. Verified on a small standalone crate at
+#      `--depth 1` (~a handful of combinations, compiles in seconds). Partitioning is a
+#      crate-independent property of cargo-hack, so proving it here proves it for aws-config.
+
+C_RED='\033[1;31m'
+C_GREEN='\033[1;32m'
+C_YELLOW='\033[1;33m'
+C_RESET='\033[0m'
+
+set -euo pipefail
+cd smithy-rs
+
+N="${1:-4}"   # number of partitions; keep in sync with the check-aws-config matrix in ci.yml
+# A crate that builds standalone (no generated SDK needed) so this test can run in test-codegen.
+PROBE_DIR="rust-runtime/aws-smithy-types"
+
+echo -e "${C_YELLOW}# Guarding check-aws-config partition coverage (N=${N})...${C_RESET}"
+
+# --- Assertion 1: the flag exists (the exact 0.6.27 regression) --------------------------------
+if ! cargo hack --help 2>&1 | grep -q -- '--partition'; then
+    echo -e "${C_RED}FAIL: installed cargo-hack has no --partition flag (needs >= 0.6.31).${C_RESET}"
+    cargo hack --version || true
+    exit 1
+fi
+echo "cargo-hack supports --partition: $(cargo hack --version)"
+
+# --- Assertion 2: partitions are a complete, disjoint cover ------------------------------------
+pushd "${PROBE_DIR}" &>/dev/null
+
+# cargo-hack prints `info: running ... (k/TOTAL)` for combos IN the partition and
+# `info: skipping ... (k/TOTAL)` for combos NOT in it. --depth 1 keeps the set tiny and fast.
+HACK_ARGS=(check --feature-powerset --exclude-all-features --depth 1)
+
+total_run=0
+union_file="$(mktemp)"
+TOTAL=""
+for (( i=1; i<=N; i++ )); do
+    log="$(mktemp)"
+    # --partition MUST precede the subcommand, or it is forwarded to cargo and errors.
+    cargo hack --partition "${i}/${N}" "${HACK_ARGS[@]}" >"${log}" 2>&1 || {
+        echo -e "${C_RED}FAIL: partition ${i}/${N} invocation errored:${C_RESET}"; cat "${log}"; exit 1; }
+
+    # `|| true` on every grep: a partition may legitimately run or skip zero combinations
+    # (e.g. an empty trailing partition when TOTAL < N), and grep exits 1 on no match, which
+    # would otherwise abort under `set -e`.
+    ran="$(grep -c 'info: running '  "${log}" || true)"
+    skipped="$(grep -c 'info: skipping ' "${log}" || true)"
+    seen=$(( ran + skipped ))
+    echo "  partition ${i}/${N}: ran=${ran} skipped=${skipped} (accounted ${seen})"
+
+    # Every partition sees the same full set as its denominator.
+    if [[ -z "${TOTAL}" ]]; then TOTAL="${seen}"; fi
+    if [[ "${seen}" -ne "${TOTAL}" ]]; then
+        echo -e "${C_RED}FAIL: partition ${i}/${N} accounted ${seen}, expected ${TOTAL}.${C_RESET}"; exit 1
+    fi
+
+    (grep 'info: running ' "${log}" || true) | sed -E 's/.*running .(cargo[^`]*). on.*/\1/' >>"${union_file}"
+    total_run=$(( total_run + ran ))
+done
+
+# Completeness: the partitions together run the whole set.
+if [[ "${total_run}" -ne "${TOTAL}" ]]; then
+    echo -e "${C_RED}FAIL: partitions ran ${total_run} combinations but the full set is ${TOTAL} — coverage lost.${C_RESET}"
+    exit 1
+fi
+
+# Disjointness: no combination runs in more than one partition.
+distinct="$(sort -u "${union_file}" | wc -l | tr -d ' ')"
+if [[ "${distinct}" -ne "${TOTAL}" ]]; then
+    echo -e "${C_RED}FAIL: partitions overlap — ${total_run} runs but ${distinct} distinct combinations.${C_RESET}"
+    exit 1
+fi
+
+popd &>/dev/null
+echo -e "${C_GREEN}PASS: ${N} partitions are a complete, disjoint cover of all ${TOTAL} combinations.${C_RESET}"

--- a/tools/ci-scripts/check-aws-config-partition-coverage
+++ b/tools/ci-scripts/check-aws-config-partition-coverage
@@ -3,22 +3,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Guards the `check-aws-config` feature-powerset partitioning (see tools/ci-scripts/
-# check-aws-config, MODE=featureset). Splitting the powerset across N `cargo hack --partition`
-# legs is only safe if the legs form a COMPLETE and DISJOINT cover of the full powerset — every
-# feature combination runs in exactly one leg, none dropped, none duplicated. If that breaks
-# (a cargo-hack without `--partition`, the flag in the wrong position so it is silently ignored,
-# or an upstream behavior change), coverage would shrink while CI stayed green.
-#
-# This regression bit us once: cargo-hack 0.6.27 has no `--partition` flag (added in 0.6.31),
-# so the featureset legs errored with "unexpected argument '--partition'". This test would have
-# caught that at near-zero cost.
-#
-# It runs two cheap assertions, neither of which needs the generated SDK:
-#   1. The installed cargo-hack actually supports `--partition` (the exact regression above).
-#   2. Partitioning is a complete, disjoint cover. Verified on a small standalone crate at
-#      `--depth 1` (~a handful of combinations, compiles in seconds). Partitioning is a
-#      crate-independent property of cargo-hack, so proving it here proves it for aws-config.
+# Checks that the check-aws-config `--partition` legs cover the full feature powerset exactly
+# once, so partitioning can't silently drop coverage. Cheap; no generated SDK needed.
 
 C_RED='\033[1;31m'
 C_GREEN='\033[1;32m'
@@ -34,7 +20,7 @@ PROBE_DIR="rust-runtime/aws-smithy-types"
 
 echo -e "${C_YELLOW}# Guarding check-aws-config partition coverage (N=${N})...${C_RESET}"
 
-# --- Assertion 1: the flag exists (the exact 0.6.27 regression) --------------------------------
+# cargo-hack must support --partition (missing before 0.6.31)
 if ! cargo hack --help 2>&1 | grep -q -- '--partition'; then
     echo -e "${C_RED}FAIL: installed cargo-hack has no --partition flag (needs >= 0.6.31).${C_RESET}"
     cargo hack --version || true
@@ -42,7 +28,7 @@ if ! cargo hack --help 2>&1 | grep -q -- '--partition'; then
 fi
 echo "cargo-hack supports --partition: $(cargo hack --version)"
 
-# --- Assertion 2: partitions are a complete, disjoint cover ------------------------------------
+# Check the partitions are a complete, disjoint cover of the powerset
 pushd "${PROBE_DIR}" &>/dev/null
 
 # cargo-hack prints `info: running ... (k/TOTAL)` for combos IN the partition and
@@ -58,9 +44,7 @@ for (( i=1; i<=N; i++ )); do
     cargo hack --partition "${i}/${N}" "${HACK_ARGS[@]}" >"${log}" 2>&1 || {
         echo -e "${C_RED}FAIL: partition ${i}/${N} invocation errored:${C_RESET}"; cat "${log}"; exit 1; }
 
-    # `|| true` on every grep: a partition may legitimately run or skip zero combinations
-    # (e.g. an empty trailing partition when TOTAL < N), and grep exits 1 on no match, which
-    # would otherwise abort under `set -e`.
+    # `|| true`: a partition may run or skip zero combos, and grep exits 1 on no match under `set -e`
     ran="$(grep -c 'info: running '  "${log}" || true)"
     skipped="$(grep -c 'info: skipping ' "${log}" || true)"
     seen=$(( ran + skipped ))

--- a/tools/ci-scripts/check-aws-sdk-services
+++ b/tools/ci-scripts/check-aws-sdk-services
@@ -17,10 +17,10 @@ if [ "$ENABLE_SMOKETESTS" = "true" ]; then
     # Invoking `cargo test` at the root directory implicitly checks for the validity
     # of the top-level `Cargo.toml`
     echo "${C_YELLOW}## Running smoketests...${C_RESET}"
-    RUSTFLAGS="--cfg smoketests" cargo nextest run --all-features
+    RUSTFLAGS="--cfg smoketests" cargo nextest run --no-tests=pass --all-features
     RUSTFLAGS="--cfg smoketests" cargo test --all-features --doc
 else
-    cargo nextest run --all-features
+    cargo nextest run --no-tests=pass --all-features
     # nextest does not run doctests, so run them separately to keep coverage
     cargo test --all-features --doc
 fi

--- a/tools/ci-scripts/check-aws-sdk-services
+++ b/tools/ci-scripts/check-aws-sdk-services
@@ -17,9 +17,12 @@ if [ "$ENABLE_SMOKETESTS" = "true" ]; then
     # Invoking `cargo test` at the root directory implicitly checks for the validity
     # of the top-level `Cargo.toml`
     echo "${C_YELLOW}## Running smoketests...${C_RESET}"
-    RUSTFLAGS="--cfg smoketests" cargo test --all-features
+    RUSTFLAGS="--cfg smoketests" cargo nextest run --all-features
+    RUSTFLAGS="--cfg smoketests" cargo test --all-features --doc
 else
-    cargo test --all-features
+    cargo nextest run --all-features
+    # nextest does not run doctests, so run them separately to keep coverage
+    cargo test --all-features --doc
 fi
 
 # TODO reenable these tests when they have lockfiles

--- a/tools/ci-scripts/check-aws-sdk-services
+++ b/tools/ci-scripts/check-aws-sdk-services
@@ -7,6 +7,9 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib-doctest-helper.sh"
+
 set -eux
 cd aws-sdk
 
@@ -21,8 +24,8 @@ if [ "$ENABLE_SMOKETESTS" = "true" ]; then
     RUSTFLAGS="--cfg smoketests" cargo test --all-features --doc
 else
     cargo nextest run --no-tests=pass --all-features
-    # nextest does not run doctests, so run them separately to keep coverage
-    cargo test --all-features --doc
+    # nextest does not run doctests, so run them separately (only where a lib target exists)
+    run_doctests_if_lib ""
 fi
 
 # TODO reenable these tests when they have lockfiles

--- a/tools/ci-scripts/check-aws-sdk-smoketest-docs-clippy-udeps
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-docs-clippy-udeps
@@ -6,33 +6,53 @@
 
 set -eux
 
+# Optional arg selects a phase so this job can fan out across parallel legs. The phases use
+# different toolchains/flags and don't share compiled artifacts, so splitting them adds no
+# extra compilation:
+#   docs  - cargo doc + clippy on the smoketest, plus the integration-test check
+#   types - cargo hack udeps + the per-crate check-external-types loop
+#   all   - both (default; local dev and any non-matrix caller)
+phase="${1:-all}"
+run_phase() { [[ "${phase}" == "$1" || "${phase}" == "all" ]]; }
+
 # Docs, clippy, etc on the smoketest itself
 pushd aws-sdk-smoketest &>/dev/null
 
-# Override "fail on warning" for smoke test docs since DynamoDB's modeled docs cause rustdoc warnings
-RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
+if run_phase docs; then
+    # Override "fail on warning" for smoke test docs since DynamoDB's modeled docs cause rustdoc warnings
+    RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
-cargo clippy --all-features
-# running `cargo hack` runs this in the prod workspace and ensures that each crate is run individually
-cargo +"${RUST_NIGHTLY_VERSION}" hack udeps --all-features
+    cargo clippy --all-features
+fi
+
+if run_phase types; then
+    # running `cargo hack` runs this in the prod workspace and ensures that each crate is run individually
+    cargo +"${RUST_NIGHTLY_VERSION}" hack udeps --all-features
+fi
 popd &>/dev/null
 
-# Move the smoketest artifacts into smithy-rs and check the integration tests
-# (which use path dependencies into the generated artifacts) against them.
+# Move the smoketest artifacts into smithy-rs (needed by both the integration-test check and the
+# external-types loop below).
 mkdir -p smithy-rs/aws/sdk/build
 mv aws-sdk-smoketest smithy-rs/aws/sdk/build/aws-sdk
-pushd smithy-rs/aws/sdk/integration-tests
-cargo check
-popd &>/dev/null
 
-pushd smithy-rs/aws/sdk/build/aws-sdk/sdk &>/dev/null
-for crate_path in $(ls | grep -v "aws-"); do
-    if [[ -d "${crate_path}" ]]; then
-        pushd "${crate_path}" &>/dev/null
-        # Override "fail on warning" for smoke test docs since DynamoDB's modeled docs cause rustdoc warnings,
-        # and `cargo-check-external-types` relies on rustdoc JSON output.
-        RUSTDOCFLAGS="" cargo +"${RUST_NIGHTLY_VERSION}" check-external-types --all-features --config ../../../../sdk-external-types.toml
-        popd &>/dev/null
-    fi
-done
-popd &>/dev/null
+if run_phase docs; then
+    # Check the integration tests, which use path dependencies into the generated artifacts.
+    pushd smithy-rs/aws/sdk/integration-tests
+    cargo check
+    popd &>/dev/null
+fi
+
+if run_phase types; then
+    pushd smithy-rs/aws/sdk/build/aws-sdk/sdk &>/dev/null
+    for crate_path in $(ls | grep -v "aws-"); do
+        if [[ -d "${crate_path}" ]]; then
+            pushd "${crate_path}" &>/dev/null
+            # Override "fail on warning" for smoke test docs since DynamoDB's modeled docs cause rustdoc warnings,
+            # and `cargo-check-external-types` relies on rustdoc JSON output.
+            RUSTDOCFLAGS="" cargo +"${RUST_NIGHTLY_VERSION}" check-external-types --all-features --config ../../../../sdk-external-types.toml
+            popd &>/dev/null
+        fi
+    done
+    popd &>/dev/null
+fi

--- a/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
@@ -6,11 +6,14 @@
 
 set -eux
 cd aws-sdk-smoketest
-cargo test --all-features
+cargo nextest run --all-features
+# nextest does not run doctests, so run them separately to keep coverage
+cargo test --all-features --doc
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then
         echo "#### Testing ${test_dir}..."
-        cargo test --all-features --manifest-path "${test_dir}/Cargo.toml"
+        cargo nextest run --all-features --manifest-path "${test_dir}/Cargo.toml"
+        cargo test --all-features --doc --manifest-path "${test_dir}/Cargo.toml"
     fi
 done

--- a/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
@@ -14,6 +14,9 @@ for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then
         echo "#### Testing ${test_dir}..."
         cargo nextest run --all-features --manifest-path "${test_dir}/Cargo.toml"
-        cargo test --all-features --doc --manifest-path "${test_dir}/Cargo.toml"
+        # doctests only for crates with a library target (--doc errors on binary-only crates)
+        if [ -f "${test_dir}/src/lib.rs" ]; then
+            cargo test --all-features --doc --manifest-path "${test_dir}/Cargo.toml"
+        fi
     fi
 done

--- a/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
@@ -6,14 +6,14 @@
 
 set -eux
 cd aws-sdk-smoketest
-cargo nextest run --all-features
+cargo nextest run --no-tests=pass --all-features
 # nextest does not run doctests, so run them separately to keep coverage
 cargo test --all-features --doc
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then
         echo "#### Testing ${test_dir}..."
-        cargo nextest run --all-features --manifest-path "${test_dir}/Cargo.toml"
+        cargo nextest run --no-tests=pass --all-features --manifest-path "${test_dir}/Cargo.toml"
         # doctests only for crates with a library target (--doc errors on binary-only crates)
         if [ -f "${test_dir}/src/lib.rs" ]; then
             cargo test --all-features --doc --manifest-path "${test_dir}/Cargo.toml"

--- a/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
@@ -4,19 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib-doctest-helper.sh"
+
 set -eux
 cd aws-sdk-smoketest
 cargo nextest run --no-tests=pass --all-features
-# nextest does not run doctests, so run them separately to keep coverage
-cargo test --all-features --doc
+# nextest does not run doctests, so run them separately (only where a lib target exists)
+run_doctests_if_lib ""
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then
         echo "#### Testing ${test_dir}..."
         cargo nextest run --no-tests=pass --all-features --manifest-path "${test_dir}/Cargo.toml"
-        # doctests only for crates with a library target (--doc errors on binary-only crates)
-        if [ -f "${test_dir}/src/lib.rs" ]; then
-            cargo test --all-features --doc --manifest-path "${test_dir}/Cargo.toml"
-        fi
+        run_doctests_if_lib "" --manifest-path "${test_dir}/Cargo.toml"
     fi
 done

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -12,18 +12,43 @@ cd aws-sdk
 # Remove examples from workspace
 sed -i '/"examples\//d' Cargo.toml
 
-cargo check --all-targets --all-features
+# Optional `i/N` shards the ~300 service crates across parallel legs. No arg checks the whole
+# workspace (local dev and any non-matrix caller).
+PARTITION="${1:-}"
 
-for test_dir in tests/*; do
-    if [ -f "${test_dir}/Cargo.toml" ]; then
-        echo "#### Checking ${test_dir}..."
-        cargo check --all-targets --all-features --manifest-path "${test_dir}/Cargo.toml"
+if [[ -n "${PARTITION}" ]]; then
+    i="${PARTITION%/*}"
+    n="${PARTITION#*/}"
+    # Round-robin the sorted workspace members into this leg's slice, then check just those crates
+    mapfile -t all_pkgs < <(cargo metadata --no-deps --format-version 1 | python3 -c '
+import json, sys
+for name in sorted(p["name"] for p in json.load(sys.stdin)["packages"]):
+    print(name)')
+    pkg_args=()
+    for idx in "${!all_pkgs[@]}"; do
+        if (( idx % n == i - 1 )); then
+            pkg_args+=(-p "${all_pkgs[$idx]}")
+        fi
+    done
+    cargo check --all-targets --all-features "${pkg_args[@]}"
+else
+    cargo check --all-targets --all-features
+fi
+
+# The integration-test check and the large-file guard cover the whole SDK, so run them once (on the
+# first leg, or when unpartitioned) rather than repeating them on every shard.
+if [[ -z "${PARTITION}" || "${PARTITION%/*}" == "1" ]]; then
+    for test_dir in tests/*; do
+        if [ -f "${test_dir}/Cargo.toml" ]; then
+            echo "#### Checking ${test_dir}..."
+            cargo check --all-targets --all-features --manifest-path "${test_dir}/Cargo.toml"
+        fi
+    done
+
+    large_file_count="$(find sdk -iname '*.rs' -type f -size +1M | wc -l | bc)"
+    if [[ "${large_file_count}" != "0" ]]; then
+        echo "Found ${large_file_count} generated code files larger than 1 MB:"
+        find sdk -iname '*.rs' -type f -size +1M
+        exit 1
     fi
-done
-
-large_file_count="$(find sdk -iname '*.rs' -type f -size +1M | wc -l | bc)"
-if [[ "${large_file_count}" != "0" ]]; then
-    echo "Found ${large_file_count} generated code files larger than 1 MB:"
-    find sdk -iname '*.rs' -type f -size +1M
-    exit 1
 fi

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -13,6 +13,15 @@ set -eux
 
 : "$RUST_NIGHTLY_VERSION"
 
+# Optional first argument selects a single runtime workspace to check, so CI can run
+# `rust-runtime` and `aws/rust-runtime` as two parallel matrix legs instead of one serial job.
+# With no argument, both are checked (local dev and any non-matrix caller).
+if [[ $# -gt 0 ]]; then
+    runtime_paths=("$1")
+else
+    runtime_paths=("rust-runtime" "aws/rust-runtime")
+fi
+
 cd smithy-rs
 
 echo -e "# ${C_YELLOW}Auditing runtime crate version numbers...${C_RESET}"
@@ -31,9 +40,7 @@ fi
 # Array to collect MSRV mismatches
 msrv_mismatches=()
 
-for runtime_path in \
-    "rust-runtime" \
-    "aws/rust-runtime"
+for runtime_path in "${runtime_paths[@]}"
 do
     echo -e "# ${C_YELLOW}Testing ${runtime_path}...${C_RESET}"
     pushd "${runtime_path}" &>/dev/null

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -48,7 +48,7 @@ do
     cargo clippy --all-features
 
     echo -e "## ${C_YELLOW}Running 'cargo nextest run' on ${runtime_path}...${C_RESET}"
-    cargo nextest run --all-features
+    cargo nextest run --no-tests=pass --all-features
     # nextest does not run doctests, so run them separately to keep coverage
     cargo test --all-features --doc
 

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -9,6 +9,9 @@ C_RED='\033[1;31m'
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib-doctest-helper.sh"
+
 set -eux
 
 : "$RUST_NIGHTLY_VERSION"
@@ -49,8 +52,8 @@ do
 
     echo -e "## ${C_YELLOW}Running 'cargo nextest run' on ${runtime_path}...${C_RESET}"
     cargo nextest run --no-tests=pass --all-features
-    # nextest does not run doctests, so run them separately to keep coverage
-    cargo test --all-features --doc
+    # nextest does not run doctests, so run them separately (only where a lib target exists)
+    run_doctests_if_lib ""
 
     echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
 

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -13,9 +13,8 @@ set -eux
 
 : "$RUST_NIGHTLY_VERSION"
 
-# Optional first argument selects a single runtime workspace to check, so CI can run
-# `rust-runtime` and `aws/rust-runtime` as two parallel matrix legs instead of one serial job.
-# With no argument, both are checked (local dev and any non-matrix caller).
+# Optional arg selects one runtime workspace so CI can run rust-runtime and aws/rust-runtime as
+# parallel legs; with no arg both are checked (local dev and any non-matrix caller).
 if [[ $# -gt 0 ]]; then
     runtime_paths=("$1")
 else

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -16,13 +16,20 @@ set -eux
 
 : "$RUST_NIGHTLY_VERSION"
 
-# Optional arg selects one runtime workspace so CI can run rust-runtime and aws/rust-runtime as
+# Optional 1st arg selects one runtime workspace so CI can run rust-runtime and aws/rust-runtime as
 # parallel legs; with no arg both are checked (local dev and any non-matrix caller).
 if [[ $# -gt 0 ]]; then
     runtime_paths=("$1")
 else
     runtime_paths=("rust-runtime" "aws/rust-runtime")
 fi
+
+# Optional 2nd arg selects a phase so the heavy rust-runtime workspace can fan out across legs:
+#   workspace  - clippy/nextest/doc/minimal-versions + per-crate MSRV & external-types checks
+#   additional - the per-crate `additional-ci` feature-combination tests (the slow phase)
+#   all        - both (default; local dev and any non-matrix caller)
+phase="${2:-all}"
+run_phase() { [[ "${phase}" == "$1" || "${phase}" == "all" ]]; }
 
 cd smithy-rs
 
@@ -47,50 +54,53 @@ do
     echo -e "# ${C_YELLOW}Testing ${runtime_path}...${C_RESET}"
     pushd "${runtime_path}" &>/dev/null
 
-    echo -e "## ${C_YELLOW}Running 'cargo clippy' on ${runtime_path}...${C_RESET}"
-    cargo clippy --all-features
+    if run_phase workspace; then
+        echo -e "## ${C_YELLOW}Running 'cargo clippy' on ${runtime_path}...${C_RESET}"
+        cargo clippy --all-features
 
-    echo -e "## ${C_YELLOW}Running 'cargo nextest run' on ${runtime_path}...${C_RESET}"
-    cargo nextest run --no-tests=pass --all-features
-    # nextest does not run doctests, so run them separately (only where a lib target exists)
-    run_doctests_if_lib ""
+        echo -e "## ${C_YELLOW}Running 'cargo nextest run' on ${runtime_path}...${C_RESET}"
+        cargo nextest run --no-tests=pass --all-features
+        # nextest does not run doctests, so run them separately (only where a lib target exists)
+        run_doctests_if_lib ""
 
-    echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
+        echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
 
-    RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
+        RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
-    echo -e "## ${C_YELLOW}Running 'cargo minimal-versions check' on ${runtime_path}...${C_RESET}"
-    # Print out the cargo tree with minimal versions for easier debugging
-    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions tree --direct || echo "cargo minimal-versions tree failed"
-    # The `--direct` flag is used to test only direct dependencies, rather than all transitive dependencies. See:
-    # https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions
-    cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --direct --all-features
+        echo -e "## ${C_YELLOW}Running 'cargo minimal-versions check' on ${runtime_path}...${C_RESET}"
+        # Print out the cargo tree with minimal versions for easier debugging
+        cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions tree --direct || echo "cargo minimal-versions tree failed"
+        # The `--direct` flag is used to test only direct dependencies, rather than all transitive dependencies. See:
+        # https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions
+        cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --direct --all-features
 
-    for crate_path in *; do
-        if [[ -f "${crate_path}/Cargo.toml" ]]; then
-        #s
-            # verify that the MSRV is the main MSRV
-            package_msrv=$(sed -rn 's/rust-version = "(1[.][0-9]+)([.][0-9]+)?"/\1/p' "${crate_path}/Cargo.toml")
-            if [[ "${package_msrv}" != "${MAIN_MSRV}" ]]; then
-                msrv_mismatches+=("${runtime_path}/${crate_path}: toolchain MSRV is ${MAIN_MSRV}, crate MSRV is ${package_msrv}")
+        for crate_path in *; do
+            if [[ -f "${crate_path}/Cargo.toml" ]]; then
+                # verify that the MSRV is the main MSRV
+                package_msrv=$(sed -rn 's/rust-version = "(1[.][0-9]+)([.][0-9]+)?"/\1/p' "${crate_path}/Cargo.toml")
+                if [[ "${package_msrv}" != "${MAIN_MSRV}" ]]; then
+                    msrv_mismatches+=("${runtime_path}/${crate_path}: toolchain MSRV is ${MAIN_MSRV}, crate MSRV is ${package_msrv}")
+                fi
             fi
-        fi
-        if [[ -f "${crate_path}/external-types.toml" ]]; then
-            # Skip `aws-config` since it has its own checks in `check-aws-config`
-            if [[ "${crate_path}" != "aws-config" ]]; then
-                echo -e "## ${C_YELLOW}Running 'cargo check-external-types' on ${crate_path}...${C_RESET}"
-                pushd "${crate_path}" &>/dev/null
-                # Override "fail on warning" for docs since `cargo-check-external-types` relies on rustdoc JSON output.
-                RUSTDOCFLAGS="" cargo +"${RUST_NIGHTLY_VERSION}" check-external-types --all-features --config external-types.toml
-                popd &>/dev/null
+            if [[ -f "${crate_path}/external-types.toml" ]]; then
+                # Skip `aws-config` since it has its own checks in `check-aws-config`
+                if [[ "${crate_path}" != "aws-config" ]]; then
+                    echo -e "## ${C_YELLOW}Running 'cargo check-external-types' on ${crate_path}...${C_RESET}"
+                    pushd "${crate_path}" &>/dev/null
+                    # Override "fail on warning" for docs since `cargo-check-external-types` relies on rustdoc JSON output.
+                    RUSTDOCFLAGS="" cargo +"${RUST_NIGHTLY_VERSION}" check-external-types --all-features --config external-types.toml
+                    popd &>/dev/null
+                fi
             fi
-        fi
-    done
+        done
+    fi
 
     popd &>/dev/null
 
-    echo -e "${C_YELLOW}Running additional per-crate checks for ${runtime_path}...${C_RESET}"
-    ./tools/ci-scripts/additional-per-crate-checks.sh "${runtime_path}"
+    if run_phase additional; then
+        echo -e "${C_YELLOW}Running additional per-crate checks for ${runtime_path}...${C_RESET}"
+        ./tools/ci-scripts/additional-per-crate-checks.sh "${runtime_path}"
+    fi
 done
 
 # Report MSRV mismatches if any were found

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -47,8 +47,10 @@ do
     echo -e "## ${C_YELLOW}Running 'cargo clippy' on ${runtime_path}...${C_RESET}"
     cargo clippy --all-features
 
-    echo -e "## ${C_YELLOW}Running 'cargo test' on ${runtime_path}...${C_RESET}"
-    cargo test --all-features
+    echo -e "## ${C_YELLOW}Running 'cargo nextest run' on ${runtime_path}...${C_RESET}"
+    cargo nextest run --all-features
+    # nextest does not run doctests, so run them separately to keep coverage
+    cargo test --all-features --doc
 
     echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
 

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -10,6 +10,9 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib-doctest-helper.sh"
+
 if [ "$#" -ne 0 ]; then
   echo "Unexpected arguments ignored"
 fi
@@ -36,8 +39,8 @@ for sdk in aws-sdk-rust/sdk/*; do
       echo -e "${C_YELLOW}# Testing ${sdk}...${C_RESET}"
       pushd "$sdk" &>/dev/null
       cargo nextest run --no-tests=pass --all-features
-      # nextest does not run doctests, so run them separately to keep coverage
-      cargo test --all-features --doc
+      # nextest does not run doctests, so run them separately (only where a lib target exists)
+      run_doctests_if_lib ""
       popd &>/dev/null
     fi
  fi

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -35,7 +35,7 @@ for sdk in aws-sdk-rust/sdk/*; do
     if ls "$sdk/tests" | grep -v '^endpoint_tests\.rs$'; then
       echo -e "${C_YELLOW}# Testing ${sdk}...${C_RESET}"
       pushd "$sdk" &>/dev/null
-      cargo nextest run --all-features
+      cargo nextest run --no-tests=pass --all-features
       # nextest does not run doctests, so run them separately to keep coverage
       cargo test --all-features --doc
       popd &>/dev/null

--- a/tools/ci-scripts/check-semver-hazards
+++ b/tools/ci-scripts/check-semver-hazards
@@ -35,7 +35,9 @@ for sdk in aws-sdk-rust/sdk/*; do
     if ls "$sdk/tests" | grep -v '^endpoint_tests\.rs$'; then
       echo -e "${C_YELLOW}# Testing ${sdk}...${C_RESET}"
       pushd "$sdk" &>/dev/null
-      cargo test --all-features
+      cargo nextest run --all-features
+      # nextest does not run doctests, so run them separately to keep coverage
+      cargo test --all-features --doc
       popd &>/dev/null
     fi
  fi

--- a/tools/ci-scripts/check-tools
+++ b/tools/ci-scripts/check-tools
@@ -19,8 +19,11 @@ function test_tool {
     pushd "${tool_path}" &>/dev/null
     cargo +"${rust_version}" clippy --all-features
     cargo +"${rust_version}" nextest run --all-features
-    # nextest does not run doctests, so run them separately to keep coverage
-    cargo +"${rust_version}" test --all-features --doc
+    # nextest does not run doctests, so run them separately to keep coverage -- but only for
+    # crates with a library target (`cargo test --doc` errors on binary-only crates).
+    if [[ -f "src/lib.rs" ]]; then
+        cargo +"${rust_version}" test --all-features --doc
+    fi
     popd &>/dev/null
 }
 

--- a/tools/ci-scripts/check-tools
+++ b/tools/ci-scripts/check-tools
@@ -18,7 +18,9 @@ function test_tool {
     echo -e "${C_YELLOW}Testing ${tool_path}...${C_RESET}"
     pushd "${tool_path}" &>/dev/null
     cargo +"${rust_version}" clippy --all-features
-    cargo +"${rust_version}" test --all-features
+    cargo +"${rust_version}" nextest run --all-features
+    # nextest does not run doctests, so run them separately to keep coverage
+    cargo +"${rust_version}" test --all-features --doc
     popd &>/dev/null
 }
 

--- a/tools/ci-scripts/check-tools
+++ b/tools/ci-scripts/check-tools
@@ -7,6 +7,9 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib-doctest-helper.sh"
+
 set -eux
 cd smithy-rs
 
@@ -19,11 +22,8 @@ function test_tool {
     pushd "${tool_path}" &>/dev/null
     cargo +"${rust_version}" clippy --all-features
     cargo +"${rust_version}" nextest run --no-tests=pass --all-features
-    # nextest does not run doctests, so run them separately to keep coverage -- but only for
-    # crates with a library target (`cargo test --doc` errors on binary-only crates).
-    if [[ -f "src/lib.rs" ]]; then
-        cargo +"${rust_version}" test --all-features --doc
-    fi
+    # nextest does not run doctests, so run them separately (only where a lib target exists)
+    run_doctests_if_lib "${rust_version}"
     popd &>/dev/null
 }
 

--- a/tools/ci-scripts/check-tools
+++ b/tools/ci-scripts/check-tools
@@ -18,7 +18,7 @@ function test_tool {
     echo -e "${C_YELLOW}Testing ${tool_path}...${C_RESET}"
     pushd "${tool_path}" &>/dev/null
     cargo +"${rust_version}" clippy --all-features
-    cargo +"${rust_version}" nextest run --all-features
+    cargo +"${rust_version}" nextest run --no-tests=pass --all-features
     # nextest does not run doctests, so run them separately to keep coverage -- but only for
     # crates with a library target (`cargo test --doc` errors on binary-only crates).
     if [[ -f "src/lib.rs" ]]; then

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -4,6 +4,8 @@
 #  SPDX-License-Identifier: Apache-2.0
 import sys
 import os
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from diff_lib import get_cmd_output, get_cmd_status, eprint, run, run_git_commit_as_github_action, running_in_docker_build
 
 CURRENT_BRANCH = 'current'
@@ -66,37 +68,63 @@ def main(skip_generation=False):
     sdk_directory = os.path.join(repository_root, 'aws-sdk', 'sdk')
     os.chdir(sdk_directory)
 
-    failures = []
     deny_list = [
         # Proc-macro crates have no library target
         "aws-smithy-runtime-api-macros",
     ]
-    for path in os.listdir():
-        eprint(f'checking {path}...', end='')
+
+    # Collect checkable crates first (fast, serial — just filesystem + git cat-file).
+    # Use absolute paths so the parallel workers are immune to CWD races.
+    sdk_abs = os.path.abspath('.')
+    crates_to_check = []
+    for path in sorted(os.listdir()):
         if path in deny_list:
-            eprint(f"skipping {path} because it is in 'deny_list'")
+            eprint(f'skipping {path} because it is in deny_list')
         elif get_cmd_status(f'git cat-file -e base:./{path}/Cargo.toml') != 0:
             eprint(f'skipping {path} because it does not exist in base')
-        else:
+        elif os.path.isdir(path):
             (_, out, _) = get_cmd_output('cargo pkgid', cwd=path, quiet=True)
             pkgid = parse_package_id(out)
-            (status, out, err) = get_cmd_output(f'cargo semver-checks check-release '
-                                    f'--baseline-rev {BASE_BRANCH} '
-                                    # in order to get semver-checks to work with publish-false crates, need to specify
-                                    # package and manifest path explicitly
-                                    f'--manifest-path {path}/Cargo.toml '
-                                    '-v '
-                                    f'-p {pkgid} '
-                                    f'--all-features '
-                                    f'--release-type minor', check=False, quiet=True)
+            crates_to_check.append((path, pkgid, os.path.join(sdk_abs, path)))
+
+    eprint(f'{len(crates_to_check)} crates to check')
+
+    # Run cargo semver-checks in parallel. Each worker gets its own CARGO_TARGET_DIR to avoid
+    # the cargo build-lock (all share one source tree but compile to isolated target dirs).
+    # Cap at 4 workers to bound memory — rustdoc is memory-hungry on the 8-core runner.
+    max_workers = min(4, os.cpu_count() or 4)
+
+    def check_crate(item):
+        path, pkgid, abs_path = item
+        # Per-worker target dir avoids cargo build-lock contention
+        target_dir = tempfile.mkdtemp(prefix=f'semver-{path}-')
+        env = {**os.environ, 'CARGO_TARGET_DIR': target_dir}
+        manifest = os.path.join(abs_path, 'Cargo.toml')
+        (status, out, err) = get_cmd_output(
+            f'cargo semver-checks check-release '
+            f'--baseline-rev {BASE_BRANCH} '
+            f'--manifest-path {manifest} '
+            '-v '
+            f'-p {pkgid} '
+            f'--all-features '
+            f'--release-type minor',
+            check=False, quiet=True, env=env)
+        return (path, status, out, err)
+
+    failures = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(check_crate, c): c for c in crates_to_check}
+        for future in as_completed(futures):
+            path, status, out, err = future.result()
             if status == 0:
-                eprint('ok!')
+                eprint(f'checking {path}...ok!')
             else:
-                failures.append(f"{out}{err}")
-                eprint('failed!')
+                eprint(f'checking {path}...failed!')
                 if out:
                     eprint(out)
                 eprint(err)
+                failures.append(f"{out}{err}")
+
     if failures:
         eprint('One or more crates failed semver checks!')
         eprint("\n".join(failures))

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -4,6 +4,8 @@
 #  SPDX-License-Identifier: Apache-2.0
 import sys
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from diff_lib import get_cmd_output, get_cmd_status, eprint, run, run_git_commit_as_github_action, running_in_docker_build
 
 CURRENT_BRANCH = 'current'
@@ -65,38 +67,119 @@ def main(skip_generation=False):
     get_cmd_output(f'git checkout {CURRENT_BRANCH}')
     sdk_directory = os.path.join(repository_root, 'aws-sdk', 'sdk')
     os.chdir(sdk_directory)
+    sdk_abs = os.path.abspath('.')
 
-    failures = []
     deny_list = [
         # Proc-macro crates have no library target
         "aws-smithy-runtime-api-macros",
     ]
-    for path in os.listdir():
-        eprint(f'checking {path}...', end='')
+
+    # Collect the crates to check first. This part is cheap (filesystem + `git cat-file`) and stays
+    # serial so the parallel section below only does the expensive `cargo semver-checks` work.
+    # Absolute paths make the worker threads immune to any working-directory races.
+    crates_to_check = []
+    for path in sorted(os.listdir()):
         if path in deny_list:
             eprint(f"skipping {path} because it is in 'deny_list'")
         elif get_cmd_status(f'git cat-file -e base:./{path}/Cargo.toml') != 0:
             eprint(f'skipping {path} because it does not exist in base')
-        else:
+        elif os.path.isdir(path):
             (_, out, _) = get_cmd_output('cargo pkgid', cwd=path, quiet=True)
             pkgid = parse_package_id(out)
-            (status, out, err) = get_cmd_output(f'cargo semver-checks check-release '
-                                    f'--baseline-rev {BASE_BRANCH} '
-                                    # in order to get semver-checks to work with publish-false crates, need to specify
-                                    # package and manifest path explicitly
-                                    f'--manifest-path {path}/Cargo.toml '
-                                    '-v '
-                                    f'-p {pkgid} '
-                                    f'--all-features '
-                                    f'--release-type minor', check=False, quiet=True)
+            crates_to_check.append((path, pkgid, os.path.join(sdk_abs, path)))
+
+    eprint(f'{len(crates_to_check)} crates to check')
+    run_semver_checks_in_parallel(crates_to_check)
+
+
+# The registry that ships in the build image (index, downloaded `.crate` files, and their unpacked
+# `src/`) lives at CARGO_HOME=/opt/cargo/registry. A previous attempt to parallelize this loop only
+# gave each worker its own CARGO_TARGET_DIR and left CARGO_HOME shared; concurrent `cargo` processes
+# then raced to unpack the same crate sources into the one shared `registry/src`, blowing up with
+# "failed to unpack ... File exists (os error 17)". (cargo's `.package-cache` lock, which normally
+# serializes unpacking, is ineffective here because the container runs as the host uid against a
+# `build`-owned CARGO_HOME.)
+#
+# The fix is to give each worker a fully private CARGO_HOME so no two workers ever touch the same
+# mutable path — for both the head and baseline dependency sets. The large, read-only pieces (the
+# registry index, the downloaded `.crate` cache, and the git db) are symlinked in so nothing is
+# copied; only the per-worker mutable dirs (`registry/src` where crates get unpacked, and
+# `.package-cache`) are private and writable. A worker's home is reused across the crates it checks,
+# so incremental compilation still benefits.
+SEMVER_MAX_WORKERS = min(4, os.cpu_count() or 4)
+_worker_local = threading.local()
+
+
+def _worker_env():
+    """Return an env dict with a private, race-free CARGO_HOME + CARGO_TARGET_DIR for this thread."""
+    env = getattr(_worker_local, 'env', None)
+    if env is not None:
+        return env
+
+    shared_cargo_home = os.environ.get('CARGO_HOME', '/opt/cargo')
+    worker_root = os.path.join(
+        os.environ.get('TMPDIR', '/tmp'),
+        f'semver-worker-{threading.get_ident()}',
+    )
+    cargo_home = os.path.join(worker_root, 'cargo-home')
+    os.makedirs(os.path.join(cargo_home, 'registry'), exist_ok=True)
+
+    # Symlink the large read-only pieces from the shared registry (no copying); keep the dirs that
+    # cargo mutates during a check (`registry/src`, `.package-cache`) private to this worker.
+    for rel in ('registry/index', 'registry/cache', 'git'):
+        src = os.path.join(shared_cargo_home, rel)
+        if os.path.exists(src):
+            dst = os.path.join(cargo_home, rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.lexists(dst):
+                os.symlink(src, dst)
+    # Preserve the cargo config (registry mirrors, credentials, etc.) if the image sets one.
+    for config_name in ('config.toml', 'config'):
+        src = os.path.join(shared_cargo_home, config_name)
+        dst = os.path.join(cargo_home, config_name)
+        if os.path.exists(src) and not os.path.lexists(dst):
+            os.symlink(src, dst)
+
+    env = {
+        **os.environ,
+        'CARGO_HOME': cargo_home,
+        'CARGO_TARGET_DIR': os.path.join(worker_root, 'target'),
+    }
+    _worker_local.env = env
+    return env
+
+
+def _check_crate(item):
+    path, pkgid, abs_path = item
+    manifest = os.path.join(abs_path, 'Cargo.toml')
+    (status, out, err) = get_cmd_output(
+        f'cargo semver-checks check-release '
+        f'--baseline-rev {BASE_BRANCH} '
+        # in order to get semver-checks to work with publish-false crates, need to specify
+        # package and manifest path explicitly
+        f'--manifest-path {manifest} '
+        '-v '
+        f'-p {pkgid} '
+        f'--all-features '
+        f'--release-type minor',
+        check=False, quiet=True, env=_worker_env())
+    return (path, status, out, err)
+
+
+def run_semver_checks_in_parallel(crates_to_check):
+    failures = []
+    with ThreadPoolExecutor(max_workers=SEMVER_MAX_WORKERS) as executor:
+        futures = {executor.submit(_check_crate, c): c for c in crates_to_check}
+        for future in as_completed(futures):
+            path, status, out, err = future.result()
             if status == 0:
-                eprint('ok!')
+                eprint(f'checking {path}...ok!')
             else:
-                failures.append(f"{out}{err}")
-                eprint('failed!')
+                eprint(f'checking {path}...failed!')
                 if out:
                     eprint(out)
                 eprint(err)
+                failures.append(f"{out}{err}")
     if failures:
         eprint('One or more crates failed semver checks!')
         eprint("\n".join(failures))

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -4,8 +4,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 import sys
 import os
-import tempfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from diff_lib import get_cmd_output, get_cmd_status, eprint, run, run_git_commit_as_github_action, running_in_docker_build
 
 CURRENT_BRANCH = 'current'
@@ -68,63 +66,37 @@ def main(skip_generation=False):
     sdk_directory = os.path.join(repository_root, 'aws-sdk', 'sdk')
     os.chdir(sdk_directory)
 
+    failures = []
     deny_list = [
         # Proc-macro crates have no library target
         "aws-smithy-runtime-api-macros",
     ]
-
-    # Collect checkable crates first (fast, serial — just filesystem + git cat-file).
-    # Use absolute paths so the parallel workers are immune to CWD races.
-    sdk_abs = os.path.abspath('.')
-    crates_to_check = []
-    for path in sorted(os.listdir()):
+    for path in os.listdir():
+        eprint(f'checking {path}...', end='')
         if path in deny_list:
-            eprint(f'skipping {path} because it is in deny_list')
+            eprint(f"skipping {path} because it is in 'deny_list'")
         elif get_cmd_status(f'git cat-file -e base:./{path}/Cargo.toml') != 0:
             eprint(f'skipping {path} because it does not exist in base')
-        elif os.path.isdir(path):
+        else:
             (_, out, _) = get_cmd_output('cargo pkgid', cwd=path, quiet=True)
             pkgid = parse_package_id(out)
-            crates_to_check.append((path, pkgid, os.path.join(sdk_abs, path)))
-
-    eprint(f'{len(crates_to_check)} crates to check')
-
-    # Run cargo semver-checks in parallel. Each worker gets its own CARGO_TARGET_DIR to avoid
-    # the cargo build-lock (all share one source tree but compile to isolated target dirs).
-    # Cap at 4 workers to bound memory — rustdoc is memory-hungry on the 8-core runner.
-    max_workers = min(4, os.cpu_count() or 4)
-
-    def check_crate(item):
-        path, pkgid, abs_path = item
-        # Per-worker target dir avoids cargo build-lock contention
-        target_dir = tempfile.mkdtemp(prefix=f'semver-{path}-')
-        env = {**os.environ, 'CARGO_TARGET_DIR': target_dir}
-        manifest = os.path.join(abs_path, 'Cargo.toml')
-        (status, out, err) = get_cmd_output(
-            f'cargo semver-checks check-release '
-            f'--baseline-rev {BASE_BRANCH} '
-            f'--manifest-path {manifest} '
-            '-v '
-            f'-p {pkgid} '
-            f'--all-features '
-            f'--release-type minor',
-            check=False, quiet=True, env=env)
-        return (path, status, out, err)
-
-    failures = []
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(check_crate, c): c for c in crates_to_check}
-        for future in as_completed(futures):
-            path, status, out, err = future.result()
+            (status, out, err) = get_cmd_output(f'cargo semver-checks check-release '
+                                    f'--baseline-rev {BASE_BRANCH} '
+                                    # in order to get semver-checks to work with publish-false crates, need to specify
+                                    # package and manifest path explicitly
+                                    f'--manifest-path {path}/Cargo.toml '
+                                    '-v '
+                                    f'-p {pkgid} '
+                                    f'--all-features '
+                                    f'--release-type minor', check=False, quiet=True)
             if status == 0:
-                eprint(f'checking {path}...ok!')
+                eprint('ok!')
             else:
-                eprint(f'checking {path}...failed!')
+                failures.append(f"{out}{err}")
+                eprint('failed!')
                 if out:
                     eprint(out)
                 eprint(err)
-                failures.append(f"{out}{err}")
-
     if failures:
         eprint('One or more crates failed semver checks!')
         eprint("\n".join(failures))

--- a/tools/ci-scripts/lib-doctest-helper.sh
+++ b/tools/ci-scripts/lib-doctest-helper.sh
@@ -9,20 +9,38 @@
 # like the wasm test crates). This helper runs `--doc` only when a package has a plain `lib`
 # target, so the doctest step is a no-op rather than an error on those crates.
 
-# Runs `cargo [+toolchain] test --doc <extra args...>` iff the package (selected by the same
-# extra args, e.g. --manifest-path) has a plain `lib` target. Pass the toolchain (or "") first.
+# Runs `cargo [+toolchain] test --doc <extra args...>` iff the package that `--doc` would target
+# has a plain `lib` target. Pass the toolchain (or "") first.
 #   run_doctests_if_lib "<toolchain-or-empty>" [extra cargo args...]
+#
+# Note: `cargo metadata --no-deps` returns EVERY workspace member, not just the one being tested,
+# so we can't just check "does any package have a lib". We resolve the target package by the
+# manifest `--doc` will use -- the `--manifest-path` arg if given, else `<cwd>/Cargo.toml` -- and
+# check only that package's target kinds. `--doc` works only for the plain `lib` kind (not
+# `bin`, `cdylib`, `staticlib`, or `proc-macro`).
 run_doctests_if_lib() {
     local toolchain="$1"; shift
     local toolchain_arg=()
     [[ -n "${toolchain}" ]] && toolchain_arg=("+${toolchain}")
 
-    # A package can have `lib`, `cdylib`, `staticlib`, `bin`, `proc-macro`, `bench`, `test`
-    # targets. `--doc` only works for the plain `lib` kind, so check for it via cargo metadata.
+    # Determine the manifest that `cargo test --doc "$@"` will target.
+    local manifest="${PWD}/Cargo.toml"
+    local prev=""
+    for arg in "$@"; do
+        [[ "${prev}" == "--manifest-path" ]] && manifest="${arg}"
+        prev="${arg}"
+    done
+
     if cargo "${toolchain_arg[@]}" metadata --no-deps --format-version 1 "$@" 2>/dev/null \
-        | python3 -c 'import json,sys; sys.exit(0 if any("lib" in t["kind"] for p in json.load(sys.stdin)["packages"] for t in p["targets"]) else 1)'; then
+        | MANIFEST="${manifest}" python3 -c '
+import json, os, sys
+target = os.path.realpath(os.environ["MANIFEST"])
+pkgs = json.load(sys.stdin)["packages"]
+pkg = next((p for p in pkgs if os.path.realpath(p["manifest_path"]) == target), None)
+has_lib = pkg is not None and any("lib" in t["kind"] for t in pkg["targets"])
+sys.exit(0 if has_lib else 1)'; then
         cargo "${toolchain_arg[@]}" test --all-features --doc "$@"
     else
-        echo "Skipping doctests: no plain lib target"
+        echo "Skipping doctests: no plain lib target for ${manifest}"
     fi
 }

--- a/tools/ci-scripts/lib-doctest-helper.sh
+++ b/tools/ci-scripts/lib-doctest-helper.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helper for the nextest-based test scripts. Since `cargo nextest run` does not run
+# doctests, those scripts run `cargo test --doc` separately -- but `--doc` errors on packages
+# that have no doctest-capable library (binary-only crates, and `cdylib`/`staticlib`-only crates
+# like the wasm test crates). This helper runs `--doc` only when a package has a plain `lib`
+# target, so the doctest step is a no-op rather than an error on those crates.
+
+# Runs `cargo [+toolchain] test --doc <extra args...>` iff the package (selected by the same
+# extra args, e.g. --manifest-path) has a plain `lib` target. Pass the toolchain (or "") first.
+#   run_doctests_if_lib "<toolchain-or-empty>" [extra cargo args...]
+run_doctests_if_lib() {
+    local toolchain="$1"; shift
+    local toolchain_arg=()
+    [[ -n "${toolchain}" ]] && toolchain_arg=("+${toolchain}")
+
+    # A package can have `lib`, `cdylib`, `staticlib`, `bin`, `proc-macro`, `bench`, `test`
+    # targets. `--doc` only works for the plain `lib` kind, so check for it via cargo metadata.
+    if cargo "${toolchain_arg[@]}" metadata --no-deps --format-version 1 "$@" 2>/dev/null \
+        | python3 -c 'import json,sys; sys.exit(0 if any("lib" in t["kind"] for p in json.load(sys.stdin)["packages"] for t in p["targets"]) else 1)'; then
+        cargo "${toolchain_arg[@]}" test --all-features --doc "$@"
+    else
+        echo "Skipping doctests: no plain lib target"
+    fi
+}

--- a/tools/ci-scripts/lib-doctest-helper.sh
+++ b/tools/ci-scripts/lib-doctest-helper.sh
@@ -3,27 +3,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Shared helper for the nextest-based test scripts. Since `cargo nextest run` does not run
-# doctests, those scripts run `cargo test --doc` separately -- but `--doc` errors on packages
-# that have no doctest-capable library (binary-only crates, and `cdylib`/`staticlib`-only crates
-# like the wasm test crates). This helper runs `--doc` only when a package has a plain `lib`
-# target, so the doctest step is a no-op rather than an error on those crates.
+# `cargo nextest run` doesn't run doctests, so the nextest-based scripts run `cargo test --doc`
+# too -- but that errors on crates with no plain `lib` target (bin-only, and cdylib/staticlib
+# wasm crates). This helper runs `--doc` only when the target package has a `lib`, skipping it
+# otherwise.
 
-# Runs `cargo [+toolchain] test --doc <extra args...>` iff the package that `--doc` would target
-# has a plain `lib` target. Pass the toolchain (or "") first.
-#   run_doctests_if_lib "<toolchain-or-empty>" [extra cargo args...]
-#
-# Note: `cargo metadata --no-deps` returns EVERY workspace member, not just the one being tested,
-# so we can't just check "does any package have a lib". We resolve the target package by the
-# manifest `--doc` will use -- the `--manifest-path` arg if given, else `<cwd>/Cargo.toml` -- and
-# check only that package's target kinds. `--doc` works only for the plain `lib` kind (not
-# `bin`, `cdylib`, `staticlib`, or `proc-macro`).
+# run_doctests_if_lib "<toolchain-or-empty>" [extra cargo args...]
 run_doctests_if_lib() {
     local toolchain="$1"; shift
     local toolchain_arg=()
     [[ -n "${toolchain}" ]] && toolchain_arg=("+${toolchain}")
 
-    # Determine the manifest that `cargo test --doc "$@"` will target.
+    # The package `--doc` targets is the one whose manifest is --manifest-path, else <cwd>/Cargo.toml.
+    # cargo metadata --no-deps lists every workspace member, so match on that manifest specifically.
     local manifest="${PWD}/Cargo.toml"
     local prev=""
     for arg in "$@"; do


### PR DESCRIPTION
Parallelizes `check-aws-config` (base + 4 `cargo hack --partition` legs) and `check-rust-runtimes` (per-workspace legs) to cut CI wall-clock. Same checks, run in parallel.

> **⚠️ DO NOT MERGE** — draft opened for validation only.