### PR TITLE
Fixing issue with credential_process on windows

### DIFF
--- a/.changelog/fix-windows-credential-process-spaces.md
+++ b/.changelog/fix-windows-credential-process-spaces.md
@@ -1,0 +1,17 @@
+---
+applies_to: ["aws-sdk-rust"]
+authors: ["lnj"]
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix `credential_process` on Windows when the executable path contains spaces. The
+command was passed to `cmd.exe /C` as a single ordinary argument, whose default
+escaping combined with `cmd.exe`'s quote-stripping rules to mangle a quoted first
+token containing spaces (for example an executable installed under
+`C:\Program Files\...`, such as AWS AppStream 2.0's `appstream_machine_role`
+provider). The command is now appended to the `cmd.exe` command line verbatim
+(via `raw_arg`) and wrapped in an extra pair of quotes as `cmd.exe` requires, so a
+quoted path containing spaces is preserved. Behavior on non-Windows platforms is
+unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,52 @@ jobs:
       shell: bash
       run: tools/ci-scripts/test-windows.sh
 
+  # aws-config is not part of the `aws/rust-runtime` workspace and depends on
+  # generated SDK crates (STS, SSO, ...), so `test-rust-windows` (which tests the
+  # runtime workspaces from a bare checkout) cannot cover it. This job supplies
+  # the generated SDK from the `generate` job's smoketest artifact and runs the
+  # aws-config tests natively on Windows. It runs in parallel with the other
+  # jobs that depend on `generate` (e.g. `test-sdk`).
+  test-rust-windows-aws-config:
+    name: aws-config Tests on Windows
+    needs: generate
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      # Disable incremental compilation to reduce disk space use
+      CARGO_INCREMENTAL: 0
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git_ref }}
+      # Pinned to the commit hash of v2.7.3
+    - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
+      with:
+        shared-key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        workspaces: aws/rust-runtime/aws-config
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.rust_version }}
+        components: ${{ env.rust_toolchain_components }}
+    # aws-config builds against the generated SDK produced by the `generate` job.
+    # We can't use the Linux Docker build image here, so download the smoketest
+    # SDK artifact directly and place it where aws-config's path dependencies
+    # expect it (mirrors the `mv` in the Linux `check-aws-config` script).
+    - name: Download generated SDK (smoketest) artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-generate-aws-sdk-smoketest
+        path: artifacts-generate-aws-sdk-smoketest
+    - name: Extract generated SDK to aws/sdk/build/aws-sdk
+      shell: bash
+      run: |
+        tar xfz artifacts-generate-aws-sdk-smoketest/artifacts-generate-aws-sdk-smoketest.tar.gz
+        mkdir -p aws/sdk/build
+        mv aws-sdk-smoketest aws/sdk/build/aws-sdk
+    - name: Run aws-config tests
+      shell: bash
+      run: tools/ci-scripts/test-windows-aws-config.sh
+
   # We make sure that smithy-rs can be compiled on platforms that are not
   # natively supported by GitHub actions. We run as many tests as we can on
   # those platforms, but not all of them, because they require a more
@@ -442,6 +488,7 @@ jobs:
     - check-semver-hazards
     - test-sdk
     - test-rust-windows
+    - test-rust-windows-aws-config
     - test-exotic-platform-support
     # Run this job even if its dependency jobs fail
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,9 @@ jobs:
     name: Test the SDK
     needs: generate
     runs-on: ${{ matrix.test.runner }}
-    timeout-minutes: 45
+    # Defaults to 45 minutes; individual matrix entries can request more via
+    # `timeout` so that one slow action doesn't loosen the guard for the others.
+    timeout-minutes: ${{ matrix.test.timeout || 45 }}
     # To avoid repeating setup boilerplate, we have the actual test commands
     # in a matrix strategy. These commands get run in the steps after all the setup.
     strategy:
@@ -176,6 +178,12 @@ jobs:
         test:
         - action: check-aws-config
           runner: smithy_ubuntu-latest_8-core
+          # This action runs `cargo hack` over aws-config's feature powerset, so
+          # its runtime doubles with every feature added to the crate. Adding
+          # `legacy-client` (#4755) took it from 80 to 160 feature combinations
+          # and pushed it past the default 45 minutes: observed runs have
+          # completed in ~43.5 minutes and been killed at the 45 minute cap.
+          timeout: 60
         - action: check-aws-sdk-canary
           runner: smithy_ubuntu-latest_8-core
         - action: check-aws-sdk-cargo-deny

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -73,6 +73,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.10.9",
+ "tempfile",
  "time",
  "tokio",
  "tracing",
@@ -287,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -302,17 +303,19 @@ dependencies = [
  "http-body 1.1.0",
  "hyper 0.14.32",
  "hyper 1.11.0",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tracing",
 ]
@@ -363,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -388,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1181,6 +1184,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -1188,10 +1206,10 @@ dependencies = [
  "http 1.5.0",
  "hyper 1.11.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1377,6 +1395,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1763,6 +1787,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,7 +1820,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.14",
  "subtle",
  "zeroize",
 ]
@@ -1795,6 +1844,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1835,6 +1894,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -2085,6 +2154,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,11 +2280,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.43",
  "tokio",
 ]
 

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -98,6 +98,12 @@ tokio = { version = "1.23.1", features = ["full", "test-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# `tempfile` is only used by the Windows-only `credential_process` integration
+# tests, so it is declared as a target-specific dev-dependency to avoid being
+# flagged as an unused dependency on other platforms (e.g. cargo-udeps in CI).
+[target.'cfg(windows)'.dev-dependencies]
+tempfile = "3.16.0"
+
 [package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]

--- a/aws/rust-runtime/aws-config/src/credential_process.rs
+++ b/aws/rust-runtime/aws-config/src/credential_process.rs
@@ -85,11 +85,26 @@ impl CredentialProcessProvider {
         // Security: command arguments must be redacted at debug level
         tracing::debug!(command = %self.command, "loading credentials from external process");
 
-        let command = if cfg!(windows) {
+        // On Windows, the command runs through `cmd.exe /C`. The command string
+        // is appended with `raw_arg` rather than as a normal argument so that
+        // Rust does not apply its own C runtime style escaping (which `cmd.exe`
+        // does not understand), and the whole command is wrapped in an extra
+        // pair of quotes as `cmd.exe` requires. This preserves a quoted first
+        // token containing spaces. Ex: for an executable installed under
+        // `C:\Program Files\...`, such as AppStream 2.0's machine-role provider.
+        // Previously the entire string was passed as a single normal argument,
+        // whose escaping combined with `cmd.exe`'s quote-stripping to mangle
+        // such paths.
+        #[cfg(windows)]
+        let command = {
+            use std::os::windows::process::CommandExt;
             let mut command = Command::new("cmd.exe");
-            command.args(["/C", self.command.unredacted()]);
+            command.arg("/C");
+            command.raw_arg(format!("\"{}\"", self.command.unredacted()));
             command
-        } else {
+        };
+        #[cfg(not(windows))]
+        let command = {
             let mut command = Command::new("sh");
             command.args(["-c", self.command.unredacted()]);
             command
@@ -354,5 +369,89 @@ mod test {
             &vec![AwsCredentialFeature::CredentialsProcess],
             creds.get_property::<Vec<AwsCredentialFeature>>().unwrap()
         );
+    }
+}
+
+// Integration tests that actually spawn a process from a path containing a
+// space. These run only on Windows: they are the regression tests for the
+// `credential_process` quoting bug (internal: P491659165). The pre-existing
+// `credential_process` tests above use the Unix `echo` builtin and are
+// skipped on Windows.
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use crate::credential_process::CredentialProcessProvider;
+    use aws_credential_types::provider::ProvideCredentials;
+    use std::path::{Path, PathBuf};
+
+    const CREDS_JSON: &str = "{\"Version\":1,\"AccessKeyId\":\"ASIARTESTID\",\"SecretAccessKey\":\"TESTSECRETKEY\",\"SessionToken\":\"TESTSESSIONTOKEN\",\"Expiration\":\"2035-01-01T00:00:00Z\"}";
+
+    // Write a `.cmd` provider that prints valid credential JSON to stdout into
+    // `dir`, returning the path to the script. `@echo off` keeps stdout clean so
+    // the only thing emitted is the JSON document.
+    fn write_provider(dir: &Path) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let script = dir.join("provider.cmd");
+        std::fs::write(&script, format!("@echo off\r\necho {CREDS_JSON}\r\n")).unwrap();
+        script
+    }
+
+    #[tokio::test]
+    async fn spaced_path_with_argument_resolves() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let script = write_provider(&tmp.path().join("Program Space"));
+        assert!(
+            script.to_string_lossy().contains(' '),
+            "test fixture path must contain a space: {}",
+            script.display()
+        );
+
+        // Quote the path as a real config would, and pass an argument — exactly
+        // the AppStream shape: `"...PhotonRoleCredentialProvider.exe" --role=Machine`.
+        let command = format!("\"{}\" --role=Machine", script.display());
+        let provider = CredentialProcessProvider::new(command);
+
+        let creds = provider
+            .provide_credentials()
+            .await
+            .expect("credentials should resolve from a quoted spaced path with an argument");
+        assert_eq!(creds.access_key_id(), "ASIARTESTID");
+        assert_eq!(creds.secret_access_key(), "TESTSECRETKEY");
+        assert_eq!(creds.session_token(), Some("TESTSESSIONTOKEN"));
+    }
+
+    #[tokio::test]
+    async fn spaced_path_without_argument_resolves() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let script = write_provider(&tmp.path().join("Program Space"));
+
+        let command = format!("\"{}\"", script.display());
+        let provider = CredentialProcessProvider::new(command);
+
+        let creds = provider
+            .provide_credentials()
+            .await
+            .expect("credentials should resolve from a quoted spaced path with no argument");
+        assert_eq!(creds.access_key_id(), "ASIARTESTID");
+    }
+
+    #[tokio::test]
+    async fn unquoted_unspaced_path_still_resolves() {
+        // Control: an unquoted path with no spaces continues to work.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let script = write_provider(&tmp.path().join("nospace"));
+        // Only meaningful if no path component (including the temp root) has a
+        // space; otherwise the unquoted form is not a valid no-space control.
+        if script.to_string_lossy().contains(' ') {
+            return;
+        }
+
+        let command = script.display().to_string();
+        let provider = CredentialProcessProvider::new(command);
+
+        let creds = provider
+            .provide_credentials()
+            .await
+            .expect("control (unquoted, no spaces) should resolve");
+        assert_eq!(creds.access_key_id(), "ASIARTESTID");
     }
 }

--- a/aws/rust-runtime/aws-config/src/credential_process.rs
+++ b/aws/rust-runtime/aws-config/src/credential_process.rs
@@ -289,12 +289,34 @@ mod test {
     use time::OffsetDateTime;
     use tokio::time::timeout;
 
-    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
+    /// Builds a shell command that prints `json` to stdout, quoted correctly for
+    /// the shell the provider will use on this platform.
+    ///
+    /// The provider runs the command through `sh -c` on Unix and `cmd.exe /C` on
+    /// Windows, and the two disagree about quoting:
+    ///
+    /// * `sh` needs the JSON wrapped in single quotes so the double quotes inside
+    ///   it survive word splitting.
+    /// * `cmd.exe` has no notion of single quotes. It would pass them through
+    ///   literally, yielding output like `'{"Version":1}'`, which is not valid
+    ///   JSON. Its `echo` emits the remainder of the line verbatim, so the double
+    ///   quotes survive with no quoting at all.
+    ///
+    /// A runtime `cfg!` is fine here because both branches compile everywhere;
+    /// contrast with `credentials()` above, which needs `#[cfg(windows)]` because
+    /// `raw_arg` only exists on Windows.
+    fn echo_json(json: &str) -> String {
+        if cfg!(windows) {
+            format!("echo {json}")
+        } else {
+            format!("echo '{json}'")
+        }
+    }
+
     #[tokio::test]
-    #[cfg_attr(windows, ignore)]
     async fn test_credential_process() {
-        let provider = CredentialProcessProvider::new(String::from(
-            r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "SessionToken": "TESTSESSIONTOKEN", "AccountId": "123456789001", "Expiration": "2022-05-02T18:36:00+00:00" }'"#,
+        let provider = CredentialProcessProvider::new(echo_json(
+            r#"{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "SessionToken": "TESTSESSIONTOKEN", "AccountId": "123456789001", "Expiration": "2022-05-02T18:36:00+00:00" }"#,
         ));
         let creds = provider.provide_credentials().await.expect("valid creds");
         assert_eq!(creds.access_key_id(), "ASIARTESTID");
@@ -310,12 +332,10 @@ mod test {
         );
     }
 
-    // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[tokio::test]
-    #[cfg_attr(windows, ignore)]
     async fn test_credential_process_no_expiry() {
-        let provider = CredentialProcessProvider::new(String::from(
-            r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY" }'"#,
+        let provider = CredentialProcessProvider::new(echo_json(
+            r#"{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY" }"#,
         ));
         let creds = provider.provide_credentials().await.expect("valid creds");
         assert_eq!(creds.access_key_id(), "ASIARTESTID");
@@ -326,7 +346,13 @@ mod test {
 
     #[tokio::test]
     async fn credentials_process_timeouts() {
-        let provider = CredentialProcessProvider::new(String::from("sleep 1000"));
+        // Keep this sleep short. The 1ms timeout below fires long before it
+        // elapses, but the spawned process is not killed when the timed-out
+        // future is dropped, and on Windows the test is not reported as finished
+        // until that child exits, stalling the whole test binary for the
+        // duration. `sleep` still has to outlast the 1ms timeout by a wide
+        // margin for the assertion to hold.
+        let provider = CredentialProcessProvider::new(String::from("sleep 1"));
         let _creds = timeout(Duration::from_millis(1), provider.provide_credentials())
             .await
             .expect_err("timeout forced");
@@ -335,8 +361,8 @@ mod test {
     #[tokio::test]
     async fn credentials_with_fallback_account_id() {
         let provider = CredentialProcessProvider::builder()
-            .command(CommandWithSensitiveArgs::new(String::from(
-                r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY" }'"#,
+            .command(CommandWithSensitiveArgs::new(echo_json(
+                r#"{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY" }"#,
             )))
             .account_id("012345678901")
             .build();
@@ -347,8 +373,8 @@ mod test {
     #[tokio::test]
     async fn fallback_account_id_shadowed_by_account_id_in_process_output() {
         let provider = CredentialProcessProvider::builder()
-            .command(CommandWithSensitiveArgs::new(String::from(
-                r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "AccountId": "111122223333" }'"#,
+            .command(CommandWithSensitiveArgs::new(echo_json(
+                r#"{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "AccountId": "111122223333" }"#,
             )))
             .account_id("012345678901")
             .build();
@@ -359,8 +385,8 @@ mod test {
     #[tokio::test]
     async fn credential_feature() {
         let provider = CredentialProcessProvider::builder()
-            .command(CommandWithSensitiveArgs::new(String::from(
-                r#"echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "AccountId": "111122223333" }'"#,
+            .command(CommandWithSensitiveArgs::new(echo_json(
+                r#"{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "AccountId": "111122223333" }"#,
             )))
             .account_id("012345678901")
             .build();

--- a/tools/ci-scripts/test-windows-aws-config.sh
+++ b/tools/ci-scripts/test-windows-aws-config.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -eu -o pipefail
+
+# `aws-config` is not part of the `aws/rust-runtime` workspace and depends on
+# generated SDK crates (STS, SSO, ...), so it cannot be tested by
+# `test-windows.sh` alongside the other runtime crates. This script tests it
+# separately on Windows.
+#
+# The generated SDK must already be extracted to `aws/sdk/build/aws-sdk`. In CI
+# the `test-rust-windows-aws-config` job downloads the `generate-aws-sdk-smoketest`
+# artifact (produced by the `generate` job) and puts it there before running this
+# script, mirroring how the Linux `check-aws-config` job obtains the SDK.
+#
+# We deliberately build with `--no-default-features --features
+# credentials-process,rt-tokio` instead of `--all-features`: the default HTTPS
+# client pulls in `rustls`/`aws-lc-rs`, whose `aws-lc-sys` C build requires NASM
+# and does not build on the `windows-latest` runner. This is the same reason
+# `test-windows.sh` tests `aws-smithy-http-client` with `rustls-ring` only. This
+# feature set pulls in neither `aws-lc-sys` nor `openssl-sys`, and it still
+# exercises the `credential_process` provider, which is where the Windows-specific
+# `cmd.exe` handling lives (see the `credential_process` Windows integration
+# tests).
+
+if [[ ! -d "aws/sdk/build/aws-sdk/sdk" ]]; then
+  echo "error: generated SDK not found at 'aws/sdk/build/aws-sdk'." >&2
+  echo "Extract the 'generate-aws-sdk-smoketest' artifact there before running this script." >&2
+  exit 1
+fi
+
+FEATURES="credentials-process,rt-tokio"
+
+echo "Testing aws-config on Windows (--no-default-features --features ${FEATURES})"
+pushd "aws/rust-runtime/aws-config" &>/dev/null
+cargo clippy --no-default-features --features "${FEATURES}"
+cargo test --no-default-features --features "${FEATURES}"
+popd &>/dev/null

--- a/tools/ci-scripts/test-windows.sh
+++ b/tools/ci-scripts/test-windows.sh
@@ -17,7 +17,9 @@ for runtime_path in "rust-runtime" "aws/rust-runtime"; do
   cargo doc --no-deps --document-private-items --all-features --workspace "${exclusions[@]}"
   popd &>/dev/null
 done
-# TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) We don't have a way to codegen the deps needed by the aws-config crate
-# (cd aws/rust-runtime/aws-config && cargo test --all-features) # aws-config is not part of the workspace so we have to test it separately
+# aws-config is not part of these workspaces and depends on generated SDK crates,
+# so it is tested by the dedicated `test-rust-windows-aws-config` CI job (see
+# .github/workflows/ci.yml), which supplies the generated SDK and runs
+# tools/ci-scripts/test-windows-aws-config.sh.
 echo "Testing aws-smithy-http-client with Rustls/Ring and the wire harness"
 (cd rust-runtime && cargo test -p aws-smithy-http-client --features rustls-ring,wire-mock) # only ring works on windows


### PR DESCRIPTION


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Internal customer reported that `credential_process` would fail on windows if the path contained a space. That wasn't caught because we disabled most of the `credential_process` tests on Windows (due to them using unix style paths). Fixed that with [raw_arg](https://doc.rust-lang.org/std/os/windows/process/trait.CommandExt.html#tymethod.raw_arg), but still wasn't able to test it in CI.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is the larger part of this PR. Created a standalone CI task `test-rust-windows-aws-config`. It runs the `aws-config` tests with a minimal set of features `cargo test --no-default-features --features "credentials-process,rt-tokio"`  to get around issues with `aws-lc` on Windows. 

https://github.com/smithy-lang/smithy-rs/pull/4755 added a new feature to `aws-config` doubling the amount of tests run by `cargo hack`. That was timing out sometimes so this PR also increases the timeout for that test.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
