### PR TITLE
Support recursive unions in Python servers

### DIFF
--- a/.changelog/1786041646.md
+++ b/.changelog/1786041646.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- server
+authors:
+- sgtpl
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Python server SDKs now support Python conversion for boxed recursive unions.

--- a/.changelog/1786041646.md
+++ b/.changelog/1786041646.md
@@ -3,7 +3,8 @@ applies_to:
 - server
 authors:
 - sgtpl
-references: []
+references:
+- smithy-rs#4770
 breaking: false
 new_feature: false
 bug_fix: true

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerBoxedShapeGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerBoxedShapeGenerator.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.python.smithy.generators
+
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.server.python.smithy.PythonServerCargoDependency
+
+internal fun RustWriter.renderPyBoxTraits(shapeName: String) {
+    rustTemplate(
+        """
+        impl<'source> #{pyo3}::FromPyObject<'source> for std::boxed::Box<$shapeName> {
+            fn extract(ob: &'source #{pyo3}::PyAny) -> #{pyo3}::PyResult<Self> {
+                ob.extract::<$shapeName>().map(Box::new)
+            }
+        }
+
+        impl #{pyo3}::IntoPy<#{pyo3}::PyObject> for std::boxed::Box<$shapeName> {
+            fn into_py(self, py: #{pyo3}::Python<'_>) -> #{pyo3}::PyObject {
+                (*self).into_py(py)
+            }
+        }
+        """,
+        "pyo3" to PythonServerCargoDependency.PyO3.toType(),
+    )
+}

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerStructureGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerStructureGenerator.kt
@@ -64,7 +64,7 @@ class PythonServerStructureGenerator(
         super.renderStructure()
         renderPyO3Methods()
         if (!shape.hasTrait<ErrorTrait>()) {
-            renderPyBoxTraits()
+            writer.renderPyBoxTraits(name)
         }
     }
 
@@ -104,25 +104,6 @@ class PythonServerStructureGenerator(
             """,
             "BodySignature" to renderStructSignatureMembers(),
             "BodyMembers" to renderStructBodyMembers(),
-        )
-    }
-
-    private fun renderPyBoxTraits() {
-        writer.rustTemplate(
-            """
-            impl<'source> #{pyo3}::FromPyObject<'source> for std::boxed::Box<$name> {
-                fn extract(ob: &'source #{pyo3}::PyAny) -> #{pyo3}::PyResult<Self> {
-                    ob.extract::<$name>().map(Box::new)
-                }
-            }
-
-            impl #{pyo3}::IntoPy<#{pyo3}::PyObject> for std::boxed::Box<$name> {
-                fn into_py(self, py: #{pyo3}::Python<'_>) -> #{pyo3}::PyObject {
-                    (*self).into_py(py)
-                }
-            }
-            """,
-            "pyo3" to pyO3,
         )
     }
 

--- a/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGenerator.kt
+++ b/codegen-server/codegen-server-python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGenerator.kt
@@ -52,6 +52,7 @@ class PythonServerUnionGenerator(
         renderPyUnionStruct()
         renderPyUnionImpl()
         renderPyObjectConverters()
+        writer.renderPyBoxTraits(unionSymbol.name)
     }
 
     private fun renderPyUnionStruct() {

--- a/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGeneratorTest.kt
+++ b/codegen-server/codegen-server-python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGeneratorTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.python.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.cargoTest
+import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.executePythonServerCodegenVisitor
+import software.amazon.smithy.rust.codegen.server.python.smithy.testutil.generatePythonServerPluginContext
+import kotlin.io.path.appendText
+
+internal class PythonServerUnionGeneratorTest {
+    @Test
+    fun `boxed recursive union converts to and from Python`() {
+        val model =
+            """
+            namespace test
+
+            use aws.protocols#restJson1
+
+            @restJson1
+            service Service {
+                operations: [Echo],
+            }
+
+            @http(method: "POST", uri: "/echo")
+            operation Echo {
+                input: EchoInput,
+                output: EchoOutput,
+            }
+
+            structure EchoInput {
+                @required
+                value: NativeValue,
+            }
+
+            structure EchoOutput {
+                @required
+                value: NativeValue,
+            }
+
+            union NativeValue {
+                array: ArrayValue,
+                string: String,
+            }
+
+            structure ArrayValue {
+                @required
+                defaultValue: NativeValue,
+            }
+            """.asSmithyModel()
+
+        val (pluginCtx, testDir) = generatePythonServerPluginContext(model)
+        executePythonServerCodegenVisitor(pluginCtx)
+
+        val writer = RustWriter.forModule("model")
+        writer.rust(
+            """
+            ##[test]
+            fn boxed_recursive_union_converts_to_and_from_python() {
+                use pyo3::{types::IntoPyDict, Python};
+
+                pyo3::prepare_freethreaded_python();
+
+                let value = Python::with_gil(|py| {
+                    let globals = [
+                        ("NativeValue", py.get_type::<PyUnionMarkerNativeValue>()),
+                        ("ArrayValue", py.get_type::<ArrayValue>()),
+                    ]
+                    .into_py_dict(py);
+                    let locals = pyo3::types::PyDict::new(py);
+
+                    py.run(
+                        "leaf = NativeValue.string('leaf')\narray = ArrayValue(leaf)\nassert array.default_value.as_string() == 'leaf'\nvalue = NativeValue.array(array)\nassert value.as_array().default_value.as_string() == 'leaf'",
+                        Some(globals),
+                        Some(locals),
+                    )
+                    .unwrap();
+
+                    locals
+                        .get_item("value")
+                        .unwrap()
+                        .unwrap()
+                        .extract::<NativeValue>()
+                        .unwrap()
+                });
+
+                match value {
+                    NativeValue::Array(array) => match *array.default_value {
+                        NativeValue::String(value) => assert_eq!(value, "leaf"),
+                        other => panic!("expected string variant, got {other:?}"),
+                    },
+                    other => panic!("expected array variant, got {other:?}"),
+                }
+            }
+            """.trimIndent(),
+        )
+
+        testDir.resolve("src/model.rs").appendText(writer.toString())
+
+        cargoTest(testDir)
+    }
+}


### PR DESCRIPTION
## Motivation and Context

Smithy recursive-shape boxing correctly adds indirection to direct structure/union cycles, but Python server generation only provides PyO3 conversions for boxed structures. When the cycle requires a `Box<Union>`, generated PyO3 methods fail to compile because that type implements neither `FromPyObject` nor `IntoPy<PyObject>`.

## Description

Extract the existing boxed-shape PyO3 conversions into a shared renderer and use it for both structures and unions. Boxed union conversion delegates through the union's existing unboxed conversion, preserving the generated Python union representation.

The regression test models a `NativeValue` union and `ArrayValue` structure that recurse directly through a required member. It generates and compiles the Python server, constructs the recursive value from Python, exercises the boxed getter, and extracts the result back into Rust.

## Testing

- `:codegen-server:codegen-server-python:test --tests '*PythonServerUnionGeneratorTest'`
- Kotlin formatting and block-quote pre-commit hooks

