### PR TITLE
Improve doc discoverability of token bucket configuration

### DIFF
--- a/.changelog/4764.md
+++ b/.changelog/4764.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#4764
+breaking: false
+new_feature: false
+bug_fix: false
+---
+Improve discoverability of the retry token bucket: the `config::retry` module docs, the `retry_config` builder method, and the `TokenBucket` type now point to `RetryPartition::custom().token_bucket(...)` for sizing or isolating the bucket.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -128,7 +128,16 @@ class ClientModuleDocProvider(
             ClientRustModule.config -> strDoc("Configuration for $serviceName.")
             ClientRustModule.Config.auth -> strDoc("Types needed to configure auth scheme resolution.")
             ClientRustModule.Config.endpoint -> strDoc("Types needed to configure endpoint resolution.")
-            ClientRustModule.Config.retry -> strDoc("Retry configuration.")
+            ClientRustModule.Config.retry ->
+                strDoc(
+                    "Retry configuration.\n\n" +
+                        "[`RetryConfig`](crate::config::retry::RetryConfig) sets the number of retry attempts and the " +
+                        "backoff between them. Retries are additionally bounded by a retry token bucket (a shared " +
+                        "retry quota): [`TokenBucket`](crate::config::retry::TokenBucket) " +
+                        "holds the tokens and [`RetryPartition`](crate::config::retry::RetryPartition) determines which " +
+                        "clients and operations share one. To size the token bucket or give a workload its own, use " +
+                        "[`Builder::retry_partition`](crate::config::Builder::retry_partition).",
+                )
             ClientRustModule.Config.timeout -> strDoc("Timeout configuration.")
             ClientRustModule.Config.http -> strDoc("HTTP request and response types.")
             ClientRustModule.Config.interceptors -> strDoc("Types needed to implement [`Intercept`](crate::config::Intercept).")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -93,6 +93,15 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                         /// let retry_config = RetryConfig::standard().with_max_attempts(5);
                         /// let config = Config::builder().retry_config(retry_config).build();
                         /// ```
+                        ///
+                        /// ## Retry token bucket
+                        ///
+                        /// [`RetryConfig`](#{RetryConfig}) controls *how many* times to retry and *how long* to back
+                        /// off. Retries are **also** gated by a retry token bucket (also called the retry quota) that
+                        /// is shared across a [`RetryPartition`](#{RetryPartition}). To configure the token bucket — for
+                        /// example, to set
+                        /// its capacity or to give a workload its own bucket — see [`Self::retry_partition`] and
+                        /// [`RetryPartition::custom`](#{RetryPartition}::custom).
                         pub fn retry_config(mut self, retry_config: #{RetryConfig}) -> Self {
                             self.set_retry_config(Some(retry_config));
                             self
@@ -280,7 +289,9 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                         ///
                         /// ## Notes
                         ///
-                        /// - This is an advanced setting — most users won't need to modify it.
+                        /// - This is an advanced setting. A common reason to set it is to size or isolate the retry
+                        ///   token bucket — for example, giving a high-throughput workload its own bucket. Otherwise
+                        ///   most users won't need to modify it.
                         /// - A configured client rate limiter has no effect unless [`RetryConfig::adaptive`](#{RetryConfig}::adaptive) is used.
                         ///
                         /// ## Examples
@@ -295,6 +306,21 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                         ///     .retry_partition(RetryPartition::custom("custom")
                         ///         .token_bucket(token_bucket)
                         ///         .build()
+                        ///     )
+                        ///     .build();
+                        /// ```
+                        ///
+                        /// Sizing the retry token bucket (for example, for a high-throughput workload), or giving a
+                        /// workload its own bucket:
+                        /// ```no_run
+                        /// use $moduleUseName::config::Config;
+                        /// use $moduleUseName::config::retry::{RetryPartition, TokenBucket};
+                        ///
+                        /// let config = Config::builder()
+                        ///     .retry_partition(
+                        ///         RetryPartition::custom("high-throughput")
+                        ///             .token_bucket(TokenBucket::builder().capacity(5000).build())
+                        ///             .build(),
                         ///     )
                         ///     .build();
                         /// ```

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.12.1"
+version = "1.12.2"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/token_bucket.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/token_bucket.rs
@@ -34,7 +34,30 @@ const LEGACY_RETRY_TIMEOUT_COST: u32 = LEGACY_RETRY_COST * 2;
 const PERMIT_REGENERATION_AMOUNT: usize = 1;
 const DEFAULT_SUCCESS_REWARD: f32 = 0.0;
 
-/// Token bucket used for standard and adaptive retry.
+/// Token bucket that bounds retries — a client-side retry quota.
+///
+/// Each retry attempt acquires tokens from the bucket; successful requests return or refill
+/// tokens. When the bucket is empty, the retry strategy stops retrying and returns the error to
+/// the caller, even if `max_attempts` has not been reached.
+///
+/// A single token bucket is shared by every operation in a [`RetryPartition`]. Use
+/// [`TokenBucket::builder`] to configure its [`capacity`](TokenBucketBuilder::capacity) and
+/// [`refill_rate`](TokenBucketBuilder::refill_rate), and attach it to a custom [`RetryPartition`]
+/// to give a workload its own bucket instead of sharing the default one.
+///
+/// ```
+/// use aws_smithy_runtime::client::retries::TokenBucket;
+///
+/// let token_bucket = TokenBucket::builder()
+///     .capacity(5000)
+///     .refill_rate(100.0) // tokens regenerated per second
+///     .build();
+/// ```
+///
+/// A custom [`RetryPartition`] carrying this bucket can then be set on a generated client's config
+/// builder via its `retry_partition` method.
+///
+/// [`RetryPartition`]: crate::client::retries::RetryPartition
 #[derive(Clone, Debug)]
 pub struct TokenBucket {
     semaphore: Arc<Semaphore>,


### PR DESCRIPTION
## Motivation and Context
The retry token bucket was made configurable via `RetryPartition::custom().token_bucket(...)` in https://github.com/smithy-lang/smithy-rs/pull/4263, but that path was not discoverable from where users actually look when tuning retries. Someone configuring retries lands on `RetryConfig`, the `retry_config` builder method, or the `config::retry` module and finds no pointer to how the token bucket can be configured.

## Description
This PR is doc updates only:
- **`config::retry` module docs** (`ClientRustModule.kt`): expanded from the one-line "Retry configuration." to orient readers across `RetryConfig`, `RetryPartition`, and `TokenBucket` (the shared retry quota), and to point at `Builder::retry_partition`.
- **`retry_config` builder method** (`ResiliencyConfigCustomization.kt`): added a "Retry token bucket" section noting retries are also bounded by the retry quota, linking to `Self::retry_partition` and `RetryPartition::custom`.
- **`retry_partition` builder method** (`ResiliencyConfigCustomization.kt`): added a "Sizing the retry token bucket" example using `TokenBucket::builder().capacity(...)`.
- **`TokenBucket` struct docs** (`aws-smithy-runtime`): expanded to describe it as a client-side retry quota, explain capacity/refill/partition sharing, and include a runnable example; links to `RetryPartition`.

## Testing
- CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
