### PR TITLE
Fix codegen for constrained unions with a member named `error`

### DIFF
--- a/.changelog/4803.md
+++ b/.changelog/4803.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- server
+authors:
+- MinisculeGirraffe
+references:
+- smithy-rs#4803
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix code generation for constrained unions that have a member named `error`. Such a member generates an `Error` variant that shadowed the `TryFrom::Error` associated type in the generated `TryFrom` implementation, making every `Self::Error` path ambiguous and producing a crate that did not compile. The generated code now refers to the constraint violation type by name.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedUnionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedUnionGenerator.kt
@@ -105,7 +105,7 @@ class UnconstrainedUnionGenerator(
                 impl #{TryFrom}<$name> for #{ConstrainedSymbol} {
                     type Error = #{ConstraintViolationSymbol};
 
-                    fn try_from(value: $name) -> #{Result}<Self, Self::Error> {
+                    fn try_from(value: $name) -> #{Result}<Self, #{ConstraintViolationSymbol}> {
                         #{body:W}
                     }
                 }
@@ -273,6 +273,11 @@ class UnconstrainedUnionGenerator(
                     ""
                 }
 
+            // Refer to the constraint violation type by name instead of through `Self::Error`: if
+            // the union has a member named `error`, the generated variant `Self::Error` shadows the
+            // `TryFrom::Error` associated type and the path becomes ambiguous.
+            val constraintViolationSymbol = constraintViolationSymbolProvider.toSymbol(shape)
+
             if (resolveToNonPublicConstrainedType) {
                 val constrainedSymbol =
                     if (!publicConstrainedTypes && targetShape.isDirectlyConstrained(symbolProvider)) {
@@ -285,21 +290,23 @@ class UnconstrainedUnionGenerator(
                     {
                         let constrained: #{ConstrainedSymbol} = $unconstrainedVar
                             .try_into()$boxIt$boxErr
-                            .map_err(Self::Error::${UnionConstraintTraitInfo(member).name()})?;
+                            .map_err(#{ConstraintViolationSymbol}::${UnionConstraintTraitInfo(member).name()})?;
                         constrained.into()
                     }
                     """,
                     "ConstrainedSymbol" to constrainedSymbol,
+                    "ConstraintViolationSymbol" to constraintViolationSymbol,
                 )
             } else {
-                rust(
+                rustTemplate(
                     """
                     $unconstrainedVar
                         .try_into()
                         $boxIt
                         $boxErr
-                        .map_err(Self::Error::${UnionConstraintTraitInfo(member).name()})?
+                        .map_err(#{ConstraintViolationSymbol}::${UnionConstraintTraitInfo(member).name()})?
                     """,
+                    "ConstraintViolationSymbol" to constraintViolationSymbol,
                 )
             }
         }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedUnionGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedUnionGeneratorTest.kt
@@ -19,6 +19,8 @@ import software.amazon.smithy.rust.codegen.server.smithy.createInlineModuleCreat
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionConversionGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerRestJsonProtocol
 import software.amazon.smithy.rust.codegen.server.smithy.renderInlineMemoryModules
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.HttpTestType
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
 import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverRenderWithModelBuilder
 import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverTestCodegenContext
 
@@ -114,5 +116,62 @@ class UnconstrainedUnionGeneratorTest {
         }
         project.renderInlineMemoryModules()
         project.compileAndTest()
+    }
+
+    @Test
+    fun `a constrained union with a member named error should compile`() {
+        // A union member named `error` renders as an `Error` variant on the constrained union. In the
+        // generated `impl TryFrom<...> for Union`, that variant makes the path `Self::Error` ambiguous
+        // with the `TryFrom::Error` associated type, so the generator must name the constraint
+        // violation type explicitly. Both `try_from` code paths are exercised: the member targeting a
+        // structure resolves to a public constrained type, and the member targeting an unconstrained
+        // list that can reach a constrained shape resolves to a `pub(crate)` constrained type.
+        val model =
+            """
+            ${'$'}version: "2"
+            namespace com.example
+            use aws.protocols#restJson1
+            use smithy.framework#ValidationException
+
+            @restJson1
+            service TestService {
+                version: "0.1",
+                operations: [TestOperation]
+            }
+
+            @http(uri: "/test", method: "POST")
+            operation TestOperation {
+                input := {
+                    @required
+                    unionWithErrorStructure: UnionWithErrorStructure
+
+                    @required
+                    unionWithErrorList: UnionWithErrorList
+                }
+                errors: [ValidationException]
+            }
+
+            union UnionWithErrorStructure {
+                error: ConstrainedStructure
+                other: String
+            }
+
+            union UnionWithErrorList {
+                error: ConstrainedStructureList
+                other: String
+            }
+
+            structure ConstrainedStructure {
+                @required
+                requiredMember: String
+            }
+
+            list ConstrainedStructureList {
+                member: ConstrainedStructure
+            }
+            """.asSmithyModel()
+
+        // Ensure the generated SDK compiles.
+        serverIntegrationTest(model, testCoverage = HttpTestType.Default) { _, _ -> }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.25
+codegenVersion=0.1.26


### PR DESCRIPTION
## Motivation and Context

Fixes #4803.

We are modeling a state machine in our Smithy contract. Each state carries different associated data, so a union is the natural representation, and `error` is one of the terminal states. That makes `error` a member name we genuinely want rather than something we can rename for the sake of codegen:

```smithy
union Status {
    pending: PendingStatus
    running: RunningStatus
    succeeded: SucceededStatus
    error: ErrorStatus   // terminal state, carries failure detail
}
```

A constrained union with a member named `error` generates a crate that does not compile. `UnconstrainedUnionGenerator` refers to its own error type as `Self::Error` in the generated `TryFrom` impl. The member `error` becomes the variant `Self::Error`, which shadows the `TryFrom::Error` associated type, so every such path is ambiguous and fails the deny-by-default `ambiguous_associated_items` lint:

```
error: ambiguous associated item
  --> src/unconstrained.rs:44:42
44 |         ) -> ::std::result::Result<Self, Self::Error> {
   |                                          ^^^^^^^^^^^ help: use fully-qualified syntax
note: `Error` could refer to the variant defined here
 8 |     Error(crate::model::ConstrainedStructure),
note: `Error` could also refer to the associated type defined here
   = note: `#[deny(ambiguous_associated_items)]` (part of `#[deny(future_incompatible)]`) on by default
```

The only workaround today is to rename the member, which means the wire contract has to bend around a codegen detail.

## Description

Refer to the constraint violation type by name instead of through `Self::Error`, at all three sites in `UnconstrainedUnionGenerator`:

- the `try_from` return type, which becomes `Result<Self, ConstraintViolation>` rather than `Result<Self, Self::Error>`
- the `map_err` in the `resolveToNonPublicConstrainedType` branch
- the `map_err` in the `else` branch (this one also changes `rust(...)` to `rustTemplate(...)` so the symbol can be interpolated)

The `constraintViolationSymbolProvider` already accounts for `publicConstrainedTypes`, so the emitted path is correct whether the constraint violation type is public or `pub(crate)`.

I checked the other `Self::Error` sites in codegen — `UnconstrainedMapGenerator`, `UnconstrainedCollectionGenerator`, `ServerBuilderGenerator`, `ServerBuilderGeneratorWithoutPublicConstrainedTypes`, `ConstrainedMapGenerator`, `ConstrainedCollectionGenerator`, and `TraitInfo`. In all of those `Self` is a struct or newtype, so no variant can shadow the associated type. The union generator was the only affected place.

## Testing

Added `a constrained union with a member named error should compile` to `UnconstrainedUnionGeneratorTest`, a compile-only `serverIntegrationTest` following the existing `UnionWithUnitTest` pattern. The model has two constrained unions with an `error` member, chosen to cover both `try_from` code paths:

- `error: ConstrainedStructure` exercises the `else` branch (public constrained type)
- `error: ConstrainedStructureList`, an unconstrained list whose member can reach a constrained shape, exercises the `resolveToNonPublicConstrainedType` branch (`pub(crate)` constrained type)

Verified the test is a real regression test: with the generator fix reverted but the test kept, it fails with exactly four `ambiguous associated item` errors — the `try_from` return type and the `map_err` for each of the two unions, covering all patched sites. With the fix applied it passes.

I also confirmed from the generated `unconstrained.rs` that the two unions really do take different branches. `UnionWithErrorStructure` emits a bare `.map_err(...)?`, while `UnionWithErrorList` emits the `let constrained: crate::constrained::constrained_structure_list_constrained::ConstrainedStructureListConstrained = ...; constrained.into()` form, which is the `pub(crate)` path.

Also ran the `ktlint`, `kotlin-block-quotes`, and `sdk-lints` pre-commit hooks against the changed files; all pass, including the changelogger's `Changelog.next` validation of the new entry.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
