### PR TITLE
fix(server): move AlbHealthCheckLayer to A-position in pokemon-service example

### DIFF
--- a/.changelog/fix-pokemon-healthcheck-layer.md
+++ b/.changelog/fix-pokemon-healthcheck-layer.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["server"]
+authors: ["sachinsharma3191"]
+references: ["smithy-rs#4631", "smithy-rs#3607", "smithy-rs#3606"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Move `AlbHealthCheckLayer` in the pokemon-service example from B-position (inside `PokemonServiceConfig`) to A-position (wrapping the router). The layer was previously registered on `/ping`, which is already owned by the modeled `CheckHealth` operation, so the health check handler was never reached. It now listens on `/health` and wraps the final service so requests are answered before routing.

--- a/examples/pokemon-service/src/main.rs
+++ b/examples/pokemon-service/src/main.rs
@@ -104,10 +104,6 @@ pub async fn main() {
     let config = PokemonServiceConfig::builder()
         // Set up shared state and middlewares.
         .layer(AddExtensionLayer::new(Arc::new(State::default())))
-        // Handle `/ping` health check requests.
-        .layer(AlbHealthCheckLayer::from_handler("/ping", |_req| async {
-            StatusCode::OK
-        }))
         // Add server request IDs.
         .layer(ServerRequestIdProviderLayer::new())
         .http_plugin(http_plugins)
@@ -142,6 +138,16 @@ pub async fn main() {
         .build();
 
     let service = metrics_layer.layer(app);
+
+    // Handle out-of-band health check requests at `/health` by returning a `200 OK`.
+    //
+    // This layer is applied in "A position", wrapping the router so that health checks are answered
+    // before routing, rather than being dispatched as a modeled operation. `/health` is intentionally
+    // not part of the Smithy model; contrast this with the modeled `CheckHealth` operation at `/ping`.
+    //
+    // See <https://smithy-lang.github.io/smithy-rs/design/server/middleware.html> for the difference
+    // between A and B position middleware.
+    let service = AlbHealthCheckLayer::from_handler("/health", |_req| async { StatusCode::OK }).layer(service);
 
     // Using `IntoMakeServiceWithConnectInfo`, rather than `into_make_service`, to adjoin the `SocketAddr`
     // connection info.

--- a/examples/pokemon-service/tests/simple.rs
+++ b/examples/pokemon-service/tests/simple.rs
@@ -99,11 +99,11 @@ async fn simple_integration_test() {
 async fn health_check() {
     let server = common::run_server().await;
 
-    let url = common::base_url(server.port) + "/ping";
+    let url = common::base_url(server.port) + "/health";
     let uri = url.parse::<hyper::Uri>().expect("invalid URL");
 
-    // Since the `/ping` route is not modeled in Smithy, we use a regular
-    // Hyper HTTP client to make a request to it.
+    // `/health` is served by the `AlbHealthCheckLayer` wrapping the router, and is not a modeled
+    // operation, so we use a regular Hyper HTTP client to make a request to it.
     let request = hyper::Request::builder()
         .uri(uri)
         .body(http_body_util::Empty::<bytes::Bytes>::new())


### PR DESCRIPTION
## Summary
- The `AlbHealthCheckLayer` was registered in B-position (inside `PokemonServiceConfig::builder()`) on `/ping`, but the modeled `CheckHealth` operation already owns that route. The health check handler was never reached.
- Moved the layer to A-position (wrapping the router after `metrics_layer`) and changed the path to `/health` so it does not collide with the modeled operation.
- Updated the integration test to hit `/health` instead of `/ping`.

Fixes #4631, #3607, #3606

## Test plan
- [x] Updated `health_check` integration test in `examples/pokemon-service/tests/simple.rs` to use `/health`
- [ ] `cargo build -p pokemon-service` compiles
- [ ] `cargo test -p pokemon-service --test simple` passes the health check test