### PR TITLE
Fix RUSTSEC-2026-0253 by updating lru

### DIFF
--- a/.changelog/lru-rustsec-2026-0253.md
+++ b/.changelog/lru-rustsec-2026-0253.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client", "aws-sdk-rust"]
+authors: ["shrey4796"]
+references: ["aws-sdk-rust#1451"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Update the `lru` dependency to 0.18.2 to address RUSTSEC-2026-0253.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -1099,20 +1099,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
@@ -1377,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1458,11 +1452,11 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -37,7 +37,7 @@ http-1x = { package = "http", version = "1.3.1" }
 http-body-1x = { package = "http-body", version = "1.0.1" }
 http-body-util = "0.1.3"
 hmac = "0.13"
-lru = "0.16.3"
+lru = "0.18.2"
 ring = "0.17.5"
 sha2 = "0.11"
 tokio = "1.49.0"

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -2688,20 +2688,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
@@ -3108,7 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -3312,11 +3306,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -291,7 +291,7 @@ data class CargoDependency(
         val Hex: CargoDependency = CargoDependency("hex", CratesIo("0.4.3"))
         val Hmac: CargoDependency = CargoDependency("hmac", CratesIo("0.13"))
         val LazyStatic: CargoDependency = CargoDependency("lazy_static", CratesIo("1.4.0"))
-        val Lru: CargoDependency = CargoDependency("lru", CratesIo("0.16.3"))
+        val Lru: CargoDependency = CargoDependency("lru", CratesIo("0.18.2"))
         val Md5: CargoDependency = CargoDependency("md-5", CratesIo("0.11.0"), rustName = "md5")
         val PercentEncoding: CargoDependency =
             CargoDependency("percent-encoding", CratesIo("2.0.0"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.24
+codegenVersion=0.1.25


### PR DESCRIPTION
## Motivation and Context

The generated aws-sdk-s3 dependency graph resolves lru 0.16.4, which is affected by RUSTSEC-2026-0253. The advisory requires lru 0.18.2 or newer. This addresses aws-sdk-rust#1451.

## Description

- Update the code generator and aws-inlineable dependency declarations from lru 0.16.3 to 0.18.2.
- Regenerate the AWS runtime and SDK Cargo.lock files.
- Add the required changelog entry.
- No published crate version is manually changed; generated SDK versioning is handled by the release process.

## Testing

- aws-inlineable tests: 36 passed.
- Locked aws-inlineable tests: 36 passed.
- Generated SDK compilation and dependency inspection confirmed lru 0.18.2 for aws-sdk-s3.
- AWS SDK code generation checks passed.
- Changelog previews for smithy-rs and aws-sdk-rust passed.
- git diff --check passed.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the .changelog directory, specifying client in the applies_to key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the .changelog directory, specifying aws-sdk-rust in the applies_to key.

## AI-assisted review

This change was prepared and validated with AI assistance. The implementation, generated dependency graph, lockfiles, tests, and changelog were reviewed before submission; maintainer review is still required.

Because this PR originates from a fork, please manually invoke the PR Bot and Canary workflows as described in CONTRIBUTING.md.