### PR TITLE
fix(server): inline format arguments in generated constraint violation code

### DIFF
--- a/.changelog/fix-uninlined-format-args-server.md
+++ b/.changelog/fix-uninlined-format-args-server.md
@@ -6,4 +6,4 @@ breaking: false
 new_feature: false
 bug_fix: true
 ---
-Inline format arguments in generated server code to satisfy the `clippy::uninlined_format_args` lint. All `format!("{}", var)` / `write!(f, "{}", var)` patterns in constraint violation display implementations are now `format!("{var}")` / `write!(f, "{var}")`.
+Inline format arguments in generated server code to satisfy the `clippy::uninlined_format_args` lint and remove the `allow(clippy::uninlined_format_args)` workaround from `ServerRequiredCustomizations`. All positional format arguments in constraint violation display implementations, validation error messages, and validation exception decorators are now inlined into their format strings.

--- a/.changelog/fix-uninlined-format-args-server.md
+++ b/.changelog/fix-uninlined-format-args-server.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["server"]
+authors: ["sachinsharma3191"]
+references: ["smithy-rs#4366"]
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Inline format arguments in generated server code to satisfy the `clippy::uninlined_format_args` lint. All `format!("{}", var)` / `write!(f, "{}", var)` patterns in constraint violation display implementations are now `format!("{var}")` / `write!(f, "{var}")`.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/EnumTraitValidationErrorMessage.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/EnumTraitValidationErrorMessage.kt
@@ -9,7 +9,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.EnumTrait
 
 fun EnumTrait.validationErrorMessage() =
-    "Value at '{}' failed to satisfy constraint: Member must satisfy enum value set: [${enumValueSet()}]"
+    "Value at '{path}' failed to satisfy constraint: Member must satisfy enum value set: [${enumValueSet()}]"
 
 fun EnumTrait.shapeConstraintViolationDisplayMessage(shape: Shape) =
     "Value provided for '${shape.id}' failed to satisfy constraint: Member must satisfy enum value set: [${enumValueSet()}]"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/LengthTraitValidationErrorMessage.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/LengthTraitValidationErrorMessage.kt
@@ -9,10 +9,10 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.LengthTrait
 
 fun LengthTrait.validationErrorMessage() =
-    "Value with length {} at '{}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"
+    "Value with length {length} at '{}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"
 
 fun LengthTrait.shapeConstraintViolationDisplayMessage(shape: Shape) =
-    "Value with length {} provided for '${shape.id}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"
+    "Value with length {length} provided for '${shape.id}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"
 
 fun LengthTrait.lengthDescription() =
     if (this.min.isPresent && this.max.isPresent) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/LengthTraitValidationErrorMessage.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/LengthTraitValidationErrorMessage.kt
@@ -9,7 +9,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.LengthTrait
 
 fun LengthTrait.validationErrorMessage() =
-    "Value with length {length} at '{}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"
+    "Value with length {length} at '{path}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"
 
 fun LengthTrait.shapeConstraintViolationDisplayMessage(shape: Shape) =
     "Value with length {length} provided for '${shape.id}' failed to satisfy constraint: Member must have length ${this.lengthDescription()}"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PatternTraitValidationErrorMessage.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PatternTraitValidationErrorMessage.kt
@@ -9,7 +9,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.PatternTrait
 
 fun PatternTrait.validationErrorMessage() =
-    "Value at '{}' failed to satisfy constraint: Member must satisfy regular expression pattern: {}"
+    "Value at '{path}' failed to satisfy constraint: Member must satisfy regular expression pattern: {}"
 
 fun PatternTrait.shapeConstraintViolationDisplayMessage(shape: Shape) =
     "Value provided for `${shape.id}` failed to satisfy the constraint: Member must match the regular expression pattern: {}"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RangeTraitValidationErrorMessage.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RangeTraitValidationErrorMessage.kt
@@ -9,7 +9,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.RangeTrait
 
 fun RangeTrait.validationErrorMessage() =
-    "Value at '{}' failed to satisfy constraint: Member must be ${this.rangeDescription()}"
+    "Value at '{path}' failed to satisfy constraint: Member must be ${this.rangeDescription()}"
 
 fun RangeTrait.shapeConstraintViolationDisplayMessage(shape: Shape) =
     "Value for `${shape.id}`failed to satisfy constraint: Member must be ${this.rangeDescription()}"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/UniqueItemsTraitValidationErrorMessage.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/UniqueItemsTraitValidationErrorMessage.kt
@@ -11,10 +11,10 @@ import software.amazon.smithy.model.traits.UniqueItemsTrait
 fun UniqueItemsTrait.validationErrorMessage() =
     // We're using the `Debug` representation of `Vec<usize>` here e.g. `[0, 2, 3]`, which is the exact format we need
     // to match the expected format of the error message in the protocol tests.
-    "Value with repeated values at indices {:?} at '{}' failed to satisfy constraint: Member must have unique values"
+    "Value with repeated values at indices {duplicate_indices:?} at '{path}' failed to satisfy constraint: Member must have unique values"
 
 fun UniqueItemsTrait.shapeConstraintViolationDisplayMessage(shape: Shape) =
     """
-    Value with repeated values at indices {:?} provided for '${shape.id}' 
+    Value with repeated values at indices {duplicate_indices:?} provided for '${shape.id}'
     failed to satisfy constraint: Member must have unique values
     """.trimIndent().replace("\n", "")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
@@ -116,7 +116,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                                 rust(
                                     """
                                     Self::Length(length) => crate::model::ValidationExceptionField {
-                                        message: format!("${it.lengthTrait.validationErrorMessage()}", length, &path),
+                                        message: format!("${it.lengthTrait.validationErrorMessage()}", &path),
                                         name: path,
                                         reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                                     },
@@ -184,7 +184,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                         rust(
                             """
                             Self::Length(length) => crate::model::ValidationExceptionField {
-                                message: format!("${it.lengthTrait.validationErrorMessage()}", length, &path),
+                                message: format!("${it.lengthTrait.validationErrorMessage()}", &path),
                                 name: path,
                                 reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                             },
@@ -222,7 +222,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                     rust(
                         """
                         Self::Length(length) => crate::model::ValidationExceptionField {
-                            message: format!("${it.validationErrorMessage()}", length, &path),
+                            message: format!("${it.validationErrorMessage()}", &path),
                             name: path,
                             reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                         },
@@ -253,7 +253,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                             rust(
                                 """
                                 ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
-                                    message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
+                                    message: format!("Value at '{path}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null"),
                                     name: path + "/${it.forMember.memberName}",
                                     reason: crate::model::ValidationExceptionFieldReason::Other,
                                 },
@@ -277,7 +277,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                             rust(
                                 """
                                 Self::Length(length) => crate::model::ValidationExceptionField {
-                                    message: format!("${it.lengthTrait.validationErrorMessage()}", length, &path),
+                                    message: format!("${it.lengthTrait.validationErrorMessage()}", &path),
                                     name: path,
                                     reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                                 },

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/CustomValidationExceptionWithReasonDecorator.kt
@@ -116,7 +116,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                                 rust(
                                     """
                                     Self::Length(length) => crate::model::ValidationExceptionField {
-                                        message: format!("${it.lengthTrait.validationErrorMessage()}", &path),
+                                        message: format!("${it.lengthTrait.validationErrorMessage()}"),
                                         name: path,
                                         reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                                     },
@@ -143,12 +143,12 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
     override fun enumShapeConstraintViolationImplBlock(enumTrait: EnumTrait) =
         writable {
             val enumValueSet = enumTrait.enumDefinitionValues.joinToString(", ")
-            val message = "Value at '{}' failed to satisfy constraint: Member must satisfy enum value set: [$enumValueSet]"
+            val message = "Value at '{path}' failed to satisfy constraint: Member must satisfy enum value set: [$enumValueSet]"
             rustTemplate(
                 """
                 pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField {
                     crate::model::ValidationExceptionField {
-                        message: format!(r##"$message"##, &path),
+                        message: format!(r##"$message"##),
                         name: path,
                         reason: crate::model::ValidationExceptionFieldReason::ValueNotValid,
                     }
@@ -165,7 +165,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                 pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField {
                     match self {
                         Self::Range(_) => crate::model::ValidationExceptionField {
-                            message: format!("${rangeInfo.rangeTrait.validationErrorMessage()}", &path),
+                            message: format!("${rangeInfo.rangeTrait.validationErrorMessage()}"),
                             name: path,
                             reason: crate::model::ValidationExceptionFieldReason::ValueNotValid,
                         }
@@ -184,7 +184,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                         rust(
                             """
                             Self::Length(length) => crate::model::ValidationExceptionField {
-                                message: format!("${it.lengthTrait.validationErrorMessage()}", &path),
+                                message: format!("${it.lengthTrait.validationErrorMessage()}"),
                                 name: path,
                                 reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                             },
@@ -222,7 +222,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                     rust(
                         """
                         Self::Length(length) => crate::model::ValidationExceptionField {
-                            message: format!("${it.validationErrorMessage()}", &path),
+                            message: format!("${it.validationErrorMessage()}"),
                             name: path,
                             reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                         },
@@ -277,7 +277,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                             rust(
                                 """
                                 Self::Length(length) => crate::model::ValidationExceptionField {
-                                    message: format!("${it.lengthTrait.validationErrorMessage()}", &path),
+                                    message: format!("${it.lengthTrait.validationErrorMessage()}"),
                                     name: path,
                                     reason: crate::model::ValidationExceptionFieldReason::LengthNotValid,
                                 },
@@ -289,7 +289,7 @@ class ValidationExceptionWithReasonConversionGenerator(private val codegenContex
                                 """
                                 Self::UniqueItems { duplicate_indices, .. } =>
                                     crate::model::ValidationExceptionField {
-                                        message: format!("${it.uniqueItemsTrait.validationErrorMessage()}", &duplicate_indices, &path),
+                                        message: format!("${it.uniqueItemsTrait.validationErrorMessage()}"),
                                         name: path,
                                         reason: crate::model::ValidationExceptionFieldReason::ValueNotValid,
                                     },

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
@@ -34,8 +34,7 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
         codegenContext: ServerCodegenContext,
         baseCustomizations: List<LibRsCustomization>,
     ): List<LibRsCustomization> =
-        // TODO(https://github.com/smithy-lang/smithy-rs/issues/4366) Remove additionalClippyLints once the issue is resolved
-        baseCustomizations + AllowLintsCustomization(additionalClippyLints = listOf("uninlined_format_args", "clone_on_copy"))
+        baseCustomizations + AllowLintsCustomization(additionalClippyLints = listOf("clone_on_copy"))
 
     override fun extras(
         codegenContext: ServerCodegenContext,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SigV4EventStreamSupportStructures.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SigV4EventStreamSupportStructures.kt
@@ -100,7 +100,7 @@ object SigV4EventStreamSupportStructures {
                     fn fmt(&self, f: &mut #{Formatter}<'_>) -> #{fmt_Result} {
                         match self {
                             ExtractionError::InvalidPayload { error } => {
-                                write!(f, "invalid payload: {}", error)
+                                write!(f, "invalid payload: {error}")
                             }
                             ExtractionError::InvalidTimestamp => {
                                 write!(f, "invalid or missing timestamp header")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
@@ -142,7 +142,7 @@ class SmithyValidationExceptionConversionGenerator(private val codegenContext: S
                     rust(
                         """
                         Self::Length(length) => crate::model::ValidationExceptionField {
-                            message: format!("${it.validationErrorMessage()}", &path),
+                            message: format!("${it.validationErrorMessage()}"),
                             path,
                         },""",
                     )
@@ -169,7 +169,7 @@ class SmithyValidationExceptionConversionGenerator(private val codegenContext: S
                 """
                 pub(crate) fn as_validation_exception_field(self, path: #{String}) -> crate::model::ValidationExceptionField {
                     crate::model::ValidationExceptionField {
-                        message: format!(r##"$message"##, &path),
+                        message: format!(r##"$message"##),
                         path,
                     }
                 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/SmithyValidationExceptionDecorator.kt
@@ -142,7 +142,7 @@ class SmithyValidationExceptionConversionGenerator(private val codegenContext: S
                     rust(
                         """
                         Self::Length(length) => crate::model::ValidationExceptionField {
-                            message: format!("${it.validationErrorMessage()}", length, &path),
+                            message: format!("${it.validationErrorMessage()}", &path),
                             path,
                         },""",
                     )
@@ -207,7 +207,7 @@ class SmithyValidationExceptionConversionGenerator(private val codegenContext: S
                             rust(
                                 """
                                 ConstraintViolation::${it.name()} => crate::model::ValidationExceptionField {
-                                    message: format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path),
+                                    message: format!("Value at '{path}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null"),
                                     path: path + "/${it.forMember.memberName}",
                                 },
                                 """,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
@@ -329,7 +329,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                         "FieldAssignments" to
                                             fieldAssignments(
                                                 "path.clone()",
-                                                "format!(${lengthTrait.validationErrorMessage().dq()}, length, &path)",
+                                                "format!(${lengthTrait.validationErrorMessage().dq()}, &path)",
                                             ),
                                     )
                                 }
@@ -395,7 +395,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                         "path.clone()",
                                         "format!(${
                                             blobLength.lengthTrait.validationErrorMessage().dq()
-                                        }, length, &path)",
+                                        }, &path)",
                                     ),
                             )
                         }
@@ -433,7 +433,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                             "FieldAssignments" to
                                 fieldAssignments(
                                     "path.clone()",
-                                    """format!(${it.validationErrorMessage().dq()}, length, &path)""",
+                                    """format!(${it.validationErrorMessage().dq()}, &path)""",
                                 ),
                         )
                     }
@@ -523,7 +523,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                 "FieldAssignments" to
                                     fieldAssignments(
                                         """path.clone() + "/${it.forMember.memberName}"""",
-                                        """format!("Value at '{}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null", path)""",
+                                        """format!("Value at '{path}/${it.forMember.memberName}' failed to satisfy constraint: Member must not be null")""",
                                     ),
                             )
                         }
@@ -571,7 +571,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                                 "format!(${
                                                     collectionTraitInfo.lengthTrait.validationErrorMessage()
                                                         .dq()
-                                                }, length, &path)",
+                                                }, &path)",
                                             ),
                                     )
                                 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/UserProvidedValidationExceptionDecorator.kt
@@ -329,7 +329,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                         "FieldAssignments" to
                                             fieldAssignments(
                                                 "path.clone()",
-                                                "format!(${lengthTrait.validationErrorMessage().dq()}, &path)",
+                                                "format!(${lengthTrait.validationErrorMessage().dq()})",
                                             ),
                                     )
                                 }
@@ -352,7 +352,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                                 "path.clone()",
                                                 "format!(${
                                                     patternTrait.validationErrorMessage().dq()
-                                                }, &path, ${patternTrait.pattern.toString().dq()})",
+                                                }, ${patternTrait.pattern.toString().dq()})",
                                             ),
                                     )
                                 }
@@ -395,7 +395,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                         "path.clone()",
                                         "format!(${
                                             blobLength.lengthTrait.validationErrorMessage().dq()
-                                        }, &path)",
+                                        })",
                                     ),
                             )
                         }
@@ -433,7 +433,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                             "FieldAssignments" to
                                 fieldAssignments(
                                     "path.clone()",
-                                    """format!(${it.validationErrorMessage().dq()}, &path)""",
+                                    """format!(${it.validationErrorMessage().dq()})""",
                                 ),
                         )
                     }
@@ -465,7 +465,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                 """,
                 *preludeScope,
                 *codegenScope,
-                "FieldAssignments" to fieldAssignments("path.clone()", """format!(r##"$message"##, &path)"""),
+                "FieldAssignments" to fieldAssignments("path.clone()", """format!(r##"$message"##)"""),
             )
         }
     }
@@ -491,7 +491,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                 "FieldAssignments" to
                     fieldAssignments(
                         "path.clone()",
-                        """format!(${rangeInfo.rangeTrait.validationErrorMessage().dq()}, &path)""",
+                        """format!(${rangeInfo.rangeTrait.validationErrorMessage().dq()})""",
                     ),
             )
         }
@@ -571,7 +571,7 @@ class UserProvidedValidationExceptionConversionGenerator(
                                                 "format!(${
                                                     collectionTraitInfo.lengthTrait.validationErrorMessage()
                                                         .dq()
-                                                }, &path)",
+                                                })",
                                             ),
                                     )
                                 }
@@ -592,8 +592,6 @@ class UserProvidedValidationExceptionConversionGenerator(
                                                     ${
                                                     collectionTraitInfo.uniqueItemsTrait.validationErrorMessage().dq()
                                                 },
-                                                    &duplicate_indices,
-                                                    &path
                                                 )
                                                 """,
                                             ),

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/CollectionConstraintViolationGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/CollectionConstraintViolationGenerator.kt
@@ -122,8 +122,7 @@ class CollectionConstraintViolationGenerator(
             if (memberConstraintVariantPresent) {
                 rustTemplate(
                     """
-                    Self::Member(index, failing_member) => format!("Value at index {index} failed to satisfy constraint. {}",
-                       failing_member)
+                    Self::Member(index, failing_member) => format!("Value at index {index} failed to satisfy constraint. {failing_member}")
                     """,
                 )
             }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedBlobGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedBlobGenerator.kt
@@ -188,7 +188,7 @@ data class BlobLength(val lengthTrait: LengthTrait) : BlobConstraintGenerator {
                 rust(
                     """
                     Self::Length(length) => crate::model::ValidationExceptionField {
-                        message: format!("${lengthTrait.validationErrorMessage()}", &path),
+                        message: format!("${lengthTrait.validationErrorMessage()}"),
                         path,
                     },
                     """,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedBlobGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedBlobGenerator.kt
@@ -188,7 +188,7 @@ data class BlobLength(val lengthTrait: LengthTrait) : BlobConstraintGenerator {
                 rust(
                     """
                     Self::Length(length) => crate::model::ValidationExceptionField {
-                        message: format!("${lengthTrait.validationErrorMessage()}", length, &path),
+                        message: format!("${lengthTrait.validationErrorMessage()}", &path),
                         path,
                     },
                     """,
@@ -227,7 +227,7 @@ data class BlobLength(val lengthTrait: LengthTrait) : BlobConstraintGenerator {
             rustTemplate(
                 """
                 Self::Length(length) => {
-                    format!("${lengthTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}", length)
+                    format!("${lengthTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}")
                 },
                 """,
             )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
@@ -260,7 +260,7 @@ sealed class CollectionTraitInfo {
                         """
                         Self::UniqueItems { duplicate_indices, .. } =>
                             crate::model::ValidationExceptionField {
-                                message: format!("${uniqueItemsTrait.validationErrorMessage()}", &duplicate_indices, &path),
+                                message: format!("${uniqueItemsTrait.validationErrorMessage()}"),
                                 path,
                             },
                         """,
@@ -328,7 +328,7 @@ sealed class CollectionTraitInfo {
                 rustTemplate(
                     """
                     Self::UniqueItems { duplicate_indices, .. } =>
-                        format!("${uniqueItemsTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}", &duplicate_indices),
+                        format!("${uniqueItemsTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}"),
                     """,
                 )
             }
@@ -348,7 +348,7 @@ sealed class CollectionTraitInfo {
                     rust(
                         """
                         Self::Length(length) => crate::model::ValidationExceptionField {
-                            message: format!("${lengthTrait.validationErrorMessage()}", &path),
+                            message: format!("${lengthTrait.validationErrorMessage()}"),
                             path,
                         },
                         """,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
@@ -348,7 +348,7 @@ sealed class CollectionTraitInfo {
                     rust(
                         """
                         Self::Length(length) => crate::model::ValidationExceptionField {
-                            message: format!("${lengthTrait.validationErrorMessage()}", length, &path),
+                            message: format!("${lengthTrait.validationErrorMessage()}", &path),
                             path,
                         },
                         """,
@@ -378,7 +378,7 @@ sealed class CollectionTraitInfo {
                 rustTemplate(
                     """
                     Self::Length(length) => {
-                        format!("${lengthTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}", length)
+                        format!("${lengthTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}")
                     },
                     """,
                 )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedNumberGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedNumberGenerator.kt
@@ -178,7 +178,7 @@ data class Range(val rangeTrait: RangeTrait) {
                 rust(
                     """
                     Self::Range(_) => crate::model::ValidationExceptionField {
-                        message: format!("${rangeTrait.validationErrorMessage()}", &path),
+                        message: format!("${rangeTrait.validationErrorMessage()}"),
                         path,
                     },
                     """,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedStringGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedStringGenerator.kt
@@ -226,7 +226,7 @@ data class Length(val lengthTrait: LengthTrait) : StringTraitInfo() {
                 rust(
                     """
                     Self::Length(length) => crate::model::ValidationExceptionField {
-                        message: format!("${lengthTrait.validationErrorMessage()}", &path),
+                        message: format!("${lengthTrait.validationErrorMessage()}"),
                         path,
                     },
                     """,
@@ -318,7 +318,7 @@ data class Pattern(val symbol: Symbol, val patternTrait: PatternTrait, val isSen
             val pattern = patternTrait.pattern.toString().replace("#", "##")
             rust(
                 """
-                format!("${patternTrait.validationErrorMessage()}", &path, r##"$pattern"##)
+                format!("${patternTrait.validationErrorMessage()}", r##"$pattern"##)
                 """,
             )
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedStringGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedStringGenerator.kt
@@ -226,7 +226,7 @@ data class Length(val lengthTrait: LengthTrait) : StringTraitInfo() {
                 rust(
                     """
                     Self::Length(length) => crate::model::ValidationExceptionField {
-                        message: format!("${lengthTrait.validationErrorMessage()}", length, &path),
+                        message: format!("${lengthTrait.validationErrorMessage()}", &path),
                         path,
                     },
                     """,
@@ -269,7 +269,7 @@ data class Length(val lengthTrait: LengthTrait) : StringTraitInfo() {
             rustTemplate(
                 """
                 Self::Length(length) => {
-                    format!("${lengthTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}", length)
+                    format!("${lengthTrait.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}")
                 },
                 """,
             )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/MapConstraintViolationGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/MapConstraintViolationGenerator.kt
@@ -93,8 +93,8 @@ class MapConstraintViolationGenerator(
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                         match self {
                             ${if (shape.hasTrait<LengthTrait>()) "#{LengthMatchingArm}" else ""}
-                            ${if (keyConstraintViolationExists) """Self::Key(key_constraint_violation) => write!(f, "{}", key_constraint_violation),""" else ""}
-                            ${if (valueConstraintViolationExists) """Self::Value(_, value_constraint_violation) => write!(f, "{}", value_constraint_violation),""" else ""}
+                            ${if (keyConstraintViolationExists) """Self::Key(key_constraint_violation) => write!(f, "{key_constraint_violation}"),""" else ""}
+                            ${if (valueConstraintViolationExists) """Self::Value(_, value_constraint_violation) => write!(f, "{value_constraint_violation}"),""" else ""}
                         }
                     }
                 }
@@ -133,7 +133,7 @@ class MapConstraintViolationGenerator(
                 rustTemplate(
                     """
                     Self::Length(length) => {
-                        write!(f, "${it.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}", length)
+                        write!(f, "${it.shapeConstraintViolationDisplayMessage(shape).replace("#", "##")}")
                     },
                     """,
                 )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -772,7 +772,7 @@ class ServerServiceGenerator(
 
                         writeln!(f, "\nUse the dedicated methods on `$builderName` to register the missing handlers:")?;
                         for setter_name in self.operation_names2setter_methods.values() {
-                            writeln!(f, "- {}", setter_name)?;
+                            writeln!(f, "- {setter_name}")?;
                         }
                         Ok(())
                     }


### PR DESCRIPTION
## Summary
- Generated server code used `format!("{}", var)` / `write!(f, "{}", var)` patterns that trip Clippy's `uninlined_format_args` lint.
- Inlined captured variables directly into format strings across all constraint violation generators and validation exception decorators.
- In `LengthTraitValidationErrorMessage.kt`, changed `{}`→`{length}` in the format template so downstream callers no longer need to pass `length` as a positional argument — updated all call sites accordingly.

Fixes #4366

## Test plan
- [ ] `./gradlew codegen-server-test:assemble --quiet` compiles successfully
- [ ] Generated code passes `cargo clippy -- -D clippy::uninlined_format_args`
- [ ] `./gradlew test` passes