### PR TITLE
Add static stability cache

### DIFF
--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "aws-smithy-async",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "arbitrary",
  "aws-credential-types",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.1"
+version = "1.13.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-credential-types"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Types for AWS SDK credentials."
 edition = "2021"

--- a/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
+++ b/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
@@ -19,6 +19,19 @@ use aws_smithy_runtime_api::client::identity::Identity;
 use crate::attributes::AccountId;
 use crate::credential_feature::AwsCredentialFeature;
 
+/// Marks credentials (or a token) as produced by a **built-in AWS provider that is eligible for
+/// static-stability caching** — i.e. the AWS `StaticStabilityCache` may keep serving them past
+/// expiration on a failed refresh (subject to backoff).
+///
+/// Built-in providers (IMDS, ECS/EKS container, STS AssumeRole[WithWebIdentity], SSO, Login,
+/// Cognito) stamp this on the `Credentials` they produce; the `From<Credentials> for Identity`
+/// conversion lifts it to an `Identity`-level property, and the cache reads it back generically via
+/// `Identity::property::<StaticStabilityEligible>()`. Custom/process providers stamp nothing and
+/// therefore get caching-only behavior.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StaticStabilityEligible;
+
 /// AWS SDK Credentials
 ///
 /// An opaque struct representing credentials that may be used in an AWS SDK, modeled on
@@ -410,6 +423,12 @@ impl From<Credentials> for Identity {
                 layer.store_append(AwsCredentialFeature::ResolvedAccountId);
             }
             builder.set_property(layer.freeze());
+        }
+
+        // Lift the static-stability eligibility marker (stamped by built-in providers) from the
+        // Credentials onto the generic Identity, so the cache reads it without a downcast.
+        if val.get_property::<StaticStabilityEligible>().is_some() {
+            builder.set_property(StaticStabilityEligible);
         }
 
         builder.data(val).build().expect("set required fields")

--- a/aws/rust-runtime/aws-credential-types/src/lib.rs
+++ b/aws/rust-runtime/aws-credential-types/src/lib.rs
@@ -28,7 +28,7 @@ mod credentials_impl;
 pub mod provider;
 pub mod token_fn;
 
-pub use credentials_impl::{Credentials, CredentialsBuilder};
+pub use credentials_impl::{Credentials, CredentialsBuilder, StaticStabilityEligible};
 
 /// AWS Access Token
 ///

--- a/aws/rust-runtime/aws-credential-types/src/provider/error.rs
+++ b/aws/rust-runtime/aws-credential-types/src/provider/error.rs
@@ -46,6 +46,12 @@ pub struct Unhandled {
     source: Box<dyn Error + Send + Sync + 'static>,
 }
 
+/// Details for [`CredentialsError::Unrecoverable`]
+#[derive(Debug)]
+pub struct Unrecoverable {
+    source: Box<dyn Error + Send + Sync + 'static>,
+}
+
 /// Error returned when credentials failed to load.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -76,6 +82,10 @@ pub enum CredentialsError {
     /// - Returned data not UTF-8
     /// - A provider returns data that is missing required fields
     Unhandled(Unhandled),
+
+    /// The credentials provider experienced a terminal, non-recoverable error; the caller must act
+    /// (e.g. re-authenticate, `aws sso login`).
+    Unrecoverable(Unrecoverable),
 }
 
 impl CredentialsError {
@@ -132,6 +142,21 @@ impl CredentialsError {
     pub fn provider_timed_out(timeout_duration: Duration) -> Self {
         Self::ProviderTimedOut(ProviderTimedOut { timeout_duration })
     }
+
+    /// The credentials provider experienced a terminal, non-recoverable error.
+    ///
+    /// The caller must act (for example, re-authenticate).
+    pub fn unrecoverable(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+        Self::Unrecoverable(Unrecoverable {
+            source: source.into(),
+        })
+    }
+
+    /// Returns `true` if this is a terminal, non-recoverable error
+    /// ([`CredentialsError::Unrecoverable`]).
+    pub fn is_unrecoverable(&self) -> bool {
+        matches!(self, Self::Unrecoverable(_))
+    }
 }
 
 impl fmt::Display for CredentialsError {
@@ -154,6 +179,12 @@ impl fmt::Display for CredentialsError {
             CredentialsError::Unhandled(_) => {
                 write!(f, "unexpected credentials error")
             }
+            CredentialsError::Unrecoverable(_) => {
+                write!(
+                    f,
+                    "a non-recoverable error occurred while loading credentials"
+                )
+            }
         }
     }
 }
@@ -168,6 +199,7 @@ impl Error for CredentialsError {
             CredentialsError::InvalidConfiguration(details) => Some(details.source.as_ref() as _),
             CredentialsError::ProviderError(details) => Some(details.source.as_ref() as _),
             CredentialsError::Unhandled(details) => Some(details.source.as_ref() as _),
+            CredentialsError::Unrecoverable(details) => Some(details.source.as_ref() as _),
         }
     }
 }

--- a/aws/rust-runtime/aws-runtime/Cargo.toml
+++ b/aws/rust-runtime/aws-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.10.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "Runtime support code for the AWS SDK. This crate isn't intended to be used directly."
 edition = "2021"
@@ -36,6 +36,7 @@ http-body-1x = { package = "http-body", version = "1.0.1"}
 percent-encoding = "2.3.1"
 pin-project-lite = "0.2.14"
 regex-lite = { version = "0.1.5", optional = true }
+tokio = { version = "1.49.0", features = ["sync"] }
 tracing = "0.1.44"
 uuid = { version = "1" }
 

--- a/aws/rust-runtime/aws-runtime/external-types.toml
+++ b/aws/rust-runtime/aws-runtime/external-types.toml
@@ -2,6 +2,7 @@ allowed_external_types = [
     "aws_sigv4::*",
     "aws_smithy_types::*",
     "aws_smithy_runtime_api::*",
+    "aws_smithy_async::*",
     "aws_types::*",
     "bytes::bytes::Bytes",
 

--- a/aws/rust-runtime/aws-runtime/external-types.toml
+++ b/aws/rust-runtime/aws-runtime/external-types.toml
@@ -2,7 +2,6 @@ allowed_external_types = [
     "aws_sigv4::*",
     "aws_smithy_types::*",
     "aws_smithy_runtime_api::*",
-    "aws_smithy_async::*",
     "aws_types::*",
     "bytes::bytes::Bytes",
 

--- a/aws/rust-runtime/aws-runtime/src/lib.rs
+++ b/aws/rust-runtime/aws-runtime/src/lib.rs
@@ -50,3 +50,6 @@ pub mod fs_util;
 /// Supporting code for parsing AWS config values set in a user's environment or
 /// in a shared config file.
 pub mod env_config;
+
+/// Static-stability credentials caching and auth-failure invalidation for AWS clients.
+pub mod static_stability;

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -51,8 +51,9 @@ const BACKOFF_JITTER_SECS: u64 = 300;
 
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_millis(3100);
 
-// NOTE: `pessimistic_load_timeout` below is deliberately duplicated from `aws-smithy-runtime`'s
-// `LazyCache` rather than imported, to avoid the one-way `pub` API exposure.
+// NOTE: `pessimistic_load_timeout` below is deliberately duplicated from
+// `aws_smithy_runtime::client::identity::cache::lazy::pessimistic_load_timeout` rather than
+// imported, to avoid the one-way `pub` API exposure.
 //
 // Derive a pessimistic load timeout from the configured retry/timeout so the source's own retries
 // can finish before the cache kills the future.

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -102,7 +102,6 @@ type NonRecoverablePredicate = Arc<dyn Fn(&BoxError) -> bool + Send + Sync>;
 pub struct StaticStabilityCache {
     partitions: RwLock<HashMap<IdentityCachePartition, Arc<Partition>>>,
     load_timeout: Option<Duration>,
-    mandatory_window: Duration,
     non_recoverable: Option<NonRecoverablePredicate>,
     // Tests only, `None` in production (jittered 300..=600s backoff).
     backoff_override: Option<Duration>,
@@ -114,7 +113,6 @@ impl fmt::Debug for StaticStabilityCache {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StaticStabilityCache")
             .field("load_timeout", &self.load_timeout)
-            .field("mandatory_window", &self.mandatory_window)
             .field(
                 "non_recoverable",
                 &self.non_recoverable.as_ref().map(|_| "<predicate>"),
@@ -129,20 +127,26 @@ impl StaticStabilityCache {
         StaticStabilityCacheBuilder::default()
     }
 
-    fn new(
-        load_timeout: Option<Duration>,
-        mandatory_window: Duration,
-        backoff_override: Option<Duration>,
-        advisory_window_override: Option<Duration>,
-    ) -> Self {
+    fn new(load_timeout: Option<Duration>) -> Self {
         Self {
             partitions: RwLock::new(HashMap::new()),
             load_timeout,
-            mandatory_window,
             non_recoverable: Some(Arc::new(aws_non_recoverable)),
-            backoff_override,
-            advisory_window_override,
+            backoff_override: None,
+            advisory_window_override: None,
         }
+    }
+
+    // Test-only overrides for the otherwise non-configurable refresh backoff and advisory window.
+    #[cfg(test)]
+    fn with_overrides(
+        mut self,
+        backoff_override: Option<Duration>,
+        advisory_window_override: Option<Duration>,
+    ) -> Self {
+        self.backoff_override = backoff_override;
+        self.advisory_window_override = advisory_window_override;
+        self
     }
 
     // Get-or-create the per-source partition.
@@ -227,7 +231,7 @@ impl StaticStabilityCache {
                                 .advisory_window_override
                                 .unwrap_or_else(|| advisory_window_for(lifetime(expiry, now)));
                             st.advisory_at = Some(sub(expiry, advisory_window));
-                            st.mandatory_at = Some(sub(expiry, self.mandatory_window));
+                            st.mandatory_at = Some(sub(expiry, DEFAULT_MANDATORY_WINDOW));
                         } else {
                             // Ineligible (custom/process): a single caching-only window at expiry.
                             let at = sub(expiry, CACHING_ONLY_BUFFER_TIME);
@@ -482,7 +486,6 @@ fn validate(has_time_source: bool, has_sleep_impl: bool) -> Result<(), BoxError>
 #[derive(Clone, Debug, Default)]
 pub struct StaticStabilityCacheBuilder {
     load_timeout: Option<Duration>,
-    mandatory_window: Option<Duration>,
 }
 
 impl StaticStabilityCacheBuilder {
@@ -495,13 +498,7 @@ impl StaticStabilityCacheBuilder {
 
     /// Builds a [`SharedIdentityCache`] wrapping the configured [`StaticStabilityCache`].
     pub fn build(self) -> SharedIdentityCache {
-        StaticStabilityCache::new(
-            self.load_timeout,
-            self.mandatory_window.unwrap_or(DEFAULT_MANDATORY_WINDOW),
-            None,
-            None,
-        )
-        .into_shared()
+        StaticStabilityCache::new(self.load_timeout).into_shared()
     }
 }
 
@@ -659,9 +656,7 @@ mod tests {
             results: Mutex::new(queue),
             contacts: contacts.clone(),
         });
-        let cache = StaticStabilityCache::new(
-            None,
-            DEFAULT_MANDATORY_WINDOW,
+        let cache = StaticStabilityCache::new(None).with_overrides(
             s.given.refresh_backoff_seconds.map(Duration::from_secs),
             s.given
                 .configured_advisory_window_seconds

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -35,6 +35,7 @@ use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::retry::RetryConfig;
 use aws_smithy_types::timeout::TimeoutConfig;
 use std::collections::HashMap;
+use std::error::Error;
 use std::fmt;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, SystemTime};
@@ -451,11 +452,21 @@ fn jittered_backoff() -> Duration {
     Duration::from_secs(BACKOFF_MIN_SECS + fastrand::u64(0..=BACKOFF_JITTER_SECS))
 }
 
-// Default non-recoverable predicate injected into the cache by the AWS layer:
-// a terminal `CredentialsError::Unrecoverable` bypasses backoff and static stability.
+// Default non-recoverable predicate injected into the cache by the AWS layer: a terminal
+// `CredentialsError::Unrecoverable` anywhere in the source chain bypasses backoff and static
+// stability. Providers such as `ChainProvider` wrap the base-provider error, so walk the chain
+// rather than inspecting only the outermost error.
 fn aws_non_recoverable(err: &BoxError) -> bool {
-    err.downcast_ref::<CredentialsError>()
-        .is_some_and(CredentialsError::is_unrecoverable)
+    let mut source: Option<&(dyn Error + 'static)> = Some(&**err);
+    while let Some(e) = source {
+        if e.downcast_ref::<CredentialsError>()
+            .is_some_and(CredentialsError::is_unrecoverable)
+        {
+            return true;
+        }
+        source = e.source();
+    }
+    false
 }
 
 fn validate(has_time_source: bool, has_sleep_impl: bool) -> Result<(), BoxError> {
@@ -869,6 +880,25 @@ mod tests {
         assert_eq!(advisory_window_for(m(89)), m(15));
         assert_eq!(advisory_window_for(m(90)), m(60)); // boundary
         assert_eq!(advisory_window_for(m(6 * 60)), m(60));
+    }
+
+    // A non-recoverable error wrapped by an outer provider error (as `ChainProvider` produces) is
+    // still detected by walking the source chain, not just the outermost error.
+    #[test]
+    fn non_recoverable_walks_source_chain() {
+        let wrapped: BoxError =
+            CredentialsError::provider_error(CredentialsError::unrecoverable("expired SSO token"))
+                .into();
+        assert!(
+            aws_non_recoverable(&wrapped),
+            "a nested Unrecoverable must be detected"
+        );
+
+        let recoverable: BoxError = CredentialsError::provider_error("STS 503").into();
+        assert!(
+            !aws_non_recoverable(&recoverable),
+            "no Unrecoverable anywhere in the chain"
+        );
     }
 
     // Ineligible (custom/process) identity: no serve-stale.

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -21,7 +21,6 @@ use aws_credential_types::provider::error::CredentialsError;
 use aws_credential_types::StaticStabilityEligible;
 use aws_smithy_async::future::timeout::Timeout;
 use aws_smithy_async::rt::sleep::AsyncSleep;
-use aws_smithy_async::time::{SharedTimeSource, TimeSource};
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::identity::{
     Identity, IdentityCachePartition, IdentityFuture, ResolveCachedIdentity, ResolveIdentity,
@@ -102,8 +101,6 @@ type NonRecoverablePredicate = Arc<dyn Fn(&BoxError) -> bool + Send + Sync>;
 /// See the [module docs](self). Build one with [`StaticStabilityCache::builder`].
 pub struct StaticStabilityCache {
     partitions: RwLock<HashMap<IdentityCachePartition, Arc<Partition>>>,
-    // Used by `invalidate`.
-    time_source: SharedTimeSource,
     load_timeout: Option<Duration>,
     mandatory_window: Duration,
     non_recoverable: Option<NonRecoverablePredicate>,
@@ -133,7 +130,6 @@ impl StaticStabilityCache {
     }
 
     fn new(
-        time_source: SharedTimeSource,
         load_timeout: Option<Duration>,
         mandatory_window: Duration,
         backoff_override: Option<Duration>,
@@ -141,7 +137,6 @@ impl StaticStabilityCache {
     ) -> Self {
         Self {
             partitions: RwLock::new(HashMap::new()),
-            time_source,
             load_timeout,
             mandatory_window,
             non_recoverable: Some(Arc::new(aws_non_recoverable)),
@@ -180,7 +175,6 @@ impl StaticStabilityCache {
         resolver: &SharedIdentityResolver,
         runtime_components: &RuntimeComponents,
         config_bag: &ConfigBag,
-        now: SystemTime,
     ) -> Result<Identity, BoxError> {
         let prev = part.state.lock().unwrap().cached.clone();
 
@@ -189,21 +183,14 @@ impl StaticStabilityCache {
             .load_timeout
             .unwrap_or_else(|| pessimistic_load_timeout(config_bag));
         let timeout_future = sleep_impl.sleep(load_timeout);
-        let refreshed: Result<Identity, BoxError> = async move {
+        let resolved: Result<Identity, BoxError> = async move {
             match Timeout::new(
                 resolver.resolve_identity(runtime_components, config_bag),
                 timeout_future,
             )
             .await
             {
-                // Success with fresh credentials.
-                Ok(Ok(id)) if !expired(id.expiration(), now) => Ok(id),
-                // An `Ok` response with expiration <= now is treated as a failed refresh
-                // (retain + back off).
-                Ok(Ok(_stale)) => {
-                    Err("credential source returned already-expired credentials".into())
-                }
-                Ok(Err(e)) => Err(e),
+                Ok(result) => result,
                 // Timeout: converts a *hung* source into a serve-cached decision (recoverable).
                 Err(_elapsed) => {
                     Err(format!("credential resolution timed out after {:?}", load_timeout).into())
@@ -212,6 +199,20 @@ impl StaticStabilityCache {
         }
         .instrument(tracing::debug_span!("load_identity"))
         .await;
+
+        // The source call may have taken a while (up to the load timeout), so read `now` fresh from
+        // the (validated) runtime time source rather than a pre-await value.
+        let now = runtime_components.time_source().expect("validated").now();
+
+        // An `Ok` response already expired by `now` is treated as a failed refresh (retain + back
+        // off), not cached as fresh.
+        let refreshed = resolved.and_then(|id| {
+            if expired(id.expiration(), now) {
+                Err("credential source returned already-expired credentials".into())
+            } else {
+                Ok(id)
+            }
+        });
 
         match refreshed {
             Ok(id) => {
@@ -303,10 +304,7 @@ impl ResolveCachedIdentity for StaticStabilityCache {
         config_bag: &'a ConfigBag,
     ) -> IdentityFuture<'a> {
         IdentityFuture::new(async move {
-            let now = runtime_components
-                .time_source()
-                .map(|ts| ts.now())
-                .unwrap_or_else(|| self.time_source.now());
+            let now = runtime_components.time_source().expect("validated").now();
             let part = self.partition(resolver.cache_partition());
 
             // 1) snapshot + classify under the SYNC lock — no `.await` held
@@ -318,7 +316,7 @@ impl ResolveCachedIdentity for StaticStabilityCache {
                 // Advisory: refresh only if we win the gate, else serve cached now.
                 Decision::Advisory(cached) => match part.refresh_gate.try_lock() {
                     Ok(_permit) => {
-                        self.refresh(&part, &resolver, runtime_components, config_bag, now)
+                        self.refresh(&part, &resolver, runtime_components, config_bag)
                             .await
                     }
                     Err(_) => Ok(cached),
@@ -331,7 +329,7 @@ impl ResolveCachedIdentity for StaticStabilityCache {
                         return Ok(id);
                     }
                     // No rate-limiting during initial-fetch.
-                    self.refresh(&part, &resolver, runtime_components, config_bag, now)
+                    self.refresh(&part, &resolver, runtime_components, config_bag)
                         .await
                 }
             }
@@ -339,17 +337,16 @@ impl ResolveCachedIdentity for StaticStabilityCache {
     }
 
     fn invalidate(&self, rejected: &Identity) {
-        let now = self.time_source.now();
         for part in self.snapshot_partitions() {
             let mut st = part.state.lock().unwrap();
             if st.cached.as_ref().is_some_and(|c| c.ptr_eq(rejected)) {
                 // Route the next resolution through the mandatory path. classify() keys off
-                // advisory_at/mandatory_at (not expiration), so collapse both to `now`.
-                // Deliberately leave next_refresh_allowed_at (backoff) and cached
-                // (static stability) untouched.
-                st.expiration = Some(now);
-                st.advisory_at = Some(now);
-                st.mandatory_at = Some(now);
+                // advisory_at/mandatory_at, so collapse them to the epoch (a definitely-past time)
+                // — no time source needed here. Deliberately leave next_refresh_allowed_at
+                // (backoff) and cached (static stability) untouched.
+                st.expiration = Some(SystemTime::UNIX_EPOCH);
+                st.advisory_at = Some(SystemTime::UNIX_EPOCH);
+                st.mandatory_at = Some(SystemTime::UNIX_EPOCH);
                 break; // an identity is cached in exactly one partition
             }
         }
@@ -484,21 +481,11 @@ fn validate(has_time_source: bool, has_sleep_impl: bool) -> Result<(), BoxError>
 /// Builder for [`StaticStabilityCache`].
 #[derive(Clone, Debug, Default)]
 pub struct StaticStabilityCacheBuilder {
-    time_source: Option<SharedTimeSource>,
     load_timeout: Option<Duration>,
     mandatory_window: Option<Duration>,
 }
 
 impl StaticStabilityCacheBuilder {
-    /// Sets the time source used by `invalidate` (which receives no runtime components).
-    ///
-    /// `resolve_cached_identity` prefers the time source from `RuntimeComponents`; this only
-    /// backstops `invalidate`.
-    pub fn time_source(mut self, time_source: impl TimeSource + 'static) -> Self {
-        self.time_source = Some(SharedTimeSource::new(time_source));
-        self
-    }
-
     /// Sets the timeout bounding a single credential-source resolution. When unset, a default
     /// timeout is derived from the configured retry/timeout.
     pub fn load_timeout(mut self, load_timeout: Duration) -> Self {
@@ -509,7 +496,6 @@ impl StaticStabilityCacheBuilder {
     /// Builds a [`SharedIdentityCache`] wrapping the configured [`StaticStabilityCache`].
     pub fn build(self) -> SharedIdentityCache {
         StaticStabilityCache::new(
-            self.time_source.unwrap_or_default(),
             self.load_timeout,
             self.mandatory_window.unwrap_or(DEFAULT_MANDATORY_WINDOW),
             None,
@@ -674,7 +660,6 @@ mod tests {
             contacts: contacts.clone(),
         });
         let cache = StaticStabilityCache::new(
-            SharedTimeSource::new(time.clone()),
             None,
             DEFAULT_MANDATORY_WINDOW,
             s.given.refresh_backoff_seconds.map(Duration::from_secs),
@@ -841,9 +826,7 @@ mod tests {
                 contacts: contacts.clone(),
             });
             Self {
-                cache: StaticStabilityCache::builder()
-                    .time_source(time.clone())
-                    .build(),
+                cache: StaticStabilityCache::builder().build(),
                 resolver,
                 components,
                 config_bag: ConfigBag::base(),
@@ -1048,9 +1031,7 @@ mod tests {
                 Ok(identity(2, 7200, true)),
             ]),
         });
-        let cache = StaticStabilityCache::builder()
-            .time_source(time.clone())
-            .build();
+        let cache = StaticStabilityCache::builder().build();
 
         // Seed the initial fetch: permit exactly one source resolution.
         gate.notify_one();
@@ -1108,9 +1089,7 @@ mod tests {
                 Ok(identity(2, 10_000, true)),
             ]),
         });
-        let cache = StaticStabilityCache::builder()
-            .time_source(time.clone())
-            .build();
+        let cache = StaticStabilityCache::builder().build();
 
         gate.notify_one();
         let seed = cache

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -977,6 +977,67 @@ mod tests {
         assert!(contacted);
     }
 
+    // Two partitions, rejected identity in a non-sole partition: `invalidate` must find the
+    // matching slot by identity (ptr_eq) and collapse only it, leaving the other untouched.
+    // Partition iteration order is unspecified (HashMap), so this covers the walk-past-a-
+    // non-match path regardless of order.
+    #[tokio::test]
+    async fn invalidate_targets_only_the_matching_partition() {
+        let time = ManualTimeSource::new(epoch(0));
+        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(sleep))
+            .build()
+            .unwrap();
+        let cfg = ConfigBag::base();
+        let cache = StaticStabilityCache::new(None);
+
+        // Two sources -> two distinct cache partitions.
+        let contacts_a = Arc::new(AtomicUsize::new(0));
+        let resolver_a = SharedIdentityResolver::new(MockSource {
+            results: Mutex::new(vec![Ok(identity(1, 3600, true))]),
+            contacts: contacts_a.clone(),
+        });
+        let contacts_b = Arc::new(AtomicUsize::new(0));
+        let resolver_b = SharedIdentityResolver::new(MockSource {
+            results: Mutex::new(vec![
+                Ok(identity(2, 3600, true)),
+                Ok(identity(3, 3600, true)),
+            ]),
+            contacts: contacts_b.clone(),
+        });
+
+        // Seed both partitions.
+        let (a1, _) = source_get(&cache, &resolver_a, &components, &cfg, &contacts_a).await;
+        assert_eq!(id_of(&a1.unwrap()), 1);
+        let (b1, _) = source_get(&cache, &resolver_b, &components, &cfg, &contacts_b).await;
+        let served_b = b1.unwrap();
+        assert_eq!(id_of(&served_b), 2);
+
+        // Reject the identity living in the second source's partition.
+        cache.invalidate(&served_b);
+
+        // That partition refreshes on the next resolve (mandatory path; source contacted).
+        let (b2, contacted_b) =
+            source_get(&cache, &resolver_b, &components, &cfg, &contacts_b).await;
+        assert_eq!(id_of(&b2.unwrap()), 3, "rejected partition must refresh");
+        assert!(contacted_b, "invalidated partition must contact the source");
+
+        // The other partition is untouched: still served from cache, no source contact.
+        let (a2, contacted_a) =
+            source_get(&cache, &resolver_a, &components, &cfg, &contacts_a).await;
+        assert_eq!(
+            id_of(&a2.unwrap()),
+            1,
+            "non-matching partition must be unaffected"
+        );
+        assert!(
+            !contacted_a,
+            "invalidate must not touch a non-matching partition"
+        );
+    }
+
     // A source whose resolution blocks on a gate until released — for concurrency tests.
     #[derive(Debug)]
     struct GatedSource {

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -1,0 +1,1115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Static-stability credentials caching for AWS clients.
+//!
+//! `StaticStabilityCache` is the default identity cache for AWS clients (installed by codegen and
+//! `aws-config`). It is a retain-always, partition-keyed cache that provides *static stability*: on
+//! a failed credential refresh it keeps serving the previously-resolved identity past expiration
+//! (subject to backoff), so applications continue signing requests through a credential-source
+//! outage. It caches any `Identity` — credentials and bearer tokens alike — and reads its
+//! static-stability eligibility from a generic identity property.
+//!
+//! The `invalidation` submodule carries the auth-failure detection half of invalidation;
+//! the cache's `ResolveCachedIdentity::invalidate` is the action half.
+
+pub mod invalidation;
+
+use aws_credential_types::provider::error::CredentialsError;
+use aws_credential_types::StaticStabilityEligible;
+use aws_smithy_async::future::timeout::Timeout;
+use aws_smithy_async::rt::sleep::AsyncSleep;
+use aws_smithy_async::time::{SharedTimeSource, TimeSource};
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::identity::{
+    Identity, IdentityCachePartition, IdentityFuture, ResolveCachedIdentity, ResolveIdentity,
+    SharedIdentityCache, SharedIdentityResolver,
+};
+use aws_smithy_runtime_api::client::runtime_components::{
+    RuntimeComponents, RuntimeComponentsBuilder,
+};
+use aws_smithy_runtime_api::shared::IntoShared;
+use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::retry::RetryConfig;
+use aws_smithy_types::timeout::TimeoutConfig;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, SystemTime};
+use tracing::Instrument;
+
+// Blocking refresh point before expiration
+const DEFAULT_MANDATORY_WINDOW: Duration = Duration::from_secs(60);
+// Refresh point before expiry for caching-only (ineligible) identities
+const CACHING_ONLY_BUFFER_TIME: Duration = Duration::from_secs(10);
+// Uniform backoff floor after a failed refresh.
+const BACKOFF_MIN_SECS: u64 = 300;
+// Uniform backoff jitter span (300..=600s total).
+const BACKOFF_JITTER_SECS: u64 = 300;
+
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_millis(3100);
+
+// NOTE: `pessimistic_load_timeout` below is deliberately duplicated from `aws-smithy-runtime`'s
+// `LazyCache` rather than imported, to avoid the one-way `pub` API exposure.
+//
+// Derive a pessimistic load timeout from the configured retry/timeout so the source's own retries
+// can finish before the cache kills the future.
+fn pessimistic_load_timeout(config_bag: &ConfigBag) -> Duration {
+    let retry_config = config_bag
+        .load::<RetryConfig>()
+        .cloned()
+        .unwrap_or_else(RetryConfig::standard);
+    let timeout_config = config_bag
+        .load::<TimeoutConfig>()
+        .cloned()
+        .unwrap_or_else(TimeoutConfig::disabled);
+
+    let attempts = retry_config.max_attempts();
+    let initial_backoff = retry_config.initial_backoff().as_secs_f64();
+    let max_backoff = retry_config.max_backoff().as_secs_f64();
+
+    // Worst-case total backoff: sum of min(initial * 2^i, max_backoff) for each retry.
+    let total_backoff: f64 = (0..attempts.saturating_sub(1))
+        .map(|i| (initial_backoff * 2.0_f64.powi(i as i32)).min(max_backoff))
+        .sum();
+
+    // Per-attempt ceiling: connect_timeout (floored at the default, doubled to approximate a full
+    // attempt) or operation_attempt_timeout when larger.
+    let connect = timeout_config
+        .connect_timeout()
+        .unwrap_or(DEFAULT_CONNECT_TIMEOUT)
+        .max(DEFAULT_CONNECT_TIMEOUT)
+        .as_secs_f64();
+    let attempt_ceiling = timeout_config
+        .operation_attempt_timeout()
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    let per_attempt = (connect * 2.0).max(attempt_ceiling);
+    let total_attempts = attempts as f64 * per_attempt;
+
+    // Floor: at least one attempt's worth of budget even if max_attempts is 0.
+    let computed = total_backoff + total_attempts;
+    Duration::from_secs_f64(computed.max(per_attempt))
+}
+
+type NonRecoverablePredicate = Arc<dyn Fn(&BoxError) -> bool + Send + Sync>;
+
+/// The default identity cache for AWS clients: retain-always, partition-keyed, static-stability.
+///
+/// See the [module docs](self). Build one with [`StaticStabilityCache::builder`].
+pub struct StaticStabilityCache {
+    partitions: RwLock<HashMap<IdentityCachePartition, Arc<Partition>>>,
+    // Used by `invalidate`.
+    time_source: SharedTimeSource,
+    load_timeout: Option<Duration>,
+    mandatory_window: Duration,
+    non_recoverable: Option<NonRecoverablePredicate>,
+    // Tests only, `None` in production (jittered 300..=600s backoff).
+    backoff_override: Option<Duration>,
+    // Tests only, `None` in production (advisory window from the lifetime table).
+    advisory_window_override: Option<Duration>,
+}
+
+impl fmt::Debug for StaticStabilityCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StaticStabilityCache")
+            .field("load_timeout", &self.load_timeout)
+            .field("mandatory_window", &self.mandatory_window)
+            .field(
+                "non_recoverable",
+                &self.non_recoverable.as_ref().map(|_| "<predicate>"),
+            )
+            .finish()
+    }
+}
+
+impl StaticStabilityCache {
+    /// Returns a builder for [`StaticStabilityCache`].
+    pub fn builder() -> StaticStabilityCacheBuilder {
+        StaticStabilityCacheBuilder::default()
+    }
+
+    fn new(
+        time_source: SharedTimeSource,
+        load_timeout: Option<Duration>,
+        mandatory_window: Duration,
+        backoff_override: Option<Duration>,
+        advisory_window_override: Option<Duration>,
+    ) -> Self {
+        Self {
+            partitions: RwLock::new(HashMap::new()),
+            time_source,
+            load_timeout,
+            mandatory_window,
+            non_recoverable: Some(Arc::new(aws_non_recoverable)),
+            backoff_override,
+            advisory_window_override,
+        }
+    }
+
+    // Get-or-create the per-source partition.
+    // Read-mostly: the hit path takes only a shared read lock.
+    fn partition(&self, key: IdentityCachePartition) -> Arc<Partition> {
+        if let Some(p) = self.partitions.read().unwrap().get(&key).cloned() {
+            return p;
+        }
+        // Unbounded: a client-level cache sees only its configured resolvers (a small, static set),
+        // and per-operation `config_override` uses its own cache — so partitions don't grow with
+        // request volume. `entry` also collapses the check-then-insert race with another writer.
+        self.partitions
+            .write()
+            .unwrap()
+            .entry(key)
+            .or_insert_with(|| Arc::new(Partition::default()))
+            .clone()
+    }
+
+    fn snapshot_partitions(&self) -> Vec<Arc<Partition>> {
+        self.partitions.read().unwrap().values().cloned().collect()
+    }
+
+    // Refresh a partition from the source, then commit (success) or serve-cached/back-off/raise
+    // (failure). The source `.await` is held under the async `refresh_gate` only (acquired by the
+    // caller); the sync `state` lock is taken only for the brief snapshot/commit sections.
+    async fn refresh(
+        &self,
+        part: &Partition,
+        resolver: &SharedIdentityResolver,
+        runtime_components: &RuntimeComponents,
+        config_bag: &ConfigBag,
+        now: SystemTime,
+    ) -> Result<Identity, BoxError> {
+        let prev = part.state.lock().unwrap().cached.clone();
+
+        let sleep_impl = runtime_components.sleep_impl().expect("validated");
+        let load_timeout = self
+            .load_timeout
+            .unwrap_or_else(|| pessimistic_load_timeout(config_bag));
+        let timeout_future = sleep_impl.sleep(load_timeout);
+        let refreshed: Result<Identity, BoxError> = async move {
+            match Timeout::new(
+                resolver.resolve_identity(runtime_components, config_bag),
+                timeout_future,
+            )
+            .await
+            {
+                // Success with fresh credentials.
+                Ok(Ok(id)) if !expired(id.expiration(), now) => Ok(id),
+                // An `Ok` response with expiration <= now is treated as a failed refresh
+                // (retain + back off).
+                Ok(Ok(_stale)) => {
+                    Err("credential source returned already-expired credentials".into())
+                }
+                Ok(Err(e)) => Err(e),
+                // Timeout: converts a *hung* source into a serve-cached decision (recoverable).
+                Err(_elapsed) => {
+                    Err(format!("credential resolution timed out after {:?}", load_timeout).into())
+                }
+            }
+        }
+        .instrument(tracing::debug_span!("load_identity"))
+        .await;
+
+        match refreshed {
+            Ok(id) => {
+                let mut st = part.state.lock().unwrap();
+                st.cached = Some(id.clone());
+                match id.expiration() {
+                    Some(expiry) => {
+                        st.expiration = Some(expiry);
+                        if eligible(&id) {
+                            // Static-stability overlay: advisory + mandatory windows.
+                            let advisory_window = self
+                                .advisory_window_override
+                                .unwrap_or_else(|| advisory_window_for(lifetime(expiry, now)));
+                            st.advisory_at = Some(sub(expiry, advisory_window));
+                            st.mandatory_at = Some(sub(expiry, self.mandatory_window));
+                        } else {
+                            // Ineligible (custom/process): a single caching-only window at expiry.
+                            let at = sub(expiry, CACHING_ONLY_BUFFER_TIME);
+                            st.advisory_at = Some(at);
+                            st.mandatory_at = Some(at);
+                        }
+                    }
+                    // Non-expiring identity: no expiration-based refresh. Served indefinitely
+                    // (classify returns Valid when `expiration` is None); only invalidation, which
+                    // sets `expiration = now`, forces a refresh.
+                    None => {
+                        st.expiration = None;
+                        st.advisory_at = None;
+                        st.mandatory_at = None;
+                    }
+                }
+                st.next_refresh_allowed_at = None; // clear backoff
+                Ok(id)
+            }
+            Err(err) => {
+                // A non-recoverable error raises immediately — before backoff and
+                // before serve-cached. The cache holds only a predicate, naming no error types.
+                if self.non_recoverable.as_ref().is_some_and(|p| p(&err)) {
+                    return Err(err);
+                }
+                let mut st = part.state.lock().unwrap();
+                // Backoff AND serve-stale are BOTH static stability — gated on eligibility.
+                match prev {
+                    Some(c) if eligible(&c) => {
+                        st.next_refresh_allowed_at =
+                            Some(now + self.backoff_override.unwrap_or_else(jittered_backoff));
+                        tracing::warn!(
+                            error = ?err,
+                            "credential refresh failed; serving cached credentials (static stability)"
+                        );
+                        Ok(c)
+                    }
+                    // Ineligible: serve only if still valid, else raise.
+                    Some(c) if !expired(st.expiration, now) => Ok(c),
+                    _ => Err(err),
+                }
+            }
+        }
+    }
+}
+
+impl ResolveCachedIdentity for StaticStabilityCache {
+    fn validate_base_client_config(
+        &self,
+        runtime_components: &RuntimeComponentsBuilder,
+        _cfg: &ConfigBag,
+    ) -> Result<(), BoxError> {
+        validate(
+            runtime_components.time_source().is_some(),
+            runtime_components.sleep_impl().is_some(),
+        )
+    }
+
+    fn validate_final_config(
+        &self,
+        runtime_components: &RuntimeComponents,
+        _cfg: &ConfigBag,
+    ) -> Result<(), BoxError> {
+        validate(
+            runtime_components.time_source().is_some(),
+            runtime_components.sleep_impl().is_some(),
+        )
+    }
+
+    fn resolve_cached_identity<'a>(
+        &'a self,
+        resolver: SharedIdentityResolver,
+        runtime_components: &'a RuntimeComponents,
+        config_bag: &'a ConfigBag,
+    ) -> IdentityFuture<'a> {
+        IdentityFuture::new(async move {
+            let now = runtime_components
+                .time_source()
+                .map(|ts| ts.now())
+                .unwrap_or_else(|| self.time_source.now());
+            let part = self.partition(resolver.cache_partition());
+
+            // 1) snapshot + classify under the SYNC lock — no `.await` held
+            let decision = { classify(&part.state.lock().unwrap(), now) };
+
+            match decision {
+                // Valid or backed-off: serve cached, no source contact.
+                Decision::Valid(id) | Decision::RateLimited(id) => Ok(id),
+                // Advisory: refresh only if we win the gate, else serve cached now.
+                Decision::Advisory(cached) => match part.refresh_gate.try_lock() {
+                    Ok(_permit) => {
+                        self.refresh(&part, &resolver, runtime_components, config_bag, now)
+                            .await
+                    }
+                    Err(_) => Ok(cached),
+                },
+                // Mandatory (incl. expired) and initial fetch: block on the gate, then
+                // reuse an in-flight result if another task refreshed while we waited.
+                Decision::Mandatory | Decision::Initial => {
+                    let _permit = part.refresh_gate.lock().await;
+                    if let Some(id) = part.recheck(now) {
+                        return Ok(id);
+                    }
+                    // No rate-limiting during initial-fetch.
+                    self.refresh(&part, &resolver, runtime_components, config_bag, now)
+                        .await
+                }
+            }
+        })
+    }
+
+    fn invalidate(&self, rejected: &Identity) {
+        let now = self.time_source.now();
+        for part in self.snapshot_partitions() {
+            let mut st = part.state.lock().unwrap();
+            if st.cached.as_ref().is_some_and(|c| c.ptr_eq(rejected)) {
+                // Route the next resolution through the mandatory path. classify() keys off
+                // advisory_at/mandatory_at (not expiration), so collapse both to `now`.
+                // Deliberately leave next_refresh_allowed_at (backoff) and cached
+                // (static stability) untouched.
+                st.expiration = Some(now);
+                st.advisory_at = Some(now);
+                st.mandatory_at = Some(now);
+                break; // an identity is cached in exactly one partition
+            }
+        }
+    }
+}
+
+// One cache slot per credential source (per `IdentityCachePartition`).
+#[derive(Debug, Default)]
+struct Partition {
+    // Guards the synchronous snapshot/commit sections. NEVER held across `.await`.
+    state: Mutex<CachedState>,
+    // Async single-flight gate for the source call. Held across `.await`.
+    refresh_gate: tokio::sync::Mutex<()>,
+}
+
+impl Partition {
+    // Re-classify after acquiring the gate: another task may have refreshed while we waited.
+    fn recheck(&self, now: SystemTime) -> Option<Identity> {
+        let st = self.state.lock().unwrap();
+        match classify(&st, now) {
+            Decision::Valid(id) | Decision::RateLimited(id) => Some(id),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct CachedState {
+    // Retain-always; only ever *replaced* on success, never cleared.
+    cached: Option<Identity>,
+    expiration: Option<SystemTime>,
+    // Non-blocking refresh point.
+    advisory_at: Option<SystemTime>,
+    // Blocking refresh point (<= expiration).
+    mandatory_at: Option<SystemTime>,
+    // Backoff gate after a failed refresh.
+    next_refresh_allowed_at: Option<SystemTime>,
+}
+
+enum Decision {
+    Valid(Identity),
+    RateLimited(Identity),
+    Advisory(Identity),
+    Mandatory,
+    Initial,
+}
+
+fn classify(st: &CachedState, now: SystemTime) -> Decision {
+    let Some(id) = st.cached.clone() else {
+        return Decision::Initial;
+    };
+    // Non-expiring identity (source reported no expiration): serve indefinitely. Only invalidation
+    // (which sets `expiration = now`) forces a refresh.
+    if st.expiration.is_none() {
+        return Decision::Valid(id);
+    }
+    if matches!(st.advisory_at, Some(a) if now < a) {
+        return Decision::Valid(id);
+    }
+    // Backoff gate sits AFTER Valid, BEFORE the advisory/mandatory split so an
+    // expired-but-backed-off credential is served without contacting the source.
+    if matches!(st.next_refresh_allowed_at, Some(t) if now < t) {
+        return Decision::RateLimited(id);
+    }
+    match st.mandatory_at {
+        Some(m) if now < m => Decision::Advisory(id),
+        _ => Decision::Mandatory, // at/after mandatory_at, includes past-expiry
+    }
+}
+
+fn eligible(id: &Identity) -> bool {
+    id.property::<StaticStabilityEligible>().is_some()
+}
+
+fn expired(expiration: Option<SystemTime>, now: SystemTime) -> bool {
+    matches!(expiration, Some(exp) if exp <= now)
+}
+
+fn sub(t: SystemTime, d: Duration) -> SystemTime {
+    t.checked_sub(d).unwrap_or(t)
+}
+
+fn lifetime(expiry: SystemTime, now: SystemTime) -> Duration {
+    expiry.duration_since(now).unwrap_or_default()
+}
+
+// Advisory window tiers, selected by remaining credential lifetime:
+// `<= 20min -> 5min`, `> 20min && < 90min -> 15min`, `>= 90min -> 60min`.
+fn advisory_window_for(lifetime: Duration) -> Duration {
+    if lifetime <= Duration::from_secs(20 * 60) {
+        Duration::from_secs(5 * 60)
+    } else if lifetime < Duration::from_secs(90 * 60) {
+        Duration::from_secs(15 * 60)
+    } else {
+        Duration::from_secs(60 * 60)
+    }
+}
+
+fn jittered_backoff() -> Duration {
+    Duration::from_secs(BACKOFF_MIN_SECS + fastrand::u64(0..=BACKOFF_JITTER_SECS))
+}
+
+// Default non-recoverable predicate injected into the cache by the AWS layer:
+// a terminal `CredentialsError::Unrecoverable` bypasses backoff and static stability.
+fn aws_non_recoverable(err: &BoxError) -> bool {
+    err.downcast_ref::<CredentialsError>()
+        .is_some_and(CredentialsError::is_unrecoverable)
+}
+
+fn validate(has_time_source: bool, has_sleep_impl: bool) -> Result<(), BoxError> {
+    if !has_time_source {
+        return Err("StaticStabilityCache requires a time source to be configured".into());
+    }
+    if !has_sleep_impl {
+        return Err(
+            "StaticStabilityCache requires an async sleep implementation to be configured".into(),
+        );
+    }
+    Ok(())
+}
+
+/// Builder for [`StaticStabilityCache`].
+#[derive(Clone, Debug, Default)]
+pub struct StaticStabilityCacheBuilder {
+    time_source: Option<SharedTimeSource>,
+    load_timeout: Option<Duration>,
+    mandatory_window: Option<Duration>,
+}
+
+impl StaticStabilityCacheBuilder {
+    /// Sets the time source used by `invalidate` (which receives no runtime components).
+    ///
+    /// `resolve_cached_identity` prefers the time source from `RuntimeComponents`; this only
+    /// backstops `invalidate`.
+    pub fn time_source(mut self, time_source: impl TimeSource + 'static) -> Self {
+        self.time_source = Some(SharedTimeSource::new(time_source));
+        self
+    }
+
+    /// Sets the timeout bounding a single credential-source resolution. When unset, a default
+    /// timeout is derived from the configured retry/timeout.
+    pub fn load_timeout(mut self, load_timeout: Duration) -> Self {
+        self.load_timeout = Some(load_timeout);
+        self
+    }
+
+    /// Builds a [`SharedIdentityCache`] wrapping the configured [`StaticStabilityCache`].
+    pub fn build(self) -> SharedIdentityCache {
+        StaticStabilityCache::new(
+            self.time_source.unwrap_or_default(),
+            self.load_timeout,
+            self.mandatory_window.unwrap_or(DEFAULT_MANDATORY_WINDOW),
+            None,
+            None,
+        )
+        .into_shared()
+    }
+}
+
+#[cfg(test)]
+impl StaticStabilityCache {
+    // Advisory window (expiration - advisory_at) of the sole partition, for suite assertions.
+    fn advisory_window(&self) -> Option<Duration> {
+        let parts = self.partitions.read().unwrap();
+        let part = parts.values().next()?;
+        let st = part.state.lock().unwrap();
+        match (st.expiration, st.advisory_at) {
+            (Some(exp), Some(adv)) => exp.duration_since(adv).ok(),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_smithy_async::test_util::tick_advance_sleep::tick_advance_time_and_sleep;
+    use aws_smithy_async::test_util::ManualTimeSource;
+    use serde::Deserialize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Data-driven execution of the modeled credential-refresh test suite (test-data/). Our
+    // implementation diverges from the suite in two spots, handled inline: invalidation matches by
+    // pointer identity rather than access key id, and the refresh backoff uses a fixed test value
+    // (production jitters it). The configured advisory window is applied via a test-only builder
+    // knob. A `rateLimited` expectation coincides with `sourceContacted == false` for a credential
+    // past its refresh point, so it needs no separate assertion.
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Scenario {
+        documentation: String,
+        given: Given,
+        steps: Vec<Step>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Given {
+        cached_credentials: String,
+        access_key_id: Option<String>,
+        configured_advisory_window_seconds: Option<u64>,
+        refresh_backoff_seconds: Option<u64>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "type", rename_all = "camelCase")]
+    enum Step {
+        #[serde(rename_all = "camelCase")]
+        GetCredentials {
+            response: Option<String>,
+            lifetime_seconds: Option<u64>,
+            expected: Expected,
+        },
+        #[serde(rename_all = "camelCase")]
+        Invalidate {
+            rejected_access_key_id: String,
+        },
+        AdvanceTime {
+            seconds: u64,
+        },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Expected {
+        result: String,
+        source_contacted: bool,
+        advisory_window_seconds: Option<u64>,
+    }
+
+    const SUITE: &str = include_str!("../test-data/credential-refresh-tests.json");
+    // Seed lifetime 60min -> advisory_at=2700, mandatory_at=3540, expiry=3600.
+    const SEED_LIFE: u64 = 3600;
+
+    async fn source_get(
+        cache: &StaticStabilityCache,
+        resolver: &SharedIdentityResolver,
+        rc: &RuntimeComponents,
+        cfg: &ConfigBag,
+        contacts: &AtomicUsize,
+    ) -> (Result<Identity, BoxError>, bool) {
+        let before = contacts.load(Ordering::SeqCst);
+        let r = cache
+            .resolve_cached_identity(resolver.clone(), rc, cfg)
+            .await;
+        (r, contacts.load(Ordering::SeqCst) > before)
+    }
+
+    async fn run_scenario(s: &Scenario) {
+        let doc = s.documentation.as_str();
+        let seeded = s.given.cached_credentials != "none";
+        // Place the seeded credential in the requested window (seed lifetime 3600).
+        let start = match s.given.cached_credentials.as_str() {
+            "valid" => 1000,
+            "advisory" => 3000,
+            "mandatory" => 3550,
+            "expired" => 3700,
+            "none" => 0,
+            other => panic!("{doc}: unknown cachedCredentials {other:?}"),
+        };
+
+        // Pre-walk the steps to build the source queue in order and assign fresh ids, computing
+        // each fresh response's expiry against the clock at that step.
+        let mut queue: Vec<Result<Identity, BoxError>> = Vec::new();
+        if seeded {
+            queue.push(Ok(identity(1, SEED_LIFE, true)));
+        }
+        let mut next_id = 1u32;
+        let mut fresh_ids = std::collections::VecDeque::new();
+        let mut clk = start;
+        for step in &s.steps {
+            match step {
+                Step::AdvanceTime { seconds } => clk += seconds,
+                Step::GetCredentials {
+                    response,
+                    lifetime_seconds,
+                    ..
+                } => match response.as_deref() {
+                    Some("freshCredentials") => {
+                        next_id += 1;
+                        fresh_ids.push_back(next_id);
+                        let life = lifetime_seconds.unwrap_or(SEED_LIFE);
+                        queue.push(Ok(identity(next_id, clk + life, true)));
+                    }
+                    Some("staleCredentials") => {
+                        next_id += 1;
+                        queue.push(Ok(identity(next_id, clk, true))); // expiry <= now
+                    }
+                    Some("error") => queue.push(Err("recoverable".into())),
+                    Some("nonRecoverableError") => {
+                        queue.push(Err(CredentialsError::unrecoverable("terminal").into()))
+                    }
+                    Some(other) => panic!("{doc}: unknown response {other:?}"),
+                    None => {}
+                },
+                Step::Invalidate { .. } => {}
+            }
+        }
+
+        // Build an isolated harness: a concrete cache (for internal accessors) with a
+        // fixed backoff.
+        let time = ManualTimeSource::new(epoch(0));
+        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(sleep))
+            .build()
+            .unwrap();
+        let contacts = Arc::new(AtomicUsize::new(0));
+        let resolver = SharedIdentityResolver::new(MockSource {
+            results: Mutex::new(queue),
+            contacts: contacts.clone(),
+        });
+        let cache = StaticStabilityCache::new(
+            SharedTimeSource::new(time.clone()),
+            None,
+            DEFAULT_MANDATORY_WINDOW,
+            s.given.refresh_backoff_seconds.map(Duration::from_secs),
+            s.given
+                .configured_advisory_window_seconds
+                .map(Duration::from_secs),
+        );
+        let cfg = ConfigBag::base();
+
+        // Establish the given-state: fetch once to cache the seed, then move into the window.
+        let mut cached_id = 1u32;
+        let mut served: Option<Identity> = None;
+        if seeded {
+            let (r, _) = source_get(&cache, &resolver, &components, &cfg, &contacts).await;
+            served = Some(r.expect("seed fetch"));
+            time.set_time(epoch(start));
+        }
+
+        // Execute the steps.
+        let mut clk = start;
+        for step in &s.steps {
+            match step {
+                Step::AdvanceTime { seconds } => {
+                    clk += seconds;
+                    time.set_time(epoch(clk));
+                }
+                Step::Invalidate {
+                    rejected_access_key_id,
+                } => {
+                    // ptr_eq translation: a matching access key id invalidates the served instance;
+                    // a stale id invalidates a different allocation (a no-op).
+                    if s.given.access_key_id.as_deref() == Some(rejected_access_key_id.as_str()) {
+                        cache.invalidate(served.as_ref().expect("a served identity"));
+                    } else {
+                        cache.invalidate(&identity(999, SEED_LIFE, true));
+                    }
+                }
+                Step::GetCredentials { expected, .. } => {
+                    let (r, contacted) =
+                        source_get(&cache, &resolver, &components, &cfg, &contacts).await;
+                    assert_eq!(
+                        contacted, expected.source_contacted,
+                        "{doc}: sourceContacted"
+                    );
+                    match expected.result.as_str() {
+                        "cachedCredentials" => {
+                            let got = r.expect("cachedCredentials");
+                            assert_eq!(id_of(&got), cached_id, "{doc}: cached id");
+                            served = Some(got);
+                        }
+                        "newCredentials" => {
+                            let got = r.expect("newCredentials");
+                            cached_id = fresh_ids.pop_front().expect("a queued fresh id");
+                            assert_eq!(id_of(&got), cached_id, "{doc}: new id");
+                            served = Some(got);
+                        }
+                        "noCredentialsError" => assert!(r.is_err(), "{doc}: noCredentialsError"),
+                        "nonRecoverableError" => {
+                            let Err(e) = r else {
+                                panic!("{doc}: expected nonRecoverableError");
+                            };
+                            assert!(
+                                e.downcast_ref::<CredentialsError>()
+                                    .is_some_and(CredentialsError::is_unrecoverable),
+                                "{doc}: nonRecoverableError"
+                            );
+                        }
+                        other => panic!("{doc}: unknown result {other:?}"),
+                    }
+                    if let Some(w) = expected.advisory_window_seconds {
+                        assert_eq!(
+                            cache.advisory_window(),
+                            Some(Duration::from_secs(w)),
+                            "{doc}: advisoryWindowSeconds"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_suite() {
+        let scenarios: Vec<Scenario> = serde_json::from_str(SUITE).expect("valid suite json");
+        assert_eq!(scenarios.len(), 23, "expected the full modeled suite");
+        for s in &scenarios {
+            run_scenario(s).await;
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct TestCreds {
+        id: u32,
+    }
+
+    fn epoch(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    // Build an identity with a distinguishing id, an absolute expiration, and (optionally) the
+    // static-stability eligibility marker.
+    fn identity(id: u32, expiry_secs: u64, eligible: bool) -> Identity {
+        let mut b = Identity::builder()
+            .data(TestCreds { id })
+            .expiration(epoch(expiry_secs));
+        if eligible {
+            b = b.property(StaticStabilityEligible);
+        }
+        b.build().unwrap()
+    }
+
+    fn id_of(identity: &Identity) -> u32 {
+        identity.data::<TestCreds>().unwrap().id
+    }
+
+    // Mock credential source: returns queued results in order and counts how many times it is
+    // actually contacted (so tests can assert `sourceContacted`).
+    #[derive(Debug)]
+    struct MockSource {
+        results: Mutex<Vec<Result<Identity, BoxError>>>,
+        contacts: Arc<AtomicUsize>,
+    }
+
+    impl ResolveIdentity for MockSource {
+        fn resolve_identity<'a>(
+            &'a self,
+            _rc: &'a RuntimeComponents,
+            _cfg: &'a ConfigBag,
+        ) -> IdentityFuture<'a> {
+            self.contacts.fetch_add(1, Ordering::SeqCst);
+            let mut list = self.results.lock().unwrap();
+            let next = if list.is_empty() {
+                Err("mock source: no more results".into())
+            } else {
+                list.remove(0)
+            };
+            IdentityFuture::ready(next)
+        }
+    }
+
+    struct Harness {
+        cache: SharedIdentityCache,
+        resolver: SharedIdentityResolver,
+        components: RuntimeComponents,
+        config_bag: ConfigBag,
+        time: ManualTimeSource,
+        contacts: Arc<AtomicUsize>,
+    }
+
+    impl Harness {
+        fn new(results: Vec<Result<Identity, BoxError>>) -> Self {
+            let time = ManualTimeSource::new(epoch(0));
+            // A tick-advance sleep never fires unless explicitly ticked, so the (immediately
+            // resolving) mock source always wins the refresh Timeout race — no spurious timeouts.
+            let (_tick, sleep) = tick_advance_time_and_sleep();
+            let components = RuntimeComponentsBuilder::for_tests()
+                .with_time_source(Some(time.clone()))
+                .with_sleep_impl(Some(sleep))
+                .build()
+                .unwrap();
+            let contacts = Arc::new(AtomicUsize::new(0));
+            let resolver = SharedIdentityResolver::new(MockSource {
+                results: Mutex::new(results),
+                contacts: contacts.clone(),
+            });
+            Self {
+                cache: StaticStabilityCache::builder()
+                    .time_source(time.clone())
+                    .build(),
+                resolver,
+                components,
+                config_bag: ConfigBag::base(),
+                time,
+                contacts,
+            }
+        }
+
+        // One `getCredentials` step: returns the result and whether the source was contacted.
+        async fn get(&self) -> (Result<Identity, BoxError>, bool) {
+            let before = self.contacts.load(Ordering::SeqCst);
+            let result = self
+                .cache
+                .resolve_cached_identity(self.resolver.clone(), &self.components, &self.config_bag)
+                .await;
+            let contacted = self.contacts.load(Ordering::SeqCst) > before;
+            (result, contacted)
+        }
+
+        fn advance_to(&self, secs: u64) {
+            self.time.set_time(epoch(secs));
+        }
+    }
+
+    // Window selection (advisoryWindowSeconds) by remaining lifetime:
+    // <=20min -> 5min, >20 && <90 -> 15min, >=90 -> 60min.
+    #[test]
+    fn advisory_window_selection() {
+        let m = |mins: u64| Duration::from_secs(mins * 60);
+        assert_eq!(advisory_window_for(m(10)), m(5));
+        assert_eq!(advisory_window_for(m(20)), m(5)); // boundary, inclusive
+        assert_eq!(advisory_window_for(m(21)), m(15));
+        assert_eq!(advisory_window_for(m(60)), m(15));
+        assert_eq!(advisory_window_for(m(89)), m(15));
+        assert_eq!(advisory_window_for(m(90)), m(60)); // boundary
+        assert_eq!(advisory_window_for(m(6 * 60)), m(60));
+    }
+
+    // Ineligible (custom/process) identity: no serve-stale.
+    // expected: a failed refresh after expiry raises rather than serving stale.
+    #[tokio::test]
+    async fn ineligible_error_after_expiry_is_raised() {
+        let h = Harness::new(vec![Ok(identity(1, 3600, false)), Err("transient".into())]);
+        assert_eq!(id_of(&h.get().await.0.unwrap()), 1);
+
+        h.advance_to(3700); // expired
+        let (r, _contacted) = h.get().await;
+        assert!(
+            r.is_err(),
+            "ineligible creds must not be served past expiry on failure"
+        );
+    }
+
+    // A failed refresh applies the real (jittered) backoff: within it the source is not contacted
+    // (rate-limited); once it elapses the refresh is retried and succeeds. This is the only test
+    // exercising `jittered_backoff()` — the JSON suite injects a fixed backoff.
+    #[tokio::test]
+    async fn backoff_rate_limits_then_recovers() {
+        let h = Harness::new(vec![
+            Ok(identity(1, 3600, true)),
+            Err("transient".into()),
+            Ok(identity(2, 7200, true)),
+        ]);
+        assert_eq!(id_of(&h.get().await.0.unwrap()), 1);
+
+        h.advance_to(3700); // expired -> failed refresh -> serve cached + backoff
+        let (r, contacted) = h.get().await;
+        assert_eq!(id_of(&r.unwrap()), 1, "failed refresh serves cached");
+        assert!(contacted, "a refresh was attempted");
+
+        h.advance_to(3800); // < 300s later: strictly inside the backoff -> rate-limited
+        let (r, contacted) = h.get().await;
+        assert_eq!(id_of(&r.unwrap()), 1);
+        assert!(!contacted, "within backoff: source not contacted");
+
+        h.advance_to(3700 + 601); // past the max backoff (600s) -> refresh retried
+        let (r, contacted) = h.get().await;
+        assert_eq!(
+            id_of(&r.unwrap()),
+            2,
+            "refresh retried once backoff elapsed"
+        );
+        assert!(contacted);
+    }
+
+    // A source that reports no expiration is treated as non-expiring: fetched once and served
+    // indefinitely, never refreshed on a timer. Only invalidation forces a refresh.
+    #[tokio::test]
+    async fn no_expiry_served_indefinitely() {
+        let no_expiry = Identity::builder()
+            .data(TestCreds { id: 1 })
+            .property(StaticStabilityEligible)
+            .build()
+            .unwrap();
+        assert_eq!(no_expiry.expiration(), None);
+        // Seed a single response: a timer-driven refresh would exhaust it and flip `contacted`.
+        let h = Harness::new(vec![Ok(no_expiry)]);
+        assert_eq!(id_of(&h.get().await.0.unwrap()), 1);
+
+        // Advance far past any window a synthetic expiry could have produced (the old default was
+        // 15m). A non-expiring identity is still served without contacting the source.
+        h.advance_to(100 * 3600); // 100 hours
+        let (r, contacted) = h.get().await;
+        assert_eq!(id_of(&r.unwrap()), 1);
+        assert!(
+            !contacted,
+            "a no-expiration identity is non-expiring: served indefinitely, never refreshed on a timer"
+        );
+    }
+
+    // A non-expiring identity still refreshes when invalidated (auth failure) —
+    // invalidation is the only refresh trigger for creds without an expiration.
+    #[tokio::test]
+    async fn no_expiry_refreshes_on_invalidation() {
+        let no_expiry = Identity::builder()
+            .data(TestCreds { id: 1 })
+            .property(StaticStabilityEligible)
+            .build()
+            .unwrap();
+        let h = Harness::new(vec![Ok(no_expiry), Ok(identity(2, 3600, true))]);
+
+        let served = h.get().await.0.unwrap();
+        assert_eq!(id_of(&served), 1);
+
+        // Without invalidation it would never refresh; invalidating the served identity forces it.
+        h.cache.invalidate(&served);
+
+        let (r, contacted) = h.get().await;
+        assert_eq!(
+            id_of(&r.unwrap()),
+            2,
+            "invalidation forces a refresh even for a no-expiration identity"
+        );
+        assert!(contacted);
+    }
+
+    // A source whose resolution blocks on a gate until released — for concurrency tests.
+    #[derive(Debug)]
+    struct GatedSource {
+        gate: Arc<tokio::sync::Notify>,
+        contacts: Arc<AtomicUsize>,
+        results: Mutex<Vec<Result<Identity, BoxError>>>,
+    }
+
+    impl ResolveIdentity for GatedSource {
+        fn resolve_identity<'a>(
+            &'a self,
+            _rc: &'a RuntimeComponents,
+            _cfg: &'a ConfigBag,
+        ) -> IdentityFuture<'a> {
+            let next = self.results.lock().unwrap().remove(0);
+            let (gate, contacts) = (self.gate.clone(), self.contacts.clone());
+            IdentityFuture::new(async move {
+                contacts.fetch_add(1, Ordering::SeqCst);
+                gate.notified().await; // block until released
+                next
+            })
+        }
+    }
+
+    // Within the advisory window, only ONE caller refreshes; the others return cached
+    // immediately without waiting or contacting the source (non-blocking single-flight).
+    #[tokio::test]
+    async fn advisory_concurrent_single_flight() {
+        let time = ManualTimeSource::new(epoch(0));
+        // Tick-advance sleep: never ticked here, so the refresh Timeout never fires and a
+        // gate-blocked source stays blocked until the driver releases it (deterministic, no
+        // real time).
+        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(sleep))
+            .build()
+            .unwrap();
+        let cfg = ConfigBag::base();
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let contacts = Arc::new(AtomicUsize::new(0));
+        let resolver = SharedIdentityResolver::new(GatedSource {
+            gate: gate.clone(),
+            contacts: contacts.clone(),
+            results: Mutex::new(vec![
+                Ok(identity(1, 3600, true)),
+                Ok(identity(2, 7200, true)),
+            ]),
+        });
+        let cache = StaticStabilityCache::builder()
+            .time_source(time.clone())
+            .build();
+
+        // Seed the initial fetch: permit exactly one source resolution.
+        gate.notify_one();
+        let seed = cache
+            .resolve_cached_identity(resolver.clone(), &components, &cfg)
+            .await
+            .unwrap();
+        assert_eq!(id_of(&seed), 1);
+        assert_eq!(contacts.load(Ordering::SeqCst), 1);
+
+        time.set_time(epoch(3000)); // advisory window (2700 <= now < 3540)
+
+        // Two concurrent advisory callers + a driver that releases the single in-flight refresh.
+        let get1 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
+        let get2 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
+        let driver = async {
+            tokio::task::yield_now().await;
+            gate.notify_one();
+        };
+        let (r1, r2, ()) = tokio::join!(get1, get2, driver);
+
+        let mut ids = [id_of(&r1.unwrap()), id_of(&r2.unwrap())];
+        ids.sort();
+        assert_eq!(
+            ids,
+            [1, 2],
+            "one caller refreshed (id=2), the other served cached (id=1)"
+        );
+        assert_eq!(
+            contacts.load(Ordering::SeqCst),
+            2,
+            "single-flight: only one refresh contacted the source"
+        );
+    }
+
+    // Concurrency test 2: within the mandatory window / expired, one caller refreshes and all
+    // others WAIT for it and reuse the result (no additional source contacts).
+    #[tokio::test]
+    async fn mandatory_concurrent_single_flight_all_reuse() {
+        let time = ManualTimeSource::new(epoch(0));
+        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(sleep))
+            .build()
+            .unwrap();
+        let cfg = ConfigBag::base();
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let contacts = Arc::new(AtomicUsize::new(0));
+        let resolver = SharedIdentityResolver::new(GatedSource {
+            gate: gate.clone(),
+            contacts: contacts.clone(),
+            results: Mutex::new(vec![
+                Ok(identity(1, 3600, true)),
+                Ok(identity(2, 10_000, true)),
+            ]),
+        });
+        let cache = StaticStabilityCache::builder()
+            .time_source(time.clone())
+            .build();
+
+        gate.notify_one();
+        let seed = cache
+            .resolve_cached_identity(resolver.clone(), &components, &cfg)
+            .await
+            .unwrap();
+        assert_eq!(id_of(&seed), 1);
+        assert_eq!(contacts.load(Ordering::SeqCst), 1);
+
+        time.set_time(epoch(3700)); // expired -> mandatory path (blocking lock + recheck)
+
+        // Three concurrent callers + a driver that releases the single in-flight refresh.
+        let get1 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
+        let get2 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
+        let get3 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
+        let driver = async {
+            tokio::task::yield_now().await;
+            gate.notify_one();
+        };
+        let (r1, r2, r3, ()) = tokio::join!(get1, get2, get3, driver);
+
+        // Every caller receives the one refreshed identity; only one refresh contacted the source.
+        assert_eq!(id_of(&r1.unwrap()), 2);
+        assert_eq!(id_of(&r2.unwrap()), 2);
+        assert_eq!(id_of(&r3.unwrap()), 2);
+        assert_eq!(
+            contacts.load(Ordering::SeqCst),
+            2,
+            "one refresh shared by all waiters"
+        );
+    }
+}

--- a/aws/rust-runtime/aws-runtime/src/static_stability/invalidation.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability/invalidation.rs
@@ -16,9 +16,15 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
 
-/// Detects a credential/token auth failure (`ExpiredToken` / `InvalidToken`) on the operation
-/// response and signals the orchestrator — via the data-free [`InvalidateResolvedIdentity`] config
-/// marker — to invalidate the resolved identity.
+/// AWS error codes indicating the request's credentials are no longer valid, so the resolved
+/// identity must be invalidated. Both spellings are listed because AWS services are inconsistent.
+/// `AccessDenied` is intentionally excluded: that is authorization, not credential validity.
+const CREDENTIAL_AUTH_FAILURE_ERRORS: &[&str] =
+    &["ExpiredToken", "ExpiredTokenException", "InvalidToken"];
+
+/// Detects a credential/token auth failure (`ExpiredToken`, `ExpiredTokenException`, or
+/// `InvalidToken`) on the operation response and signals the orchestrator — via the data-free
+/// [`InvalidateResolvedIdentity`] config marker — to invalidate the resolved identity.
 ///
 /// This is **detection only**: the interceptor has no identity (the signed request is already gone
 /// post-transmit), so the orchestrator makes the actual `invalidate` call with the in-scope signing
@@ -68,8 +74,7 @@ where
             .and_then(|err| err.as_operation_error())
             .and_then(|err| err.downcast_ref::<E>())
             .and_then(|err| err.code())
-            // NOT AccessDenied — that's authorization, not credential validity.
-            .is_some_and(|code| matches!(code, "ExpiredToken" | "InvalidToken"));
+            .is_some_and(|code| CREDENTIAL_AUTH_FAILURE_ERRORS.contains(&code));
         if is_auth_failure {
             cfg.interceptor_state()
                 .store_put(InvalidateResolvedIdentity);
@@ -136,6 +141,10 @@ mod tests {
         assert!(
             sets_invalidate_marker("ExpiredToken"),
             "ExpiredToken must trigger invalidation"
+        );
+        assert!(
+            sets_invalidate_marker("ExpiredTokenException"),
+            "STS/SSO-OIDC ExpiredTokenException must trigger invalidation"
         );
         assert!(
             sets_invalidate_marker("InvalidToken"),

--- a/aws/rust-runtime/aws-runtime/src/static_stability/invalidation.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability/invalidation.rs
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Auth-failure detection for static-stability credential invalidation.
+
+use aws_smithy_runtime::client::orchestrator::InvalidateResolvedIdentity;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::context::AfterDeserializationInterceptorContextRef;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+use std::error::Error as StdError;
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Detects a credential/token auth failure (`ExpiredToken` / `InvalidToken`) on the operation
+/// response and signals the orchestrator — via the data-free [`InvalidateResolvedIdentity`] config
+/// marker — to invalidate the resolved identity.
+///
+/// This is **detection only**: the interceptor has no identity (the signed request is already gone
+/// post-transmit), so the orchestrator makes the actual `invalidate` call with the in-scope signing
+/// identity. Registered per-operation by AWS codegen (like `AwsErrorCodeClassifier<E>`).
+pub struct CredentialAuthFailureInterceptor<E> {
+    _marker: PhantomData<fn() -> E>,
+}
+
+impl<E> CredentialAuthFailureInterceptor<E> {
+    /// Creates a new [`CredentialAuthFailureInterceptor`].
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<E> Default for CredentialAuthFailureInterceptor<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> fmt::Debug for CredentialAuthFailureInterceptor<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CredentialAuthFailureInterceptor")
+    }
+}
+
+impl<E> Intercept for CredentialAuthFailureInterceptor<E>
+where
+    E: StdError + ProvideErrorMetadata + Send + Sync + 'static,
+{
+    fn name(&self) -> &'static str {
+        "CredentialAuthFailure"
+    }
+
+    fn read_after_deserialization(
+        &self,
+        context: &AfterDeserializationInterceptorContextRef<'_>,
+        _runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let is_auth_failure = context
+            .output_or_error()
+            .err()
+            .and_then(|err| err.as_operation_error())
+            .and_then(|err| err.downcast_ref::<E>())
+            .and_then(|err| err.code())
+            // NOT AccessDenied — that's authorization, not credential validity.
+            .is_some_and(|code| matches!(code, "ExpiredToken" | "InvalidToken"));
+        if is_auth_failure {
+            cfg.interceptor_state()
+                .store_put(InvalidateResolvedIdentity);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_smithy_runtime_api::client::interceptors::context::{Error, Input, InterceptorContext};
+    use aws_smithy_runtime_api::client::orchestrator::OrchestratorError;
+    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+    use aws_smithy_types::error::ErrorMetadata;
+
+    // A minimal operation error carrying a modeled error code.
+    #[derive(Debug)]
+    struct CodedError {
+        metadata: ErrorMetadata,
+    }
+
+    impl CodedError {
+        fn new(code: &'static str) -> Self {
+            Self {
+                metadata: ErrorMetadata::builder().code(code).build(),
+            }
+        }
+    }
+
+    impl fmt::Display for CodedError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "coded error")
+        }
+    }
+
+    impl StdError for CodedError {}
+
+    impl ProvideErrorMetadata for CodedError {
+        fn meta(&self) -> &ErrorMetadata {
+            &self.metadata
+        }
+    }
+
+    // Runs the interceptor against a deserialized operation error with the given code and reports
+    // whether it set the `InvalidateResolvedIdentity` marker.
+    fn sets_invalidate_marker(code: &'static str) -> bool {
+        let interceptor = CredentialAuthFailureInterceptor::<CodedError>::new();
+        let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
+        let mut cfg = ConfigBag::base();
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(
+            CodedError::new(code),
+        ))));
+        let ctx_ref = AfterDeserializationInterceptorContextRef::from(&ctx);
+        interceptor
+            .read_after_deserialization(&ctx_ref, &rc, &mut cfg)
+            .unwrap();
+        cfg.load::<InvalidateResolvedIdentity>().is_some()
+    }
+
+    #[test]
+    fn triggers_on_expired_and_invalid_token_only() {
+        assert!(
+            sets_invalidate_marker("ExpiredToken"),
+            "ExpiredToken must trigger invalidation"
+        );
+        assert!(
+            sets_invalidate_marker("InvalidToken"),
+            "InvalidToken must trigger invalidation"
+        );
+        // AccessDenied is authorization, not credential validity — must NOT invalidate.
+        assert!(
+            !sets_invalidate_marker("AccessDenied"),
+            "AccessDenied is authz, not credential validity"
+        );
+        assert!(
+            !sets_invalidate_marker("ThrottlingException"),
+            "unrelated errors must not trigger invalidation"
+        );
+    }
+}

--- a/aws/rust-runtime/aws-runtime/test-data/credential-refresh-tests.json
+++ b/aws/rust-runtime/aws-runtime/test-data/credential-refresh-tests.json
@@ -1,0 +1,344 @@
+[
+  {
+    "documentation": "Valid cached credentials: no refresh is attempted and the caller receives the cached credentials.",
+    "given": { "cachedCredentials": "valid" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "expected": { "result": "cachedCredentials", "sourceContacted": false, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Advisory window, refresh succeeds: the caller receives the newly refreshed credentials.",
+    "given": { "cachedCredentials": "advisory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Advisory window, refresh fails: the resolver applies the refresh backoff and the caller receives the existing cached credentials.",
+    "given": { "cachedCredentials": "advisory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Mandatory window, refresh succeeds: the caller receives the newly refreshed credentials.",
+    "given": { "cachedCredentials": "mandatory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Mandatory window, refresh fails: the resolver applies the refresh backoff and the caller receives the cached credentials.",
+    "given": { "cachedCredentials": "mandatory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Expired credentials are refreshed successfully: the caller receives the newly refreshed credentials.",
+    "given": { "cachedCredentials": "expired" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Expired credentials, refresh fails: the resolver applies the refresh backoff and the caller receives the expired cached credentials rather than raising.",
+    "given": { "cachedCredentials": "expired" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "No cached credentials and the initial fetch fails: the SDK raises, since there are no cached credentials to fall back on. The next call retries and succeeds.",
+    "given": { "cachedCredentials": "none" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "expected": { "result": "noCredentialsError", "sourceContacted": true, "rateLimited": false }
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Advisory window, source returns stale credentials (Expiration at or before now): treated as a failed refresh. The resolver applies the refresh backoff and returns the existing cached credentials.",
+    "given": { "cachedCredentials": "advisory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "staleCredentials",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Mandatory window, source returns stale credentials: same as the advisory case, treated as a failed refresh.",
+    "given": { "cachedCredentials": "mandatory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "staleCredentials",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+
+  {
+    "documentation": "A 10-minute credential lifetime selects the 5-minute advisory window (lifetime <= 20 minutes).",
+    "given": { "cachedCredentials": "none" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "lifetimeSeconds": 600,
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false, "advisoryWindowSeconds": 300 }
+      }
+    ]
+  },
+  {
+    "documentation": "A 20.5-minute credential lifetime selects the 15-minute advisory window (lifetime > 20 and < 90 minutes).",
+    "given": { "cachedCredentials": "none" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "lifetimeSeconds": 1230,
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false, "advisoryWindowSeconds": 900 }
+      }
+    ]
+  },
+  {
+    "documentation": "A 6-hour credential lifetime selects the 60-minute advisory window (lifetime >= 90 minutes).",
+    "given": { "cachedCredentials": "none" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "lifetimeSeconds": 21600,
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false, "advisoryWindowSeconds": 3600 }
+      }
+    ]
+  },
+  {
+    "documentation": "After a successful refresh returns credentials with a different lifetime, the SDK recomputes the advisory window. The first credentials have a 6-hour lifetime (60-minute window); after advancing into that window, the refreshed credentials have a 10-minute lifetime (5-minute window).",
+    "given": { "cachedCredentials": "none" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "lifetimeSeconds": 21600,
+        "documentation": "Initial fetch returns 6-hour credentials, selecting the 60-minute advisory window.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false, "advisoryWindowSeconds": 3600 }
+      },
+      {
+        "type": "advanceTime",
+        "seconds": 18060
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "lifetimeSeconds": 600,
+        "documentation": "59 minutes remain until expiration, inside the 60-minute advisory window, so the SDK refreshes. The new 10-minute credentials select the 5-minute advisory window.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false, "advisoryWindowSeconds": 300 }
+      }
+    ]
+  },
+  {
+    "documentation": "A customer-configured advisory window overrides the table. Credentials with a 6-hour lifetime would map to 60 minutes, but the configured 30-minute window is used instead.",
+    "given": { "cachedCredentials": "none", "configuredAdvisoryWindowSeconds": 1800 },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "lifetimeSeconds": 21600,
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false, "advisoryWindowSeconds": 1800 }
+      }
+    ]
+  },
+
+  {
+    "documentation": "Advisory window, non-recoverable failure: the SDK raises immediately. Because no refresh backoff is applied, the next call contacts the source again rather than being rate limited.",
+    "given": { "cachedCredentials": "advisory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "nonRecoverableError",
+        "documentation": "Non-recoverable failure: the SDK raises and does not apply the refresh backoff.",
+        "expected": { "result": "nonRecoverableError", "sourceContacted": true, "rateLimited": false }
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "documentation": "No refresh backoff was applied, so this call contacts the source again and succeeds.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Mandatory window, non-recoverable failure: the SDK raises immediately. Because no refresh backoff is applied, the next call contacts the source again rather than being rate limited.",
+    "given": { "cachedCredentials": "mandatory" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "nonRecoverableError",
+        "documentation": "Non-recoverable failure: the SDK raises and does not apply the refresh backoff.",
+        "expected": { "result": "nonRecoverableError", "sourceContacted": true, "rateLimited": false }
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "documentation": "No refresh backoff was applied, so this call contacts the source again and succeeds.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+
+  {
+    "documentation": "Invalidate with an access key ID matching the cached credentials routes the next getCredentials through the mandatory refresh path, and the refresh succeeds.",
+    "given": { "cachedCredentials": "valid", "accessKeyId": "AKID-1" },
+    "steps": [
+      { "type": "invalidate", "rejectedAccessKeyId": "AKID-1" },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Invalidate with a matching access key ID routes the next getCredentials through the mandatory refresh path; the refresh fails and the SDK continues using the cached credentials.",
+    "given": { "cachedCredentials": "valid", "accessKeyId": "AKID-1" },
+    "steps": [
+      { "type": "invalidate", "rejectedAccessKeyId": "AKID-1" },
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Invalidate during an active backoff: the SDK does not contact the credential source. Once the refresh backoff has elapsed, the next getCredentials attempts a refresh.",
+    "given": { "cachedCredentials": "expired", "accessKeyId": "AKID-1", "refreshBackoffSeconds": 420 },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "documentation": "Refresh fails, so the SDK applies the refresh backoff.",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      },
+      {
+        "type": "advanceTime",
+        "seconds": 60
+      },
+      { "type": "invalidate", "rejectedAccessKeyId": "AKID-1" },
+      {
+        "type": "getCredentials",
+        "documentation": "60s elapsed and the refresh backoff has not yet elapsed, so even after invalidation the SDK does not contact the credential source.",
+        "expected": { "result": "cachedCredentials", "sourceContacted": false, "rateLimited": true }
+      },
+      {
+        "type": "advanceTime",
+        "seconds": 425
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "documentation": "485s elapsed total and the refresh backoff has elapsed, so the SDK contacts the credential source and the refresh succeeds.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "Invalidate with a stale access key ID (a concurrent refresh already replaced the credentials): the cache is unchanged and the next getCredentials does not contact the source.",
+    "given": { "cachedCredentials": "valid", "accessKeyId": "AKID-2" },
+    "steps": [
+      { "type": "invalidate", "rejectedAccessKeyId": "AKID-1" },
+      {
+        "type": "getCredentials",
+        "expected": { "result": "cachedCredentials", "sourceContacted": false, "rateLimited": false }
+      }
+    ]
+  },
+
+  {
+    "documentation": "After a failed refresh, the SDK does not contact the credential source again until the refresh backoff has elapsed.",
+    "given": { "cachedCredentials": "expired", "refreshBackoffSeconds": 420 },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "error",
+        "documentation": "Refresh fails, so the SDK applies the refresh backoff.",
+        "expected": { "result": "cachedCredentials", "sourceContacted": true, "rateLimited": false }
+      },
+      {
+        "type": "advanceTime",
+        "seconds": 300
+      },
+      {
+        "type": "getCredentials",
+        "documentation": "300s elapsed and the refresh backoff has not yet elapsed, so the SDK does not contact the credential source.",
+        "expected": { "result": "cachedCredentials", "sourceContacted": false, "rateLimited": true }
+      },
+      {
+        "type": "advanceTime",
+        "seconds": 425
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "documentation": "725s elapsed total and the refresh backoff has elapsed, so the SDK contacts the credential source and the refresh succeeds.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  },
+  {
+    "documentation": "No cached credentials and the initial fetch fails with a non-recoverable error: the SDK raises the error directly rather than a generic NoCredentialsError. Because no refresh backoff is applied, the next call contacts the source again.",
+    "given": { "cachedCredentials": "none" },
+    "steps": [
+      {
+        "type": "getCredentials",
+        "response": "nonRecoverableError",
+        "documentation": "Non-recoverable failure: the SDK raises and does not apply the refresh backoff.",
+        "expected": { "result": "nonRecoverableError", "sourceContacted": true, "rateLimited": false }
+      },
+      {
+        "type": "getCredentials",
+        "response": "freshCredentials",
+        "documentation": "No refresh backoff was applied, so this call contacts the source again and succeeds.",
+        "expected": { "result": "newCredentials", "sourceContacted": true, "rateLimited": false }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Motivation and Context
This PR is the second in the series to support consistent credentials refresh across credentials providers.

- PR 1 — #4766
- PR 2 (**this PR**) — `aws-runtime` + `aws-credential-types` (a new refresh cache using the generic hook)
- PR 3 — `aws-config` + codegen (wiring)
  
These PRs will be merged into a feature branch.

## Description
This PR introduces the credentials refresh cache itself, built on the generic hooks from #4766, together with the AWS-land signals it consults. The cache is not yet installed as a client default, so this PR changes no runtime behavior on its own.

Specifically, it adds:
- `StaticStabilityCache` (`aws-runtime`): a retain-always identity cache implementing the refresh lifecycle — advisory (non-blocking) and mandatory (blocking) refresh windows selected from the credential lifetime, single-flight refresh, serve-cached-on-failure with a jittered backoff, and invalidation via the `ResolveCachedIdentity::invalidate` hook from #4766.
- `CredentialAuthFailureInterceptor` (`aws-runtime`): a per-operation interceptor (registered by AWS codegen, alongside `AwsErrorCodeClassifier`) that flags an authentication failure so the orchestrator invalidates the signing identity via the `InvalidateResolvedIdentity` marker.
- `StaticStabilityEligible` (`aws-credential-types`): a marker property stamped on the `Identity` by built-in providers and lifted in `From<Credentials> for Identity`; the cache reads it to decide whether serve-cached-on-failure (static stability) applies.
- `CredentialsError::Unrecoverable` + `unrecoverable()` / `is_unrecoverable()` (`aws-credential-types`): a terminal signal a provider raises to fast-fail a refresh; the cache's injected predicate recognizes it and re-raises immediately without applying the backoff.

Design decisions that motivate the changes:
- The cache is realized generically over `Identity` (credentials *and* bearer tokens). The three AWS-specific facts it needs are supplied from AWS-land without the generic core knowing any credential types:
  - **eligibility** is the `StaticStabilityEligible` property read via `id.property::<>()`
  - **non-recoverability** is an injected `Fn(&BoxError) -> bool` predicate that recognizes `CredentialsError::Unrecoverable`
  - **invalidation** matches the rejected identity by `Identity::ptr_eq`.
- A failed refresh of an eligible identity serves the cached credentials and applies a jittered backoff instead of raising, so a credential-source outage doesn't break in-flight workloads; subsequent calls are rate-limited until the backoff elapses. This is the static-stability behavior.
- Non-recoverable refresh errors bypass static stability (raised to the caller immediately with no backoff) so actionable errors (e.g. "reauthenticate") aren't delayed. Which provider errors are non-recoverable (STS by error code across the provider family; Login's `AccessDeniedException` from `CreateOAuth2Token`) is classified in the next PR.

## Testing
- Added a data-driven suite, `test_suite`, that executes the modeled credential-refresh scenarios from `aws-runtime/test-data/credential-refresh-tests.json` (valid/advisory/mandatory/expired × success/failure, window-tier selection, a configured advisory window, invalidation, backoff timing, and non-recoverable errors).
- Added manual tests for behaviors the sequential JSON runner cannot express: single-flight concurrency (non-blocking in the advisory window, blocking-and-reuse in the mandatory window), the real jittered backoff, ineligible (custom/process) identities, and identities without an expiration.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
