### PR TITLE
fix(codegen): address Rust 1.97 Clippy lints

### DIFF
--- a/.changelog/rust-1.97-generated-clippy.md
+++ b/.changelog/rust-1.97-generated-clippy.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- server
+- aws-sdk-rust
+authors:
+- prayankm-ics
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix generated Rust 1.97 Clippy failures caused by redundant explicit borrows in error formatting and manual `Option` matching in paginator accessors.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/NestedAccessorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/NestedAccessorGenerator.kt
@@ -86,15 +86,7 @@ class NestedAccessorGenerator(private val codegenContext: CodegenContext) {
                 val head = path.first()
                 if (symbolProvider.toSymbol(head).isOptional()) {
                     if (reference) {
-                        rustTemplate(
-                            """
-                            let input = match &input.${symbolProvider.toMemberName(head)} {
-                                #{None} => return #{None},
-                                #{Some}(t) => t
-                            };
-                            """,
-                            *preludeScope,
-                        )
+                        rust("let input = input.${symbolProvider.toMemberName(head)}.as_ref()?;")
                     } else {
                         rustTemplate(
                             """

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGeneratorTest.kt
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.generators
 
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
@@ -16,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
 import software.amazon.smithy.rust.codegen.core.util.letIf
+import kotlin.io.path.readText
 
 internal class PaginatorGeneratorTest {
     private val model =
@@ -78,12 +81,16 @@ internal class PaginatorGeneratorTest {
 
     @Test
     fun `generate paginators that compile`() {
-        clientIntegrationTest(model) { clientCodegenContext, rustCrate ->
-            rustCrate.integrationTest("paginators_generated") {
-                Attribute.AllowUnusedImports.render(this)
-                rust("use ${clientCodegenContext.moduleUseName()}::operation::paginated_list::paginator::PaginatedListPaginator;")
+        val testDir =
+            clientIntegrationTest(model) { clientCodegenContext, rustCrate ->
+                rustCrate.integrationTest("paginators_generated") {
+                    Attribute.AllowUnusedImports.render(this)
+                    rust("use ${clientCodegenContext.moduleUseName()}::operation::paginated_list::paginator::PaginatedListPaginator;")
+                }
             }
-        }
+        val lens = testDir.resolve("src/lens.rs").readText()
+        lens shouldContain "let input = input.inner.as_ref()?;"
+        lens shouldNotContain "let input = match &input.inner"
     }
 
     // Regression: when a @paginated operation's top-level outputToken targets a @required member,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/ErrorImplGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/ErrorImplGenerator.kt
@@ -164,12 +164,7 @@ class ErrorImplGenerator(
                         write("""::std::write!(f, ": {}", $REDACTION)?;""")
                     } else {
                         ifSet(it, symbolProvider.toSymbol(it), ValueExpression.Reference("&self.message")) { field ->
-                            val referenced = field.asRef()
-                            if (referenced.startsWith("&")) {
-                                write("""::std::write!(f, ": {}", $referenced)?;""")
-                            } else {
-                                write("""::std::write!(f, ": {$referenced}")?;""")
-                            }
+                            write("""::std::write!(f, ": {}", ${field.asValue()})?;""")
                         }
                     }
                 }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/ErrorImplGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/ErrorImplGeneratorTest.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.core.smithy.generators.error
 
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
@@ -42,6 +43,40 @@ class ErrorImplGeneratorTest {
                 """
                 let err = MyError::builder().build();
                 assert_eq!(err.retryable_error_kind(), aws_smithy_types::retry::ErrorKind::ServerError);
+                assert_eq!(err.to_string(), "MyError");
+
+                let err = MyError::builder().message("message").build();
+                assert_eq!(err.to_string(), "MyError: message");
+                """,
+            )
+        }
+    }
+
+    @Test
+    fun `required error messages format without redundant borrows`() {
+        val requiredMessageModel =
+            """
+            namespace com.test
+
+            @error("server")
+            structure RequiredMessageError {
+                @required
+                message: String
+            }
+            """.asSmithyModel()
+        val provider = testSymbolProvider(requiredMessageModel)
+        val project = TestWorkspace.testProject(provider)
+        val errorShape = requiredMessageModel.expectShape(ShapeId.from("com.test#RequiredMessageError")) as StructureShape
+        errorShape.renderWithModelBuilder(requiredMessageModel, provider, project)
+        project.moduleFor(errorShape) {
+            val errorTrait = errorShape.getTrait<ErrorTrait>()!!
+            ErrorImplGenerator(requiredMessageModel, provider, this, errorShape, errorTrait, emptyList()).render(CodegenTarget.CLIENT)
+
+            toString() shouldContain """::std::write!(f, ": {}", self.message)?;"""
+            compileAndTest(
+                """
+                let err = RequiredMessageError::builder().message("message").build().unwrap();
+                assert_eq!(err.to_string(), "RequiredMessageError: message");
                 """,
             )
         }


### PR DESCRIPTION
## Summary

- generate `Option::as_ref()?` for borrowed nested paginator accessors
- format error messages without redundant explicit borrows
- add focused regression coverage and a nonbreaking changelog

## Verification

- `./gradlew :codegen-client:test --tests "*PaginatorGeneratorTest*" :codegen-core:test --tests "*ErrorImplGeneratorTest*"`
- generated the VIPMS Rust SDK and ran its build, unit tests, doctests, and `cargo clippy --all-targets --all-features -- -D warnings` with Rust 1.97.1
