### PR TITLE
Export big-number types from Python servers

### DIFF
--- a/.changelog/1786041645.md
+++ b/.changelog/1786041645.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- server
+authors:
+- sgtpl
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Python server SDKs now export `BigInteger` and `BigDecimal` from their `types` module.

--- a/.changelog/1786041645.md
+++ b/.changelog/1786041645.md
@@ -3,7 +3,8 @@ applies_to:
 - server
 authors:
 - sgtpl
-references: []
+references:
+- smithy-rs#4769
 breaking: false
 new_feature: false
 bug_fix: true

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
@@ -130,6 +130,8 @@ class PythonServerModuleGenerator(
             """
             let types = #{pyo3}::types::PyModule::new(py, "types")?;
             types.add_class::<#{SmithyPython}::types::Blob>()?;
+            types.add_class::<#{SmithyPython}::types::BigInteger>()?;
+            types.add_class::<#{SmithyPython}::types::BigDecimal>()?;
             types.add_class::<#{SmithyPython}::types::DateTime>()?;
             types.add_class::<#{SmithyPython}::types::Format>()?;
             types.add_class::<#{SmithyPython}::types::ByteStream>()?;

--- a/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerTypesTest.kt
+++ b/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerTypesTest.kt
@@ -150,6 +150,98 @@ internal class PythonServerTypesTest {
     }
 
     @Test
+    fun `big number types are exported and usable from Python`() {
+        val model =
+            """
+            namespace test
+
+            use aws.protocols#restJson1
+
+            @restJson1
+            service Service {
+                operations: [Echo],
+            }
+
+            @http(method: "POST", uri: "/echo")
+            operation Echo {
+                input: EchoInput,
+                output: EchoOutput,
+            }
+
+            structure EchoInput {
+                @required
+                integer: BigInteger,
+                @required
+                decimal: BigDecimal,
+            }
+
+            structure EchoOutput {
+                @required
+                integer: BigInteger,
+                @required
+                decimal: BigDecimal,
+            }
+            """.asSmithyModel()
+
+        val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
+        executePythonServerCodegenVisitor(pluginCtx)
+
+        val writer = RustWriter.forModule("service")
+        writer.rust(
+            """
+            ##[test]
+            fn big_number_types_are_exported_and_usable_from_python() {
+                use pyo3::{types::PyModule, Python};
+
+                pyo3::prepare_freethreaded_python();
+
+                Python::with_gil(|py| {
+                    let module = PyModule::new(py, "generated_server").unwrap();
+                    crate::python_module_export::python_library(py, module).unwrap();
+
+                    let types = module.getattr("types").unwrap();
+                    let exported_types = types
+                        .getattr("__all__")
+                        .unwrap()
+                        .extract::<Vec<String>>()
+                        .unwrap();
+                    assert!(exported_types.contains(&"BigInteger".to_owned()));
+                    assert!(exported_types.contains(&"BigDecimal".to_owned()));
+
+                    let integer = types
+                        .getattr("BigInteger")
+                        .unwrap()
+                        .call1(("123456789012345678901234567890",))
+                        .unwrap();
+                    let decimal = types
+                        .getattr("BigDecimal")
+                        .unwrap()
+                        .call1(("12345678901234567890.123456789",))
+                        .unwrap();
+
+                    let input = module
+                        .getattr("input")
+                        .unwrap()
+                        .getattr("EchoInput")
+                        .unwrap()
+                        .call1((integer, decimal))
+                        .unwrap()
+                        .extract::<crate::input::EchoInput>()
+                        .unwrap();
+
+                    assert_eq!(input.integer.as_ref(), "123456789012345678901234567890");
+                    assert_eq!(input.decimal.as_ref(), "12345678901234567890.123456789");
+                });
+            }
+            """.trimIndent(),
+        )
+
+        testDir.resolve("src/service.rs").appendText(writer.toString())
+
+        cargoTest(testDir)
+    }
+
+    @Test
     fun `timestamp type`() {
         val model =
             """


### PR DESCRIPTION
## Motivation and Context

Python server SDKs use PyO3 wrappers for Smithy `BigInteger` and `BigDecimal`, but generated `types` modules do not register those classes. Generated type information can therefore reference Python types that users cannot import or access.

This is a follow-up to the big-number wrappers introduced in #4418.

## Description

Register `BigInteger` and `BigDecimal` alongside the existing Python wrapper types. Because PyO3 adds registered classes to the module's `__all__`, this also makes both classes discoverable by the generated stub tooling.

The regression test generates a server with modeled big-number members, verifies both classes are exported, constructs them from Python, and extracts the modeled input back into Rust without losing precision.

## Testing

- `:codegen-server:codegen-server-python:test --tests '*PythonServerTypesTest.big number types are exported and usable from Python'`
- Kotlin formatting and block-quote pre-commit hooks
