### PR TITLE
feat(client): add turmoil test transport to aws-smithy-http-client

### DIFF
--- a/.changelog/turmoil-test-client.md
+++ b/.changelog/turmoil-test-client.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client"]
+authors: ["jasgin"]
+references: ["smithy-rs#4806"]
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add a test-only `test_util::turmoil_client` to `aws-smithy-http-client` (behind the new mutually-exclusive `turmoil-06` / `turmoil-07` features, selecting the `turmoil` 0.6 or 0.7 major version) that drives the real HTTP client over the [turmoil](https://docs.rs/turmoil) discrete-event network simulator. Call `turmoil_client(resolver, port)` to get a `SharedHttpClient`; it runs through the same connection pool, connect/read timeout, and error-classification stack as the production client, so only the transport is replaced. TLS is not layered on top (the transport is plaintext). All hyper IO plumbing (`TokioIo`, `hyper::rt::{Read, Write}`, `Connection`) is crate-private, so consumers never depend on hyper internals.

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",
@@ -542,6 +542,8 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tracing",
+ "turmoil 0.6.6",
+ "turmoil 0.7.2",
 ]
 
 [[package]]
@@ -2801,6 +2803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3718,6 +3727,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,6 +4124,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4949,6 +4984,36 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "turmoil"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0d6c134ef37268c94d50fb74252af1c34c5c88389e2c1af85654da944ceb52"
+dependencies = [
+ "bytes",
+ "indexmap 2.14.0",
+ "rand 0.8.7",
+ "rand_distr 0.4.3",
+ "scoped-tls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "turmoil"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0061c28f1469e94771bb8aa626ce6b29265c2fb5034115046a170b0cba2e33d2"
+dependencies = [
+ "bytes",
+ "indexmap 2.14.0",
+ "rand 0.9.5",
+ "rand_distr 0.5.1",
+ "scoped-tls",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "typenum"

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-smithy-http-client"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
 description = "HTTP client abstractions for generated smithy clients"
-version = "1.4.0"
+version = "1.5.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/smithy-lang/smithy-rs"
@@ -72,6 +72,20 @@ legacy-test-util = [
     "aws-smithy-types/http-body-0-4-x",
 ]
 
+# Test-only support for the turmoil network simulator (enables `test_util::turmoil_client`).
+# Pick the feature matching the `turmoil` major version your test harness uses;
+# `turmoil-06` and `turmoil-07` are mutually exclusive.
+turmoil-06 = ["__turmoil", "dep:turmoil-0-6"]
+turmoil-07 = ["__turmoil", "dep:turmoil-0-7"]
+
+# Internal marker enabled by any `turmoil-*` feature. Not part of the public API;
+# gates the shared, version-agnostic turmoil transport code.
+__turmoil = [
+    "test-util",
+    "default-client",
+    "tokio/net",
+]
+
 legacy-rustls-ring = ["dep:legacy-hyper-rustls", "dep:legacy-rustls", "dep:rustls-native-certs", "hyper-014"]
 
 __rustls = ["dep:rustls", "dep:hyper-rustls", "dep:tokio-rustls", "default-client"]
@@ -124,6 +138,8 @@ indexmap = { version = "2.10.0", features = ["serde"], optional = true }
 http-body-util = { version = "0.1.3", optional = true }
 httparse = { version = "1.10.1", optional = true }
 socket2 = { version = "0.6", optional = true }
+turmoil-0-6 = { package = "turmoil", version = "0.6", optional = true }
+turmoil-0-7 = { package = "turmoil", version = "0.7", optional = true }
 # end test util stack
 
 [dev-dependencies]
@@ -160,8 +176,17 @@ name = "custom-dns"
 required-features = ["rustls-ring"]
 doc-scrape-examples = true
 
+[[test]]
+name = "turmoil_test"
+required-features = ["__turmoil"]
+
 [package.metadata.smithy-rs-release-tooling]
 stable = true
+
+# Under `--all-features` both turmoil features enable at once; `turmoil-07` then
+# wins and `turmoil-0-6` is left unused. It is used when `turmoil-06` is enabled alone.
+[package.metadata.cargo-udeps.ignore]
+normal = ["turmoil-0-6"]
 
 [package.metadata.docs.rs]
 all-features = false

--- a/rust-runtime/aws-smithy-http-client/src/test_util.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util.rs
@@ -65,3 +65,8 @@ pub use never::NeverTcpConnector;
 mod body;
 #[cfg(all(feature = "default-client", feature = "wire-mock"))]
 pub mod wire;
+
+#[cfg(feature = "__turmoil")]
+mod turmoil;
+#[cfg(feature = "__turmoil")]
+pub use turmoil::turmoil_client;

--- a/rust-runtime/aws-smithy-http-client/src/test_util/turmoil.rs
+++ b/rust-runtime/aws-smithy-http-client/src/test_util/turmoil.rs
@@ -1,0 +1,176 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Turmoil-backed test transport.
+//!
+//! [`turmoil_client`] builds a [`SharedHttpClient`] that connects over the
+//! [`turmoil`] discrete-event network simulator, so tests can drive the *real*
+//! HTTP client (connection pool, connect/read timeouts, error classification)
+//! over a simulated network.
+//!
+//! Construct it from a [`SharedDnsResolver`] and a port. The helper deliberately
+//! hides every hyper IO detail: consumers never touch
+//! [`hyper_util::rt::TokioIo`], `hyper::rt::{Read, Write}`, or the hyper
+//! `Connection`/`Connect` traits. All of that plumbing is crate-private
+//! (`TurmoilTcpConnector`/`TurmoilConnection`).
+//!
+//! Enable exactly one of the mutually exclusive `turmoil-06` / `turmoil-07`
+//! features to select which major version of the `turmoil` crate is linked; the
+//! transport code below is identical across both.
+//!
+//! The transport is **plaintext**: no TLS is layered on top.
+
+use std::future::Future;
+use std::io::{Error, ErrorKind};
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use aws_smithy_runtime_api::client::dns::{ResolveDns, SharedDnsResolver};
+use aws_smithy_runtime_api::client::http::SharedHttpClient;
+use http_1x::Uri;
+use hyper::rt::{Read, Write};
+use hyper_util::client::legacy::connect::{Connected, Connection};
+use hyper_util::rt::TokioIo;
+
+// The `turmoil-06` and `turmoil-07` features select which major version of the
+// `turmoil` crate is linked. Their public APIs are identical for the surface we
+// use, so alias the enabled one to a single `turmoil` path and keep the rest of
+// this module version-agnostic.
+#[cfg(all(feature = "turmoil-06", not(feature = "turmoil-07")))]
+use turmoil_0_6 as turmoil;
+#[cfg(feature = "turmoil-07")]
+use turmoil_0_7 as turmoil;
+
+use turmoil::net::TcpStream;
+
+use crate::client::build_with_tcp_conn_fn;
+
+/// Build a [`SharedHttpClient`] that drives requests over the [`turmoil`]
+/// discrete-event network simulator.
+///
+/// Resolves target hosts with `resolver` and connects on `port`. The client runs
+/// through the same connection pool, connect/read timeout, and error-classification
+/// stack as the production client — only the transport is replaced. No hyper types
+/// appear in this API; all `tower::Service`/`Connection` plumbing is crate-private.
+///
+/// The transport is **plaintext**: no TLS is layered on top.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "__turmoil")]
+/// # {
+/// use aws_smithy_http_client::test_util::turmoil_client;
+/// use aws_smithy_runtime_api::client::dns::SharedDnsResolver;
+///
+/// # fn resolver() -> SharedDnsResolver { unimplemented!() }
+/// let http_client = turmoil_client(resolver(), 8891);
+/// # }
+/// ```
+pub fn turmoil_client(resolver: impl Into<SharedDnsResolver>, port: u16) -> SharedHttpClient {
+    let connector = TurmoilTcpConnector {
+        resolver: resolver.into(),
+        port,
+    };
+    build_with_tcp_conn_fn(None, None, None, move || connector.clone())
+}
+
+/// Crate-private `tower::Service<Uri>` that performs the turmoil connect. Kept
+/// out of the public API so the hyper IO bounds it satisfies never leak.
+#[derive(Clone)]
+struct TurmoilTcpConnector {
+    resolver: SharedDnsResolver,
+    port: u16,
+}
+
+impl tower::Service<Uri> for TurmoilTcpConnector {
+    type Response = TurmoilConnection;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, dst: Uri) -> Self::Future {
+        let resolver = self.resolver.clone();
+        let port = self.port;
+        Box::pin(async move {
+            let host = match dst.host() {
+                Some(host) => host.to_string(),
+                None => {
+                    return Err(Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("URI has no host: {dst}"),
+                    ))
+                }
+            };
+            // Test transport: connect to the first resolved address only. Turmoil
+            // hosts are single-node, so there is deliberately no happy-eyeballs /
+            // multi-address fallback here (that lives in the production connector).
+            let ip_addr = resolver
+                .resolve_dns(&host)
+                .await
+                .map_err(|e| Error::new(ErrorKind::NotFound, e))?
+                .into_iter()
+                .next();
+            match ip_addr {
+                Some(ip_addr) => {
+                    let stream = TcpStream::connect(SocketAddr::new(ip_addr, port)).await?;
+                    Ok(TurmoilConnection(TokioIo::new(stream)))
+                }
+                None => Err(Error::new(
+                    ErrorKind::NotFound,
+                    format!("no IP address resolved for {host}"),
+                )),
+            }
+        })
+    }
+}
+
+/// Crate-private turmoil TCP connection that satisfies the smithy HTTP client's
+/// IO bounds.
+///
+/// Wraps a [`turmoil::net::TcpStream`] (via [`TokioIo`]) and implements hyper's
+/// [`Read`]/[`Write`] plus [`Connection`] — `turmoil::net::TcpStream` does not
+/// implement hyper-util's `Connection`, so this newtype supplies it. Not part of
+/// the public API.
+#[derive(Debug)]
+struct TurmoilConnection(TokioIo<TcpStream>);
+
+impl Connection for TurmoilConnection {
+    fn connected(&self) -> Connected {
+        Connected::new()
+    }
+}
+
+impl Read for TurmoilConnection {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: hyper::rt::ReadBufCursor<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl Write for TurmoilConnection {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/tests/turmoil_test.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/turmoil_test.rs
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! End-to-end tests for `test_util::turmoil_client`.
+//!
+//! These drive the *real* smithy HTTP client (connection pool, connect/read
+//! timeouts, error classification) over the [`turmoil`] discrete-event network
+//! simulator. Each turmoil host runs on a paused tokio runtime, so the
+//! connect-timeout assertion below fires against simulated time and is
+//! deterministic.
+
+#![cfg(feature = "__turmoil")]
+
+// The `turmoil-06` / `turmoil-07` features select which major version of the
+// `turmoil` crate is linked; alias the enabled one so the test body stays
+// version-agnostic. These features are intended to be mutually exclusive, but
+// some tooling enables every feature at once, so `turmoil-07` takes precedence
+// when both are enabled (matching `src/test_util/turmoil.rs`).
+#[cfg(all(feature = "turmoil-06", not(feature = "turmoil-07")))]
+use turmoil_0_6 as turmoil;
+#[cfg(feature = "turmoil-07")]
+use turmoil_0_7 as turmoil;
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use aws_smithy_async::rt::sleep::TokioSleep;
+use aws_smithy_async::time::SystemTimeSource;
+use aws_smithy_http_client::test_util::turmoil_client;
+use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, SharedDnsResolver};
+use aws_smithy_runtime_api::client::http::{HttpClient, HttpConnector, HttpConnectorSettings};
+use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+
+const PORT: u16 = 8891;
+
+/// Minimal fixed-address [`ResolveDns`] that points the client at a single IP
+/// regardless of the requested hostname. In these tests the IP is the one
+/// turmoil assigned to the `"server"` host (via [`turmoil::lookup`]).
+#[derive(Debug, Clone)]
+struct StaticResolver(IpAddr);
+
+impl ResolveDns for StaticResolver {
+    fn resolve_dns<'a>(&'a self, _name: &'a str) -> DnsFuture<'a> {
+        let ip = self.0;
+        DnsFuture::new(async move { Ok(vec![ip]) })
+    }
+}
+
+/// Runtime components carrying a real Tokio sleep impl so connect/read timeouts
+/// fire against turmoil's (paused) simulated clock.
+fn runtime_components() -> aws_smithy_runtime_api::client::runtime_components::RuntimeComponents {
+    RuntimeComponentsBuilder::for_tests()
+        .with_time_source(Some(SystemTimeSource::new()))
+        .with_sleep_impl(Some(TokioSleep::new()))
+        .build()
+        .unwrap()
+}
+
+/// A request driven through `turmoil_client` traverses the simulated network to
+/// a turmoil-hosted HTTP/1.1 server and gets a 200 back.
+#[test]
+fn round_trip_returns_200() {
+    let mut sim = turmoil::Builder::new().build();
+
+    sim.host("server", || async move {
+        let listener = turmoil::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, PORT)).await?;
+        loop {
+            let (mut stream, _) = listener.accept().await?;
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                // Read the request head; we don't need the body for this test.
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf).await;
+                let response =
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+                let _ = stream.write_all(response).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    sim.client("client", async move {
+        // Resolve the address turmoil assigned to the server host.
+        let server_ip = turmoil::lookup("server");
+        let client = turmoil_client(SharedDnsResolver::new(StaticResolver(server_ip)), PORT);
+        let settings = HttpConnectorSettings::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .read_timeout(Duration::from_secs(5))
+            .build();
+        let connector = client.http_connector(&settings, &runtime_components());
+        let response = connector
+            .call(HttpRequest::get("http://server").unwrap())
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status().as_u16(), 200);
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+/// When the network to the server is severed, the client surfaces a connect
+/// timeout (proving the real timeout/error-classification stack runs over the
+/// simulated transport).
+#[test]
+fn connect_timeout_is_classified() {
+    let mut sim = turmoil::Builder::new().build();
+
+    // The server binds and loops on accept, but the link is held below, so the
+    // TCP connect never reaches it. The failure comes purely from the network
+    // hold, which is what makes the client's connect timeout fire.
+    sim.host("server", || async move {
+        let listener = turmoil::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, PORT)).await?;
+        loop {
+            let _ = listener.accept().await;
+        }
+    });
+
+    sim.client("client", async move {
+        let server_ip = turmoil::lookup("server");
+        // Sever the link so the TCP connect handshake can never complete.
+        turmoil::hold("client", "server");
+        let client = turmoil_client(SharedDnsResolver::new(StaticResolver(server_ip)), PORT);
+        let settings = HttpConnectorSettings::builder()
+            .connect_timeout(Duration::from_millis(500))
+            .build();
+        let connector = client.http_connector(&settings, &runtime_components());
+        let err = connector
+            .call(HttpRequest::get("http://server").unwrap())
+            .await
+            .expect_err("connect should time out");
+        assert!(err.is_timeout(), "expected a connect timeout, got: {err:?}");
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}


### PR DESCRIPTION
https://github.com/smithy-lang/smithy-rs/issues/4806

Add a test-only `test_util::turmoil_client` (behind the new `turmoil` feature) that drives the real HTTP client over the turmoil discrete-event network simulator. It runs through the same connection pool, connect/read timeout, and error-classification stack as the production client; only the transport is replaced. The transport is plaintext (no TLS), and all hyper IO plumbing (TokioIo, hyper::rt Read/Write, Connection) is crate-private so consumers never depend on hyper internals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
