### PR TITLE
fix(server-metrics): Make DefaultMetricsPlugin body-generic

### DIFF
--- a/.changelog/body-generic-metrics-plugin.md
+++ b/.changelog/body-generic-metrics-plugin.md
@@ -1,0 +1,16 @@
+---
+applies_to:
+- server
+authors:
+- rcoh
+- jasgin
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Make `DefaultMetricsPlugin`'s `Service` impl generic over the request body type instead of
+hardcoding `hyper::body::Incoming`. The plugin only reads request *extensions* (operation name,
+service name, request ID) and never touches the body, so it composes with any body type. This
+fixes a compilation error when using `DefaultMetricsPlugin` with request bodies other than
+`hyper::body::Incoming`.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics"
-version = "0.2.1"
+version = "0.1.3"
 dependencies = [
  "aws-smithy-http-server 0.65.10",
  "aws-smithy-http-server 0.67.0",

--- a/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-metrics"
-version = "0.2.1"
+version = "0.1.3"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",

--- a/rust-runtime/aws-smithy-http-server-metrics/src/plugin.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/plugin.rs
@@ -30,7 +30,7 @@ use crate::types::aws_smithy_http_server::plugin::HttpMarker;
 use crate::types::aws_smithy_http_server::plugin::Plugin;
 use crate::types::aws_smithy_http_server::request::request_id::ServerRequestId;
 use crate::types::aws_smithy_http_server::service::ServiceShape;
-use crate::types::HttpRequest;
+use crate::types::GenericHttpRequest;
 use crate::types::HttpResponse;
 
 pin_project! {
@@ -201,15 +201,15 @@ where
         }
     }
 }
-impl<Ser> DefaultMetricsPluginService<Ser>
-where
-    Ser: Service<HttpRequest, Response = HttpResponse>,
-    Ser::Future: Send + 'static,
-{
+impl<Ser> DefaultMetricsPluginService<Ser> {
     /// Gets the default request metrics that can be retrieved from the request object directly
     ///
     /// Assigns None to those that need information from the outer metrics layer to be set
-    fn get_default_request_metrics(&self, req: &HttpRequest) -> DefaultRequestMetrics {
+    ///
+    /// Generic over the request body `B`: the plugin only reads request
+    /// *extensions* (never the body), so it composes with any body type,
+    /// including the `BoxBodySync` produced by `LambdaHandler`.
+    fn get_default_request_metrics<B>(&self, req: &GenericHttpRequest<B>) -> DefaultRequestMetrics {
         DefaultRequestMetrics {
             service: Some(self.service.to_string()),
             service_version: self.service_version.map(|n| n.to_string()),
@@ -223,16 +223,16 @@ where
     }
 }
 
-impl<Ser> Service<HttpRequest> for DefaultMetricsPluginService<Ser>
+impl<Ser, B> Service<GenericHttpRequest<B>> for DefaultMetricsPluginService<Ser>
 where
-    Ser: Service<HttpRequest, Response = HttpResponse>,
+    Ser: Service<GenericHttpRequest<B>, Response = HttpResponse>,
     Ser::Future: Send + 'static,
 {
     type Response = Ser::Response;
     type Error = Ser::Error;
     type Future = DefaultMetricsFuture<Ser::Future>;
 
-    fn call(&mut self, mut req: HttpRequest) -> Self::Future {
+    fn call(&mut self, mut req: GenericHttpRequest<B>) -> Self::Future {
         let mut stopwatch = Stopwatch::new();
         let operation_timer_guard = stopwatch.start_owned();
 

--- a/rust-runtime/aws-smithy-http-server-metrics/src/types.rs
+++ b/rust-runtime/aws-smithy-http-server-metrics/src/types.rs
@@ -37,6 +37,7 @@ use http_02 as http;
 pub(crate) type RequestBody = hyper_014::Body;
 
 pub(crate) type ResponseBody = aws_smithy_http_server::body::BoxBody;
+pub(crate) type GenericHttpRequest<B> = http::Request<B>;
 pub type HttpRequest = http::Request<RequestBody>; // pub because needed in macro
 pub(crate) type HttpResponse = http::Response<ResponseBody>;
 pub(crate) type HttpRequestParts = http::request::Parts;


### PR DESCRIPTION
https://github.com/smithy-lang/smithy-rs/issues/4775

DefaultMetricsPlugin's Service impl was hardcoded to http::Request<hyper::body::Incoming>, but its call only reads request extensions (operation/service/request-id) and never touches the body. This makes the plugin unusable with request bodies other than Incoming (e.g. BoxBodySync).

Make the plugin's Service impl and get_default_request_metrics helper generic over the request body B. No emission logic changes; the response type stays HttpResponse.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
