### PR TITLE
ci: retry and verify the build image's network fetches

### DIFF
--- a/.github/workflows/manual-canary.yml
+++ b/.github/workflows/manual-canary.yml
@@ -29,6 +29,15 @@ on:
         type: string
 run-name: ${{ github.workflow }} for Pull Request ${{ inputs.pull_request_number }}
 
+# Every checkout below sets `allow-unsafe-pr-checkout: true`. `actions/checkout` refuses to fetch a
+# fork's ref when the run was triggered by `pull_request_target` -- the fork-canary door -- because
+# doing so executes untrusted code with the base repo's secrets. That is exactly what this workflow
+# does, knowingly: running the contributor's code against the canary credentials is the whole point,
+# and the gate is the `safe-to-run-canary` label, not the checkout action. `fork-canary.yml` holds
+# the reasoning and the guards (write-access labeler, fork-only, SHA pinned and re-asserted below,
+# label revoked on every push). The flag is inert on the `workflow_dispatch` door, where a
+# maintainer's dispatch is already the attestation.
+
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
   group: manual-canary-${{ inputs.pull_request_number }}
@@ -82,6 +91,7 @@ jobs:
             # the `docker-build` action won't find the built Docker image.
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
+        allow-unsafe-pr-checkout: true
     - uses: ./smithy-rs/.github/actions/free-disk-space
     - name: Acquire base image
       id: acquire
@@ -101,6 +111,7 @@ jobs:
       with:
         path: smithy-rs
         ref: ${{ inputs.commit_sha }}
+        allow-unsafe-pr-checkout: true
     - name: Generate a subset of SDKs for the canary
       uses: ./smithy-rs/.github/actions/docker-build
       with:
@@ -121,6 +132,7 @@ jobs:
       with:
         path: smithy-rs
         ref: ${{ inputs.commit_sha }}
+        allow-unsafe-pr-checkout: true
     - name: Configure credentials
       id: creds
       uses: aws-actions/configure-aws-credentials@v4
@@ -149,6 +161,7 @@ jobs:
       with:
         path: smithy-rs
         ref: ${{ inputs.commit_sha }}
+        allow-unsafe-pr-checkout: true
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -14,7 +14,17 @@ RUN yum -y updateinfo && yum clean all && rm -rf /var/cache/yum
 
 FROM bare_base_image as musl_toolchain
 RUN yum -y install --allowerasing tar gzip gcc make && \
-    curl https://musl.libc.org/releases/musl-1.2.5.tar.gz -o musl-1.2.5.tar.gz && \
+    # musl.libc.org is a small volunteer-run host and has taken this stage down three times in the
+    # last two weeks (connect timeouts and resets). Retry, and cap the connect wait -- the bare form
+    # sat for 135s before giving up. `-f` matters too: without it an HTTP error page is written to
+    # the tarball and the failure surfaces as a confusing `tar` error instead.
+    #
+    # The checksum is not optional hardening: this was the only download in this file without one,
+    # while rustup-init and node both verify. Fork PRs build this image locally on every run, so this
+    # stage is on the critical path for external contributions.
+    curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+        https://musl.libc.org/releases/musl-1.2.5.tar.gz -o musl-1.2.5.tar.gz && \
+    echo "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz" | sha256sum --check && \
     tar xzf musl-1.2.5.tar.gz && \
     (cd musl-1.2.5 && ./configure && make install) && \
     rm -rf musl-1.2.5* && \
@@ -70,10 +80,10 @@ RUN yum -y install --allowerasing \
     yum clean all && rm -rf /var/cache/yum && \
     set -eux; \
     if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]]; then \
-        curl https://static.rust-lang.org/rustup/archive/1.24.3/aarch64-unknown-linux-gnu/rustup-init --output rustup-init; \
+        curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 https://static.rust-lang.org/rustup/archive/1.24.3/aarch64-unknown-linux-gnu/rustup-init --output rustup-init; \
         echo "32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1 rustup-init" | sha256sum --check; \
     else \
-        curl https://static.rust-lang.org/rustup/archive/1.24.3/x86_64-unknown-linux-gnu/rustup-init --output rustup-init; \
+        curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 https://static.rust-lang.org/rustup/archive/1.24.3/x86_64-unknown-linux-gnu/rustup-init --output rustup-init; \
         echo "3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338 rustup-init" | sha256sum --check; \
     fi; \
     chmod +x rustup-init; \
@@ -180,7 +190,7 @@ RUN set -eux; \
             ;; \
     esac; \
     # Download and verify Node.js
-    curl -fsSL "${NODE_URL}" -o node.tar.xz; \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 "${NODE_URL}" -o node.tar.xz; \
     echo "${NODE_CHECKSUM}  node.tar.xz" | sha256sum --check; \
     # Extract and install
     mkdir -p "${NODE_HOME}"; \
@@ -224,7 +234,7 @@ RUN set -eux; \
     useradd -m -g build build && \
     chmod 775 /home/build && \
     cd /tmp && \
-    curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o awscliv2.zip && \
+    curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o awscliv2.zip && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm -rf awscliv2.zip aws && \


### PR DESCRIPTION
The `musl` fetch in the build image has failed three times in two weeks — 08-13 (timeout), [a contributor's fork PR on 08-19](https://github.com/smithy-lang/smithy-rs/actions/runs/32235207023/job/96105836443) (`curl: (35) Recv failure: Connection reset by peer`), and [a canary test on 08-21](https://github.com/vcjana/smithy-rs/actions/runs/32517090001/job/96881824545) (`curl: (28) Failed to connect ... after 135683 ms`). Fork PRs build this image locally on every run, so it's on the critical path for every external contribution.

Adds retries and `--connect-timeout` to all four network fetches in `tools/ci-build/Dockerfile`, plus a sha256 check on musl — the only download in the file that had none. Checksum was produced by downloading the real tarball; that download itself timed out once and succeeded on retry.