### PR TITLE
Back builtin credential providers with static stability

### DIFF
--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -52,6 +52,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
             EndpointOverrideMetricDecorator(),
             UserAgentDecorator(),
             SigV4AuthDecorator(),
+            StaticStabilityCacheDecorator(),
             HttpRequestChecksumDecorator(),
             HttpResponseChecksumDecorator(),
             IntegrationTestDecorator(),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -52,7 +52,7 @@ val DECORATORS: List<ClientCodegenDecorator> =
             EndpointOverrideMetricDecorator(),
             UserAgentDecorator(),
             SigV4AuthDecorator(),
-            StaticStabilityCacheDecorator(),
+            StaticStabilityDecorator(),
             HttpRequestChecksumDecorator(),
             HttpResponseChecksumDecorator(),
             IntegrationTestDecorator(),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/StaticStabilityCacheDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/StaticStabilityCacheDecorator.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginSection
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+
+/**
+ * Installs `StaticStabilityCache` as the default identity cache for AWS clients built directly from
+ * a `Config` (that is, without `aws-config`).
+ *
+ * It is registered on the generated `ServiceRuntimePlugin` and installs the cache only when the
+ * customer has not already configured one. It is gated on `BehaviorVersion >= v2026_08_01`, so
+ * older behavior versions keep `LazyCache`.
+ *
+ * Clients built through `aws-config` instead receive the same cache from `ConfigLoader::load()`.
+ */
+class StaticStabilityCacheDecorator : ClientCodegenDecorator {
+    override val name: String = "StaticStabilityCache"
+    override val order: Byte = 0
+
+    override fun serviceRuntimePluginCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ServiceRuntimePluginCustomization>,
+    ): List<ServiceRuntimePluginCustomization> = baseCustomizations + StaticStabilityCacheCustomization(codegenContext)
+}
+
+private class StaticStabilityCacheCustomization(
+    codegenContext: ClientCodegenContext,
+) : ServiceRuntimePluginCustomization() {
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val codegenScope =
+        arrayOf(
+            "StaticStabilityCache" to
+                AwsRuntimeType.awsRuntime(runtimeConfig)
+                    .resolve("static_stability::StaticStabilityCache"),
+            "BehaviorVersion" to
+                RuntimeType.smithyRuntimeApiClient(runtimeConfig)
+                    .resolve("client::behavior_version::BehaviorVersion"),
+        )
+
+    override fun section(section: ServiceRuntimePluginSection): Writable =
+        writable {
+            when (section) {
+                // Runs inside `ServiceRuntimePlugin::new`, where the `runtime_components` builder
+                // and the service `Config` are in scope.
+                is ServiceRuntimePluginSection.RegisterRuntimeComponents -> {
+                    rustTemplate(
+                        """
+                        // Install the default only when the customer hasn't configured a cache, so
+                        // an explicit `.identity_cache(..)` (e.g. the assume-role provider's
+                        // `no_cache()`) is kept. Gated on the behavior version.
+                        if ${section.serviceConfigName}.identity_cache().is_none()
+                            && ${section.serviceConfigName}
+                                .behavior_version
+                                .expect("behavior version is set before the service runtime plugin runs")
+                                .is_at_least(#{BehaviorVersion}::v2026_08_01())
+                        {
+                            runtime_components
+                                .set_identity_cache(Some(#{StaticStabilityCache}::builder().build()));
+                        }
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                else -> {}
+            }
+        }
+}

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/StaticStabilityDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/StaticStabilityDecorator.kt
@@ -5,8 +5,11 @@
 
 package software.amazon.smithy.rustsdk
 
+import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationSection
 import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginSection
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -15,23 +18,33 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 
 /**
- * Installs `StaticStabilityCache` as the default identity cache for AWS clients built directly from
- * a `Config` (that is, without `aws-config`).
+ * Wires up static stability for AWS clients — the identity cache that owns consistent credential
+ * refresh, plus the interceptor that invalidates credentials a target service rejects.
  *
- * It is registered on the generated `ServiceRuntimePlugin` and installs the cache only when the
- * customer has not already configured one. It is gated on `BehaviorVersion >= v2026_08_01`, so
- * older behavior versions keep `LazyCache`.
+ * On the generated `ServiceRuntimePlugin`, it installs `StaticStabilityCache` as the default
+ * identity cache for clients built directly from a `Config` (without `aws-config`) — only when the
+ * customer hasn't configured one, and only at `BehaviorVersion >= v2026_08_01` (older versions keep
+ * `LazyCache`). Clients built through `aws-config` get the same cache from `ConfigLoader::load()`.
  *
- * Clients built through `aws-config` instead receive the same cache from `ConfigLoader::load()`.
+ * On every operation, it registers `CredentialAuthFailureInterceptor`: when a target service
+ * rejects a request with `ExpiredToken`/`InvalidToken`, the interceptor sets a data-free config-bag
+ * marker, and the orchestrator invalidates the signing identity so the next resolution refreshes.
  */
-class StaticStabilityCacheDecorator : ClientCodegenDecorator {
-    override val name: String = "StaticStabilityCache"
+class StaticStabilityDecorator : ClientCodegenDecorator {
+    override val name: String = "StaticStability"
     override val order: Byte = 0
 
     override fun serviceRuntimePluginCustomizations(
         codegenContext: ClientCodegenContext,
         baseCustomizations: List<ServiceRuntimePluginCustomization>,
     ): List<ServiceRuntimePluginCustomization> = baseCustomizations + StaticStabilityCacheCustomization(codegenContext)
+
+    override fun operationCustomizations(
+        codegenContext: ClientCodegenContext,
+        operation: OperationShape,
+        baseCustomizations: List<OperationCustomization>,
+    ): List<OperationCustomization> =
+        baseCustomizations + CredentialAuthFailureInterceptorCustomization(codegenContext, operation)
 }
 
 private class StaticStabilityCacheCustomization(
@@ -75,5 +88,31 @@ private class StaticStabilityCacheCustomization(
 
                 else -> {}
             }
+        }
+}
+
+private class CredentialAuthFailureInterceptorCustomization(
+    codegenContext: ClientCodegenContext,
+    private val operation: OperationShape,
+) : OperationCustomization() {
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val symbolProvider = codegenContext.symbolProvider
+
+    override fun section(section: OperationSection) =
+        when (section) {
+            is OperationSection.AdditionalInterceptors ->
+                writable {
+                    section.registerInterceptor(runtimeConfig, this) {
+                        rustTemplate(
+                            "#{CredentialAuthFailureInterceptor}::<#{OperationError}>::new()",
+                            "CredentialAuthFailureInterceptor" to
+                                AwsRuntimeType.awsRuntime(runtimeConfig)
+                                    .resolve("static_stability::invalidation::CredentialAuthFailureInterceptor"),
+                            "OperationError" to symbolProvider.symbolForOperationError(operation),
+                        )
+                    }
+                }
+
+            else -> emptySection
         }
 }

--- a/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/StaticStabilityCacheDecoratorTest.kt
+++ b/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/StaticStabilityCacheDecoratorTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import SdkCodegenIntegrationTest
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+
+internal class StaticStabilityCacheDecoratorTest {
+    @Test
+    fun `bare AWS client defaults to the static-stability cache at v2026_08_01`() {
+        awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { ctx, rustCrate ->
+            val rc = ctx.runtimeConfig
+            val moduleName = ctx.moduleUseName()
+            val codegenScope =
+                arrayOf(
+                    *RuntimeType.preludeScope,
+                    "Credentials" to AwsRuntimeType.awsCredentialTypesTestUtil(rc).resolve("Credentials"),
+                    "StaticStabilityEligible" to
+                        AwsRuntimeType.awsCredentialTypes(rc).resolve("StaticStabilityEligible"),
+                    "ProvideCredentials" to
+                        AwsRuntimeType.awsCredentialTypes(rc).resolve("provider::ProvideCredentials"),
+                    "ProvideCredentialsFuture" to
+                        AwsRuntimeType.awsCredentialTypes(rc).resolve("provider::future::ProvideCredentials"),
+                    "CredentialsError" to
+                        AwsRuntimeType.awsCredentialTypes(rc).resolve("provider::error::CredentialsError"),
+                    "Region" to AwsRuntimeType.awsTypes(rc).resolve("region::Region"),
+                    "BehaviorVersion" to
+                        RuntimeType.smithyRuntimeApiClient(rc).resolve("client::behavior_version::BehaviorVersion"),
+                    "StaticTimeSource" to RuntimeType.smithyAsync(rc).resolve("time::StaticTimeSource"),
+                    "SharedAsyncSleep" to RuntimeType.smithyAsync(rc).resolve("rt::sleep::SharedAsyncSleep"),
+                    "TokioSleep" to
+                        CargoDependency.smithyAsync(rc).withFeature("rt-tokio").toType()
+                            .resolve("rt::sleep::TokioSleep"),
+                )
+            rustCrate.integrationTest("static_stability_cache_default") {
+                addDependency(CargoDependency.Tokio.toDevDependency().withFeature("test-util"))
+                rustTemplate(
+                    """
+                    use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
+                    use aws_smithy_types::body::SdkBody;
+                    use std::sync::{Arc, Mutex};
+                    use std::time::{Duration, UNIX_EPOCH};
+
+                    // Vends one eligible credential, then fails every later refresh.
+                    ##[derive(Debug, Clone)]
+                    struct OnceThenFail(Arc<Mutex<Option<#{Credentials}>>>);
+                    impl #{ProvideCredentials} for OnceThenFail {
+                        fn provide_credentials<'a>(&'a self) -> #{ProvideCredentialsFuture}<'a>
+                        where
+                            Self: 'a,
+                        {
+                            let next = self.0.lock().unwrap().take();
+                            #{ProvideCredentialsFuture}::ready(match next {
+                                #{Some}(creds) => #{Ok}(creds),
+                                #{None} => #{Err}(#{CredentialsError}::provider_error("source unavailable")),
+                            })
+                        }
+                    }
+
+                    // Returns whether a second call still succeeds after the refresh fails.
+                    async fn second_call_succeeds(bv: #{BehaviorVersion}) -> bool {
+                        let http_client = StaticReplayClient::new(vec![
+                            ReplayEvent::new(
+                                http::Request::builder().body(SdkBody::from("")).unwrap(),
+                                http::Response::builder().status(200).body(SdkBody::from("{}")).unwrap(),
+                            ),
+                            ReplayEvent::new(
+                                http::Request::builder().body(SdkBody::from("")).unwrap(),
+                                http::Response::builder().status(200).body(SdkBody::from("{}")).unwrap(),
+                            ),
+                        ]);
+
+                        // Fixed clock; the seed expires 1s out, so the second call is already in the
+                        // mandatory-refresh window and must contact the (now-failing) source.
+                        let now = UNIX_EPOCH + Duration::from_secs(1000);
+                        let mut seed = #{Credentials}::new(
+                            "AKIDSTATIC",
+                            "secret",
+                            #{None},
+                            #{Some}(now + Duration::from_secs(1)),
+                            "test",
+                        );
+                        seed.set_property(#{StaticStabilityEligible});
+
+                        let config = $moduleName::Config::builder()
+                            .behavior_version(bv)
+                            .http_client(http_client)
+                            .time_source(#{StaticTimeSource}::new(now))
+                            .sleep_impl(#{SharedAsyncSleep}::new(#{TokioSleep}::new()))
+                            .credentials_provider(OnceThenFail(Arc::new(Mutex::new(#{Some}(seed)))))
+                            .region(#{Region}::new("us-west-2"))
+                            .build();
+                        let client = $moduleName::Client::from_conf(config);
+
+                        client
+                            .some_operation()
+                            .send()
+                            .await
+                            .expect("first call caches credentials");
+                        client.some_operation().send().await.is_ok()
+                    }
+
+                    ##[::tokio::test]
+                    async fn static_stability_cache_serves_cached_on_refresh_failure() {
+                        assert!(
+                            second_call_succeeds(#{BehaviorVersion}::v2026_08_01()).await,
+                            "at v2026_08_01 the static-stability cache should serve the cached credential",
+                        );
+                    }
+
+                    ##[allow(deprecated)]
+                    ##[::tokio::test]
+                    async fn older_behavior_version_errors_on_refresh_failure() {
+                        assert!(
+                            !second_call_succeeds(#{BehaviorVersion}::v2024_03_28()).await,
+                            "without the static-stability cache a failed refresh should error",
+                        );
+                    }
+                    """,
+                    *codegenScope,
+                )
+            }
+        }
+    }
+}

--- a/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/StaticStabilityDecoratorTest.kt
+++ b/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/StaticStabilityDecoratorTest.kt
@@ -12,7 +12,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
 
-internal class StaticStabilityCacheDecoratorTest {
+internal class StaticStabilityDecoratorTest {
     @Test
     fun `bare AWS client defaults to the static-stability cache at v2026_08_01`() {
         awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { ctx, rustCrate ->
@@ -121,6 +121,96 @@ internal class StaticStabilityCacheDecoratorTest {
                         assert!(
                             !second_call_succeeds(#{BehaviorVersion}::v2024_03_28()).await,
                             "without the static-stability cache a failed refresh should error",
+                        );
+                    }
+                    """,
+                    *codegenScope,
+                )
+            }
+
+            rustCrate.integrationTest("credential_auth_failure_interceptor") {
+                addDependency(CargoDependency.Tokio.toDevDependency().withFeature("test-util"))
+                rustTemplate(
+                    """
+                    use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
+                    use aws_smithy_types::body::SdkBody;
+                    use std::sync::{Arc, Mutex};
+                    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+                    // Vends a fresh, non-expired, eligible credential on every call, counting calls.
+                    ##[derive(Debug, Clone)]
+                    struct CountingProvider {
+                        calls: Arc<Mutex<usize>>,
+                        now: SystemTime,
+                    }
+                    impl #{ProvideCredentials} for CountingProvider {
+                        fn provide_credentials<'a>(&'a self) -> #{ProvideCredentialsFuture}<'a>
+                        where
+                            Self: 'a,
+                        {
+                            let mut calls = self.calls.lock().unwrap();
+                            *calls += 1;
+                            let mut creds = #{Credentials}::new(
+                                format!("AKID{}", *calls),
+                                "secret",
+                                #{None},
+                                #{Some}(self.now + Duration::from_secs(3600)),
+                                "test",
+                            );
+                            creds.set_property(#{StaticStabilityEligible});
+                            #{ProvideCredentialsFuture}::ready(#{Ok}(creds))
+                        }
+                    }
+
+                    // A target-service `ExpiredToken` rejection invalidates the signing identity via
+                    // the per-operation interceptor, so the next call must re-resolve credentials.
+                    ##[::tokio::test]
+                    async fn expired_token_invalidates_and_reresolves() {
+                        let now = UNIX_EPOCH + Duration::from_secs(1000);
+                        let calls = Arc::new(Mutex::new(0usize));
+
+                        let http_client = StaticReplayClient::new(vec![
+                            // First attempt is rejected with `ExpiredToken`.
+                            ReplayEvent::new(
+                                http::Request::builder().body(SdkBody::from("")).unwrap(),
+                                http::Response::builder()
+                                    .status(403)
+                                    .header("x-amzn-errortype", "ExpiredToken")
+                                    .body(SdkBody::from("{}"))
+                                    .unwrap(),
+                            ),
+                            // Second attempt succeeds with the re-resolved credential.
+                            ReplayEvent::new(
+                                http::Request::builder().body(SdkBody::from("")).unwrap(),
+                                http::Response::builder().status(200).body(SdkBody::from("{}")).unwrap(),
+                            ),
+                        ]);
+
+                        let config = $moduleName::Config::builder()
+                            .behavior_version(#{BehaviorVersion}::v2026_08_01())
+                            .http_client(http_client)
+                            .time_source(#{StaticTimeSource}::new(now))
+                            .sleep_impl(#{SharedAsyncSleep}::new(#{TokioSleep}::new()))
+                            .credentials_provider(CountingProvider { calls: calls.clone(), now })
+                            .region(#{Region}::new("us-west-2"))
+                            .build();
+                        let client = $moduleName::Client::from_conf(config);
+
+                        // The rejected request surfaces as an error and is not retried.
+                        let first = client.some_operation().send().await;
+                        assert!(first.is_err(), "the ExpiredToken response should surface as an error");
+
+                        // Invalidation forces the next resolution to contact the provider again.
+                        client
+                            .some_operation()
+                            .send()
+                            .await
+                            .expect("second call should succeed after re-resolution");
+
+                        assert_eq!(
+                            *calls.lock().unwrap(),
+                            2,
+                            "invalidation must force credential re-resolution",
                         );
                     }
                     """,

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.13.2"
+version = "1.14.1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -137,6 +137,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "regex-lite",
+ "tokio",
  "tracing",
  "uuid",
 ]
@@ -288,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.4.0"
+version = "1.3.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -296,7 +297,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.16",
+ "h2 0.4.15",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -366,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.14.0"
+version = "1.13.2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -571,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -874,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -901,36 +902,36 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1003,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1105,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1171,7 +1172,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.16",
+ "h2 0.4.15",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -1238,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1252,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1265,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1279,17 +1280,16 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1300,15 +1300,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1405,9 +1405,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1493,9 +1493,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.47"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
  "num-traits",
 ]
@@ -1612,15 +1612,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1821,7 +1821,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.14",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2169,18 +2169,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.20"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.20"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2228,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2480,9 +2480,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2524,9 +2524,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2537,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2547,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -2657,9 +2657,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "writeable"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xmlparser"
@@ -2698,18 +2698,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2745,9 +2745,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2767,11 +2767,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.11.0"
+version = "1.11.1"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/http_credential_provider.rs
+++ b/aws/rust-runtime/aws-config/src/http_credential_provider.rs
@@ -14,6 +14,7 @@ use aws_credential_types::attributes::AccountId;
 use aws_credential_types::credential_feature::AwsCredentialFeature;
 use aws_credential_types::provider::{self, error::CredentialsError};
 use aws_credential_types::Credentials;
+use aws_credential_types::StaticStabilityEligible;
 use aws_smithy_runtime::client::metrics::MetricsRuntimePlugin;
 use aws_smithy_runtime::client::orchestrator::operation::Operation;
 use aws_smithy_runtime::client::retries::classifiers::{
@@ -63,6 +64,7 @@ impl HttpCredentialProvider {
                     creds
                         .get_property_mut_or_default::<Vec<AwsCredentialFeature>>()
                         .push(AwsCredentialFeature::CredentialsHttp);
+                    creds.set_property(StaticStabilityEligible);
                     creds
                 });
         match credentials {

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -17,6 +17,7 @@ use aws_credential_types::provider::{self, error::CredentialsError, future, Prov
 use aws_credential_types::Credentials;
 use aws_credential_types::StaticStabilityEligible;
 use aws_smithy_async::time::SharedTimeSource;
+use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
 use aws_types::os_shim_internal::Env;
 use std::borrow::Cow;
 use std::error::Error as StdError;
@@ -56,6 +57,12 @@ pub struct ImdsCredentialsProvider {
     profile: Option<String>,
     time_source: SharedTimeSource,
     last_retrieved_credentials: Arc<RwLock<Option<Credentials>>>,
+    // Whether static stability is provided by the identity cache instead of by this provider.
+    // True at v2026_08_01+ (default cache is the StaticStabilityCache): this provider reports the
+    // true expiration and surfaces a failed refresh as an error. False for older behavior versions
+    // (LazyCache): this provider offers static stability itself — extending stale expirations and
+    // serving the last-retrieved credentials on a failed refresh.
+    static_stability_via_cache: bool,
 }
 
 /// Builder for [`ImdsCredentialsProvider`]
@@ -112,12 +119,21 @@ impl Builder {
         let client = self
             .imds_override
             .unwrap_or_else(|| imds::Client::builder().configure(&provider_config).build());
+        // An unset behavior version resolves to `latest()`, so a hand-built provider aligns with
+        // the modern default identity cache (the StaticStabilityCache) and doesn't double-cover it
+        // — the cache owns static stability. Pin an older behavior version to keep this provider's
+        // own (legacy) static stability instead.
+        let static_stability_via_cache = provider_config
+            .behavior_version()
+            .unwrap_or_else(BehaviorVersion::latest)
+            .is_at_least(BehaviorVersion::v2026_08_01());
         ImdsCredentialsProvider {
             client,
             env,
             profile: self.profile_override,
             time_source: provider_config.time_source(),
             last_retrieved_credentials: Arc::new(RwLock::new(self.last_retrieved_credentials)),
+            static_stability_via_cache,
         }
     }
 }
@@ -135,6 +151,9 @@ impl ProvideCredentials for ImdsCredentialsProvider {
     }
 
     fn fallback_on_interrupt(&self) -> Option<Credentials> {
+        if self.static_stability_via_cache {
+            return None;
+        }
         self.last_retrieved_credentials.read().unwrap().clone()
     }
 }
@@ -182,6 +201,10 @@ impl ImdsCredentialsProvider {
     //
     // This allows continued use of the credentials even when IMDS returns expired ones.
     fn maybe_extend_expiration(&self, expiration: SystemTime) -> SystemTime {
+        // Deferred to the identity cache: report the true expiration.
+        if self.static_stability_via_cache {
+            return expiration;
+        }
         let now = self.time_source.now();
         // If credentials from IMDS are not stale, use them as they are.
         if now < expiration {
@@ -276,7 +299,12 @@ impl ImdsCredentialsProvider {
     }
 
     async fn credentials(&self) -> provider::Result {
-        match self.retrieve_credentials().await {
+        let result = self.retrieve_credentials().await;
+        // Deferred to the identity cache: surface the failure instead of serving last-retrieved.
+        if self.static_stability_via_cache {
+            return result;
+        }
+        match result {
             creds @ Ok(_) => creds,
             // Any failure while retrieving credentials MUST NOT impede use of existing credentials.
             err => match &*self.last_retrieved_credentials.read().unwrap() {
@@ -384,6 +412,7 @@ mod test {
         // There should not be logs indicating credentials are extended for stability.
         assert!(!logs_contain(WARNING_FOR_EXTENDING_CREDENTIALS_EXPIRY));
     }
+    // Legacy path (behavior version < v2026_08_01): the provider extends the stale expiry itself.
     #[tokio::test]
     #[traced_test]
     async fn expired_credentials_should_be_extended() {
@@ -409,7 +438,8 @@ mod test {
         let provider_config = ProviderConfig::no_configuration()
             .with_http_client(http_client.clone())
             .with_sleep_impl(sleep)
-            .with_time_source(time_source);
+            .with_time_source(time_source)
+            .with_behavior_version(Some(BehaviorVersion::v2026_01_12()));
         let client = crate::imds::Client::builder()
             .configure(&provider_config)
             .build();
@@ -425,6 +455,54 @@ mod test {
         assert!(logs_contain(WARNING_FOR_EXTENDING_CREDENTIALS_EXPIRY));
     }
 
+    // Counterpart to `expired_credentials_should_be_extended`: at v2026_08_01 the cache owns static
+    // stability, so the provider reports the true (past) expiration and does not extend it.
+    #[tokio::test]
+    #[traced_test]
+    async fn expired_credentials_are_not_extended_at_v2026_08_01() {
+        let http_client = StaticReplayClient::new(vec![
+                ReplayEvent::new(
+                    token_request("http://169.254.169.254", 21600),
+                    token_response(21600, TOKEN_A),
+                ),
+                ReplayEvent::new(
+                    imds_request("http://169.254.169.254/latest/meta-data/iam/security-credentials/", TOKEN_A),
+                    imds_response(r#"profile-name"#),
+                ),
+                ReplayEvent::new(
+                    imds_request("http://169.254.169.254/latest/meta-data/iam/security-credentials/profile-name", TOKEN_A),
+                    imds_response("{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-20T21:42:26Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"ASIARTEST\",\n  \"SecretAccessKey\" : \"testsecret\",\n  \"Token\" : \"testtoken\",\n  \"Expiration\" : \"2021-09-21T04:16:53Z\"\n}"),
+                ),
+            ]);
+
+        // Same already-expired credentials as the legacy test, but at v2026_08_01.
+        let time_of_request_to_fetch_credentials = UNIX_EPOCH + Duration::from_secs(1632246085);
+        let (time_source, sleep) = instant_time_and_sleep(time_of_request_to_fetch_credentials);
+
+        let provider_config = ProviderConfig::no_configuration()
+            .with_http_client(http_client.clone())
+            .with_sleep_impl(sleep)
+            .with_time_source(time_source)
+            .with_behavior_version(Some(BehaviorVersion::v2026_08_01()));
+        let client = crate::imds::Client::builder()
+            .configure(&provider_config)
+            .build();
+        let provider = ImdsCredentialsProvider::builder()
+            .configure(&provider_config)
+            .imds_client(client)
+            .build();
+        let creds = provider.provide_credentials().await.expect("valid creds");
+        // The true expiration (2021-09-21T04:16:53Z) is reported unchanged.
+        assert_eq!(
+            creds.expiry(),
+            UNIX_EPOCH.checked_add(Duration::from_secs(1632197813))
+        );
+        http_client.assert_requests_match(&[]);
+        // No expiry extension, so no extension warning.
+        assert!(!logs_contain(WARNING_FOR_EXTENDING_CREDENTIALS_EXPIRY));
+    }
+
+    // Legacy path (behavior version < v2026_08_01): the provider serves last-retrieved on failure.
     #[tokio::test]
     #[cfg(feature = "default-https-client")]
     async fn read_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials() {
@@ -436,6 +514,10 @@ mod test {
         let expected = aws_credential_types::Credentials::for_tests();
         let provider = ImdsCredentialsProvider::builder()
             .imds_client(client)
+            .configure(
+                &ProviderConfig::no_configuration()
+                    .with_behavior_version(Some(BehaviorVersion::v2026_01_12())),
+            )
             // seed fallback credentials for testing
             .last_retrieved_credentials(expected.clone())
             .build();
@@ -463,6 +545,32 @@ mod test {
         );
     }
 
+    // Counterpart to the fallback tests: at v2026_08_01 the cache owns serve-cached, so a failed
+    // refresh surfaces as an error rather than serving the seeded last-retrieved credentials.
+    #[tokio::test]
+    #[cfg(feature = "default-https-client")]
+    async fn refresh_failure_errors_at_v2026_08_01_instead_of_serving_last_retrieved() {
+        let client = crate::imds::Client::builder()
+            // 240.* can never be resolved
+            .endpoint("http://240.0.0.0")
+            .unwrap()
+            .build();
+        let provider = ImdsCredentialsProvider::builder()
+            .imds_client(client)
+            .configure(
+                &ProviderConfig::no_configuration()
+                    .with_behavior_version(Some(BehaviorVersion::v2026_08_01())),
+            )
+            // Seed a fallback; at v2026_08_01 it must NOT be served.
+            .last_retrieved_credentials(aws_credential_types::Credentials::for_tests())
+            .build();
+        let actual = provider.provide_credentials().await;
+        assert!(
+            actual.is_err(),
+            "at v2026_08_01 a failed refresh must error, not serve last-retrieved: {actual:?}"
+        );
+    }
+
     // TODO(https://github.com/awslabs/aws-sdk-rust/issues/1117) This test is ignored on Windows because it uses Unix-style paths
     #[cfg_attr(windows, ignore)]
     #[tokio::test]
@@ -477,7 +585,10 @@ mod test {
         let expected = aws_credential_types::Credentials::for_tests();
         let provider = ImdsCredentialsProvider::builder()
             .imds_client(client)
-            .configure(&ProviderConfig::no_configuration())
+            .configure(
+                &ProviderConfig::no_configuration()
+                    .with_behavior_version(Some(BehaviorVersion::v2026_01_12())),
+            )
             // seed fallback credentials for testing
             .last_retrieved_credentials(expected.clone())
             .build();
@@ -525,7 +636,10 @@ mod test {
             ]);
         let provider = ImdsCredentialsProvider::builder()
             .imds_client(make_imds_client(&http_client))
-            .configure(&ProviderConfig::no_configuration())
+            .configure(
+                &ProviderConfig::no_configuration()
+                    .with_behavior_version(Some(BehaviorVersion::v2026_01_12())),
+            )
             .build();
         let creds1 = provider.provide_credentials().await.expect("valid creds");
         assert_eq!(creds1.access_key_id(), "ASIARTEST");

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -197,11 +197,19 @@ impl ImdsCredentialsProvider {
         }
     }
 
-    // Extend the cached expiration time if necessary
+    // Determines the expiration to report for freshly fetched IMDS credentials.
     //
-    // This allows continued use of the credentials even when IMDS returns expired ones.
+    // When the identity cache owns static stability (the default from
+    // `BehaviorVersion::v2026_08_01`), report the true expiration and let the cache decide how to
+    // handle expired credentials from IMDS: it treats an expired response as a failed refresh and
+    // keeps serving the last successfully cached credential, so static stability applies at refresh
+    // time. Before the first successful fetch there is nothing cached to fall back on, so an expired
+    // response on the initial fetch surfaces as an error rather than being used.
+    //
+    // On older behavior versions this provider owns static stability itself: it extends a stale
+    // expiration so the already-fetched credentials continue to be used until the next refresh.
     fn maybe_extend_expiration(&self, expiration: SystemTime) -> SystemTime {
-        // Deferred to the identity cache: report the true expiration.
+        // Cache path: report the true expiration; the identity cache owns static stability.
         if self.static_stability_via_cache {
             return expiration;
         }

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -15,6 +15,7 @@ use crate::provider_config::ProviderConfig;
 use aws_credential_types::credential_feature::AwsCredentialFeature;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
 use aws_credential_types::Credentials;
+use aws_credential_types::StaticStabilityEligible;
 use aws_smithy_async::time::SharedTimeSource;
 use aws_types::os_shim_internal::Env;
 use std::borrow::Cow;
@@ -269,6 +270,7 @@ impl ImdsCredentialsProvider {
             creds
                 .get_property_mut_or_default::<Vec<AwsCredentialFeature>>()
                 .push(AwsCredentialFeature::CredentialsImds);
+            creds.set_property(StaticStabilityEligible);
             creds
         })
     }

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -223,6 +223,7 @@ mod loader {
         ProvideCredentials, SharedCredentialsProvider,
     };
     use aws_credential_types::Credentials;
+    use aws_runtime::static_stability::StaticStabilityCache;
     use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep, SharedAsyncSleep};
     use aws_smithy_async::time::{SharedTimeSource, TimeSource};
     use aws_smithy_runtime::client::identity::IdentityCache;
@@ -1043,6 +1044,11 @@ mod loader {
 
             let identity_cache = match self.identity_cache {
                 None => match self.behavior_version {
+                    // For this behavior version and later, the default identity cache is the
+                    // static-stability cache.
+                    Some(bv) if bv.is_at_least(BehaviorVersion::v2026_08_01()) => {
+                        Some(StaticStabilityCache::builder().build())
+                    }
                     #[allow(deprecated)]
                     Some(bv) if bv.is_at_least(BehaviorVersion::v2024_03_28()) => {
                         Some(IdentityCache::lazy().build())

--- a/aws/rust-runtime/aws-config/src/login.rs
+++ b/aws/rust-runtime/aws-config/src/login.rs
@@ -17,6 +17,7 @@ use aws_credential_types::credential_feature::AwsCredentialFeature;
 use aws_credential_types::provider;
 use aws_credential_types::provider::future;
 use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_signin::config::Builder as SignInClientConfigBuilder;
 use aws_sdk_signin::operation::create_o_auth2_token::CreateOAuth2TokenError;
 use aws_sdk_signin::types::{CreateOAuth2TokenRequestBody, OAuth2ErrorCode};
@@ -200,6 +201,7 @@ impl LoginCredentialsProvider {
         creds
             .get_property_mut_or_default::<Vec<AwsCredentialFeature>>()
             .push(feat);
+        creds.set_property(StaticStabilityEligible);
         Ok(creds)
     }
 }

--- a/aws/rust-runtime/aws-config/src/login.rs
+++ b/aws/rust-runtime/aws-config/src/login.rs
@@ -163,18 +163,19 @@ impl LoginCredentialsProvider {
             .await
             .map_err(|err| {
                 let service_err = err.into_service_error();
-                let message = match &service_err {
+                let (message, non_recoverable) = match &service_err {
                     CreateOAuth2TokenError::AccessDeniedException(e) => match e.error {
-                        OAuth2ErrorCode::InsufficientPermissions => Some("Unable to refresh credentials due to insufficient permissions. You may be missing permission for the 'CreateOAuth2Token' action.".to_string()),
-                        OAuth2ErrorCode::TokenExpired => Some("Your session has expired. Please reauthenticate.".to_string()),
-                        OAuth2ErrorCode::UserCredentialsChanged => Some("Unable to refresh credentials because of a change in your password. Please reauthenticate with your new password.".to_string()),
-                        _ => None,
+                        OAuth2ErrorCode::InsufficientPermissions => (Some("Unable to refresh credentials due to insufficient permissions. You may be missing permission for the 'CreateOAuth2Token' action.".to_string()), true),
+                        OAuth2ErrorCode::TokenExpired => (Some("Your session has expired. Please reauthenticate.".to_string()), true),
+                        OAuth2ErrorCode::UserCredentialsChanged => (Some("Unable to refresh credentials because of a change in your password. Please reauthenticate with your new password.".to_string()), true),
+                        _ => (None, false),
                     }
-                    _ => None,
+                    _ => (None, false),
                 };
 
                 LoginTokenError::RefreshFailed {
                     message,
+                    non_recoverable,
                     source: service_err.into(),
                 }
             })?;

--- a/aws/rust-runtime/aws-config/src/login/token.rs
+++ b/aws/rust-runtime/aws-config/src/login/token.rs
@@ -92,6 +92,7 @@ pub(super) enum LoginTokenError {
     WrongIdentityType(Identity),
     RefreshFailed {
         message: Option<String>,
+        non_recoverable: bool,
         source: Box<dyn StdError + Send + Sync>,
     },
     Other {
@@ -173,6 +174,20 @@ impl From<aws_smithy_json::deserialize::error::DeserializeError> for LoginTokenE
 
 impl From<LoginTokenError> for CredentialsError {
     fn from(val: LoginTokenError) -> CredentialsError {
+        let non_recoverable = matches!(
+            &val,
+            LoginTokenError::MissingField(_)
+                | LoginTokenError::RefreshFailed {
+                    non_recoverable: true,
+                    ..
+                }
+        ) || matches!(
+            &val,
+            LoginTokenError::IoError { source, .. } if source.kind() == std::io::ErrorKind::NotFound
+        );
+        if non_recoverable {
+            return CredentialsError::non_recoverable(val);
+        }
         match val {
             LoginTokenError::FailedToFormatDateTime { .. } => {
                 CredentialsError::invalid_configuration(val)
@@ -185,6 +200,50 @@ impl From<LoginTokenError> for CredentialsError {
             LoginTokenError::RefreshFailed { .. } => CredentialsError::provider_error(val),
             LoginTokenError::WrongIdentityType(_) => CredentialsError::invalid_configuration(val),
             LoginTokenError::Other { .. } => CredentialsError::unhandled(val),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn is_non_recoverable(err: LoginTokenError) -> bool {
+        CredentialsError::from(err).is_non_recoverable()
+    }
+
+    #[test]
+    fn login_non_recoverable_classification() {
+        for err in [
+            LoginTokenError::MissingField("accessToken"),
+            LoginTokenError::IoError {
+                what: "read",
+                path: "/does/not/exist".into(),
+                source: std::io::Error::from(std::io::ErrorKind::NotFound),
+            },
+            LoginTokenError::RefreshFailed {
+                message: None,
+                non_recoverable: true,
+                source: "access denied".into(),
+            },
+        ] {
+            assert!(is_non_recoverable(err));
+        }
+        for err in [
+            LoginTokenError::ExpiredToken,
+            LoginTokenError::JsonError("malformed".into()),
+            LoginTokenError::RefreshFailed {
+                message: None,
+                non_recoverable: false,
+                source: "server error".into(),
+            },
+            LoginTokenError::IoError {
+                what: "read",
+                path: "/denied".into(),
+                source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+            },
+        ] {
+            assert!(!is_non_recoverable(err));
         }
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -15,6 +15,7 @@ use crate::web_identity_token::{StaticConfiguration, WebIdentityTokenCredentials
 use aws_credential_types::provider::{
     self, error::CredentialsError, ProvideCredentials, SharedCredentialsProvider,
 };
+use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sts::config::Credentials;
 use aws_sdk_sts::Client as StsClient;
 use aws_smithy_async::time::SharedTimeSource;
@@ -57,6 +58,14 @@ impl AssumeRoleProvider {
             assume_role_output.assumed_role_user,
             "AssumeRoleProvider",
         )
+        .map(|mut creds| {
+            // Mark profile-based (role-chaining) assume-role credentials as eligible for
+            // static-stability caching, mirroring the standalone `sts::AssumeRoleProvider`.
+            // Without this, the `StaticStabilityCache` treats them as caching-only and will not
+            // serve them past expiration on a failed refresh.
+            creds.set_property(StaticStabilityEligible);
+            creds
+        })
     }
 }
 
@@ -296,6 +305,59 @@ mod test {
             ),
             "`{}` did not match expected error",
             err
+        );
+    }
+
+    #[tokio::test]
+    async fn profile_assume_role_creds_are_static_stability_eligible() {
+        use super::AssumeRoleProvider;
+        use aws_credential_types::StaticStabilityEligible;
+        use aws_smithy_async::rt::sleep::{SharedAsyncSleep, TokioSleep};
+        use aws_smithy_async::time::{SharedTimeSource, StaticTimeSource};
+        use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
+        use aws_smithy_types::body::SdkBody;
+        use aws_types::region::Region;
+        use aws_types::SdkConfig;
+        use std::time::{Duration, UNIX_EPOCH};
+
+        const ASSUME_ROLE_XML: &str = "<AssumeRoleResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">\n  <AssumeRoleResult>\n    <AssumedRoleUser>\n      <AssumedRoleId>AROAR42TAWARILN3MNKUT:assume-role-from-profile</AssumedRoleId>\n      <Arn>arn:aws:sts::130633740322:assumed-role/assume-provider-test/assume-role-from-profile</Arn>\n    </AssumedRoleUser>\n    <Credentials>\n      <AccessKeyId>ASIARCORRECT</AccessKeyId>\n      <SecretAccessKey>secretkeycorrect</SecretAccessKey>\n      <SessionToken>tokencorrect</SessionToken>\n      <Expiration>2009-02-13T23:31:30Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n  <ResponseMetadata>\n    <RequestId>d9d47248-fd55-4686-ad7c-0fb7cd1cddd7</RequestId>\n  </ResponseMetadata>\n</AssumeRoleResponse>\n";
+
+        let http_client = StaticReplayClient::new(vec![ReplayEvent::new(
+            http::Request::new(SdkBody::from("request body")),
+            http::Response::builder()
+                .status(200)
+                .body(SdkBody::from(ASSUME_ROLE_XML))
+                .unwrap(),
+        )]);
+
+        let sdk_config = SdkConfig::builder()
+            .http_client(http_client)
+            .region(Region::new("us-east-1"))
+            .time_source(StaticTimeSource::new(
+                UNIX_EPOCH + Duration::from_secs(1234567890 - 120),
+            ))
+            .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+            .behavior_version(crate::BehaviorVersion::latest())
+            .build();
+
+        let provider = AssumeRoleProvider {
+            role_arn: "arn:aws:iam::130633740322:role/assume-provider-test".to_string(),
+            external_id: None,
+            session_name: Some("test-session".to_string()),
+            time_source: SharedTimeSource::new(StaticTimeSource::new(
+                UNIX_EPOCH + Duration::from_secs(1234567890 - 120),
+            )),
+        };
+
+        let assumed = provider
+            .credentials(Credentials::for_tests(), &sdk_config)
+            .await
+            .expect("assume role should succeed against the mocked STS response");
+
+        assert_eq!(assumed.access_key_id(), "ASIARCORRECT");
+        assert!(
+            assumed.get_property::<StaticStabilityEligible>().is_some(),
+            "profile role-chaining assume-role creds must be StaticStabilityEligible"
         );
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -19,6 +19,7 @@ use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sts::config::Credentials;
 use aws_sdk_sts::Client as StsClient;
 use aws_smithy_async::time::SharedTimeSource;
+use aws_smithy_runtime::client::identity::IdentityCache;
 use aws_types::SdkConfig;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -40,6 +41,8 @@ impl AssumeRoleProvider {
         let config = sdk_config
             .to_builder()
             .credentials_provider(SharedCredentialsProvider::new(input_credentials))
+            // No inner identity cache; the outer credentials cache owns caching.
+            .identity_cache(IdentityCache::no_cache())
             .build();
         let client = StsClient::new(&config);
         let session_name = &self.session_name.as_ref().cloned().unwrap_or_else(|| {

--- a/aws/rust-runtime/aws-config/src/sso/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/sso/credentials.rs
@@ -11,13 +11,19 @@
 //! This provider is included automatically when profiles are loaded.
 
 use super::cache::load_cached_token;
+use super::token::SsoTokenProviderError;
 use crate::identity::IdentityCache;
 use crate::provider_config::ProviderConfig;
 use crate::sso::SsoTokenProvider;
 use aws_credential_types::credential_feature::AwsCredentialFeature;
-use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
+use aws_credential_types::provider::{
+    self,
+    error::{CredentialsError, TokenError},
+    future, ProvideCredentials,
+};
 use aws_credential_types::Credentials;
 use aws_credential_types::StaticStabilityEligible;
+use aws_sdk_sso::operation::get_role_credentials::GetRoleCredentialsError;
 use aws_sdk_sso::types::RoleCredentials;
 use aws_sdk_sso::Client as SsoClient;
 use aws_smithy_async::time::SharedTimeSource;
@@ -25,6 +31,7 @@ use aws_smithy_types::DateTime;
 use aws_types::os_shim_internal::{Env, Fs};
 use aws_types::region::Region;
 use aws_types::SdkConfig;
+use std::error::Error as _;
 
 /// SSO Credentials Provider
 ///
@@ -238,6 +245,22 @@ pub(crate) struct SsoProviderConfig {
     pub(crate) session_name: Option<String>,
 }
 
+fn resolved_token_error_is_non_recoverable(err: &TokenError) -> bool {
+    err.source()
+        .and_then(|source| source.downcast_ref::<SsoTokenProviderError>())
+        .is_some_and(|e| {
+            matches!(
+                e,
+                SsoTokenProviderError::ExpiredToken
+                    | SsoTokenProviderError::FailedToLoadToken { .. }
+            )
+        })
+}
+
+fn get_role_credentials_error_is_non_recoverable(err: &GetRoleCredentialsError) -> bool {
+    matches!(err, GetRoleCredentialsError::UnauthorizedException(_))
+}
+
 async fn load_sso_credentials(
     sso_provider_config: &SsoProviderConfig,
     sdk_config: &SdkConfig,
@@ -250,12 +273,18 @@ async fn load_sso_credentials(
         token_provider
             .resolve_token(time_source)
             .await
-            .map_err(CredentialsError::provider_error)?
+            .map_err(|err| {
+                if resolved_token_error_is_non_recoverable(&err) {
+                    CredentialsError::non_recoverable(err)
+                } else {
+                    CredentialsError::provider_error(err)
+                }
+            })?
     } else {
         // Backwards compatible token loading that uses `start_url` instead of `session_name`
         load_cached_token(env, fs, &sso_provider_config.start_url)
             .await
-            .map_err(CredentialsError::provider_error)?
+            .map_err(CredentialsError::non_recoverable)?
     };
 
     let config = sdk_config
@@ -272,7 +301,16 @@ async fn load_sso_credentials(
         .account_id(&sso_provider_config.account_id)
         .send()
         .await
-        .map_err(CredentialsError::provider_error)?;
+        .map_err(|err| {
+            if err
+                .as_service_error()
+                .is_some_and(get_role_credentials_error_is_non_recoverable)
+            {
+                CredentialsError::non_recoverable(err)
+            } else {
+                CredentialsError::provider_error(err)
+            }
+        })?;
     let credentials: RoleCredentials = resp
         .role_credentials
         .ok_or_else(|| CredentialsError::unhandled("SSO did not return credentials"))?;
@@ -297,4 +335,45 @@ async fn load_sso_credentials(
         .provider_name("SSO");
     builder.set_session_token(credentials.session_token);
     Ok(builder.build())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aws_sdk_sso::types::error::UnauthorizedException;
+    use aws_smithy_types::error::ErrorMetadata;
+
+    #[test]
+    fn sso_token_error_classification() {
+        for err in [
+            TokenError::provider_error(SsoTokenProviderError::ExpiredToken),
+            TokenError::provider_error(SsoTokenProviderError::FailedToLoadToken {
+                source: "missing token file".into(),
+            }),
+        ] {
+            assert!(resolved_token_error_is_non_recoverable(&err));
+        }
+        for err in [
+            TokenError::provider_error(SsoTokenProviderError::BadExpirationTimeFromSsoOidc),
+            TokenError::provider_error("network error"),
+        ] {
+            assert!(!resolved_token_error_is_non_recoverable(&err));
+        }
+    }
+
+    #[test]
+    fn get_role_credentials_error_classification() {
+        assert!(get_role_credentials_error_is_non_recoverable(
+            &GetRoleCredentialsError::UnauthorizedException(
+                UnauthorizedException::builder().build()
+            )
+        ));
+        assert!(!get_role_credentials_error_is_non_recoverable(
+            &GetRoleCredentialsError::generic(
+                ErrorMetadata::builder()
+                    .code("TooManyRequestsException")
+                    .build()
+            )
+        ));
+    }
 }

--- a/aws/rust-runtime/aws-config/src/sso/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/sso/credentials.rs
@@ -17,6 +17,7 @@ use crate::sso::SsoTokenProvider;
 use aws_credential_types::credential_feature::AwsCredentialFeature;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
 use aws_credential_types::Credentials;
+use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sso::types::RoleCredentials;
 use aws_sdk_sso::Client as SsoClient;
 use aws_smithy_async::time::SharedTimeSource;
@@ -93,6 +94,7 @@ impl SsoCredentialsProvider {
             creds
                 .get_property_mut_or_default::<Vec<AwsCredentialFeature>>()
                 .push(AwsCredentialFeature::CredentialsSso);
+            creds.set_property(StaticStabilityEligible);
             creds
         })
     }

--- a/aws/rust-runtime/aws-config/src/sso/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/sso/credentials.rs
@@ -10,7 +10,7 @@
 //!
 //! This provider is included automatically when profiles are loaded.
 
-use super::cache::load_cached_token;
+use super::cache::{load_cached_token, CachedSsoTokenError};
 use super::token::SsoTokenProviderError;
 use crate::identity::IdentityCache;
 use crate::provider_config::ProviderConfig;
@@ -257,6 +257,27 @@ fn resolved_token_error_is_non_recoverable(err: &TokenError) -> bool {
         })
 }
 
+// Classifies a failure from the legacy `load_cached_token` path. A cached SSO token that is missing
+// or malformed is non-recoverable: it requires re-authentication (`aws sso login`) and retrying the
+// load will not fix it. Transient or environmental failures are left recoverable so that static
+// stability continues serving the last successfully cached credentials.
+fn cached_sso_token_error_is_non_recoverable(err: &CachedSsoTokenError) -> bool {
+    match err {
+        // Malformed token file, or a required field that is missing or cannot be parsed.
+        CachedSsoTokenError::MissingField(_)
+        | CachedSsoTokenError::InvalidField { .. }
+        | CachedSsoTokenError::JsonError(_)
+        | CachedSsoTokenError::FailedToFormatDateTime { .. } => true,
+        // A missing token file is non-recoverable; other I/O errors (e.g. a transient permission or
+        // resource issue) may succeed on a later attempt, so they remain recoverable.
+        CachedSsoTokenError::IoError { source, .. } => {
+            source.kind() == std::io::ErrorKind::NotFound
+        }
+        // No positive knowledge that a retry will fail, so keep these recoverable.
+        CachedSsoTokenError::NoHomeDirectory | CachedSsoTokenError::Other(_) => false,
+    }
+}
+
 fn get_role_credentials_error_is_non_recoverable(err: &GetRoleCredentialsError) -> bool {
     matches!(err, GetRoleCredentialsError::UnauthorizedException(_))
 }
@@ -284,7 +305,13 @@ async fn load_sso_credentials(
         // Backwards compatible token loading that uses `start_url` instead of `session_name`
         load_cached_token(env, fs, &sso_provider_config.start_url)
             .await
-            .map_err(CredentialsError::non_recoverable)?
+            .map_err(|err| {
+                if cached_sso_token_error_is_non_recoverable(&err) {
+                    CredentialsError::non_recoverable(err)
+                } else {
+                    CredentialsError::provider_error(err)
+                }
+            })?
     };
 
     let config = sdk_config
@@ -375,5 +402,50 @@ mod test {
                     .build()
             )
         ));
+    }
+
+    #[test]
+    fn cached_sso_token_error_classification() {
+        use std::io::{Error as IoError, ErrorKind};
+        use std::path::PathBuf;
+
+        // Missing or malformed cached tokens require re-authentication -> non-recoverable.
+        for err in [
+            CachedSsoTokenError::MissingField("accessToken"),
+            CachedSsoTokenError::InvalidField {
+                field: "expiresAt",
+                source: "invalid".into(),
+            },
+            CachedSsoTokenError::JsonError("invalid json".into()),
+            CachedSsoTokenError::FailedToFormatDateTime {
+                source: "bad datetime".into(),
+            },
+            CachedSsoTokenError::IoError {
+                what: "read",
+                path: PathBuf::from("/tmp/token.json"),
+                source: IoError::from(ErrorKind::NotFound),
+            },
+        ] {
+            assert!(
+                cached_sso_token_error_is_non_recoverable(&err),
+                "expected non-recoverable: {err}"
+            );
+        }
+
+        // Transient or environmental failures remain recoverable so static stability applies.
+        for err in [
+            CachedSsoTokenError::IoError {
+                what: "read",
+                path: PathBuf::from("/tmp/token.json"),
+                source: IoError::from(ErrorKind::PermissionDenied),
+            },
+            CachedSsoTokenError::NoHomeDirectory,
+            CachedSsoTokenError::Other("unexpected".into()),
+        ] {
+            assert!(
+                !cached_sso_token_error_is_non_recoverable(&err),
+                "expected recoverable: {err}"
+            );
+        }
     }
 }

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -9,6 +9,7 @@ use aws_credential_types::credential_feature::AwsCredentialFeature;
 use aws_credential_types::provider::{
     self, error::CredentialsError, future, ProvideCredentials, SharedCredentialsProvider,
 };
+use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sts::operation::assume_role::builders::AssumeRoleFluentBuilder;
 use aws_sdk_sts::operation::assume_role::AssumeRoleError;
 use aws_sdk_sts::types::{PolicyDescriptorType, Tag};
@@ -348,6 +349,7 @@ impl Inner {
             creds
                 .get_property_mut_or_default::<Vec<AwsCredentialFeature>>()
                 .push(AwsCredentialFeature::CredentialsStsAssumeRole);
+            creds.set_property(StaticStabilityEligible);
             creds
         })
     }

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -11,11 +11,9 @@ use aws_credential_types::provider::{
 };
 use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sts::operation::assume_role::builders::AssumeRoleFluentBuilder;
-use aws_sdk_sts::operation::assume_role::AssumeRoleError;
 use aws_sdk_sts::types::{PolicyDescriptorType, Tag};
 use aws_sdk_sts::Client as StsClient;
 use aws_smithy_runtime::client::identity::IdentityCache;
-use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
@@ -327,22 +325,20 @@ impl Inner {
                     "AssumeRoleProvider",
                 )
             }
-            Err(SdkError::ServiceError(ref context))
-                if matches!(
-                    context.err(),
-                    AssumeRoleError::RegionDisabledException(_)
-                        | AssumeRoleError::MalformedPolicyDocumentException(_)
-                ) =>
-            {
-                Err(CredentialsError::invalid_configuration(
-                    assumed.err().unwrap(),
-                ))
+            Err(err) => {
+                let non_recoverable = match err.as_service_error() {
+                    Some(service_err) => {
+                        tracing::warn!(error = %DisplayErrorContext(service_err), "STS refused to grant assume role");
+                        super::util::assume_role_error_is_non_recoverable(service_err)
+                    }
+                    None => false,
+                };
+                if non_recoverable {
+                    Err(CredentialsError::non_recoverable(err))
+                } else {
+                    Err(CredentialsError::provider_error(err))
+                }
             }
-            Err(SdkError::ServiceError(ref context)) => {
-                tracing::warn!(error = %DisplayErrorContext(context.err()), "STS refused to grant assume role");
-                Err(CredentialsError::provider_error(assumed.err().unwrap()))
-            }
-            Err(err) => Err(CredentialsError::provider_error(err)),
         };
 
         assumed.map(|mut creds| {

--- a/aws/rust-runtime/aws-config/src/sts/util.rs
+++ b/aws/rust-runtime/aws-config/src/sts/util.rs
@@ -6,7 +6,10 @@
 use aws_credential_types::attributes::AccountId;
 use aws_credential_types::provider::{self, error::CredentialsError};
 use aws_credential_types::Credentials as AwsCredentials;
+use aws_sdk_sts::operation::assume_role::AssumeRoleError;
+use aws_sdk_sts::operation::assume_role_with_web_identity::AssumeRoleWithWebIdentityError;
 use aws_sdk_sts::types::{AssumedRoleUser, Credentials as StsCredentials};
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -62,4 +65,107 @@ fn parse_account_id(arn: &str) -> Result<AccountId, CredentialsError> {
     let account_id = split.next().ok_or_else(invalid_format)?;
 
     Ok(account_id.into())
+}
+
+pub(crate) fn assume_role_error_is_non_recoverable(err: &AssumeRoleError) -> bool {
+    matches!(
+        err,
+        AssumeRoleError::MalformedPolicyDocumentException(_)
+            | AssumeRoleError::PackedPolicyTooLargeException(_)
+            | AssumeRoleError::RegionDisabledException(_)
+    ) || err.code() == Some("AccessDenied")
+}
+
+pub(crate) fn web_identity_error_is_non_recoverable(err: &AssumeRoleWithWebIdentityError) -> bool {
+    matches!(
+        err,
+        AssumeRoleWithWebIdentityError::IdpRejectedClaimException(_)
+            | AssumeRoleWithWebIdentityError::InvalidIdentityTokenException(_)
+            | AssumeRoleWithWebIdentityError::MalformedPolicyDocumentException(_)
+            | AssumeRoleWithWebIdentityError::PackedPolicyTooLargeException(_)
+            | AssumeRoleWithWebIdentityError::RegionDisabledException(_)
+    ) || err.code() == Some("AccessDenied")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aws_sdk_sts::types::error::{
+        ExpiredTokenException, IdpCommunicationErrorException, IdpRejectedClaimException,
+        InvalidIdentityTokenException, MalformedPolicyDocumentException,
+        PackedPolicyTooLargeException, RegionDisabledException,
+    };
+    use aws_smithy_types::error::ErrorMetadata;
+
+    fn error_with_code(code: &str) -> ErrorMetadata {
+        ErrorMetadata::builder().code(code).build()
+    }
+
+    #[test]
+    fn assume_role_non_recoverable_classification() {
+        for err in [
+            AssumeRoleError::MalformedPolicyDocumentException(
+                MalformedPolicyDocumentException::builder().build(),
+            ),
+            AssumeRoleError::PackedPolicyTooLargeException(
+                PackedPolicyTooLargeException::builder().build(),
+            ),
+            AssumeRoleError::RegionDisabledException(RegionDisabledException::builder().build()),
+            AssumeRoleError::generic(error_with_code("AccessDenied")),
+        ] {
+            assert!(
+                assume_role_error_is_non_recoverable(&err),
+                "expected non-recoverable: {err:?}"
+            );
+        }
+        for err in [
+            AssumeRoleError::ExpiredTokenException(ExpiredTokenException::builder().build()),
+            AssumeRoleError::generic(error_with_code("ThrottlingException")),
+        ] {
+            assert!(
+                !assume_role_error_is_non_recoverable(&err),
+                "expected recoverable: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn web_identity_non_recoverable_classification() {
+        for err in [
+            AssumeRoleWithWebIdentityError::IdpRejectedClaimException(
+                IdpRejectedClaimException::builder().build(),
+            ),
+            AssumeRoleWithWebIdentityError::InvalidIdentityTokenException(
+                InvalidIdentityTokenException::builder().build(),
+            ),
+            AssumeRoleWithWebIdentityError::MalformedPolicyDocumentException(
+                MalformedPolicyDocumentException::builder().build(),
+            ),
+            AssumeRoleWithWebIdentityError::PackedPolicyTooLargeException(
+                PackedPolicyTooLargeException::builder().build(),
+            ),
+            AssumeRoleWithWebIdentityError::RegionDisabledException(
+                RegionDisabledException::builder().build(),
+            ),
+            AssumeRoleWithWebIdentityError::generic(error_with_code("AccessDenied")),
+        ] {
+            assert!(
+                web_identity_error_is_non_recoverable(&err),
+                "expected non-recoverable: {err:?}"
+            );
+        }
+        for err in [
+            AssumeRoleWithWebIdentityError::IdpCommunicationErrorException(
+                IdpCommunicationErrorException::builder().build(),
+            ),
+            AssumeRoleWithWebIdentityError::ExpiredTokenException(
+                ExpiredTokenException::builder().build(),
+            ),
+        ] {
+            assert!(
+                !web_identity_error_is_non_recoverable(&err),
+                "expected recoverable: {err:?}"
+            );
+        }
+    }
 }

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -65,6 +65,7 @@ use crate::provider_config::ProviderConfig;
 use crate::sts;
 use aws_credential_types::credential_feature::AwsCredentialFeature;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
+use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sts::{types::PolicyDescriptorType, Client as StsClient};
 use aws_smithy_async::time::SharedTimeSource;
 use aws_smithy_types::error::display::DisplayErrorContext;
@@ -163,6 +164,7 @@ impl WebIdentityTokenCredentialsProvider {
             creds
                 .get_property_mut_or_default::<Vec<AwsCredentialFeature>>()
                 .push(AwsCredentialFeature::CredentialsProfileStsWebIdToken);
+            creds.set_property(StaticStabilityEligible);
             creds
         })
     }

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -68,6 +68,7 @@ use aws_credential_types::provider::{self, error::CredentialsError, future, Prov
 use aws_credential_types::StaticStabilityEligible;
 use aws_sdk_sts::{types::PolicyDescriptorType, Client as StsClient};
 use aws_smithy_async::time::SharedTimeSource;
+use aws_smithy_runtime::client::identity::IdentityCache;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal::{Env, Fs};
 
@@ -240,10 +241,16 @@ impl Builder {
     pub fn build(self) -> WebIdentityTokenCredentialsProvider {
         let conf = self.config.unwrap_or_default();
         let source = self.source.unwrap_or_else(|| Source::Env(conf.env()));
+        // No inner identity cache; the outer credentials cache owns caching.
+        let client_config = conf
+            .client_config()
+            .into_builder()
+            .identity_cache(IdentityCache::no_cache())
+            .build();
         WebIdentityTokenCredentialsProvider {
             source,
             fs: conf.fs(),
-            sts_client: StsClient::new(&conf.client_config()),
+            sts_client: StsClient::new(&client_config),
             time_source: conf.time_source(),
             policy: self.policy,
             policy_arns: self.policy_arns,

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -285,7 +285,14 @@ async fn load_credentials(
         .await
         .map_err(|sdk_error| {
             tracing::warn!(error = %DisplayErrorContext(&sdk_error), "STS returned an error assuming web identity role");
-            CredentialsError::provider_error(sdk_error)
+            if sdk_error
+                .as_service_error()
+                .is_some_and(sts::util::web_identity_error_is_non_recoverable)
+            {
+                CredentialsError::non_recoverable(sdk_error)
+            } else {
+                CredentialsError::provider_error(sdk_error)
+            }
         })?;
     sts::util::into_credentials(resp.credentials, resp.assumed_role_user, "WebIdentityToken")
 }

--- a/aws/rust-runtime/aws-credential-types/src/provider/error.rs
+++ b/aws/rust-runtime/aws-credential-types/src/provider/error.rs
@@ -46,9 +46,9 @@ pub struct Unhandled {
     source: Box<dyn Error + Send + Sync + 'static>,
 }
 
-/// Details for [`CredentialsError::Unrecoverable`]
+/// Details for [`CredentialsError::NonRecoverable`]
 #[derive(Debug)]
-pub struct Unrecoverable {
+pub struct NonRecoverable {
     source: Box<dyn Error + Send + Sync + 'static>,
 }
 
@@ -85,7 +85,7 @@ pub enum CredentialsError {
 
     /// The credentials provider experienced a terminal, non-recoverable error; the caller must act
     /// (e.g. re-authenticate, `aws sso login`).
-    Unrecoverable(Unrecoverable),
+    NonRecoverable(NonRecoverable),
 }
 
 impl CredentialsError {
@@ -146,16 +146,16 @@ impl CredentialsError {
     /// The credentials provider experienced a terminal, non-recoverable error.
     ///
     /// The caller must act (for example, re-authenticate).
-    pub fn unrecoverable(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
-        Self::Unrecoverable(Unrecoverable {
+    pub fn non_recoverable(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+        Self::NonRecoverable(NonRecoverable {
             source: source.into(),
         })
     }
 
     /// Returns `true` if this is a terminal, non-recoverable error
-    /// ([`CredentialsError::Unrecoverable`]).
-    pub fn is_unrecoverable(&self) -> bool {
-        matches!(self, Self::Unrecoverable(_))
+    /// ([`CredentialsError::NonRecoverable`]).
+    pub fn is_non_recoverable(&self) -> bool {
+        matches!(self, Self::NonRecoverable(_))
     }
 }
 
@@ -179,7 +179,7 @@ impl fmt::Display for CredentialsError {
             CredentialsError::Unhandled(_) => {
                 write!(f, "unexpected credentials error")
             }
-            CredentialsError::Unrecoverable(_) => {
+            CredentialsError::NonRecoverable(_) => {
                 write!(
                     f,
                     "a non-recoverable error occurred while loading credentials"
@@ -199,7 +199,7 @@ impl Error for CredentialsError {
             CredentialsError::InvalidConfiguration(details) => Some(details.source.as_ref() as _),
             CredentialsError::ProviderError(details) => Some(details.source.as_ref() as _),
             CredentialsError::Unhandled(details) => Some(details.source.as_ref() as _),
-            CredentialsError::Unrecoverable(details) => Some(details.source.as_ref() as _),
+            CredentialsError::NonRecoverable(details) => Some(details.source.as_ref() as _),
         }
     }
 }

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -504,14 +504,14 @@ impl Error for CachedNonRecoverableError {
 }
 
 // Default non-recoverable predicate injected into the cache by the AWS layer: a terminal
-// `CredentialsError::Unrecoverable` anywhere in the source chain bypasses backoff and static
+// `CredentialsError::NonRecoverable` anywhere in the source chain bypasses backoff and static
 // stability. Providers such as `ChainProvider` wrap the base-provider error, so walk the chain
 // rather than inspecting only the outermost error.
 fn aws_non_recoverable(err: &BoxError) -> bool {
     let mut source: Option<&(dyn Error + 'static)> = Some(&**err);
     while let Some(e) = source {
         if e.downcast_ref::<CredentialsError>()
-            .is_some_and(CredentialsError::is_unrecoverable)
+            .is_some_and(CredentialsError::is_non_recoverable)
         {
             return true;
         }
@@ -686,7 +686,7 @@ mod tests {
                     }
                     Some("error") => queue.push(Err("recoverable".into())),
                     Some("nonRecoverableError") => {
-                        queue.push(Err(CredentialsError::unrecoverable("terminal").into()))
+                        queue.push(Err(CredentialsError::non_recoverable("terminal").into()))
                     }
                     Some(other) => panic!("{doc}: unknown response {other:?}"),
                     None => {}
@@ -925,18 +925,19 @@ mod tests {
     // still detected by walking the source chain, not just the outermost error.
     #[test]
     fn non_recoverable_walks_source_chain() {
-        let wrapped: BoxError =
-            CredentialsError::provider_error(CredentialsError::unrecoverable("expired SSO token"))
-                .into();
+        let wrapped: BoxError = CredentialsError::provider_error(
+            CredentialsError::non_recoverable("expired SSO token"),
+        )
+        .into();
         assert!(
             aws_non_recoverable(&wrapped),
-            "a nested Unrecoverable must be detected"
+            "a nested NonRecoverable must be detected"
         );
 
         let recoverable: BoxError = CredentialsError::provider_error("STS 503").into();
         assert!(
             !aws_non_recoverable(&recoverable),
-            "no Unrecoverable anywhere in the chain"
+            "no NonRecoverable anywhere in the chain"
         );
     }
 
@@ -944,7 +945,7 @@ mod tests {
     fn cached_non_recoverable_error_is_not_double_printed() {
         use aws_smithy_types::error::display::DisplayErrorContext;
 
-        let err: BoxError = CredentialsError::unrecoverable("terminal").into();
+        let err: BoxError = CredentialsError::non_recoverable("terminal").into();
         let rendered = DisplayErrorContext(CachedNonRecoverableError(Arc::from(err))).to_string();
 
         let inner_msg = "a non-recoverable error occurred while loading credentials";
@@ -1317,7 +1318,7 @@ mod tests {
             contacts: contacts.clone(),
             results: Mutex::new(vec![
                 Ok(identity(1, 3600, true)),
-                Err(CredentialsError::unrecoverable("terminal").into()),
+                Err(CredentialsError::non_recoverable("terminal").into()),
             ]),
         });
         let cache = StaticStabilityCache::builder().build();

--- a/aws/rust-runtime/aws-runtime/src/static_stability.rs
+++ b/aws/rust-runtime/aws-runtime/src/static_stability.rs
@@ -287,11 +287,13 @@ impl StaticStabilityCache {
                 // Backoff AND serve-stale are BOTH static stability — gated on eligibility.
                 match prev {
                     Some(c) if eligible(&c) => {
-                        st.next_refresh_allowed_at =
-                            Some(now + self.backoff_override.unwrap_or_else(jittered_backoff));
+                        let backoff = self.backoff_override.unwrap_or_else(jittered_backoff);
+                        st.next_refresh_allowed_at = Some(now + backoff);
                         tracing::warn!(
                             error = ?err,
-                            "credential refresh failed; serving cached credentials (static stability)"
+                            "credential refresh failed; serving cached credentials (static stability). \
+                             A refresh will be attempted again after {} seconds",
+                            backoff.as_secs()
                         );
                         Ok(c)
                     }
@@ -567,10 +569,13 @@ impl StaticStabilityCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aws_smithy_async::test_util::tick_advance_sleep::tick_advance_time_and_sleep;
-    use aws_smithy_async::test_util::ManualTimeSource;
+    use aws_smithy_async::test_util::tick_advance_sleep::{
+        tick_advance_time_and_sleep, TickAdvanceTime,
+    };
+    use aws_smithy_async::time::TimeSource;
     use serde::Deserialize;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tracing_test::traced_test;
 
     // Data-driven execution of the modeled credential-refresh test suite (test-data/). Our
     // implementation diverges from the suite in two spots, handled inline: invalidation matches by
@@ -692,8 +697,7 @@ mod tests {
 
         // Build an isolated harness: a concrete cache (for internal accessors) with a
         // fixed backoff.
-        let time = ManualTimeSource::new(epoch(0));
-        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let (time, sleep) = tick_advance_time_and_sleep();
         let components = RuntimeComponentsBuilder::for_tests()
             .with_time_source(Some(time.clone()))
             .with_sleep_impl(Some(sleep))
@@ -718,16 +722,14 @@ mod tests {
         if seeded {
             let (r, _) = source_get(&cache, &resolver, &components, &cfg, &contacts).await;
             served = Some(r.expect("seed fetch"));
-            time.set_time(epoch(start));
+            time.tick(Duration::from_secs(start)).await;
         }
 
         // Execute the steps.
-        let mut clk = start;
         for step in &s.steps {
             match step {
                 Step::AdvanceTime { seconds } => {
-                    clk += seconds;
-                    time.set_time(epoch(clk));
+                    time.tick(Duration::from_secs(*seconds)).await;
                 }
                 Step::Invalidate {
                     rejected_access_key_id,
@@ -846,16 +848,13 @@ mod tests {
         resolver: SharedIdentityResolver,
         components: RuntimeComponents,
         config_bag: ConfigBag,
-        time: ManualTimeSource,
+        time: TickAdvanceTime,
         contacts: Arc<AtomicUsize>,
     }
 
     impl Harness {
         fn new(results: Vec<Result<Identity, BoxError>>) -> Self {
-            let time = ManualTimeSource::new(epoch(0));
-            // A tick-advance sleep never fires unless explicitly ticked, so the (immediately
-            // resolving) mock source always wins the refresh Timeout race — no spurious timeouts.
-            let (_tick, sleep) = tick_advance_time_and_sleep();
+            let (time, sleep) = tick_advance_time_and_sleep();
             let components = RuntimeComponentsBuilder::for_tests()
                 .with_time_source(Some(time.clone()))
                 .with_sleep_impl(Some(sleep))
@@ -887,8 +886,11 @@ mod tests {
             (result, contacted)
         }
 
-        fn advance_to(&self, secs: u64) {
-            self.time.set_time(epoch(secs));
+        async fn advance_to(&self, secs: u64) {
+            let delta = epoch(secs)
+                .duration_since(self.time.now())
+                .expect("advance_to only moves the clock forward");
+            self.time.tick(delta).await;
         }
     }
 
@@ -968,7 +970,7 @@ mod tests {
         let h = Harness::new(vec![Ok(identity(1, 3600, false)), Err("transient".into())]);
         assert_eq!(id_of(&h.get().await.0.unwrap()), 1);
 
-        h.advance_to(3700); // expired
+        h.advance_to(3700).await; // expired
         let (r, _contacted) = h.get().await;
         assert!(
             r.is_err(),
@@ -988,17 +990,17 @@ mod tests {
         ]);
         assert_eq!(id_of(&h.get().await.0.unwrap()), 1);
 
-        h.advance_to(3700); // expired -> failed refresh -> serve cached + backoff
+        h.advance_to(3700).await; // expired -> failed refresh -> serve cached + backoff
         let (r, contacted) = h.get().await;
         assert_eq!(id_of(&r.unwrap()), 1, "failed refresh serves cached");
         assert!(contacted, "a refresh was attempted");
 
-        h.advance_to(3800); // < 300s later: strictly inside the backoff -> rate-limited
+        h.advance_to(3800).await; // < 300s later: strictly inside the backoff -> rate-limited
         let (r, contacted) = h.get().await;
         assert_eq!(id_of(&r.unwrap()), 1);
         assert!(!contacted, "within backoff: source not contacted");
 
-        h.advance_to(3700 + 601); // past the max backoff (600s) -> refresh retried
+        h.advance_to(3700 + 601).await; // past the max backoff (600s) -> refresh retried
         let (r, contacted) = h.get().await;
         assert_eq!(
             id_of(&r.unwrap()),
@@ -1006,6 +1008,48 @@ mod tests {
             "refresh retried once backoff elapsed"
         );
         assert!(contacted);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn failed_refresh_logs_next_attempt_timing() {
+        let (time, sleep) = tick_advance_time_and_sleep();
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(time.clone()))
+            .with_sleep_impl(Some(sleep))
+            .build()
+            .unwrap();
+        let cfg = ConfigBag::base();
+        let resolver = SharedIdentityResolver::new(MockSource {
+            results: Mutex::new(vec![Ok(identity(1, 3600, true)), Err("transient".into())]),
+            contacts: Arc::new(AtomicUsize::new(0)),
+        });
+        // Pin the backoff so the logged duration is deterministic.
+        let cache =
+            StaticStabilityCache::new(None).with_overrides(Some(Duration::from_secs(420)), None);
+
+        let seed = cache
+            .resolve_cached_identity(resolver.clone(), &components, &cfg)
+            .await
+            .unwrap();
+        assert_eq!(id_of(&seed), 1);
+
+        // Expire the credential so the next resolve triggers a (failing) refresh.
+        time.tick(Duration::from_secs(3700)).await;
+        let served = cache
+            .resolve_cached_identity(resolver.clone(), &components, &cfg)
+            .await
+            .unwrap();
+        assert_eq!(id_of(&served), 1, "failed refresh serves cached");
+
+        assert!(
+            logs_contain("credential refresh failed"),
+            "log must include the failure"
+        );
+        assert!(
+            logs_contain("attempted again after 420 seconds"),
+            "log must state when the next refresh will be attempted"
+        );
     }
 
     // A source that reports no expiration is treated as non-expiring: fetched once and served
@@ -1024,7 +1068,7 @@ mod tests {
 
         // Advance far past any window a synthetic expiry could have produced (the old default was
         // 15m). A non-expiring identity is still served without contacting the source.
-        h.advance_to(100 * 3600); // 100 hours
+        h.advance_to(100 * 3600).await; // 100 hours
         let (r, contacted) = h.get().await;
         assert_eq!(id_of(&r.unwrap()), 1);
         assert!(
@@ -1065,8 +1109,7 @@ mod tests {
     // non-match path regardless of order.
     #[tokio::test]
     async fn invalidate_targets_only_the_matching_partition() {
-        let time = ManualTimeSource::new(epoch(0));
-        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let (time, sleep) = tick_advance_time_and_sleep();
         let components = RuntimeComponentsBuilder::for_tests()
             .with_time_source(Some(time.clone()))
             .with_sleep_impl(Some(sleep))
@@ -1148,11 +1191,7 @@ mod tests {
     // immediately without waiting or contacting the source (non-blocking single-flight).
     #[tokio::test]
     async fn advisory_concurrent_single_flight() {
-        let time = ManualTimeSource::new(epoch(0));
-        // Tick-advance sleep: never ticked here, so the refresh Timeout never fires and a
-        // gate-blocked source stays blocked until the driver releases it (deterministic, no
-        // real time).
-        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let (time, sleep) = tick_advance_time_and_sleep();
         let components = RuntimeComponentsBuilder::for_tests()
             .with_time_source(Some(time.clone()))
             .with_sleep_impl(Some(sleep))
@@ -1180,7 +1219,7 @@ mod tests {
         assert_eq!(id_of(&seed), 1);
         assert_eq!(contacts.load(Ordering::SeqCst), 1);
 
-        time.set_time(epoch(3000)); // advisory window (2700 <= now < 3540)
+        time.tick(Duration::from_secs(3000)).await; // advisory window (2700 <= now < 3540)
 
         // Two concurrent advisory callers + a driver that releases the single in-flight refresh.
         let get1 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
@@ -1209,8 +1248,7 @@ mod tests {
     // others WAIT for it and reuse the result (no additional source contacts).
     #[tokio::test]
     async fn mandatory_concurrent_single_flight_all_reuse() {
-        let time = ManualTimeSource::new(epoch(0));
-        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let (time, sleep) = tick_advance_time_and_sleep();
         let components = RuntimeComponentsBuilder::for_tests()
             .with_time_source(Some(time.clone()))
             .with_sleep_impl(Some(sleep))
@@ -1237,7 +1275,7 @@ mod tests {
         assert_eq!(id_of(&seed), 1);
         assert_eq!(contacts.load(Ordering::SeqCst), 1);
 
-        time.set_time(epoch(3700)); // expired -> mandatory path (blocking lock + recheck)
+        time.tick(Duration::from_secs(3700)).await; // expired -> mandatory path (blocking lock + recheck)
 
         // Three concurrent callers + a driver that releases the single in-flight refresh.
         let get1 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);
@@ -1265,8 +1303,7 @@ mod tests {
     // source.
     #[tokio::test]
     async fn mandatory_concurrent_non_recoverable_reuses_cached_error() {
-        let time = ManualTimeSource::new(epoch(0));
-        let (_tick, sleep) = tick_advance_time_and_sleep();
+        let (time, sleep) = tick_advance_time_and_sleep();
         let components = RuntimeComponentsBuilder::for_tests()
             .with_time_source(Some(time.clone()))
             .with_sleep_impl(Some(sleep))
@@ -1293,7 +1330,7 @@ mod tests {
         assert_eq!(id_of(&seed), 1);
         assert_eq!(contacts.load(Ordering::SeqCst), 1);
 
-        time.set_time(epoch(3700)); // expired -> mandatory path
+        time.tick(Duration::from_secs(3700)).await; // expired -> mandatory path
 
         // Three concurrent callers + a driver that releases the single in-flight refresh.
         let get1 = cache.resolve_cached_identity(resolver.clone(), &components, &cfg);

--- a/aws/sdk/integration-tests/telemetry/tests/spans.rs
+++ b/aws/sdk/integration-tests/telemetry/tests/spans.rs
@@ -89,9 +89,9 @@ async fn all_expected_operation_spans_emitted_with_correct_nesting() {
         .was_closed_exactly(1)
         .finalize();
 
-    let lazy_load_identity = assertion_registry
+    let load_identity = assertion_registry
         .build()
-        .with_name("lazy_load_identity")
+        .with_name("load_identity")
         .with_parent_name(OPERATION_NAME)
         .with_parent_name(TRY_OP)
         .with_parent_name(TRY_ATTEMPT)
@@ -159,7 +159,7 @@ async fn all_expected_operation_spans_emitted_with_correct_nesting() {
     apply_configuration.assert();
     serialization.assert();
     orchestrate_endpoint.assert();
-    lazy_load_identity.assert();
+    load_identity.assert();
     deserialize_streaming.assert();
     deserialization.assert();
     try_attempt.assert();

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.24
+codegenVersion=0.1.25


### PR DESCRIPTION
## Motivation and Context
This is the final PR (PR 3) in the series to support consistent credentials refresh across credential providers. It wires the `StaticStabilityCache` into `aws-config` and codegen, making it the default identity cache for AWS SDK clients.

- PR 1 — #4766 (generic hooks)
- PR 2 — #4774 (`StaticStabilityCache` + AWS-land signals)
- PR 2 follow-up — #4781 (short-lived non-recoverable error cache)
- PR 3 (**this PR**) — `aws-config` + codegen (wiring)

These PRs merge into the `ysaito/consistent-credentials-refresh` feature branch.

## Description
#4774 added the cache but never installed it. This PR flips the switch: at `BehaviorVersion::v2026_08_01` (the date will be updated before the feature branch is merged to main), AWS clients use `StaticStabilityCache` by default. The default gets installed in two places so it doesn't matter how the client is built: `aws-config`'s `ConfigLoader::load()`, and the generated `ServiceRuntimePlugin` (new `StaticStabilityDecorator`) for clients built straight from a `Config`.

The following changes need to be made for the built-in credentials providers to be static stability eligible:
- Each built-in provider stamps `StaticStabilityEligible` on the credentials it returns (IMDS, ECS/EKS container, `AssumeRole` including profile role chains, `AssumeRoleWithWebIdentity`, SSO, Login). Process and customer-provided providers deliberately don't stamp it, so they stay caching-only. S3 Express is out of scope entirely, as it uses its own bucket-scoped identity cache and doesn't go through this path.
- IMDS stops doing its own static stability. It used to extend stale expirations and return the last credentials it saw; now (at `v2026_08_01`) it reports the real expiration and lets a refresh failure surface, so that behavior lives in one place. Older behavior versions keep the old IMDS logic.
- Every operation gets `CredentialAuthFailureInterceptor` registered in codegen (next to `AwsErrorCodeClassifier`). When a service rejects a request with `ExpiredToken`/`InvalidToken`, it invalidates the signing identity so the next call refreshes.

This PR also fixes what counts as a non-recoverable error (raised to the caller right away rather than retried with backoff), per the latest revision of the design. Specifically, the following errors are considered non-recoverable errors:
- STS / web identity: `AccessDenied` (matched by error code), `MalformedPolicyDocument`, `PackedPolicyTooLarge`, `RegionDisabled`, and for web identity also `IDPRejectedClaim` / `InvalidIdentityToken`.
- SSO: an expired/missing/malformed cached token (caught client-side), and `UnauthorizedException` from `GetRoleCredentials`.
- Login: a missing or incomplete cached token, and `AccessDeniedException` from `CreateOAuth2Token` with code `TOKEN_EXPIRED`, `USER_CREDENTIALS_CHANGED`, or `INSUFFICIENT_PERMISSIONS`.

## Testing
- New codegen test (`StaticStabilityDecoratorTest`): a client built without `aws-config` picks up the static-stability cache at `v2026_08_01` and keeps serving cached credentials when a refresh fails (older versions error out instead);
- Extended the IMDS tests to cover both paths — extend/serve-last-retrieved below `v2026_08_01`, and real-expiration/error-on-failure at `v2026_08_01`.
- Added tests confirming each provider's non-recoverable error classification behaves as intended.

Ignore a failure in semver compliance check, since this PR renames `CredentialsError::Unrecoverable` to `CredentialsError::NonRecoverable` within the feature branch. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
