### PR TITLE
Revert server crate version bumps

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server"
-version = "0.67.0"
+version = "0.66.6"
 dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-http 0.64.0",
@@ -610,7 +610,7 @@ name = "aws-smithy-http-server-metrics"
 version = "0.2.1"
 dependencies = [
  "aws-smithy-http-server 0.65.10",
- "aws-smithy-http-server 0.67.0",
+ "aws-smithy-http-server 0.66.6",
  "aws-smithy-http-server-metrics-macro",
  "aws-smithy-legacy-http-server",
  "futures",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-metrics-macro"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-server-python"
-version = "0.68.0"
+version = "0.67.2"
 dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-legacy-http-server"
-version = "0.66.0"
+version = "0.65.16"
 dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-json 0.63.0",

--- a/rust-runtime/aws-smithy-http-server-metrics-macro/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-metrics-macro/Cargo.toml
@@ -3,7 +3,7 @@ proc-macro = true
 
 [package]
 name = "aws-smithy-http-server-metrics-macro"
-version = "0.2.0"
+version = "0.1.2"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Jason Gin <jasgin@amazon.com>",

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-python"
-version = "0.68.0"
+version = "0.67.2"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server-typescript/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server-typescript"
-version = "0.2.0"
+version = "0.1.3"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-http-server"
-version = "0.67.0"
+version = "0.66.6"
 authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/rust-runtime/aws-smithy-legacy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-legacy-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-legacy-http-server"
-version = "0.66.0"
+version = "0.65.16"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## Motivation and Context
PR #4692 bumped several server crate versions as part of the MSRV 1.94.1 update. Those changes cause internal compatibility issues because older generated/internal consumers ended up with mixed server runtime crate versions in the same dependency graph.

This PR keeps the MSRV bump but moves the affected server-family crates back onto their previous patch lines so we do not force a new minor-version line for this change.

`aws-smithy-http-server-metrics` is intentionally not reverted here; that's already handled separately in #4776.

## Description

This PR reverts the version bumps for the following crates while keeping `rust-version = 1.94.1`:
  - `aws-smithy-http-server`
  - `aws-smithy-legacy-http-server`
  - `aws-smithy-http-server-metrics-macro`
  - `aws-smithy-http-server-python`
  - `aws-smithy-http-server-typescript`

It also updates `rust-runtime/Cargo.lock` to match the reverted crate versions.

## Testing

- Ran `cargo metadata --locked --offline --format-version 1 --manifest-path rust-runtime/Cargo.toml`

## Checklist
- No changelogs for this PR

---
  _By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._