### PR TITLE
Add identity-cache invalidation

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -366,7 +366,7 @@ version = "0.61.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d37cd9b566efa38233b081038602e92f5b54c87f270b7f5922f6e33c6b4d"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-schema 0.1.0",
  "aws-smithy-types 1.6.1",
  "minicbor",
@@ -377,7 +377,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.2",
  "criterion",
@@ -412,7 +412,7 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
@@ -431,7 +431,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -462,7 +462,7 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "bytes",
  "bytes-utils",
@@ -483,7 +483,7 @@ version = "0.64.0"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
@@ -507,7 +507,7 @@ version = "1.2.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "base64 0.22.1",
  "bytes",
@@ -551,7 +551,7 @@ dependencies = [
  "aws-smithy-cbor 0.61.10",
  "aws-smithy-http 0.62.6",
  "aws-smithy-json 0.61.9",
- "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "aws-smithy-xml 0.60.15",
  "bytes",
@@ -579,7 +579,7 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "bytes",
@@ -692,7 +692,7 @@ dependencies = [
 name = "aws-smithy-json"
 version = "0.63.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.2",
  "proptest",
@@ -706,7 +706,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.64.0",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "bytes",
  "bytes-utils",
@@ -731,7 +731,7 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
  "bytes",
@@ -761,7 +761,7 @@ dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "http 1.4.2",
  "tokio",
@@ -771,7 +771,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.3.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "serial_test",
 ]
 
@@ -795,7 +795,7 @@ name = "aws-smithy-protocol-test"
 version = "0.64.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -812,7 +812,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",
@@ -829,7 +829,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.2",
  "bytes",
@@ -853,23 +853,6 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.14.0"
-dependencies = [
- "aws-smithy-async 1.3.0",
- "aws-smithy-runtime-api-macros 1.1.0",
- "aws-smithy-types 1.6.2",
- "bytes",
- "http 0.2.12",
- "http 1.4.2",
- "pin-project-lite",
- "proptest",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
@@ -882,6 +865,23 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.15.0"
+dependencies = [
+ "aws-smithy-async 1.3.0",
+ "aws-smithy-runtime-api-macros 1.1.0",
+ "aws-smithy-types 1.6.2",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "proptest",
+ "tokio",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aws-smithy-runtime-api 1.14.0",
  "aws-smithy-types 1.6.1",
  "http 1.4.2",
 ]
@@ -919,7 +919,7 @@ dependencies = [
 name = "aws-smithy-schema"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "http 1.4.2",
 ]
@@ -1001,7 +1001,7 @@ name = "aws-smithy-wasm"
 version = "0.2.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-types 1.6.2",
  "http-body-util",
  "sync_wrapper",
@@ -1022,7 +1022,7 @@ name = "aws-smithy-xml"
 version = "0.62.0"
 dependencies = [
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.2",
  "base64 0.13.1",
@@ -2510,7 +2510,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.14.0",
+ "aws-smithy-runtime-api 1.15.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.2",
  "aws-smithy-xml 0.62.0",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
@@ -23,6 +23,7 @@ enum Inner {
     V2025_01_17,
     V2025_08_07,
     V2026_01_12,
+    V2026_08_01,
 }
 
 impl BehaviorVersion {
@@ -35,9 +36,23 @@ impl BehaviorVersion {
     /// If, however, you're writing a service that is very latency sensitive, or that has written
     /// code to tune Rust SDK behaviors, consider pinning to a specific major version.
     ///
-    /// The latest version is currently [`BehaviorVersion::v2026_01_12`]
+    /// The latest version is currently [`BehaviorVersion::v2026_08_01`]
     pub fn latest() -> Self {
-        Self::v2026_01_12()
+        Self::v2026_08_01()
+    }
+
+    /// Behavior version for August 1st, 2026.
+    ///
+    /// This version changes the default identity cache for AWS SDK clients to one that supports
+    /// consistent identity refresh behavior. Generic Smithy clients (non-AWS) continue to use the
+    /// lazy identity cache.
+    ///
+    /// NOTE: the exact release date encoded in `v2026_08_01` is provisional and will be finalized
+    /// at release.
+    pub fn v2026_08_01() -> Self {
+        Self {
+            inner: Inner::V2026_08_01,
+        }
     }
 
     /// Behavior version for January 12th, 2026.
@@ -145,11 +160,14 @@ mod tests {
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2025_01_17()));
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2025_08_07()));
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2026_01_12()));
+        assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2026_08_01()));
         assert!(!BehaviorVersion::v2023_11_09().is_at_least(BehaviorVersion::v2024_03_28()));
+        assert!(!BehaviorVersion::v2026_01_12().is_at_least(BehaviorVersion::v2026_08_01()));
         assert!(Inner::V2024_03_28 > Inner::V2023_11_09);
         assert!(Inner::V2023_11_09 < Inner::V2024_03_28);
         assert!(Inner::V2024_03_28 < Inner::V2025_01_17);
         assert!(Inner::V2025_01_17 < Inner::V2025_08_07);
         assert!(Inner::V2025_08_07 < Inner::V2026_01_12);
+        assert!(Inner::V2026_01_12 < Inner::V2026_08_01);
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
@@ -65,6 +65,13 @@ pub trait ResolveCachedIdentity: fmt::Debug + Send + Sync {
         config_bag: &'a ConfigBag,
     ) -> IdentityFuture<'a>;
 
+    /// Marks the cached identity for refresh.
+    ///
+    /// The default implementation is a no-op; caches override it to support invalidation.
+    fn invalidate(&self, rejected: &Identity) {
+        let _ = rejected;
+    }
+
     #[doc = include_str!("../../rustdoc/validate_base_client_config.md")]
     fn validate_base_client_config(
         &self,
@@ -106,6 +113,10 @@ impl ResolveCachedIdentity for SharedIdentityCache {
     ) -> IdentityFuture<'a> {
         self.0
             .resolve_cached_identity(resolver, runtime_components, config_bag)
+    }
+
+    fn invalidate(&self, rejected: &Identity) {
+        self.0.invalidate(rejected)
     }
 }
 
@@ -302,6 +313,15 @@ impl Identity {
             .get(&TypeId::of::<T>())
             .and_then(|b| b.downcast_ref())
     }
+
+    /// Returns `true` if `self` and `other` share the same underlying identity data allocation.
+    ///
+    /// Compares the `Arc` data-pointer (allocation identity), **not** the data contents: clones of
+    /// an `Identity` share their `data` allocation and compare equal, while independently built
+    /// `Identity` values compare unequal even when their contents are identical.
+    pub fn ptr_eq(&self, other: &Identity) -> bool {
+        Arc::ptr_eq(&self.data, &other.data)
+    }
 }
 
 impl Debug for Identity {
@@ -484,5 +504,24 @@ mod tests {
         assert_eq!(Some(expiration), identity.expiration());
         assert!(identity.property::<PropertyAlpha>().is_some());
         assert!(identity.property::<PropertyBeta>().is_some());
+    }
+
+    #[test]
+    fn ptr_eq_true_for_clone() {
+        // A clone shares the same underlying `data` allocation, so it is `ptr_eq` to the original.
+        let identity = Identity::new("some-identity-data", None);
+        let clone = identity.clone();
+        assert!(identity.ptr_eq(&clone));
+        assert!(clone.ptr_eq(&identity)); // symmetric
+        assert!(identity.ptr_eq(&identity)); // reflexive
+    }
+
+    #[test]
+    fn ptr_eq_false_for_independently_built_identities() {
+        // Identities built separately have distinct `data` allocations, so they are not `ptr_eq`
+        // even when their contents are identical.
+        let a = Identity::new("same-data", None);
+        let b = Identity::new("same-data", None);
+        assert!(!a.ptr_eq(&b));
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -52,6 +52,11 @@ pub mod operation;
 
 /// Config-bag marker requesting that the identity resolved for the current attempt be invalidated
 /// after the target service rejected it with an authentication failure.
+///
+/// Read (and consumed) at the end of `try_attempt`, while the resolved identity is still in
+/// scope, so it must be set no later than the `read_after_deserialization` interceptor hook.
+/// Setting it from `read_after_attempt` is too late: that hook runs afterward in `finally_attempt`,
+/// so the flag would be missed on the final (retries-exhausted) attempt.
 #[doc(hidden)]
 #[derive(Clone, Debug)]
 pub struct InvalidateResolvedIdentity;

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -15,6 +15,7 @@ use auth::{resolve_identity, sign_request};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::http::{HttpClient, HttpConnector, HttpConnectorSettings};
+use aws_smithy_runtime_api::client::identity::ResolveCachedIdentity;
 use aws_smithy_runtime_api::client::interceptors::context::{
     Error, Input, InterceptorContext, Output, RewindResult,
 };
@@ -30,7 +31,7 @@ use aws_smithy_runtime_api::client::ser_de::{
 };
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
-use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::retry::{MergeRetryConfig, RetryConfig, RetrySpec};
 use aws_smithy_types::timeout::{MergeTimeoutConfig, TimeoutConfig};
 use endpoints::apply_endpoint;
@@ -48,6 +49,16 @@ mod http;
 
 /// Utility for making one-off unmodeled requests with the orchestrator.
 pub mod operation;
+
+/// Config-bag marker requesting that the identity resolved for the current attempt be invalidated
+/// after the target service rejected it with an authentication failure.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct InvalidateResolvedIdentity;
+
+impl Storable for InvalidateResolvedIdentity {
+    type Storer = StoreReplace<Self>;
+}
 
 macro_rules! halt {
     ([$ctx:ident] => $err:expr) => {{
@@ -543,6 +554,16 @@ async fn try_attempt(
 
     ctx.enter_after_deserialization_phase();
     run_interceptors!(halt_on_err: read_after_deserialization(ctx, runtime_components, cfg));
+
+    // An interceptor may flag (via `InvalidateResolvedIdentity`) that the service rejected the
+    // resolved identity. Honor it with the in-scope signing identity, then consume the marker so a
+    // stale flag can't affect the next attempt. `invalidate` is a trait-default no-op for caches
+    // that don't override it.
+    if cfg.load::<InvalidateResolvedIdentity>().is_some() {
+        runtime_components.identity_cache().invalidate(&identity);
+        cfg.interceptor_state()
+            .unset::<InvalidateResolvedIdentity>();
+    }
 }
 
 async fn finally_attempt(


### PR DESCRIPTION
## Motivation and Context
This PR is the first in the series to support consistent credentials refresh across credentials providers.

- PR 1 (this PR) — `aws-smithy-runtime-api` + `aws-smithy-runtime` (generic hook)
- PR 2 — `aws-runtime` + `aws-credential-types` (a new refresh cache using the generic hook)
- PR 3 — `aws-config` + codegen (wiring)

These PRs will be merged into a feature branch.

## Description
This PR primarily introduces generic hooks in the Smithy runtime that a new credentials refresh cache makes use of in a subsequent PR. The invalidation hook is a trait-default no-op, and the new `BehaviorVersion` gates nothing until PR 2/PR 3 land.

Specifically, it adds:
- `Identity::ptr_eq`: compares two identities by their underlying data allocation (not contents), so a cache can distinguish a served identity from a later-refreshed one.
- `ResolveCachedIdentity::invalidate(&Identity)`: a default-no-op trait hook (with `SharedIdentityCache` delegation) that a cache overrides to mark a cached identity for refresh.
- `InvalidateResolvedIdentity`: a config-bag marker, used by the orchestrator in `try_attempt`, which calls `invalidate` with the in-scope signing identity and then consumes the marker.
- `BehaviorVersion::v2026_08_01`: a new behavior version (date tentative) under which AWS SDK clients default to an identity cache that supports consistent identity refresh; older versions and non-AWS clients keep the lazy cache.

Design decisions that motivate the changes:
- The refresh lifecycle lives in a new cache in `aws-runtime`, installed as the default identity cache for AWS clients, leaving the generic `LazyCache` untouched. It is realized generically over `Identity` (credentials *and* bearer tokens) with no downcast to `Credentials`, which is why the hooks in this PR (`ptr_eq`, `invalidate`) are defined on the generic `Identity` / `ResolveCachedIdentity` in `aws-smithy-runtime-api` rather than in AWS-land.
- The cache is a brand-new, retain-always type; `ExpiringCache` and the generic `LazyCache` are left as-is. So the hooks added here are purely additive and don't affect existing caches (S3 Express or non-AWS clients).
- Invalidation is the generic `invalidate(&Identity)` above, driven by the orchestrator (which holds the signing identity) after a per-operation interceptor flags an authentication failure via the data-free marker; the cache matches the rejected identity by `ptr_eq`, so it works for credentials and bearer tokens alike.

## Testing
- Added unit tests for `Identity::ptr_eq` in `aws-smithy-runtime-api`: a clone compares equal (also reflexive/symmetric), and two independently built identities with identical contents compare unequal.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
