### PR TITLE
CI check to verify runtime crates at HEAD remain compatible with latest released code generator

### DIFF
--- a/.github/workflows/ci-pr-forks.yml
+++ b/.github/workflows/ci-pr-forks.yml
@@ -51,6 +51,37 @@ jobs:
     with:
       run_canary: false
 
+  # Workflows executed directly in personal fork repositories cannot access
+  # smithy-lang's self-hosted runners. Run this focused check on a GitHub-hosted
+  # runner so contributors can validate the compatibility harness in their fork
+  # before opening an upstream PR.
+  check-released-codegen-runtime-compatibility-hosted:
+    name: Check PR semver across last released version
+    if: ${{ github.repository != 'smithy-lang/smithy-rs' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: corretto
+        java-version: 17
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.94.1
+    - name: Run focused unit tests
+      env:
+        PYTHONPATH: tools/ci-scripts
+      run: >-
+        python3 -m unittest discover
+        -s tools/ci-scripts/released_codegen_runtime_compatibility/tests -v
+    - name: Run codegen/runtime compatibility check
+      env:
+        CODEGEN_RUNTIME_LOG_LEVEL: DEBUG
+      run: ./tools/ci-scripts/released-codegen-runtime-compatibility.py verify-semver
+
   semver-checks:
     name: Check PR semver compliance
     permissions:

--- a/.github/workflows/ci-pr-forks.yml
+++ b/.github/workflows/ci-pr-forks.yml
@@ -56,7 +56,7 @@ jobs:
   # runner so contributors can validate the compatibility harness in their fork
   # before opening an upstream PR.
   check-released-codegen-runtime-compatibility-hosted:
-    name: Check PR semver across last released version
+    name: Check released codegen compatibility with current runtimes
     if: ${{ github.repository != 'smithy-lang/smithy-rs' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -80,7 +80,7 @@ jobs:
     - name: Run codegen/runtime compatibility check
       env:
         CODEGEN_RUNTIME_LOG_LEVEL: DEBUG
-      run: ./tools/ci-scripts/released-codegen-runtime-compatibility.py verify-semver
+      run: ./tools/ci-scripts/released-codegen-runtime-compatibility.py
 
   semver-checks:
     name: Check PR semver compliance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,23 @@ jobs:
       with:
         action: check-semver-hazards
 
+  # Generate client and server crates for every supported protocol with released codegen, patch
+  # their runtime dependencies to candidate crates from the current checkout, and compile them.
+  # Cargo enforces the generated dependency requirements.
+  check-released-codegen-runtime-compatibility:
+    name: Check PR semver across last released version
+    runs-on: smithy_ubuntu-latest_8-core
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: smithy-rs
+        ref: ${{ inputs.git_ref }}
+    - name: Run codegen/runtime compatibility check
+      uses: ./smithy-rs/.github/actions/docker-build
+      with:
+        action: check-released-codegen-runtime-compatibility
+
   # Test all the things that require generated code. Note: the Rust runtimes require codegen
   # to be checked since `aws-config` depends on the generated STS client.
   test-sdk:
@@ -664,6 +681,7 @@ jobs:
     - generate-full
     - test-codegen
     - check-semver-hazards
+    - check-released-codegen-runtime-compatibility
     - test-sdk
     - test-sdk-full
     - test-rust-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
   # their runtime dependencies to candidate crates from the current checkout, and compile them.
   # Cargo enforces the generated dependency requirements.
   check-released-codegen-runtime-compatibility:
-    name: Check PR semver across last released version
+    name: Check released codegen compatibility with current runtimes
     runs-on: smithy_ubuntu-latest_8-core
     timeout-minutes: 30
     steps:

--- a/tools/ci-scripts/check-released-codegen-runtime-compatibility
+++ b/tools/ci-scripts/check-released-codegen-runtime-compatibility
@@ -13,7 +13,7 @@ fi
 
 cd smithy-rs
 
-args=(verify-semver)
+args=()
 if [[ $# -eq 1 ]]; then
     args+=(--codegen-version "$1")
 fi

--- a/tools/ci-scripts/check-released-codegen-runtime-compatibility
+++ b/tools/ci-scripts/check-released-codegen-runtime-compatibility
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+    echo "Usage: check-released-codegen-runtime-compatibility [codegen-version]"
+    exit 1
+fi
+
+cd smithy-rs
+
+args=(verify-semver)
+if [[ $# -eq 1 ]]; then
+    args+=(--codegen-version "$1")
+fi
+
+./tools/ci-scripts/released-codegen-runtime-compatibility.py "${args[@]}"

--- a/tools/ci-scripts/released-codegen-runtime-compatibility.py
+++ b/tools/ci-scripts/released-codegen-runtime-compatibility.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Detect semver incompatibility between the last codegen released version and
+current rust-runtime crates at HEAD.
+
+For example, an old generated SDK may require `aws-smithy-http-server` 0.66.2
+and `aws-smithy-json` 0.62.4. If a semver-compatible HTTP server candidate starts
+exposing a new incompatible JSON version, compiling that SDK must fail.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional, Sequence
+
+from released_codegen_runtime_compatibility.cargo import CargoVerifier
+from released_codegen_runtime_compatibility.codegen import ProtocolSdkGenerator
+from released_codegen_runtime_compatibility.commands import (
+    configure_logging,
+    eprint,
+    github_error,
+)
+from released_codegen_runtime_compatibility.maven import MavenCodegenResolver
+from released_codegen_runtime_compatibility.paths import temporary_directory
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Parse the verification command and attach its handler."""
+    parser = argparse.ArgumentParser(
+        description="Verify released generated SDKs against runtime crates at HEAD."
+    )
+    parser.add_argument(
+        "--repository-root",
+        default=".",
+        help="smithy-rs repository root; defaults to the current directory",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    verify = commands.add_parser(
+        "verify-semver",
+        help="compile released SDKs with semver-eligible runtimes from HEAD",
+    )
+    verify.add_argument(
+        "--codegen-version",
+        help="generate temporary SDKs with this published Maven version",
+    )
+    verify.add_argument(
+        "--runtime-root",
+        help="runtime workspace to patch from; defaults to <repository-root>/rust-runtime",
+    )
+    verify.set_defaults(handler=verify_semver)
+    return parser.parse_args(argv)
+
+
+def temporary_prefix(codegen_version: str) -> str:
+    """Build a recognizable compatibility-work prefix containing the codegen version."""
+    return "smithy-rs-codegen-compat-{}-".format(codegen_version)
+
+
+def verify_semver(args: argparse.Namespace) -> None:
+    """Generate SDKs with published codegen and verify them with current runtimes."""
+    repository_root = Path(args.repository_root).resolve()
+    runtime_root = (
+        Path(args.runtime_root).resolve()
+        if args.runtime_root
+        else repository_root / "rust-runtime"
+    )
+    codegen = MavenCodegenResolver().resolve(args.codegen_version)
+
+    with temporary_directory(
+        prefix=temporary_prefix(codegen.version)
+    ) as temporary_root:
+        eprint(
+            "generating temporary protocol SDKs with published codegen {}".format(
+                codegen.version
+            )
+        )
+        source = ProtocolSdkGenerator(repository_root).generate(
+            codegen, temporary_root
+        )
+        CargoVerifier(runtime_root).verify(
+            source, temporary_root / "verification"
+        )
+
+    eprint("client and server semver compatibility checks passed")
+
+
+if __name__ == "__main__":
+    configure_logging()
+    try:
+        args = parse_args()
+        args.handler(args)
+    except Exception as error:
+        logging.getLogger("released-codegen-runtime-compatibility").exception(
+            "compatibility command failed"
+        )
+        github_error(str(error))
+        raise SystemExit(1)

--- a/tools/ci-scripts/released-codegen-runtime-compatibility.py
+++ b/tools/ci-scripts/released-codegen-runtime-compatibility.py
@@ -3,12 +3,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Detect semver incompatibility between the last codegen released version and
-current rust-runtime crates at HEAD.
+"""Check released codegen compatibility with runtime crates at HEAD.
 
-For example, an old generated SDK may require `aws-smithy-http-server` 0.66.2
-and `aws-smithy-json` 0.62.4. If a semver-compatible HTTP server candidate starts
-exposing a new incompatible JSON version, compiling that SDK must fail.
+The program resolves a published codegen release, generates representative
+client and server crates for every supported protocol, offers runtime crates
+from the current checkout through Cargo's crates.io patch mechanism, and
+compiles the generated workspaces. Cargo only selects patched runtime versions
+that satisfy the requirements emitted by the released code generator.
 """
 
 import argparse
@@ -16,86 +17,56 @@ import logging
 from pathlib import Path
 from typing import Optional, Sequence
 
-from released_codegen_runtime_compatibility.cargo import CargoVerifier
-from released_codegen_runtime_compatibility.codegen import ProtocolSdkGenerator
 from released_codegen_runtime_compatibility.commands import (
     configure_logging,
-    eprint,
     github_error,
 )
-from released_codegen_runtime_compatibility.maven import MavenCodegenResolver
-from released_codegen_runtime_compatibility.paths import temporary_directory
+from released_codegen_runtime_compatibility.verify_compatibility import (
+    verify_released_codegen_runtime_compatibility,
+)
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    """Parse the verification command and attach its handler."""
+    """Parse options for the released-codegen compatibility check."""
     parser = argparse.ArgumentParser(
-        description="Verify released generated SDKs against runtime crates at HEAD."
+        description="Check released codegen compatibility with runtime crates at HEAD."
     )
     parser.add_argument(
         "--repository-root",
         default=".",
         help="smithy-rs repository root; defaults to the current directory",
     )
-    commands = parser.add_subparsers(dest="command", required=True)
-
-    verify = commands.add_parser(
-        "verify-semver",
-        help="compile released SDKs with semver-eligible runtimes from HEAD",
-    )
-    verify.add_argument(
+    parser.add_argument(
         "--codegen-version",
-        help="generate temporary SDKs with this published Maven version",
+        help=(
+            "generate temporary SDKs with this published Maven version; defaults "
+            "to the latest codegen release published to Maven Central"
+        ),
     )
-    verify.add_argument(
+    parser.add_argument(
         "--runtime-root",
         help="runtime workspace to patch from; defaults to <repository-root>/rust-runtime",
     )
-    verify.set_defaults(handler=verify_semver)
     return parser.parse_args(argv)
 
 
-def temporary_prefix(codegen_version: str) -> str:
-    """Build a recognizable compatibility-work prefix containing the codegen version."""
-    return "smithy-rs-codegen-compat-{}-".format(codegen_version)
-
-
-def verify_semver(args: argparse.Namespace) -> None:
-    """Generate SDKs with published codegen and verify them with current runtimes."""
-    repository_root = Path(args.repository_root).resolve()
-    runtime_root = (
-        Path(args.runtime_root).resolve()
-        if args.runtime_root
-        else repository_root / "rust-runtime"
-    )
-    codegen = MavenCodegenResolver().resolve(args.codegen_version)
-
-    with temporary_directory(
-        prefix=temporary_prefix(codegen.version)
-    ) as temporary_root:
-        eprint(
-            "generating temporary protocol SDKs with published codegen {}".format(
-                codegen.version
-            )
-        )
-        source = ProtocolSdkGenerator(repository_root).generate(
-            codegen, temporary_root
-        )
-        CargoVerifier(runtime_root).verify(
-            source, temporary_root / "verification"
-        )
-
-    eprint("client and server semver compatibility checks passed")
-
-
-if __name__ == "__main__":
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Parse CLI options and run the released-codegen compatibility check."""
     configure_logging()
     try:
-        args = parse_args()
-        args.handler(args)
+        args = parse_args(argv)
+        verify_released_codegen_runtime_compatibility(
+            repository_root=Path(args.repository_root),
+            runtime_root=Path(args.runtime_root) if args.runtime_root else None,
+            codegen_version=args.codegen_version,
+        )
     except Exception as error:
         logging.getLogger("released-codegen-runtime-compatibility").exception(
             "compatibility command failed"
         )
         github_error(str(error))
         raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/__init__.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/__init__.py
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Released-codegen and current-runtime compatibility tooling."""

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/cargo.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/cargo.py
@@ -12,174 +12,169 @@ from .models import RuntimeCrate, Workspaces
 from .paths import copy_tree
 
 
-class CargoVerifier:
-    """Verify released generated SDKs against current runtime crate candidates.
-    Let Cargo enforce generated semver requirements through crates.io patches.
+def patch_generated_sdks_with_current_runtimes(
+    generated_sdks: Workspaces,
+    runtime_root: Path,
+    destination_root: Path,
+) -> Workspaces:
+    """Copy generated SDKs and offer current runtimes through Cargo patches.
+
+    Cargo selects a patched runtime only when its current version satisfies the
+    dependency requirement emitted by released codegen. Generated registry
+    requirements remain intact, and lockfiles are removed before resolution.
     """
-
-    def __init__(self, runtime_root: Path) -> None:
-        """Store the current runtime Cargo workspace used for candidate patches.
-        Discover package names and paths from this workspace during verification.
-        """
-        self.runtime_root = runtime_root
-
-    def verify(self, source: Workspaces, destination_root: Path) -> None:
-        """Copy, patch, and compile client and server compatibility workspaces.
-        Check both workspaces before reporting all accumulated failures.
-        """
-        workspaces = self._copy_workspaces(source, destination_root)
-        runtime_crates = self._discover_runtime_crates()
-        failures = []
-        for label, workspace in workspaces.items():
-            self._assert_registry_runtime_dependencies(workspace)
-            self._append_runtime_patches(workspace, runtime_crates)
-            eprint(
-                "checking {} workspace with {} candidate runtime crate patches".format(
-                    label, len(runtime_crates)
-                )
+    patched_sdks = _copy_workspaces(generated_sdks, destination_root)
+    runtime_crates = _discover_runtime_crates(runtime_root)
+    for label, workspace in patched_sdks.items():
+        _assert_registry_runtime_dependencies(workspace)
+        _append_runtime_patches(workspace, runtime_crates)
+        eprint(
+            "patched {} workspace with {} current runtime crates".format(
+                label, len(runtime_crates)
             )
-            try:
-                self._check_workspace(label, workspace)
-            except RuntimeError as error:
-                failures.append(str(error))
-        if failures:
-            raise RuntimeError("\n".join(failures))
-
-    def _discover_runtime_crates(self) -> Sequence[RuntimeCrate]:
-        """Read runtime workspace packages through structured Cargo metadata.
-        Return publishable AWS crates as names and local paths for patching.
-        """
-        manifest_path = self.runtime_root / "Cargo.toml"
-        _, metadata_json, _ = output(
-            [
-                "cargo",
-                "metadata",
-                "--no-deps",
-                "--format-version",
-                "1",
-                "--manifest-path",
-                manifest_path,
-            ],
-            self.runtime_root,
         )
-        metadata = json.loads(metadata_json)
-        crates: List[RuntimeCrate] = []
-        for package in metadata["packages"]:
-            if not package["name"].startswith("aws-"):
-                continue
-            # Cargo metadata represents `publish = false` as an empty registry list. Do not add
-            # unpublished crates to `[patch.crates-io]`: that would make a crate available to this
-            # test even though a customer's crates.io dependency graph could never resolve it.
-            # Patched runtime crates can still use unpublished helpers through local path
-            # dependencies.
-            if package.get("publish") == []:
-                continue
-            crates.append(
-                RuntimeCrate(
-                    name=package["name"],
-                    path=Path(package["manifest_path"]).resolve().parent,
-                )
+    return patched_sdks
+
+
+def compile_generated_sdks(generated_sdks: Workspaces) -> None:
+    """Compile client and server SDK workspaces and report all failures together."""
+    failures = []
+    for label, workspace in generated_sdks.items():
+        eprint("compiling generated {} SDK workspace".format(label))
+        try:
+            _check_workspace(label, workspace)
+        except RuntimeError as error:
+            failures.append(str(error))
+    if failures:
+        raise RuntimeError("\n".join(failures))
+    eprint("released codegen compatibility checks passed")
+
+
+def _discover_runtime_crates(runtime_root: Path) -> Sequence[RuntimeCrate]:
+    """Read publishable AWS runtime packages through structured Cargo metadata."""
+    manifest_path = runtime_root / "Cargo.toml"
+    _, metadata_json, _ = output(
+        [
+            "cargo",
+            "metadata",
+            "--no-deps",
+            "--format-version",
+            "1",
+            "--manifest-path",
+            manifest_path,
+        ],
+        runtime_root,
+    )
+    metadata = json.loads(metadata_json)
+    crates: List[RuntimeCrate] = []
+    for package in metadata["packages"]:
+        if not package["name"].startswith("aws-"):
+            continue
+        # Cargo metadata represents `publish = false` as an empty registry list. Do not add
+        # unpublished crates to `[patch.crates-io]`: that would make a crate available to this
+        # test even though a customer's crates.io dependency graph could never resolve it.
+        # Patched runtime crates can still use unpublished helpers through local path
+        # dependencies.
+        if package.get("publish") == []:
+            continue
+        crates.append(
+            RuntimeCrate(
+                name=package["name"],
+                path=Path(package["manifest_path"]).resolve().parent,
             )
-        crates.sort(key=lambda crate: crate.name)
-        if not crates:
-            raise RuntimeError(
-                "no publishable runtime crates found under {}".format(self.runtime_root)
+        )
+    crates.sort(key=lambda crate: crate.name)
+    if not crates:
+        raise RuntimeError(
+            "no publishable runtime crates found under {}".format(runtime_root)
+        )
+    return crates
+
+
+def _copy_workspaces(source: Workspaces, destination_root: Path) -> Workspaces:
+    """Copy source workspaces so patches and build outputs remain isolated."""
+    copies = {}
+    for label, workspace in source.items():
+        destination = destination_root / label
+        copy_tree(workspace, destination)
+        copies[label] = destination
+    return Workspaces(client=copies["client"], server=copies["server"])
+
+
+def _assert_registry_runtime_dependencies(workspace: Path) -> None:
+    """Reject local runtime paths because they bypass Cargo semver selection."""
+    local_runtime_paths = []
+    for manifest in workspace.rglob("Cargo.toml"):
+        if manifest == workspace / "Cargo.toml":
+            continue
+        for line in manifest.read_text().splitlines():
+            if re.match(
+                r'^\s*path\s*=\s*".*(?:rust-runtime|aws/rust-runtime)', line
+            ):
+                local_runtime_paths.append("{}: {}".format(manifest, line.strip()))
+    if local_runtime_paths:
+        raise RuntimeError(
+            "generated SDK retained local runtime dependencies:\n{}".format(
+                "\n".join(local_runtime_paths)
             )
-        return crates
+        )
 
-    def _copy_workspaces(self, source: Workspaces, destination_root: Path) -> Workspaces:
-        """Copy source workspaces to an isolated verification directory.
-        Keep Cargo patches, lockfiles, and build outputs out of generated SDKs.
-        """
-        copies = {}
-        for label, workspace in source.items():
-            destination = destination_root / label
-            copy_tree(workspace, destination)
-            copies[label] = destination
-        return Workspaces(client=copies["client"], server=copies["server"])
 
-    def _assert_registry_runtime_dependencies(self, workspace: Path) -> None:
-        """Ensure generated SDK manifests retained released registry requirements.
-        Reject local runtime paths because they bypass Cargo semver selection.
-        """
-        local_runtime_paths = []
-        for manifest in workspace.rglob("Cargo.toml"):
-            if manifest == workspace / "Cargo.toml":
-                continue
-            for line in manifest.read_text().splitlines():
-                if re.match(
-                    r'^\s*path\s*=\s*".*(?:rust-runtime|aws/rust-runtime)', line
-                ):
-                    local_runtime_paths.append(
-                        "{}: {}".format(manifest, line.strip())
-                    )
-        if local_runtime_paths:
-            raise RuntimeError(
-                "generated SDK retained local runtime dependencies:\n{}".format(
-                    "\n".join(local_runtime_paths)
-                )
-            )
+def _append_runtime_patches(
+    workspace: Path, runtime_crates: Sequence[RuntimeCrate]
+) -> None:
+    """Add current runtime paths to the crates.io patch table and remove lockfiles."""
+    manifest = workspace / "Cargo.toml"
+    contents = manifest.read_text()
+    if re.search(r"(?m)^\[patch\.crates-io\]\s*$", contents):
+        raise RuntimeError(
+            "{} already has a [patch.crates-io] section".format(manifest)
+        )
 
-    def _append_runtime_patches(
-        self, workspace: Path, runtime_crates: Sequence[RuntimeCrate]
-    ) -> None:
-        """Offer current runtime path crates through the crates.io patch table.
-        Remove lockfiles so Cargo resolves them against generated SDK requirements.
-        """
-        manifest = workspace / "Cargo.toml"
-        contents = manifest.read_text()
-        if re.search(r"(?m)^\[patch\.crates-io\]\s*$", contents):
-            raise RuntimeError(
-                "{} already has a [patch.crates-io] section".format(manifest)
-            )
+    patch_lines = ["", "# Candidate runtime release under test.", "[patch.crates-io]"]
+    for crate in runtime_crates:
+        # Cargo reads the version from this path and selects it only when it satisfies the
+        # requirement preserved in the generated SDK. An incompatible major remains unused.
+        # JSON string escaping is also valid for a TOML basic string.
+        patch_lines.append(
+            "{} = {{ path = {} }}".format(crate.name, json.dumps(str(crate.path)))
+        )
+    manifest.write_text(contents.rstrip() + "\n" + "\n".join(patch_lines) + "\n")
 
-        patch_lines = ["", "# Candidate runtime release under test.", "[patch.crates-io]"]
-        for crate in runtime_crates:
-            # Cargo reads the version from this path and selects it only when it satisfies the
-            # requirement preserved in the generated SDK. An incompatible major remains unused.
-            # JSON string escaping is also valid for a TOML basic string.
-            patch_lines.append(
-                "{} = {{ path = {} }}".format(crate.name, json.dumps(str(crate.path)))
-            )
-        manifest.write_text(contents.rstrip() + "\n" + "\n".join(patch_lines) + "\n")
+    for lockfile in workspace.rglob("Cargo.lock"):
+        lockfile.unlink()
 
-        for lockfile in workspace.rglob("Cargo.lock"):
-            lockfile.unlink()
 
-    def _check_workspace(self, label: str, workspace: Path) -> None:
-        """Compile every target and feature in one patched compatibility workspace.
-        Print duplicate dependency versions and raise a labeled error on failure.
-        """
-        cargo_env = dict(os.environ)
-        # Old generated code may legitimately use APIs that are now deprecated.
-        cargo_env.pop("RUSTFLAGS", None)
-        result = run(
-            [
-                "cargo",
-                "check",
-                "--workspace",
-                "--all-features",
-                "--all-targets",
-                "--quiet",
-            ],
+def _check_workspace(label: str, workspace: Path) -> None:
+    """Compile every target and feature in one patched compatibility workspace."""
+    cargo_env = dict(os.environ)
+    # Old generated code may legitimately use APIs that are now deprecated.
+    cargo_env.pop("RUSTFLAGS", None)
+    result = run(
+        [
+            "cargo",
+            "check",
+            "--workspace",
+            "--all-features",
+            "--all-targets",
+            "--quiet",
+        ],
+        workspace,
+        check=False,
+        env=cargo_env,
+    )
+    if result.returncode != 0:
+        eprint(
+            "{} compatibility check failed; duplicate versions follow:".format(label)
+        )
+        run(
+            ["cargo", "tree", "--duplicates"],
             workspace,
             check=False,
             env=cargo_env,
         )
-        if result.returncode != 0:
-            eprint(
-                "{} compatibility check failed; duplicate versions follow:".format(
-                    label
-                )
+        raise RuntimeError(
+            "{} SDK does not compile with semver-eligible runtime crates from HEAD".format(
+                label
             )
-            run(
-                ["cargo", "tree", "--duplicates"],
-                workspace,
-                check=False,
-                env=cargo_env,
-            )
-            raise RuntimeError(
-                "{} SDK does not compile with semver-eligible runtime crates from HEAD".format(
-                    label
-                )
-            )
+        )

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/cargo.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/cargo.py
@@ -1,0 +1,185 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from pathlib import Path
+import re
+from typing import List, Sequence
+
+from .commands import eprint, output, run
+from .models import RuntimeCrate, Workspaces
+from .paths import copy_tree
+
+
+class CargoVerifier:
+    """Verify released generated SDKs against current runtime crate candidates.
+    Let Cargo enforce generated semver requirements through crates.io patches.
+    """
+
+    def __init__(self, runtime_root: Path) -> None:
+        """Store the current runtime Cargo workspace used for candidate patches.
+        Discover package names and paths from this workspace during verification.
+        """
+        self.runtime_root = runtime_root
+
+    def verify(self, source: Workspaces, destination_root: Path) -> None:
+        """Copy, patch, and compile client and server compatibility workspaces.
+        Check both workspaces before reporting all accumulated failures.
+        """
+        workspaces = self._copy_workspaces(source, destination_root)
+        runtime_crates = self._discover_runtime_crates()
+        failures = []
+        for label, workspace in workspaces.items():
+            self._assert_registry_runtime_dependencies(workspace)
+            self._append_runtime_patches(workspace, runtime_crates)
+            eprint(
+                "checking {} workspace with {} candidate runtime crate patches".format(
+                    label, len(runtime_crates)
+                )
+            )
+            try:
+                self._check_workspace(label, workspace)
+            except RuntimeError as error:
+                failures.append(str(error))
+        if failures:
+            raise RuntimeError("\n".join(failures))
+
+    def _discover_runtime_crates(self) -> Sequence[RuntimeCrate]:
+        """Read runtime workspace packages through structured Cargo metadata.
+        Return publishable AWS crates as names and local paths for patching.
+        """
+        manifest_path = self.runtime_root / "Cargo.toml"
+        _, metadata_json, _ = output(
+            [
+                "cargo",
+                "metadata",
+                "--no-deps",
+                "--format-version",
+                "1",
+                "--manifest-path",
+                manifest_path,
+            ],
+            self.runtime_root,
+        )
+        metadata = json.loads(metadata_json)
+        crates: List[RuntimeCrate] = []
+        for package in metadata["packages"]:
+            if not package["name"].startswith("aws-"):
+                continue
+            # Cargo metadata represents `publish = false` as an empty registry list. Do not add
+            # unpublished crates to `[patch.crates-io]`: that would make a crate available to this
+            # test even though a customer's crates.io dependency graph could never resolve it.
+            # Patched runtime crates can still use unpublished helpers through local path
+            # dependencies.
+            if package.get("publish") == []:
+                continue
+            crates.append(
+                RuntimeCrate(
+                    name=package["name"],
+                    path=Path(package["manifest_path"]).resolve().parent,
+                )
+            )
+        crates.sort(key=lambda crate: crate.name)
+        if not crates:
+            raise RuntimeError(
+                "no publishable runtime crates found under {}".format(self.runtime_root)
+            )
+        return crates
+
+    def _copy_workspaces(self, source: Workspaces, destination_root: Path) -> Workspaces:
+        """Copy source workspaces to an isolated verification directory.
+        Keep Cargo patches, lockfiles, and build outputs out of generated SDKs.
+        """
+        copies = {}
+        for label, workspace in source.items():
+            destination = destination_root / label
+            copy_tree(workspace, destination)
+            copies[label] = destination
+        return Workspaces(client=copies["client"], server=copies["server"])
+
+    def _assert_registry_runtime_dependencies(self, workspace: Path) -> None:
+        """Ensure generated SDK manifests retained released registry requirements.
+        Reject local runtime paths because they bypass Cargo semver selection.
+        """
+        local_runtime_paths = []
+        for manifest in workspace.rglob("Cargo.toml"):
+            if manifest == workspace / "Cargo.toml":
+                continue
+            for line in manifest.read_text().splitlines():
+                if re.match(
+                    r'^\s*path\s*=\s*".*(?:rust-runtime|aws/rust-runtime)', line
+                ):
+                    local_runtime_paths.append(
+                        "{}: {}".format(manifest, line.strip())
+                    )
+        if local_runtime_paths:
+            raise RuntimeError(
+                "generated SDK retained local runtime dependencies:\n{}".format(
+                    "\n".join(local_runtime_paths)
+                )
+            )
+
+    def _append_runtime_patches(
+        self, workspace: Path, runtime_crates: Sequence[RuntimeCrate]
+    ) -> None:
+        """Offer current runtime path crates through the crates.io patch table.
+        Remove lockfiles so Cargo resolves them against generated SDK requirements.
+        """
+        manifest = workspace / "Cargo.toml"
+        contents = manifest.read_text()
+        if re.search(r"(?m)^\[patch\.crates-io\]\s*$", contents):
+            raise RuntimeError(
+                "{} already has a [patch.crates-io] section".format(manifest)
+            )
+
+        patch_lines = ["", "# Candidate runtime release under test.", "[patch.crates-io]"]
+        for crate in runtime_crates:
+            # Cargo reads the version from this path and selects it only when it satisfies the
+            # requirement preserved in the generated SDK. An incompatible major remains unused.
+            # JSON string escaping is also valid for a TOML basic string.
+            patch_lines.append(
+                "{} = {{ path = {} }}".format(crate.name, json.dumps(str(crate.path)))
+            )
+        manifest.write_text(contents.rstrip() + "\n" + "\n".join(patch_lines) + "\n")
+
+        for lockfile in workspace.rglob("Cargo.lock"):
+            lockfile.unlink()
+
+    def _check_workspace(self, label: str, workspace: Path) -> None:
+        """Compile every target and feature in one patched compatibility workspace.
+        Print duplicate dependency versions and raise a labeled error on failure.
+        """
+        cargo_env = dict(os.environ)
+        # Old generated code may legitimately use APIs that are now deprecated.
+        cargo_env.pop("RUSTFLAGS", None)
+        result = run(
+            [
+                "cargo",
+                "check",
+                "--workspace",
+                "--all-features",
+                "--all-targets",
+                "--quiet",
+            ],
+            workspace,
+            check=False,
+            env=cargo_env,
+        )
+        if result.returncode != 0:
+            eprint(
+                "{} compatibility check failed; duplicate versions follow:".format(
+                    label
+                )
+            )
+            run(
+                ["cargo", "tree", "--duplicates"],
+                workspace,
+                check=False,
+                env=cargo_env,
+            )
+            raise RuntimeError(
+                "{} SDK does not compile with semver-eligible runtime crates from HEAD".format(
+                    label
+                )
+            )

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/codegen.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/codegen.py
@@ -12,15 +12,18 @@ from .paths import copy_file, copy_tree, exists, gradle_wrapper
 
 PROJECT_NAME = "published-codegen-compatibility"
 SMITHY_GRADLE_PLUGIN_VERSION = "1.3.0"
-COMMON_MODEL_FILES = ("pokemon.smithy", "pokemon-common.smithy")
 PROTOCOL_MODEL_FILE = "protocols.smithy"
-MODEL_FILES = COMMON_MODEL_FILES + (PROTOCOL_MODEL_FILE,)
+MODEL_FILES = (PROTOCOL_MODEL_FILE,)
 
 Protocol = Tuple[str, str, bool]
 
 # Protocol name, service shape, and whether server codegen supports it.
 COMPATIBILITY_PROTOCOLS: Tuple[Protocol, ...] = (
-    ("rest-json-1", "com.aws.example#PokemonService", True),
+    (
+        "rest-json-1",
+        "smithy.rust.codegen.compatibility#RestJsonService",
+        True,
+    ),
     ("rest-xml", "smithy.rust.codegen.compatibility#RestXmlService", True),
     ("aws-json-1-0", "smithy.rust.codegen.compatibility#AwsJson10Service", True),
     ("aws-json-1-1", "smithy.rust.codegen.compatibility#AwsJson11Service", True),
@@ -220,9 +223,6 @@ class ProtocolSdkGenerator:
         """Write an isolated Smithy project using exact published artifacts."""
         model_root = project_root / "model"
         model_root.mkdir(parents=True)
-        for name in COMMON_MODEL_FILES:
-            source = self.repository_root / "codegen-core/common-test-models" / name
-            copy_file(source, model_root / name)
         copy_file(
             Path(__file__).resolve().with_name(PROTOCOL_MODEL_FILE),
             model_root / PROTOCOL_MODEL_FILE,

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/codegen.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/codegen.py
@@ -16,8 +16,10 @@ COMMON_MODEL_FILES = ("pokemon.smithy", "pokemon-common.smithy")
 PROTOCOL_MODEL_FILE = "protocols.smithy"
 MODEL_FILES = COMMON_MODEL_FILES + (PROTOCOL_MODEL_FILE,)
 
+Protocol = Tuple[str, str, bool]
+
 # Protocol name, service shape, and whether server codegen supports it.
-PROTOCOLS: Tuple[Tuple[str, str, bool], ...] = (
+COMPATIBILITY_PROTOCOLS: Tuple[Protocol, ...] = (
     ("rest-json-1", "com.aws.example#PokemonService", True),
     ("rest-xml", "smithy.rust.codegen.compatibility#RestXmlService", True),
     ("aws-json-1-0", "smithy.rust.codegen.compatibility#AwsJson10Service", True),
@@ -26,24 +28,58 @@ PROTOCOLS: Tuple[Tuple[str, str, bool], ...] = (
     ("ec2-query", "smithy.rust.codegen.compatibility#Ec2QueryService", False),
     ("rpc-v2-cbor", "smithy.rust.codegen.compatibility#RpcV2CborService", True),
 )
-CLIENT_MODULES = tuple(
-    "protocol-{}-client".format(protocol) for protocol, _, _ in PROTOCOLS
-)
-SERVER_PROTOCOLS = tuple(
-    protocol for protocol, _, supported in PROTOCOLS if supported
-)
-SERVER_MODULES = tuple(
-    "protocol-{}-server".format(protocol) for protocol in SERVER_PROTOCOLS
-)
-LEGACY_SERVER_MODULES = tuple(
-    "protocol-{}-server-http0x".format(protocol) for protocol in SERVER_PROTOCOLS
-)
+
+
+def _client_modules(protocols: Sequence[Protocol]) -> Tuple[str, ...]:
+    return tuple(
+        "protocol-{}-client".format(protocol) for protocol, _, _ in protocols
+    )
+
+
+def _server_modules(protocols: Sequence[Protocol]) -> Tuple[str, ...]:
+    return tuple(
+        "protocol-{}-server".format(protocol)
+        for protocol, _, supported in protocols
+        if supported
+    )
+
+
+def _legacy_server_modules(protocols: Sequence[Protocol]) -> Tuple[str, ...]:
+    return tuple(
+        "protocol-{}-server-http0x".format(protocol)
+        for protocol, _, supported in protocols
+        if supported
+    )
+
+
+CLIENT_MODULES = _client_modules(COMPATIBILITY_PROTOCOLS)
+SERVER_MODULES = _server_modules(COMPATIBILITY_PROTOCOLS)
+LEGACY_SERVER_MODULES = _legacy_server_modules(COMPATIBILITY_PROTOCOLS)
+
+
+def generate_protocol_sdks(
+    published_codegen: PublishedCodegen,
+    protocols: Sequence[Protocol],
+    repository_root: Path,
+    destination: Path,
+) -> Workspaces:
+    """Generate client and supported server SDKs for the compatibility protocols.
+
+    All projections are generated in one Gradle invocation, then copied into
+    separate minimal client and server Cargo workspaces.
+    """
+    eprint(
+        "generating protocol SDKs with published codegen {}".format(
+            published_codegen.version
+        )
+    )
+    return ProtocolSdkGenerator(repository_root).generate(
+        published_codegen, protocols, destination
+    )
 
 
 def write_generated_workspace(workspace: Path, projection_names: Sequence[str]) -> None:
-    """Create a minimal Cargo workspace around generated compatibility crates.
-    Include only named projections so Smithy and Gradle metadata stay out of SDKs.
-    """
+    """Create a minimal Cargo workspace around generated compatibility crates."""
     workspace.mkdir(parents=True, exist_ok=True)
     members = ['    "{}"'.format(projection) for projection in projection_names]
     (workspace / "Cargo.toml").write_text(
@@ -53,13 +89,13 @@ def write_generated_workspace(workspace: Path, projection_names: Sequence[str]) 
     )
 
 
-def smithy_build_config() -> Dict[str, object]:
-    """Build one client projection per supported protocol and server variants where supported.
-    Keep generated runtime dependencies untouched so Cargo can enforce semver.
-    """
+def smithy_build_config(
+    protocols: Sequence[Protocol] = COMPATIBILITY_PROTOCOLS,
+) -> Dict[str, object]:
+    """Build client projections and supported server variants for each protocol."""
     imports = ["model/{}".format(name) for name in MODEL_FILES]
     projections: Dict[str, object] = {}
-    for protocol, service, supports_server in PROTOCOLS:
+    for protocol, service, supports_server in protocols:
         common = {
             "service": service,
             "moduleVersion": "0.0.1",
@@ -88,9 +124,7 @@ def smithy_build_config() -> Dict[str, object]:
             continue
         server_module = "protocol-{}-server".format(protocol)
         server = dict(common)
-        server.update(
-            {"module": server_module, "codegen": {"http-1x": True}}
-        )
+        server.update({"module": server_module, "codegen": {"http-1x": True}})
         projections[server_module] = {
             "imports": imports,
             "plugins": {"rust-server-codegen": server},
@@ -98,9 +132,7 @@ def smithy_build_config() -> Dict[str, object]:
 
         legacy_module = "protocol-{}-server-http0x".format(protocol)
         legacy = dict(common)
-        legacy.update(
-            {"module": legacy_module, "codegen": {"http-1x": False}}
-        )
+        legacy.update({"module": legacy_module, "codegen": {"http-1x": False}})
         projections[legacy_module] = {
             "imports": imports,
             "plugins": {"rust-server-codegen": legacy},
@@ -110,9 +142,7 @@ def smithy_build_config() -> Dict[str, object]:
 
 
 def gradle_build(codegen: PublishedCodegen) -> str:
-    """Render an isolated Gradle build using exact published artifact versions.
-    Load no codegen projects from the current checkout or a historical worktree.
-    """
+    """Render an isolated Gradle build using exact published artifact versions."""
     return """plugins {{
     java
     id(\"software.amazon.smithy.gradle.smithy-base\") version \"{plugin}\"
@@ -135,24 +165,20 @@ smithy {{
 
 
 class ProtocolSdkGenerator:
-    """Generate protocol compatibility SDKs with published codegen JARs.
-    Use only the current checkout's Gradle wrapper and stable local Smithy models.
-    """
+    """Generate protocol compatibility SDKs with published codegen JARs."""
 
     def __init__(self, repository_root: Path) -> None:
-        """Store the current checkout containing Gradle and compatibility models.
-        Do not create or resolve any additional Git checkout from this location.
-        """
         self.repository_root = repository_root
 
     def generate(
-        self, codegen: PublishedCodegen, temporary_root: Path
+        self,
+        codegen: PublishedCodegen,
+        protocols: Sequence[Protocol],
+        destination: Path,
     ) -> Workspaces:
-        """Generate client and server workspaces from one published JAR release.
-        Return compact Cargo workspaces containing only generated Rust crates.
-        """
-        project_root = temporary_root / PROJECT_NAME
-        self.write_gradle_and_smithy_build(project_root, codegen)
+        """Generate compact client and server Cargo workspaces in one Gradle build."""
+        project_root = destination / PROJECT_NAME
+        self.write_gradle_and_smithy_build(project_root, codegen, protocols)
         run(
             [
                 gradle_wrapper(self.repository_root),
@@ -165,34 +191,33 @@ class ProtocolSdkGenerator:
             self.repository_root,
         )
 
-        output_root = (
-            project_root
-            / "build"
-            / "smithyprojections"
-            / PROJECT_NAME
-        )
-        generated_client = temporary_root / "generated-client"
-        generated_server = temporary_root / "generated-server"
-        for module in CLIENT_MODULES:
+        output_root = project_root / "build" / "smithyprojections" / PROJECT_NAME
+        generated_client = destination / "generated-client"
+        generated_server = destination / "generated-server"
+        client_modules = _client_modules(protocols)
+        server_modules = _server_modules(protocols)
+        legacy_server_modules = _legacy_server_modules(protocols)
+        for module in client_modules:
             self._copy_crate(
                 output_root, module, "rust-client-codegen", generated_client
             )
-        for module in SERVER_MODULES + LEGACY_SERVER_MODULES:
+        for module in server_modules + legacy_server_modules:
             self._copy_crate(
                 output_root, module, "rust-server-codegen", generated_server
             )
-        write_generated_workspace(generated_client, CLIENT_MODULES)
+        write_generated_workspace(generated_client, client_modules)
         write_generated_workspace(
-            generated_server, SERVER_MODULES + LEGACY_SERVER_MODULES
+            generated_server, server_modules + legacy_server_modules
         )
         return Workspaces(client=generated_client, server=generated_server)
 
     def write_gradle_and_smithy_build(
-        self, project_root: Path, codegen: PublishedCodegen
+        self,
+        project_root: Path,
+        codegen: PublishedCodegen,
+        protocols: Sequence[Protocol],
     ) -> None:
-        """Write an isolated Smithy Gradle project and copy its local model inputs.
-        Reference exact Maven artifacts rather than current codegen project outputs.
-        """
+        """Write an isolated Smithy project using exact published artifacts."""
         model_root = project_root / "model"
         model_root.mkdir(parents=True)
         for name in COMMON_MODEL_FILES:
@@ -218,7 +243,7 @@ rootProject.name = \"published-codegen-compatibility\"
         )
         (project_root / "build.gradle.kts").write_text(gradle_build(codegen))
         (project_root / "smithy-build.json").write_text(
-            json.dumps(smithy_build_config(), indent=4) + "\n"
+            json.dumps(smithy_build_config(protocols), indent=4) + "\n"
         )
         eprint(
             "prepared published codegen {} with Smithy {}".format(
@@ -233,9 +258,7 @@ rootProject.name = \"published-codegen-compatibility\"
         plugin: str,
         destination_root: Path,
     ) -> None:
-        """Copy one generated Rust crate out of Smithy's projection directory.
-        Fail clearly when published plugins do not produce the expected output.
-        """
+        """Copy one generated Rust crate and fail if codegen produced no manifest."""
         source = output_root / projection / plugin
         if not exists(source / "Cargo.toml"):
             raise RuntimeError("code generation did not create {}".format(source))

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/codegen.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/codegen.py
@@ -1,0 +1,243 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from typing import Dict, Sequence, Tuple
+
+from .commands import eprint, run
+from .models import PublishedCodegen, Workspaces
+from .paths import copy_file, copy_tree, exists, gradle_wrapper
+
+
+PROJECT_NAME = "published-codegen-compatibility"
+SMITHY_GRADLE_PLUGIN_VERSION = "1.3.0"
+COMMON_MODEL_FILES = ("pokemon.smithy", "pokemon-common.smithy")
+PROTOCOL_MODEL_FILE = "protocols.smithy"
+MODEL_FILES = COMMON_MODEL_FILES + (PROTOCOL_MODEL_FILE,)
+
+# Protocol name, service shape, and whether server codegen supports it.
+PROTOCOLS: Tuple[Tuple[str, str, bool], ...] = (
+    ("rest-json-1", "com.aws.example#PokemonService", True),
+    ("rest-xml", "smithy.rust.codegen.compatibility#RestXmlService", True),
+    ("aws-json-1-0", "smithy.rust.codegen.compatibility#AwsJson10Service", True),
+    ("aws-json-1-1", "smithy.rust.codegen.compatibility#AwsJson11Service", True),
+    ("aws-query", "smithy.rust.codegen.compatibility#AwsQueryService", False),
+    ("ec2-query", "smithy.rust.codegen.compatibility#Ec2QueryService", False),
+    ("rpc-v2-cbor", "smithy.rust.codegen.compatibility#RpcV2CborService", True),
+)
+CLIENT_MODULES = tuple(
+    "protocol-{}-client".format(protocol) for protocol, _, _ in PROTOCOLS
+)
+SERVER_PROTOCOLS = tuple(
+    protocol for protocol, _, supported in PROTOCOLS if supported
+)
+SERVER_MODULES = tuple(
+    "protocol-{}-server".format(protocol) for protocol in SERVER_PROTOCOLS
+)
+LEGACY_SERVER_MODULES = tuple(
+    "protocol-{}-server-http0x".format(protocol) for protocol in SERVER_PROTOCOLS
+)
+
+
+def write_generated_workspace(workspace: Path, projection_names: Sequence[str]) -> None:
+    """Create a minimal Cargo workspace around generated compatibility crates.
+    Include only named projections so Smithy and Gradle metadata stay out of SDKs.
+    """
+    workspace.mkdir(parents=True, exist_ok=True)
+    members = ['    "{}"'.format(projection) for projection in projection_names]
+    (workspace / "Cargo.toml").write_text(
+        '[workspace]\nresolver = "2"\nmembers = [\n{}\n]\n'.format(
+            ",\n".join(members)
+        )
+    )
+
+
+def smithy_build_config() -> Dict[str, object]:
+    """Build one client projection per supported protocol and server variants where supported.
+    Keep generated runtime dependencies untouched so Cargo can enforce semver.
+    """
+    imports = ["model/{}".format(name) for name in MODEL_FILES]
+    projections: Dict[str, object] = {}
+    for protocol, service, supports_server in PROTOCOLS:
+        common = {
+            "service": service,
+            "moduleVersion": "0.0.1",
+            "moduleDescription": "released codegen runtime compatibility test",
+            "moduleAuthors": ["protocoltest@example.com"],
+        }
+
+        client_module = "protocol-{}-client".format(protocol)
+        client = dict(common)
+        client.update(
+            {
+                "module": client_module,
+                "codegen": {
+                    "addMessageToErrors": True,
+                    "renameErrors": True,
+                    "enableNewSmithyRuntime": "orchestrator",
+                },
+            }
+        )
+        projections[client_module] = {
+            "imports": imports,
+            "plugins": {"rust-client-codegen": client},
+        }
+
+        if not supports_server:
+            continue
+        server_module = "protocol-{}-server".format(protocol)
+        server = dict(common)
+        server.update(
+            {"module": server_module, "codegen": {"http-1x": True}}
+        )
+        projections[server_module] = {
+            "imports": imports,
+            "plugins": {"rust-server-codegen": server},
+        }
+
+        legacy_module = "protocol-{}-server-http0x".format(protocol)
+        legacy = dict(common)
+        legacy.update(
+            {"module": legacy_module, "codegen": {"http-1x": False}}
+        )
+        projections[legacy_module] = {
+            "imports": imports,
+            "plugins": {"rust-server-codegen": legacy},
+        }
+
+    return {"version": "1.0", "projections": projections}
+
+
+def gradle_build(codegen: PublishedCodegen) -> str:
+    """Render an isolated Gradle build using exact published artifact versions.
+    Load no codegen projects from the current checkout or a historical worktree.
+    """
+    return """plugins {{
+    java
+    id(\"software.amazon.smithy.gradle.smithy-base\") version \"{plugin}\"
+}}
+
+dependencies {{
+    implementation(\"software.amazon.smithy.rust:codegen-client:{codegen}\")
+    implementation(\"software.amazon.smithy.rust:codegen-server:{codegen}\")
+    implementation(\"software.amazon.smithy:smithy-validation-model:{smithy}\")
+}}
+
+smithy {{
+    format.set(false)
+}}
+""".format(
+        plugin=SMITHY_GRADLE_PLUGIN_VERSION,
+        codegen=codegen.version,
+        smithy=codegen.smithy_version,
+    )
+
+
+class ProtocolSdkGenerator:
+    """Generate protocol compatibility SDKs with published codegen JARs.
+    Use only the current checkout's Gradle wrapper and stable local Smithy models.
+    """
+
+    def __init__(self, repository_root: Path) -> None:
+        """Store the current checkout containing Gradle and compatibility models.
+        Do not create or resolve any additional Git checkout from this location.
+        """
+        self.repository_root = repository_root
+
+    def generate(
+        self, codegen: PublishedCodegen, temporary_root: Path
+    ) -> Workspaces:
+        """Generate client and server workspaces from one published JAR release.
+        Return compact Cargo workspaces containing only generated Rust crates.
+        """
+        project_root = temporary_root / PROJECT_NAME
+        self.write_gradle_and_smithy_build(project_root, codegen)
+        run(
+            [
+                gradle_wrapper(self.repository_root),
+                "-p",
+                project_root,
+                "smithyBuild",
+                "--no-daemon",
+                "--quiet",
+            ],
+            self.repository_root,
+        )
+
+        output_root = (
+            project_root
+            / "build"
+            / "smithyprojections"
+            / PROJECT_NAME
+        )
+        generated_client = temporary_root / "generated-client"
+        generated_server = temporary_root / "generated-server"
+        for module in CLIENT_MODULES:
+            self._copy_crate(
+                output_root, module, "rust-client-codegen", generated_client
+            )
+        for module in SERVER_MODULES + LEGACY_SERVER_MODULES:
+            self._copy_crate(
+                output_root, module, "rust-server-codegen", generated_server
+            )
+        write_generated_workspace(generated_client, CLIENT_MODULES)
+        write_generated_workspace(
+            generated_server, SERVER_MODULES + LEGACY_SERVER_MODULES
+        )
+        return Workspaces(client=generated_client, server=generated_server)
+
+    def write_gradle_and_smithy_build(
+        self, project_root: Path, codegen: PublishedCodegen
+    ) -> None:
+        """Write an isolated Smithy Gradle project and copy its local model inputs.
+        Reference exact Maven artifacts rather than current codegen project outputs.
+        """
+        model_root = project_root / "model"
+        model_root.mkdir(parents=True)
+        for name in COMMON_MODEL_FILES:
+            source = self.repository_root / "codegen-core/common-test-models" / name
+            copy_file(source, model_root / name)
+        copy_file(
+            Path(__file__).resolve().with_name(PROTOCOL_MODEL_FILE),
+            model_root / PROTOCOL_MODEL_FILE,
+        )
+
+        (project_root / "settings.gradle.kts").write_text(
+            """pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositories { mavenCentral() }
+}
+rootProject.name = \"published-codegen-compatibility\"
+"""
+        )
+        (project_root / "build.gradle.kts").write_text(gradle_build(codegen))
+        (project_root / "smithy-build.json").write_text(
+            json.dumps(smithy_build_config(), indent=4) + "\n"
+        )
+        eprint(
+            "prepared published codegen {} with Smithy {}".format(
+                codegen.version, codegen.smithy_version
+            )
+        )
+
+    @staticmethod
+    def _copy_crate(
+        output_root: Path,
+        projection: str,
+        plugin: str,
+        destination_root: Path,
+    ) -> None:
+        """Copy one generated Rust crate out of Smithy's projection directory.
+        Fail clearly when published plugins do not produce the expected output.
+        """
+        source = output_root / projection / plugin
+        if not exists(source / "Cargo.toml"):
+            raise RuntimeError("code generation did not create {}".format(source))
+        destination_root.mkdir(parents=True, exist_ok=True)
+        copy_tree(source, destination_root / projection)

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/commands.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/commands.py
@@ -1,0 +1,119 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Dict, Optional, Sequence, Tuple
+
+
+LOGGER = logging.getLogger("released-codegen-runtime-compatibility")
+
+
+def configure_logging() -> None:
+    """Configure timestamped logs for local and GitHub Actions execution.
+    Allow CODEGEN_RUNTIME_LOG_LEVEL to enable DEBUG diagnostics when needed.
+    """
+    level_name = os.environ.get("CODEGEN_RUNTIME_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+
+def eprint(*args: object) -> None:
+    """Write an informational diagnostic through the configured logger.
+    Retain this small helper so call sites stay concise and consistently formatted.
+    """
+    LOGGER.info(" ".join(str(argument) for argument in args))
+
+
+def github_error(message: str) -> None:
+    """Emit a GitHub Actions error annotation for the final failure reason.
+    Escape workflow-command control characters while retaining full logs above it.
+    """
+    escaped = (
+        message.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+    print(
+        "::error title=Codegen runtime compatibility failed::{}".format(escaped),
+        file=sys.stderr,
+    )
+
+
+def run(
+    command: Sequence[object],
+    cwd: Path,
+    check: bool = True,
+    env: Optional[Dict[str, str]] = None,
+) -> subprocess.CompletedProcess:
+    """Run a streaming command and log its directory, duration, and exit status.
+    Raise after logging when the caller requires a successful command result.
+    """
+    rendered = [str(part) for part in command]
+    display = " ".join(rendered)
+    LOGGER.info("starting `%s` in `%s`", display, cwd)
+    started = time.monotonic()
+    result = subprocess.run(
+        rendered,
+        cwd=str(cwd),
+        check=False,
+        env=env,
+    )
+    duration = time.monotonic() - started
+    if result.returncode == 0:
+        LOGGER.info("finished `%s` in %.1fs", display, duration)
+    else:
+        LOGGER.error(
+            "command `%s` failed with exit code %s after %.1fs",
+            display,
+            result.returncode,
+            duration,
+        )
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, rendered)
+    return result
+
+
+def output(
+    command: Sequence[object], cwd: Path, check: bool = True
+) -> Tuple[int, str, str]:
+    """Run a captured command and log its directory, duration, and exit status.
+    Return decoded streams or raise with both streams when requested.
+    """
+    rendered = [str(part) for part in command]
+    display = " ".join(rendered)
+    LOGGER.debug("starting captured `%s` in `%s`", display, cwd)
+    started = time.monotonic()
+    result = subprocess.run(
+        rendered,
+        cwd=str(cwd),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    duration = time.monotonic() - started
+    if result.returncode == 0:
+        LOGGER.debug("finished captured `%s` in %.1fs", display, duration)
+    else:
+        LOGGER.error(
+            "captured command `%s` failed with exit code %s after %.1fs",
+            display,
+            result.returncode,
+            duration,
+        )
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            "failed to run `{}`:\n{}\n{}".format(
+                display, result.stdout, result.stderr
+            )
+        )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/maven.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/maven.py
@@ -92,3 +92,10 @@ class MavenCodegenResolver:
         """
         if not VERSION_PATTERN.match(version):
             raise RuntimeError("invalid Maven version: {!r}".format(version))
+
+
+def resolve_published_codegen(
+    requested_version: Optional[str] = None,
+) -> PublishedCodegen:
+    """Resolve a requested codegen release, or Maven Central's latest release."""
+    return MavenCodegenResolver().resolve(requested_version)

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/maven.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/maven.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from typing import Optional
+from urllib.error import URLError
+from urllib.parse import quote
+from urllib.request import urlopen
+import xml.etree.ElementTree as ET
+
+from .models import PublishedCodegen
+
+
+MAVEN_CENTRAL = "https://repo1.maven.org/maven2"
+CODEGEN_GROUP_PATH = "software/amazon/smithy/rust"
+VERSION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
+
+
+class MavenCodegenResolver:
+    """Resolve smithy-rs codegen releases from their published Maven metadata.
+    Return exact versions so client, server, and Smithy model artifacts stay aligned.
+    """
+
+    def __init__(self, repository_url: str = MAVEN_CENTRAL) -> None:
+        """Store the Maven repository used for metadata and POM resolution.
+        Allow tests or mirrors to replace Maven Central without changing generation.
+        """
+        self.repository_url = repository_url.rstrip("/")
+
+    def resolve(self, requested_version: Optional[str] = None) -> PublishedCodegen:
+        """Resolve an exact codegen version and its Smithy dependency version.
+        Select Maven's latest release when the caller does not request a version.
+        """
+        version = requested_version or self._latest_version()
+        self._validate_version(version)
+        smithy_version = self._smithy_version(version)
+        self._validate_version(smithy_version)
+        return PublishedCodegen(version=version, smithy_version=smithy_version)
+
+    def _latest_version(self) -> str:
+        """Read the latest released codegen-client version from Maven metadata.
+        Reject incomplete metadata instead of allowing a dynamic Gradle dependency.
+        """
+        root = self._read_xml(
+            "{}/{}/codegen-client/maven-metadata.xml".format(
+                self.repository_url, CODEGEN_GROUP_PATH
+            )
+        )
+        release = root.findtext("./versioning/release")
+        if not release:
+            raise RuntimeError("Maven metadata does not contain a codegen release")
+        return release.strip()
+
+    def _smithy_version(self, codegen_version: str) -> str:
+        """Read the Smithy codegen-core version used by a published client JAR.
+        Use that exact version for model dependencies loaded during generation.
+        """
+        encoded = quote(codegen_version, safe="")
+        root = self._read_xml(
+            "{0}/{1}/codegen-client/{2}/codegen-client-{2}.pom".format(
+                self.repository_url, CODEGEN_GROUP_PATH, encoded
+            )
+        )
+        namespace = {"m": "http://maven.apache.org/POM/4.0.0"}
+        for dependency in root.findall("./m:dependencies/m:dependency", namespace):
+            group = dependency.findtext("m:groupId", namespaces=namespace)
+            artifact = dependency.findtext("m:artifactId", namespaces=namespace)
+            if group == "software.amazon.smithy" and artifact == "smithy-codegen-core":
+                version = dependency.findtext("m:version", namespaces=namespace)
+                if version:
+                    return version.strip()
+        raise RuntimeError(
+            "codegen-client {} POM does not declare smithy-codegen-core".format(
+                codegen_version
+            )
+        )
+
+    def _read_xml(self, url: str) -> ET.Element:
+        """Download and parse one Maven XML document with a bounded timeout.
+        Convert network and malformed-document failures into actionable errors.
+        """
+        try:
+            with urlopen(url, timeout=30) as response:
+                return ET.fromstring(response.read())
+        except (URLError, OSError, ET.ParseError) as error:
+            raise RuntimeError("failed to read Maven metadata from {}: {}".format(url, error))
+
+    @staticmethod
+    def _validate_version(version: str) -> None:
+        """Require a Maven version safe for URLs and generated Gradle source.
+        Reject empty or syntactically surprising values before writing build files.
+        """
+        if not VERSION_PATTERN.match(version):
+            raise RuntimeError("invalid Maven version: {!r}".format(version))

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/models.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/models.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class RuntimeCrate:
+    """Identify one current runtime crate offered to Cargo as a patch.
+    Store only its package name and local source directory.
+    """
+
+    name: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class PublishedCodegen:
+    """Identify one published smithy-rs codegen release from Maven Central.
+    Keep its Smithy dependency version aligned with the selected codegen JARs.
+    """
+
+    version: str
+    smithy_version: str
+
+
+@dataclass(frozen=True)
+class Workspaces:
+    """Group representative client and server Cargo workspaces.
+    Provide stable labels used in diagnostics and failure aggregation.
+    """
+
+    client: Path
+    server: Path
+
+    def items(self) -> Tuple[Tuple[str, Path], ...]:
+        """Return labeled workspace paths in a deterministic order.
+        Keep client and server diagnostics consistent across CI runs.
+        """
+        return (("client", self.client), ("server", self.server))

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/paths.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/paths.py
@@ -1,0 +1,88 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filesystem helpers that behave identically on POSIX and Windows.
+
+Windows rejects paths longer than 260 characters unless they are given in the
+extended-length form. Generated SDK trees nest deeply enough to cross that limit
+inside a temporary directory, which fails the copy and then fails the cleanup
+that follows it. Every bulk copy and delete in this package goes through these
+helpers so the compatibility check runs the same way on a developer's Windows
+machine as it does on CI.
+"""
+
+import contextlib
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Iterator, Union
+
+
+WINDOWS = os.name == "nt"
+EXTENDED_PREFIX = "\\\\?\\"
+UNC_EXTENDED_PREFIX = "\\\\?\\UNC\\"
+
+PathLike = Union[str, Path]
+
+
+def long_path(path: PathLike) -> str:
+    """Render one path in the form Windows accepts past its 260 character limit.
+    Return the ordinary absolute path elsewhere because no other system needs it.
+    """
+    absolute = str(Path(path).resolve())
+    if not WINDOWS or absolute.startswith(EXTENDED_PREFIX):
+        return absolute
+    if absolute.startswith("\\\\"):
+        # A UNC share becomes \\?\UNC\server\share rather than keeping both leading slashes.
+        return UNC_EXTENDED_PREFIX + absolute[2:]
+    return EXTENDED_PREFIX + absolute
+
+
+def exists(path: PathLike) -> bool:
+    """Report whether one path exists even when it is too long for Windows.
+    Use the extended-length form so deep generated trees stay observable.
+    """
+    return os.path.exists(long_path(path))
+
+
+def copy_file(source: PathLike, destination: PathLike) -> None:
+    """Copy one file, preserving metadata, without tripping the Windows limit.
+    Keep the same call shape as `shutil.copy2` for readability at the call sites.
+    """
+    shutil.copy2(long_path(source), long_path(destination))
+
+
+def copy_tree(source: PathLike, destination: PathLike) -> None:
+    """Copy one directory tree without tripping the Windows path length limit.
+    Require the destination to be absent, matching `shutil.copytree` semantics.
+    """
+    shutil.copytree(long_path(source), long_path(destination))
+
+
+def remove_tree(path: PathLike) -> None:
+    """Delete one directory tree that may contain paths Windows cannot address.
+    Ignore an absent tree so callers can clean up unconditionally.
+    """
+    if exists(path):
+        shutil.rmtree(long_path(path))
+
+
+@contextlib.contextmanager
+def temporary_directory(prefix: str) -> Iterator[Path]:
+    """Provide a work directory that is removed even when it holds long paths.
+    Avoid `tempfile.TemporaryDirectory` because its cleanup cannot delete them.
+    """
+    directory = Path(tempfile.mkdtemp(prefix=prefix))
+    try:
+        yield directory
+    finally:
+        remove_tree(directory)
+
+
+def gradle_wrapper(repository_root: PathLike) -> Path:
+    """Select the Gradle wrapper this platform can actually execute.
+    Windows needs the batch wrapper because the extensionless script is a shell script.
+    """
+    name = "gradlew.bat" if WINDOWS else "gradlew"
+    return Path(repository_root) / name

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/protocols.smithy
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/protocols.smithy
@@ -6,8 +6,15 @@ use aws.protocols#awsJson1_0
 use aws.protocols#awsJson1_1
 use aws.protocols#awsQuery
 use aws.protocols#ec2Query
+use aws.protocols#restJson1
 use aws.protocols#restXml
 use smithy.protocols#rpcv2Cbor
+
+@restJson1
+service RestJsonService {
+    version: "2024-01-01"
+    operations: [RestOperation]
+}
 
 @restXml
 service RestXmlService {

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/protocols.smithy
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/protocols.smithy
@@ -1,0 +1,74 @@
+$version: "2"
+
+namespace smithy.rust.codegen.compatibility
+
+use aws.protocols#awsJson1_0
+use aws.protocols#awsJson1_1
+use aws.protocols#awsQuery
+use aws.protocols#ec2Query
+use aws.protocols#restXml
+use smithy.protocols#rpcv2Cbor
+
+@restXml
+service RestXmlService {
+    version: "2024-01-01"
+    operations: [RestOperation]
+}
+
+@awsJson1_0
+service AwsJson10Service {
+    version: "2024-01-01"
+    operations: [RpcOperation]
+}
+
+@awsJson1_1
+service AwsJson11Service {
+    version: "2024-01-01"
+    operations: [RpcOperation]
+}
+
+@xmlNamespace(uri: "https://example.com/aws-query")
+@awsQuery
+service AwsQueryService {
+    version: "2024-01-01"
+    operations: [RpcOperation]
+}
+
+@xmlNamespace(uri: "https://example.com/ec2-query")
+@ec2Query
+service Ec2QueryService {
+    version: "2024-01-01"
+    operations: [RpcOperation]
+}
+
+@rpcv2Cbor
+service RpcV2CborService {
+    version: "2024-01-01"
+    operations: [RpcOperation]
+}
+
+@http(uri: "/compatibility", method: "POST")
+operation RestOperation {
+    input := {
+        value: String
+    }
+    output := {
+        value: String
+    }
+    errors: [CompatibilityError]
+}
+
+operation RpcOperation {
+    input := {
+        value: String
+    }
+    output := {
+        value: String
+    }
+    errors: [CompatibilityError]
+}
+
+@error("client")
+structure CompatibilityError {
+    message: String
+}

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/README.md
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/README.md
@@ -1,0 +1,22 @@
+# Released codegen/runtime compatibility tests
+
+These are lightweight unit tests for the released-codegen compatibility tooling. They use mocks and temporary files; they do not generate or compile client or server SDKs.
+
+Run the suite from the repository root:
+
+```bash
+PYTHONPATH=tools/ci-scripts \
+python3 -m unittest discover \
+  -s tools/ci-scripts/released_codegen_runtime_compatibility/tests \
+  -v
+```
+
+`PYTHONPATH=tools/ci-scripts` is required so Python can import the `released_codegen_runtime_compatibility` package.
+
+To run the end-to-end check that generates protocol SDKs with published codegen and compiles them with current runtime crates, run:
+
+```bash
+./tools/ci-scripts/released-codegen-runtime-compatibility.py
+```
+
+Use `--codegen-version VERSION` to select an exact published codegen release instead of the latest release from Maven Central.

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/__init__.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cargo.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cargo.py
@@ -1,0 +1,106 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from released_codegen_runtime_compatibility.cargo import CargoVerifier
+from released_codegen_runtime_compatibility.models import RuntimeCrate
+
+
+def runtime_path(*parts: str) -> Path:
+    """Build one absolute runtime crate path for whichever platform runs the tests.
+    Resolve it the same way discovery does so comparisons hold on Windows too.
+    """
+    return Path("/repo/rust-runtime").joinpath(*parts).resolve()
+
+
+def toml_basic_string(value: str) -> str:
+    """Escape one value the way a TOML basic string requires.
+    Re-derive the expected rendering rather than reusing the code under test.
+    """
+    return '"{}"'.format(value.replace("\\", "\\\\").replace('"', '\\"'))
+
+
+class CargoVerifierTest(unittest.TestCase):
+    def test_runtime_discovery_uses_cargo_metadata(self) -> None:
+        """Verify Cargo metadata drives current runtime patch discovery.
+        Ensure unpublished and non-AWS workspace packages are excluded.
+        """
+        runtime_root = Path("/repo/rust-runtime")
+        metadata = {
+            "packages": [
+                {
+                    "name": "aws-one",
+                    "publish": None,
+                    "manifest_path": "/repo/rust-runtime/aws-one/Cargo.toml",
+                },
+                {
+                    "name": "aws-two",
+                    "publish": [],
+                    "manifest_path": "/repo/rust-runtime/aws-two/Cargo.toml",
+                },
+                {
+                    "name": "not-aws",
+                    "publish": None,
+                    "manifest_path": "/repo/rust-runtime/not-aws/Cargo.toml",
+                },
+            ]
+        }
+        with mock.patch(
+            "released_codegen_runtime_compatibility.cargo.output",
+            return_value=(0, json.dumps(metadata), ""),
+        ) as output_mock:
+            crates = CargoVerifier(runtime_root)._discover_runtime_crates()
+
+        self.assertEqual(
+            [RuntimeCrate(name="aws-one", path=runtime_path("aws-one"))],
+            crates,
+        )
+        output_mock.assert_called_once_with(
+            [
+                "cargo",
+                "metadata",
+                "--no-deps",
+                "--format-version",
+                "1",
+                "--manifest-path",
+                runtime_root / "Cargo.toml",
+            ],
+            runtime_root,
+        )
+
+    def test_append_runtime_patches(self) -> None:
+        """Verify current runtime paths are rendered into a crates.io patch table.
+        Ensure existing lockfiles are removed before compatibility resolution.
+        """
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            (workspace / "Cargo.toml").write_text("[workspace]\nmembers = []\n")
+            (workspace / "Cargo.lock").write_text("old lock")
+            crate_path = Path(temp) / 'path with "quotes"'
+            CargoVerifier(Path("/runtime"))._append_runtime_patches(
+                workspace,
+                [
+                    RuntimeCrate(
+                        name="aws-smithy-example",
+                        path=crate_path,
+                    )
+                ],
+            )
+            contents = (workspace / "Cargo.toml").read_text()
+            self.assertIn("[patch.crates-io]", contents)
+            self.assertIn(
+                "aws-smithy-example = {{ path = {} }}".format(
+                    toml_basic_string(str(crate_path))
+                ),
+                contents,
+            )
+            self.assertFalse((workspace / "Cargo.lock").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cargo.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cargo.py
@@ -7,7 +7,10 @@ import tempfile
 import unittest
 from unittest import mock
 
-from released_codegen_runtime_compatibility.cargo import CargoVerifier
+from released_codegen_runtime_compatibility.cargo import (
+    _append_runtime_patches,
+    _discover_runtime_crates,
+)
 from released_codegen_runtime_compatibility.models import RuntimeCrate
 
 
@@ -25,7 +28,7 @@ def toml_basic_string(value: str) -> str:
     return '"{}"'.format(value.replace("\\", "\\\\").replace('"', '\\"'))
 
 
-class CargoVerifierTest(unittest.TestCase):
+class CargoPatchingTest(unittest.TestCase):
     def test_runtime_discovery_uses_cargo_metadata(self) -> None:
         """Verify Cargo metadata drives current runtime patch discovery.
         Ensure unpublished and non-AWS workspace packages are excluded.
@@ -54,7 +57,7 @@ class CargoVerifierTest(unittest.TestCase):
             "released_codegen_runtime_compatibility.cargo.output",
             return_value=(0, json.dumps(metadata), ""),
         ) as output_mock:
-            crates = CargoVerifier(runtime_root)._discover_runtime_crates()
+            crates = _discover_runtime_crates(runtime_root)
 
         self.assertEqual(
             [RuntimeCrate(name="aws-one", path=runtime_path("aws-one"))],
@@ -82,7 +85,7 @@ class CargoVerifierTest(unittest.TestCase):
             (workspace / "Cargo.toml").write_text("[workspace]\nmembers = []\n")
             (workspace / "Cargo.lock").write_text("old lock")
             crate_path = Path(temp) / 'path with "quotes"'
-            CargoVerifier(Path("/runtime"))._append_runtime_patches(
+            _append_runtime_patches(
                 workspace,
                 [
                     RuntimeCrate(

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cli.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cli.py
@@ -8,6 +8,7 @@ import unittest
 from unittest import mock
 
 from released_codegen_runtime_compatibility.models import PublishedCodegen
+from released_codegen_runtime_compatibility import verify_compatibility
 
 
 ENTRYPOINT_PATH = (
@@ -23,50 +24,90 @@ ENTRYPOINT_SPEC.loader.exec_module(entrypoint)
 
 
 class CliTest(unittest.TestCase):
-    def test_verify_semver_command(self) -> None:
+    def test_arguments_default_to_latest_codegen(self) -> None:
         """Default to latest codegen while accepting an exact published version."""
-        args = entrypoint.parse_args(["verify-semver"])
-        self.assertIs(entrypoint.verify_semver, args.handler)
+        args = entrypoint.parse_args([])
         self.assertIsNone(args.codegen_version)
 
-        historical = entrypoint.parse_args(
-            ["verify-semver", "--codegen-version", "0.1.20"]
-        )
+        historical = entrypoint.parse_args(["--codegen-version", "0.1.20"])
         self.assertEqual("0.1.20", historical.codegen_version)
 
+    def test_main_directly_calls_compatibility_verifier(self) -> None:
+        """Make the entrypoint's relationship to its verification workflow explicit."""
+        with tempfile.TemporaryDirectory() as repository, mock.patch.object(
+            entrypoint, "verify_released_codegen_runtime_compatibility"
+        ) as verifier:
+            entrypoint.main(
+                [
+                    "--repository-root",
+                    repository,
+                    "--codegen-version",
+                    "0.1.20",
+                ]
+            )
+
+        verifier.assert_called_once_with(
+            repository_root=Path(repository),
+            runtime_root=None,
+            codegen_version="0.1.20",
+        )
+
+
+class VerificationTest(unittest.TestCase):
     def test_temporary_prefix_includes_codegen_version(self) -> None:
         """Include the exact published codegen version in generation work directories."""
         self.assertEqual(
             "smithy-rs-codegen-compat-0.1.24-",
-            entrypoint.temporary_prefix("0.1.24"),
+            verify_compatibility.temporary_prefix("0.1.24"),
         )
 
-    def test_verify_semver_always_generates_temporary_sdks(self) -> None:
-        """Generate SDKs from published JARs and pass them directly to Cargo verification."""
+    def test_verification_runs_each_compatibility_step(self) -> None:
+        """Resolve, generate, patch, and compile through explicit domain operations."""
         with tempfile.TemporaryDirectory() as repository:
-            args = entrypoint.parse_args(
-                ["--repository-root", repository, "verify-semver"]
-            )
+            repository_root = Path(repository)
+            runtime_root = repository_root / "custom-runtime"
             published = PublishedCodegen("0.1.24", "1.73.0")
             generated = object()
+            patched = object()
             with mock.patch.object(
-                entrypoint, "ProtocolSdkGenerator"
-            ) as generator, mock.patch.object(
-                entrypoint, "CargoVerifier"
-            ) as verifier, mock.patch.object(
-                entrypoint, "MavenCodegenResolver"
-            ) as resolver:
-                resolver.return_value.resolve.return_value = published
-                generator.return_value.generate.return_value = generated
-
-                entrypoint.verify_semver(args)
-
-                resolver.return_value.resolve.assert_called_once_with(None)
-                generation_args = generator.return_value.generate.call_args[0]
-                self.assertEqual(published, generation_args[0])
-                verifier.return_value.verify.assert_called_once_with(
-                    generated, mock.ANY
+                verify_compatibility,
+                "resolve_published_codegen",
+                return_value=published,
+            ) as resolve, mock.patch.object(
+                verify_compatibility,
+                "generate_protocol_sdks",
+                return_value=generated,
+            ) as generate, mock.patch.object(
+                verify_compatibility,
+                "patch_generated_sdks_with_current_runtimes",
+                return_value=patched,
+            ) as patch, mock.patch.object(
+                verify_compatibility, "compile_generated_sdks"
+            ) as compile_sdks:
+                verify_compatibility.verify_released_codegen_runtime_compatibility(
+                    repository_root=repository_root,
+                    runtime_root=runtime_root,
                 )
+
+        resolve.assert_called_once_with(None)
+        generate.assert_called_once_with(
+            published_codegen=published,
+            protocols=verify_compatibility.COMPATIBILITY_PROTOCOLS,
+            repository_root=repository_root.resolve(),
+            destination=mock.ANY,
+        )
+        patch.assert_called_once_with(
+            generated_sdks=generated,
+            runtime_root=runtime_root.resolve(),
+            destination_root=mock.ANY,
+        )
+        compile_sdks.assert_called_once_with(patched)
+
+        generation_destination = generate.call_args.kwargs["destination"]
+        verification_destination = patch.call_args.kwargs["destination_root"]
+        self.assertEqual("generation", generation_destination.name)
+        self.assertEqual("verification", verification_destination.name)
+        self.assertEqual(generation_destination.parent, verification_destination.parent)
 
 
 if __name__ == "__main__":

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cli.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_cli.py
@@ -1,0 +1,73 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from released_codegen_runtime_compatibility.models import PublishedCodegen
+
+
+ENTRYPOINT_PATH = (
+    Path(__file__).resolve().parents[2] / "released-codegen-runtime-compatibility.py"
+)
+ENTRYPOINT_SPEC = importlib.util.spec_from_file_location(
+    "released_codegen_runtime_compatibility_entrypoint", ENTRYPOINT_PATH
+)
+if ENTRYPOINT_SPEC is None or ENTRYPOINT_SPEC.loader is None:
+    raise RuntimeError("failed to load {}".format(ENTRYPOINT_PATH))
+entrypoint = importlib.util.module_from_spec(ENTRYPOINT_SPEC)
+ENTRYPOINT_SPEC.loader.exec_module(entrypoint)
+
+
+class CliTest(unittest.TestCase):
+    def test_verify_semver_command(self) -> None:
+        """Default to latest codegen while accepting an exact published version."""
+        args = entrypoint.parse_args(["verify-semver"])
+        self.assertIs(entrypoint.verify_semver, args.handler)
+        self.assertIsNone(args.codegen_version)
+
+        historical = entrypoint.parse_args(
+            ["verify-semver", "--codegen-version", "0.1.20"]
+        )
+        self.assertEqual("0.1.20", historical.codegen_version)
+
+    def test_temporary_prefix_includes_codegen_version(self) -> None:
+        """Include the exact published codegen version in generation work directories."""
+        self.assertEqual(
+            "smithy-rs-codegen-compat-0.1.24-",
+            entrypoint.temporary_prefix("0.1.24"),
+        )
+
+    def test_verify_semver_always_generates_temporary_sdks(self) -> None:
+        """Generate SDKs from published JARs and pass them directly to Cargo verification."""
+        with tempfile.TemporaryDirectory() as repository:
+            args = entrypoint.parse_args(
+                ["--repository-root", repository, "verify-semver"]
+            )
+            published = PublishedCodegen("0.1.24", "1.73.0")
+            generated = object()
+            with mock.patch.object(
+                entrypoint, "ProtocolSdkGenerator"
+            ) as generator, mock.patch.object(
+                entrypoint, "CargoVerifier"
+            ) as verifier, mock.patch.object(
+                entrypoint, "MavenCodegenResolver"
+            ) as resolver:
+                resolver.return_value.resolve.return_value = published
+                generator.return_value.generate.return_value = generated
+
+                entrypoint.verify_semver(args)
+
+                resolver.return_value.resolve.assert_called_once_with(None)
+                generation_args = generator.return_value.generate.call_args[0]
+                self.assertEqual(published, generation_args[0])
+                verifier.return_value.verify.assert_called_once_with(
+                    generated, mock.ANY
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_codegen.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_codegen.py
@@ -38,6 +38,14 @@ class PublishedCodegenProjectTest(unittest.TestCase):
             {protocol for protocol, _, _ in COMPATIBILITY_PROTOCOLS},
         )
 
+        rest_json = projections["protocol-rest-json-1-client"]["plugins"][
+            "rust-client-codegen"
+        ]
+        self.assertEqual(
+            "smithy.rust.codegen.compatibility#RestJsonService",
+            rest_json["service"],
+        )
+
         for module in CLIENT_MODULES:
             settings = projections[module]["plugins"]["rust-client-codegen"]
             self.assertNotIn("runtimeConfig", settings)

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_codegen.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_codegen.py
@@ -6,7 +6,7 @@ import unittest
 from released_codegen_runtime_compatibility.codegen import (
     CLIENT_MODULES,
     LEGACY_SERVER_MODULES,
-    PROTOCOLS,
+    COMPATIBILITY_PROTOCOLS,
     SERVER_MODULES,
     gradle_build,
     smithy_build_config,
@@ -35,7 +35,7 @@ class PublishedCodegenProjectTest(unittest.TestCase):
                 "ec2-query",
                 "rpc-v2-cbor",
             },
-            {protocol for protocol, _, _ in PROTOCOLS},
+            {protocol for protocol, _, _ in COMPATIBILITY_PROTOCOLS},
         )
 
         for module in CLIENT_MODULES:

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_codegen.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_codegen.py
@@ -1,0 +1,73 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from released_codegen_runtime_compatibility.codegen import (
+    CLIENT_MODULES,
+    LEGACY_SERVER_MODULES,
+    PROTOCOLS,
+    SERVER_MODULES,
+    gradle_build,
+    smithy_build_config,
+)
+from released_codegen_runtime_compatibility.models import PublishedCodegen
+
+
+class PublishedCodegenProjectTest(unittest.TestCase):
+    def test_smithy_build_covers_every_supported_protocol(self) -> None:
+        """Generate every client protocol and both HTTP stacks for server protocols.
+        Ensure no projection redirects generated dependencies to local runtimes.
+        """
+        projections = smithy_build_config()["projections"]
+        expected = set(CLIENT_MODULES + SERVER_MODULES + LEGACY_SERVER_MODULES)
+        self.assertEqual(expected, set(projections))
+        self.assertEqual(7, len(CLIENT_MODULES))
+        self.assertEqual(5, len(SERVER_MODULES))
+        self.assertEqual(5, len(LEGACY_SERVER_MODULES))
+        self.assertEqual(
+            {
+                "rest-json-1",
+                "rest-xml",
+                "aws-json-1-0",
+                "aws-json-1-1",
+                "aws-query",
+                "ec2-query",
+                "rpc-v2-cbor",
+            },
+            {protocol for protocol, _, _ in PROTOCOLS},
+        )
+
+        for module in CLIENT_MODULES:
+            settings = projections[module]["plugins"]["rust-client-codegen"]
+            self.assertNotIn("runtimeConfig", settings)
+        for module in SERVER_MODULES:
+            settings = projections[module]["plugins"]["rust-server-codegen"]
+            self.assertNotIn("runtimeConfig", settings)
+            self.assertTrue(settings["codegen"]["http-1x"])
+        for module in LEGACY_SERVER_MODULES:
+            settings = projections[module]["plugins"]["rust-server-codegen"]
+            self.assertNotIn("runtimeConfig", settings)
+            self.assertFalse(settings["codegen"]["http-1x"])
+
+    def test_gradle_build_uses_published_jars(self) -> None:
+        """Verify generation loads exact published client and server artifacts.
+        Ensure the current checkout's codegen projects cannot enter the classpath.
+        """
+        build = gradle_build(
+            PublishedCodegen(version="0.1.24", smithy_version="1.73.0")
+        )
+        self.assertIn(
+            "software.amazon.smithy.rust:codegen-client:0.1.24", build
+        )
+        self.assertIn(
+            "software.amazon.smithy.rust:codegen-server:0.1.24", build
+        )
+        self.assertIn(
+            "software.amazon.smithy:smithy-validation-model:1.73.0", build
+        )
+        self.assertNotIn("project(", build)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_commands.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_commands.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import redirect_stderr
+import io
+import unittest
+
+from released_codegen_runtime_compatibility.commands import github_error
+
+
+class GithubDiagnosticsTest(unittest.TestCase):
+    def test_github_error_escapes_workflow_characters(self) -> None:
+        """Render a visible GitHub Actions error annotation for command failures.
+        Escape newlines and percent signs so diagnostics cannot break the protocol.
+        """
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            github_error("cargo failed 100%\nserver SDK")
+
+        self.assertEqual(
+            "::error title=Codegen runtime compatibility failed::"
+            "cargo failed 100%25%0Aserver SDK\n",
+            stderr.getvalue(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_maven.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_maven.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest import mock
+import xml.etree.ElementTree as ET
+
+from released_codegen_runtime_compatibility.maven import MavenCodegenResolver
+from released_codegen_runtime_compatibility.models import PublishedCodegen
+
+
+METADATA = """<metadata>
+  <versioning><release>0.1.24</release></versioning>
+</metadata>"""
+POM = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <dependencies>
+    <dependency>
+      <groupId>software.amazon.smithy</groupId>
+      <artifactId>smithy-codegen-core</artifactId>
+      <version>1.73.0</version>
+    </dependency>
+  </dependencies>
+</project>"""
+
+
+class MavenCodegenResolverTest(unittest.TestCase):
+    def test_resolve_latest_release(self) -> None:
+        """Resolve Maven's release marker to an exact published codegen version.
+        Carry the codegen POM's Smithy version into the generation classpath.
+        """
+        resolver = MavenCodegenResolver()
+        with mock.patch.object(
+            resolver,
+            "_read_xml",
+            side_effect=[ET.fromstring(METADATA), ET.fromstring(POM)],
+        ):
+            self.assertEqual(
+                PublishedCodegen("0.1.24", "1.73.0"), resolver.resolve()
+            )
+
+    def test_resolve_requested_release(self) -> None:
+        """Keep an explicitly requested published codegen version unchanged.
+        Skip latest-version metadata while still reading its Smithy dependency.
+        """
+        resolver = MavenCodegenResolver()
+        with mock.patch.object(
+            resolver, "_read_xml", return_value=ET.fromstring(POM)
+        ) as read_xml:
+            self.assertEqual(
+                PublishedCodegen("0.1.20", "1.73.0"),
+                resolver.resolve("0.1.20"),
+            )
+            self.assertEqual(1, read_xml.call_count)
+
+    def test_reject_unsafe_version(self) -> None:
+        """Reject version text that could alter generated Gradle source.
+        Fail before making a Maven request for malformed caller input.
+        """
+        resolver = MavenCodegenResolver()
+        with mock.patch.object(resolver, "_read_xml") as read_xml:
+            with self.assertRaisesRegex(RuntimeError, "invalid Maven version"):
+                resolver.resolve('0.1.24\")')
+            read_xml.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_paths.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/tests/test_paths.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from released_codegen_runtime_compatibility import paths
+
+
+class LongPathTest(unittest.TestCase):
+    def test_extended_form_is_windows_only(self) -> None:
+        """Add the extended-length prefix only where Windows requires it.
+        Leave POSIX paths untouched so nothing changes on CI.
+        """
+        rendered = paths.long_path(Path.cwd())
+        if paths.WINDOWS:
+            self.assertTrue(rendered.startswith(paths.EXTENDED_PREFIX))
+        else:
+            self.assertFalse(rendered.startswith(paths.EXTENDED_PREFIX))
+            self.assertEqual(str(Path.cwd().resolve()), rendered)
+
+    def test_extended_form_is_not_applied_twice(self) -> None:
+        """Keep an already extended path unchanged when it is rendered again.
+        Guard against nesting the prefix through repeated helper calls.
+        """
+        once = paths.long_path(Path.cwd())
+        self.assertEqual(once, paths.long_path(once))
+
+    def test_relative_paths_become_absolute(self) -> None:
+        """Resolve relative inputs because the extended form requires a full path.
+        Keep call sites free to pass whatever `Path` they already hold.
+        """
+        self.assertEqual(paths.long_path(Path.cwd()), paths.long_path("."))
+
+
+class DeepTreeTest(unittest.TestCase):
+    """Exercise the copy and delete helpers on a tree Windows cannot address plainly.
+    Nest far past 260 characters so the extended-length form is what makes it work.
+    """
+
+    @staticmethod
+    def deep_relative_path() -> Path:
+        """Build a relative path long enough to exceed the Windows limit.
+        Mirror the nesting depth of a generated SDK's protocol serialization tree.
+        """
+        return Path(*["generated_sdk_directory_segment"] * 10) / "shape.rs"
+
+    def test_copy_and_remove_survive_long_paths(self) -> None:
+        """Copy and delete a deeply nested tree without hitting a path limit.
+        This is the failure that stopped the check from running on Windows.
+        """
+        # Hold the fixture in the package's own work directory: `tempfile` cannot delete a tree
+        # this deep on Windows, which is the whole reason these helpers exist.
+        with paths.temporary_directory("codegen-compat-test-") as root:
+            source = root / "source"
+            relative = self.deep_relative_path()
+            leaf = source / relative
+            os.makedirs(paths.long_path(leaf.parent), exist_ok=True)
+            with open(paths.long_path(leaf), "w") as handle:
+                handle.write("generated")
+
+            destination = root / "destination"
+            paths.copy_tree(source, destination)
+
+            copied = destination / relative
+            self.assertTrue(paths.exists(copied))
+            with open(paths.long_path(copied)) as handle:
+                self.assertEqual("generated", handle.read())
+
+            paths.remove_tree(destination)
+            self.assertFalse(paths.exists(destination))
+
+    def test_remove_tree_tolerates_a_missing_tree(self) -> None:
+        """Ignore an absent directory so callers can clean up unconditionally.
+        Keep teardown from masking the failure that actually mattered.
+        """
+        with tempfile.TemporaryDirectory() as temp:
+            paths.remove_tree(Path(temp) / "never-created")
+
+
+class TemporaryDirectoryTest(unittest.TestCase):
+    def test_work_directory_is_removed_even_when_deeply_nested(self) -> None:
+        """Remove the work directory even when it holds paths Windows cannot address.
+        `tempfile.TemporaryDirectory` fails this cleanup, which is why it is not used.
+        """
+        with paths.temporary_directory("codegen-compat-test-") as directory:
+            leaf = directory / DeepTreeTest.deep_relative_path()
+            os.makedirs(paths.long_path(leaf.parent), exist_ok=True)
+            with open(paths.long_path(leaf), "w") as handle:
+                handle.write("generated")
+            self.assertTrue(paths.exists(leaf))
+        self.assertFalse(paths.exists(directory))
+
+
+class GradleWrapperTest(unittest.TestCase):
+    def test_wrapper_matches_the_running_platform(self) -> None:
+        """Select the wrapper this platform can execute through `subprocess`.
+        Windows cannot exec the extensionless shell script the repository ships.
+        """
+        wrapper = paths.gradle_wrapper(Path("/repo"))
+        expected = "gradlew.bat" if paths.WINDOWS else "gradlew"
+        self.assertEqual(expected, wrapper.name)
+        self.assertEqual(Path("/repo"), wrapper.parent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci-scripts/released_codegen_runtime_compatibility/verify_compatibility.py
+++ b/tools/ci-scripts/released_codegen_runtime_compatibility/verify_compatibility.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate SDKs with released codegen and compile them with current runtimes."""
+
+from pathlib import Path
+from typing import Optional
+
+from .cargo import (
+    compile_generated_sdks,
+    patch_generated_sdks_with_current_runtimes,
+)
+from .codegen import COMPATIBILITY_PROTOCOLS, generate_protocol_sdks
+from .maven import resolve_published_codegen
+from .paths import temporary_directory
+
+
+def temporary_prefix(codegen_version: str) -> str:
+    """Build a recognizable compatibility-work prefix containing the codegen version."""
+    return "smithy-rs-codegen-compat-{}-".format(codegen_version)
+
+
+def verify_released_codegen_runtime_compatibility(
+    repository_root: Path,
+    runtime_root: Optional[Path] = None,
+    codegen_version: Optional[str] = None,
+) -> None:
+    """Generate SDKs with published codegen and verify them with current runtimes."""
+    repository_root = repository_root.resolve()
+    runtime_root = (
+        runtime_root.resolve()
+        if runtime_root is not None
+        else repository_root / "rust-runtime"
+    )
+    published_codegen = resolve_published_codegen(codegen_version)
+
+    with temporary_directory(
+        prefix=temporary_prefix(published_codegen.version)
+    ) as work_directory:
+        generated_sdks = generate_protocol_sdks(
+            published_codegen=published_codegen,
+            protocols=COMPATIBILITY_PROTOCOLS,
+            repository_root=repository_root,
+            destination=work_directory / "generation",
+        )
+        patched_sdks = patch_generated_sdks_with_current_runtimes(
+            generated_sdks=generated_sdks,
+            runtime_root=runtime_root,
+            destination_root=work_directory / "verification",
+        )
+        compile_generated_sdks(patched_sdks)


### PR DESCRIPTION
CI check to catch semver issues between last released code generator and current `rust-runtime`.

For example, a released code generator may produce:

  ```toml
  [dependencies.aws-smithy-http-server]
  version = "0.67.1"

  [dependencies.aws-smithy-json]
  version = "0.63.0"
```

For a 0.x crate, the aws-smithy-http-server requirement accepts compatible 0.67.x releases.

Suppose HEAD bumps `aws-smithy-json` from `0.63` to `0.64` and updates `aws-smithy-http-server` to depend on it, but leaves the server version in the `0.67.x` line. Cargo can then select the server from HEAD while retaining the released JSON version required directly by generated code:

```
generated server SDK
  ├── aws-smithy-json 0.63 from crates.io
  └── aws-smithy-http-server 0.67.x from HEAD
      └── aws-smithy-json 0.64 from HEAD
```

Types from different versions of a Rust crate are distinct. When a JSON type crosses the server's public API, previously generated code no longer compiles:

```rust
  error[E0277]: `?` couldn't convert the error to
  `aws_smithy_http_server::protocol::rest_json_1::rejection::RequestRejection`
    --> src/protocol_serde/shape_get_foo.rs:28:92
     |
  28 |     input = crate::protocol_serde::shape_get_foo::de_get_foo(bytes.as_ref(), input)?;
     |             -----------------------------------------------------------------------^
     |             this can't be annotated with `?` because it has type
     |             `Result<_, DeserializeError>`
     |
     = note: the trait `From<DeserializeError>` is not implemented for
             `RequestRejection`
```

The correct change is to bump aws-smithy-http-server to the next incompatible version line. Released generated code will then continue using the previously released compatible server and JSON versions.

### What this CI check does:

1. Gets the latest release versions from Maven Central , and generates temporary client and server crates using exact published `codegen-client` and `codegen-server` versions.

1. Discovers every publishable `aws-*` crate in the runtime workspace using `cargo metadata`.

1. Adds those crates as local `[patch.crates-io]` candidates without changing the version requirements generated by released codegen.

1. Removes generated lockfiles so Cargo performs fresh dependency resolution.
1. Runs `cargo check --workspace --all-features --all-targets` against both the generated client and server workspaces.

The following are generated:

```
work-directory/
  ├── generation/
  │   ├── published-codegen-compatibility/
  │   │   ├── build.gradle.kts
  │   │   ├── settings.gradle.kts
  │   │   ├── smithy-build.json
  │   │   └── model/
  │   │       ├── pokemon.smithy
  │   │       ├── pokemon-common.smithy
  │   │       └── protocols.smithy
  │   ├── generated-client/
  │   │   ├── Cargo.toml
  │   │   ├── protocol-rest-json-1-client/
  │   │   ├── protocol-rest-xml-client/
  │   │   ├── protocol-aws-json-1-0-client/
  │   │   ├── protocol-aws-json-1-1-client/
  │   │   ├── protocol-aws-query-client/
  │   │   ├── protocol-ec2-query-client/
  │   │   └── protocol-rpc-v2-cbor-client/
  │   └── generated-server/
  │       ├── Cargo.toml
  │       ├── protocol-rest-json-1-server/
  │       ├── protocol-rest-json-1-server-http0x/
  │       ├── protocol-rest-xml-server/
  │       ├── protocol-rest-xml-server-http0x/
  │       ├── protocol-aws-json-1-0-server/
  │       ├── protocol-aws-json-1-0-server-http0x/
  │       ├── protocol-aws-json-1-1-server/
  │       ├── protocol-aws-json-1-1-server-http0x/
  │       ├── protocol-rpc-v2-cbor-server/
  │       └── protocol-rpc-v2-cbor-server-http0x/
  └── verification/
      ├── client/
      │   ├── Cargo.toml                 # Includes current-runtime patches
      │   └── <copies of generated client crates>
      └── server/
          ├── Cargo.toml                 # Includes current-runtime patches
          └── <copies of generated server crates>
```

The check creates one isolated Gradle project using the latest published codegen artifacts. It generates seven client protocol crates and server crates for the five server-supported protocols using both HTTP 1.x and legacy HTTP 0.x. The generated workspaces are copied into `verification/`, where their root manifests receive `[patch.crates-io]` entries pointing to runtime crates from the PR checkout. Cargo then compiles the patched client and server workspaces independently.