### PR TITLE
Fix Python big-number exports and recursive unions

### DIFF
--- a/.changelog/1786041645.md
+++ b/.changelog/1786041645.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- server
+authors:
+- sgtpl
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Python server SDKs now export `BigInteger` and `BigDecimal` from their `types` module and support Python conversion for boxed recursive unions.

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerBoxedShapeGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerBoxedShapeGenerator.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.python.smithy.generators
+
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.server.python.smithy.PythonServerCargoDependency
+
+internal fun RustWriter.renderPyBoxTraits(shapeName: String) {
+    rustTemplate(
+        """
+        impl<'source> #{pyo3}::FromPyObject<'source> for std::boxed::Box<$shapeName> {
+            fn extract(ob: &'source #{pyo3}::PyAny) -> #{pyo3}::PyResult<Self> {
+                ob.extract::<$shapeName>().map(Box::new)
+            }
+        }
+
+        impl #{pyo3}::IntoPy<#{pyo3}::PyObject> for std::boxed::Box<$shapeName> {
+            fn into_py(self, py: #{pyo3}::Python<'_>) -> #{pyo3}::PyObject {
+                (*self).into_py(py)
+            }
+        }
+        """,
+        "pyo3" to PythonServerCargoDependency.PyO3.toType(),
+    )
+}

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
@@ -130,6 +130,8 @@ class PythonServerModuleGenerator(
             """
             let types = #{pyo3}::types::PyModule::new(py, "types")?;
             types.add_class::<#{SmithyPython}::types::Blob>()?;
+            types.add_class::<#{SmithyPython}::types::BigInteger>()?;
+            types.add_class::<#{SmithyPython}::types::BigDecimal>()?;
             types.add_class::<#{SmithyPython}::types::DateTime>()?;
             types.add_class::<#{SmithyPython}::types::Format>()?;
             types.add_class::<#{SmithyPython}::types::ByteStream>()?;

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerStructureGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerStructureGenerator.kt
@@ -64,7 +64,7 @@ class PythonServerStructureGenerator(
         super.renderStructure()
         renderPyO3Methods()
         if (!shape.hasTrait<ErrorTrait>()) {
-            renderPyBoxTraits()
+            writer.renderPyBoxTraits(name)
         }
     }
 
@@ -104,25 +104,6 @@ class PythonServerStructureGenerator(
             """,
             "BodySignature" to renderStructSignatureMembers(),
             "BodyMembers" to renderStructBodyMembers(),
-        )
-    }
-
-    private fun renderPyBoxTraits() {
-        writer.rustTemplate(
-            """
-            impl<'source> #{pyo3}::FromPyObject<'source> for std::boxed::Box<$name> {
-                fn extract(ob: &'source #{pyo3}::PyAny) -> #{pyo3}::PyResult<Self> {
-                    ob.extract::<$name>().map(Box::new)
-                }
-            }
-
-            impl #{pyo3}::IntoPy<#{pyo3}::PyObject> for std::boxed::Box<$name> {
-                fn into_py(self, py: #{pyo3}::Python<'_>) -> #{pyo3}::PyObject {
-                    (*self).into_py(py)
-                }
-            }
-            """,
-            "pyo3" to pyO3,
         )
     }
 

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGenerator.kt
@@ -52,6 +52,7 @@ class PythonServerUnionGenerator(
         renderPyUnionStruct()
         renderPyUnionImpl()
         renderPyObjectConverters()
+        writer.renderPyBoxTraits(unionSymbol.name)
     }
 
     private fun renderPyUnionStruct() {

--- a/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerTypesTest.kt
+++ b/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerTypesTest.kt
@@ -150,6 +150,98 @@ internal class PythonServerTypesTest {
     }
 
     @Test
+    fun `big number types are exported and usable from Python`() {
+        val model =
+            """
+            namespace test
+
+            use aws.protocols#restJson1
+
+            @restJson1
+            service Service {
+                operations: [Echo],
+            }
+
+            @http(method: "POST", uri: "/echo")
+            operation Echo {
+                input: EchoInput,
+                output: EchoOutput,
+            }
+
+            structure EchoInput {
+                @required
+                integer: BigInteger,
+                @required
+                decimal: BigDecimal,
+            }
+
+            structure EchoOutput {
+                @required
+                integer: BigInteger,
+                @required
+                decimal: BigDecimal,
+            }
+            """.asSmithyModel()
+
+        val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
+        executePythonServerCodegenVisitor(pluginCtx)
+
+        val writer = RustWriter.forModule("service")
+        writer.rust(
+            """
+            ##[test]
+            fn big_number_types_are_exported_and_usable_from_python() {
+                use pyo3::{types::PyModule, Python};
+
+                pyo3::prepare_freethreaded_python();
+
+                Python::with_gil(|py| {
+                    let module = PyModule::new(py, "generated_server").unwrap();
+                    crate::python_module_export::python_library(py, module).unwrap();
+
+                    let types = module.getattr("types").unwrap();
+                    let exported_types = types
+                        .getattr("__all__")
+                        .unwrap()
+                        .extract::<Vec<String>>()
+                        .unwrap();
+                    assert!(exported_types.contains(&"BigInteger".to_owned()));
+                    assert!(exported_types.contains(&"BigDecimal".to_owned()));
+
+                    let integer = types
+                        .getattr("BigInteger")
+                        .unwrap()
+                        .call1(("123456789012345678901234567890",))
+                        .unwrap();
+                    let decimal = types
+                        .getattr("BigDecimal")
+                        .unwrap()
+                        .call1(("12345678901234567890.123456789",))
+                        .unwrap();
+
+                    let input = module
+                        .getattr("input")
+                        .unwrap()
+                        .getattr("EchoInput")
+                        .unwrap()
+                        .call1((integer, decimal))
+                        .unwrap()
+                        .extract::<crate::input::EchoInput>()
+                        .unwrap();
+
+                    assert_eq!(input.integer.as_ref(), "123456789012345678901234567890");
+                    assert_eq!(input.decimal.as_ref(), "12345678901234567890.123456789");
+                });
+            }
+            """.trimIndent(),
+        )
+
+        testDir.resolve("src/service.rs").appendText(writer.toString())
+
+        cargoTest(testDir)
+    }
+
+    @Test
     fun `timestamp type`() {
         val model =
             """

--- a/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGeneratorTest.kt
+++ b/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGeneratorTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.python.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.cargoTest
+import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.executePythonServerCodegenVisitor
+import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.generatePythonServerPluginContext
+import kotlin.io.path.appendText
+
+internal class PythonServerUnionGeneratorTest {
+    @Test
+    fun `boxed recursive union converts to and from Python`() {
+        val model =
+            """
+            namespace test
+
+            use aws.protocols#restJson1
+
+            @restJson1
+            service Service {
+                operations: [Echo],
+            }
+
+            @http(method: "POST", uri: "/echo")
+            operation Echo {
+                input: EchoInput,
+                output: EchoOutput,
+            }
+
+            structure EchoInput {
+                @required
+                value: NativeValue,
+            }
+
+            structure EchoOutput {
+                @required
+                value: NativeValue,
+            }
+
+            union NativeValue {
+                array: ArrayValue,
+                string: String,
+            }
+
+            structure ArrayValue {
+                @required
+                defaultValue: NativeValue,
+            }
+            """.asSmithyModel()
+
+        val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
+        executePythonServerCodegenVisitor(pluginCtx)
+
+        val writer = RustWriter.forModule("model")
+        writer.rust(
+            """
+            ##[test]
+            fn boxed_recursive_union_converts_to_and_from_python() {
+                use pyo3::{types::IntoPyDict, Python};
+
+                pyo3::prepare_freethreaded_python();
+
+                let value = Python::with_gil(|py| {
+                    let globals = [
+                        ("NativeValue", py.get_type::<PyUnionMarkerNativeValue>()),
+                        ("ArrayValue", py.get_type::<ArrayValue>()),
+                    ]
+                    .into_py_dict(py);
+                    let locals = pyo3::types::PyDict::new(py);
+
+                    py.run(
+                        "leaf = NativeValue.string('leaf')\narray = ArrayValue(leaf)\nassert array.default_value.as_string() == 'leaf'\nvalue = NativeValue.array(array)\nassert value.as_array().default_value.as_string() == 'leaf'",
+                        Some(globals),
+                        Some(locals),
+                    )
+                    .unwrap();
+
+                    locals
+                        .get_item("value")
+                        .unwrap()
+                        .unwrap()
+                        .extract::<NativeValue>()
+                        .unwrap()
+                });
+
+                match value {
+                    NativeValue::Array(array) => match *array.default_value {
+                        NativeValue::String(value) => assert_eq!(value, "leaf"),
+                        other => panic!("expected string variant, got {other:?}"),
+                    },
+                    other => panic!("expected array variant, got {other:?}"),
+                }
+            }
+            """.trimIndent(),
+        )
+
+        testDir.resolve("src/model.rs").appendText(writer.toString())
+
+        cargoTest(testDir)
+    }
+}


### PR DESCRIPTION
## Motivation and Context

Python server SDKs use PyO3 wrappers for Smithy `BigInteger` and `BigDecimal`, but generated `types` modules do not register those classes. Generated type information can therefore reference Python types that users cannot import or access.

Directly recursive unions are boxed correctly in Rust, but generated Python servers fail to compile because `Box<Union>` lacks PyO3 `FromPyObject` and `IntoPy<PyObject>` implementations.

## Description

- Register `BigInteger` and `BigDecimal` in generated Python `types` modules, making them visible to imports and stub generation.
- Share boxed-shape PyO3 trait generation between structures and unions.
- Generate boxed PyO3 conversions for unions by delegating through their existing unboxed conversions.
- Add generated-crate runtime tests for big-number exports and recursive-union Python round trips.

## Testing

- Focused big-number and recursive-union regression tests.
- Clean, uncached `:codegen-server:codegen-server-python:test` run: 8 tests passed.
- Kotlin formatting and block-quote pre-commit hooks.

## Checklist

- [x] Added a server changelog entry.
