### PR TITLE
aws-smithy-http-client: add connection pool foundation

### DIFF
--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
  "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap 2.14.0",
+ "loom",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.43",
@@ -1927,6 +1928,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +2853,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4095,6 +4124,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -31,6 +31,8 @@ default-client = [
     "dep:rustls-native-certs"
 ]
 
+rt-tokio = ["tokio/rt"]
+
 wire-mock = [
     "test-util",
     "default-client",
@@ -138,6 +140,7 @@ rustls-pemfile = "2.2.0"
 rustls-pki-types = { version = "1.12.0", features = ["std"] }
 tokio = { version = "1.49.0", features = ["macros", "rt", "rt-multi-thread", "test-util", "full"] }
 tokio-rustls = "0.26.2"
+loom = "0.7.2"
 
 
 [[example]]
@@ -167,6 +170,7 @@ stable = true
 all-features = false
 features = [
     "default-client ",
+    "rt-tokio",
     "wire-mock",
     "test-util",
     "rustls-ring",
@@ -179,4 +183,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 # End of docs.rs metadata
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(aws_sdk_unstable)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(aws_sdk_unstable)', 'cfg(smithy_http_client_loom)'] }

--- a/rust-runtime/aws-smithy-http-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-client/Cargo.toml
@@ -140,6 +140,8 @@ rustls-pemfile = "2.2.0"
 rustls-pki-types = { version = "1.12.0", features = ["std"] }
 tokio = { version = "1.49.0", features = ["macros", "rt", "rt-multi-thread", "test-util", "full"] }
 tokio-rustls = "0.26.2"
+
+[target.'cfg(smithy_http_client_loom)'.dev-dependencies]
 loom = "0.7.2"
 
 

--- a/rust-runtime/aws-smithy-http-client/additional-ci
+++ b/rust-runtime/aws-smithy-http-client/additional-ci
@@ -17,3 +17,7 @@ cargo test --no-default-features --features default-client --test proxy_tests --
 echo "### Testing unstable custom rustls crypto provider"
 # Enabling ring because the tests use it as the "custom" provider, and it transitively enables __rustls
 RUSTFLAGS="--cfg aws_sdk_unstable" cargo test --features rustls-ring
+
+echo "### Running connection pool Loom models"
+RUSTFLAGS="--cfg smithy_http_client_loom" \
+    cargo test --lib --features default-client,rt-tokio

--- a/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
+++ b/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
@@ -116,18 +116,17 @@ on first use of that pair.
   runtime 1, eth1     │  idle H1 · H2 gen│  │  (never used)    │
                       └──────────────────┘  └──────────────────┘
 
-  bounded only        OriginState(s3)       OriginState(dynamodb)
-  spans partitions    admission · orders    admission · orders
-                      peer-cell index        peer-cell index
+  bounded only        OriginAdmission(s3)      OriginAdmission(dynamodb)
+  spans partitions    admission · orders       admission · orders
+                      peer-cell index           peer-cell index
 ```
 
 Because the partition set is fixed and the origin set is not, partitions are the outer level: each partition
 owns its own map from origin to cell, so the structure that grows is always inside one partition. A cell that
 no request has asked for does not exist.
 
-An **`OriginState`** holds what all partitions sharing an origin must agree on — the connection budget when
-one is configured, and an index of which partitions hold cells for that origin. Nothing else spans
-partitions.
+An **`OriginAdmission`** holds what all partitions sharing a bounded origin must agree on: its connection
+budget, cross-cell demand order, and index of cells for that origin. Nothing else spans partitions.
 
 #### Ownership and lifetime
 
@@ -135,29 +134,28 @@ partitions.
 ConnectionPool                         config and fixed partition set
 |-- Partition[]                        driver spawner, optional interface
 |   `-- OriginCell by OriginKey        H1 records, H2 generation, local waiters
-`-- OriginState by bounded OriginKey   admission, cross-cell orders, peer-cell index
+`-- OriginAdmission by OriginKey       permits, cross-cell orders, peer-cell index
 
 Client ------------------------------> ConnectionPool + one resolved Partition
 ```
 
-| Type             | Created                                | Destroyed                                     | Shared across partitions |
-| ---------------- | -------------------------------------- | --------------------------------------------- | ------------------------ |
-| `ConnectionPool` | by the builder                         | when the last `Client` and request release it | —                        |
-| `Partition`      | at construction, from the declared set | at pool drop                                  | no                       |
-| `OriginCell`     | first request for (partition, origin)  | not while the origin is live                  | no                       |
-| `OriginState`    | first request for a *bounded* origin   | not while the pool lives                      | yes                      |
-| `Client`         | by the caller, freely                  | by the caller                                 | —                        |
+| Type              | Created                                | Destroyed                                     | Shared across partitions |
+| ----------------- | -------------------------------------- | --------------------------------------------- | ------------------------ |
+| `ConnectionPool`  | by the builder                         | when the last `Client` and request release it | —                        |
+| `Partition`       | at construction, from the declared set | at pool drop                                  | no                       |
+| `OriginCell`      | first request for (partition, origin)  | not while the origin is live                  | no                       |
+| `OriginAdmission` | first request for a *bounded* origin   | not while the pool lives                      | yes                      |
+| `Client`          | by the caller, freely                  | by the caller                                 | —                        |
 
 `Client` is what a caller holds and what implements the smithy runtime's `HttpClient`. It pairs the pool with
 one resolved partition, so a request never searches for its partition — the handle already names it.
 
-An origin's shared state is built only for the features a caller configured. `OriginState` — the
-`OriginAdmission`, the cross-cell order, and the peer index — exists only for a bounded origin. Those parts
-have work to do only when a bound can force borrow or reclaim: on a local miss a partition establishes its own
-connection, and it borrows a peer's dispatch handle only when it *cannot* establish, capacity being bounded
-and no permit free. An unbounded origin never borrows or reclaims, so it has no `OriginState` and no
-cross-partition structure at all; its cells are the whole of it. Reuse scope governs which cells may relieve
-one another's admission pressure, so it has no effect until a bound makes that pressure possible.
+An `OriginAdmission` exists only for a bounded origin. It has work to do only when a bound can force borrow or
+reclaim: on a local miss a partition establishes its own connection, and it borrows a peer's dispatch handle
+only when it *cannot* establish, capacity being bounded and no permit free. An unbounded origin never borrows
+or reclaims, so it has no origin-wide admission or cross-partition structure; its cells are the whole of it.
+Reuse scope governs which cells may relieve one another's admission pressure, so it has no effect until a
+bound makes that pressure possible.
 
 The tree above shows where state is stored. Pool retention and post-header protocol ownership are distinct from
 bounded-origin capacity ownership:
@@ -396,6 +394,9 @@ bound against a host that sees one. Canonicalization elides the scheme's default
 Host comparison is already ASCII-case-insensitive. Two spellings are deliberately *not* unified: an
 internationalized host and its punycode form (the connector resolves what it is given; equating them would
 pull in Unicode normalization), and a fully-qualified name with a trailing dot, which is a distinct DNS name.
+IPv6 literals are parsed and normalized to the standard compressed spelling so equivalent address text has
+one identity. A URI zone identifier remains case-sensitive and is retained exactly; it is an opaque
+interface-scoped value rather than a DNS name. Unknown IP-literal forms are not case-folded.
 
 The request path does not construct an owned `OriginKey` merely to probe a partition's origin map. It first
 builds a private canonical lookup key that borrows the URI host when its bytes already have canonical form and
@@ -419,6 +420,11 @@ statistics sample. It validates the host with the structured HTTP authority pars
 scheme other than HTTP or HTTPS, an invalid host or port, and any input that does not name an origin.
 `InvalidOrigin` carries the offending component and source error for diagnostics, implements `Error`, and
 exposes no second, less strict public key representation.
+
+The implementation reads explicit port text from the already-validated `Authority` rather than relying only
+on `Authority::port_u16()`. That accessor returns `None` for both an absent port and text that cannot be
+represented as a nonzero `u16`; preserving the distinction prevents malformed, zero, or out-of-range ports
+from aliasing the scheme's default-port origin.
 
 The request's HTTP version is deliberately absent. A request marked HTTP/1.1 may dispatch on an HTTP/2
 connection, so version is a dispatch-eligibility question decided per connection, not an identity question
@@ -503,7 +509,7 @@ Client(pool, partition P): HttpClient
   `-- http_connector(settings B, components B) -> PoolConnector(pool, P, policy B)
                                                         |
                                                         `-- one ConnectionPool
-                                                            `-- one OriginState per bounded origin
+                                                            `-- one OriginAdmission per bounded origin
 ```
 
 The facade clones the complete non-exhaustive `HttpConnectorSettings` and extracts the operation components
@@ -548,7 +554,7 @@ request on partition P for origin O
 ```
 
 That is the entire path for a reuse hit. It performs no origin-wide coordination, reads no other partition's
-state, and touches no `OriginState`, admission, or peer index — its synchronization is the requesting
+state, and touches no `OriginAdmission` or peer index — its synchronization is the requesting
 partition's own cell lock. A peer can acquire that same lock when the origin is bounded and under pressure, to
 borrow a handle or claim a connection as it returns, so the lock can be contended; what the hit never does is
 consult state shared across the origin. So a pool with one partition and a pool with ninety-six do the same
@@ -629,10 +635,13 @@ travel freely across worker threads of one multithreaded runtime, which share it
 independent runtime instances. An **explicit partition** names a specific runtime through its
 `DriverSpawner`, and its client must be driven from that runtime; a thread-per-core service that pins a
 runtime per core holds each partition's client on its core, so the precondition costs nothing. Driving either
-kind of partition's client from a different runtime contradicts its placement. For an explicit partition,
-`TokioDriverSpawner` debug-asserts that the spawning runtime matches the one it named, turning the misuse into
-a test failure; the assertion is a diagnostic, not enforcement, since the socket is created before the driver
-is spawned.
+kind of partition's client from a different runtime contradicts its placement.
+
+`TokioDriverSpawner` always submits the driver to its captured handle and debug-asserts that the current
+runtime's stable `Handle::id()` matches the captured handle. The assertion turns foreign-runtime use into a
+test or debug-build failure; it is a diagnostic rather than enforcement because the socket is created before
+the driver is spawned. Tokio may reuse an ID after its runtime is dropped, so the check is not a persistent
+runtime identity or a substitute for the placement ownership rule.
 
 Hyper spawns work of its own, and it follows the connection. An HTTP/2 connection hands Hyper a connection
 task at handshake and per-stream and upgrade tasks as it runs, through an
@@ -850,19 +859,18 @@ enum DemandState {
 }
 
 struct DemandSnapshot {
-    revision: DemandRevision,
-    version: DemandVersion,
+    id: DemandId,
+    version: SnapshotVersion,
     state: DemandState,
 }
 ```
 
-A `DemandRevision` names one episode for the cell's current queue head and may receive at most one terminal
+A `DemandId` names one episode for the cell's current queue head and may receive at most one terminal
 acquisition outcome. Its protocol requirement is stable. Serving or cancelling that head terminates the
-revision; if useful demand remains, the cell creates a successor revision for the new head. A complete snapshot
-version replaces every older version for the same revision, so a delayed active publication cannot overwrite
-retirement. An inactive snapshot retires the revision. When it must queue, each active revision joins the
-applicable scheduling orders at their tails; checked identity allocation does not reuse a revision after
-wraparound.
+demand; if useful demand remains, the cell creates a successor ID for the new head. `SnapshotVersion` orders
+complete replacements for the same ID, so a delayed active publication cannot overwrite retirement. An
+inactive snapshot retires the demand. When it must queue, each active demand joins the applicable scheduling
+orders at their tails; checked identity allocation does not reuse a demand ID after wraparound.
 
 #### Bounded miss
 
@@ -1009,7 +1017,7 @@ struct ReturnClaim {
     id: ClaimId,
     source: CellId,
     target: CellId,
-    demand: DemandRevision,
+    demand: DemandId,
     mode: ClaimMode,
     phase: ClaimPhase,
     source_endpoint: ClaimEndpoint,
@@ -1135,6 +1143,13 @@ action only after releasing the previous lock, and each action retains an idempo
 domain owns the terminal state. The chain performs no await, retry loop, connector or protocol work, or work
 proportional to waiter or partition count, and schedules wakes or callbacks only after releasing its lock.
 
+Pool coordination uses a crate-level synchronization facade so production and Loom tests compile the same
+lock-bearing code. Production lock wrappers retain access to guarded state after standard-library poisoning so
+poisoning alone cannot prevent a later `Drop` fallback from returning a permit or closing a delivery fence.
+This does not make an interrupted state transition valid: code under a pool lock still preserves its
+invariants without relying on poison recovery. Test builds also assert that a thread holds at most one pool
+lock, turning the no-nesting rule into an executable check across the ordinary suite.
+
 Both stay within one origin, and neither moves a driver, so the I/O-placement guarantee from
 [Connection placement follows declared topology](#connection-placement-follows-declared-topology)
 holds under both. This is why `max_connections_per_host` below the partition count is valid rather than an
@@ -1149,7 +1164,7 @@ Within a cell, its queue orders requests. Across cells competing for one origin,
 episodes at two scopes because resources do not all reach the same targets:
 
 ```text
-OriginState(O)
+OriginAdmission(O)
   origin capacity order (all heads):
     oldest -> C2/R8(H1) -> C0/R3(H2) -> C3/R5(H2) -> C1/R9(H1)
 
@@ -1248,7 +1263,7 @@ enum TargetAckResult {
 struct DeliveryGuard {
     delivery: DeliveryId,
     target: CellId,
-    demand: DemandRevision,
+    demand: DemandId,
     state: DeliveryGuardState,
 }
 
@@ -1264,7 +1279,7 @@ enum DeliveryGuardState {
 struct PublicationGuard {
     delivery: DeliveryId,
     target: CellId,
-    demand: DemandRevision,
+    demand: DemandId,
     source: CellId,
     generation: GenerationId,
     state: PublicationGuardState,
@@ -2153,7 +2168,7 @@ already admitted.
 
 **Origins are total and canonical.** Every dispatched request maps to exactly one origin, and equivalent
 spellings of one server map to one origin. *Rules out:* a request with no cell to resolve to; one server
-splitting into two `OriginState`s whose admissions each admit the full bound. *Enforced by:* Key totality,
+splitting into two `OriginAdmission`s that each admit the full bound. *Enforced by:* Key totality,
 Canonical key, and Version independence.
 
 **Cell identity is stable.** A cell is never destroyed while its origin is reachable, and at most one cell
@@ -2419,14 +2434,17 @@ aws-smithy-http-client/src/client/
     builder.rs         — Builder typestate, validation, connector assembly
     client.rs          — Client, PoolConnector, and InvalidPartition
     partition.rs       — partition declarations and runtime/interface placement
-    origin.rs          — owned OriginKey, borrowed lookup, and stable origin registry
+    origin.rs          — owned OriginKey, borrowed lookup, and canonicalization
+    registry.rs        — PartitionRegistry, PartitionState, and stable cell publication
     cell.rs            — OriginCell, local selection, waiters, H1/H2 residency
-    admission/         — permits, demand orders, return claims, delivery
+    admission.rs       — permits, demand orders, return claims, delivery
     handshake.rs       — HTTP/1 attempts, HTTP/2 flights, ALPN convergence
     dispatch.rs        — request preparation, Hyper dispatch, response guards
     connection.rs      — records, leases, logical close, physical completion
     events.rs          — listener and lifecycle event types
     stats.rs           — origin/partition snapshots and lifecycle gauges
+aws-smithy-http-client/src/sync/
+                       — standard-library and Loom synchronization facade
 ```
 
 The inventory describes ownership boundaries, not implementation order. The `pool` module re-exports every

--- a/rust-runtime/aws-smithy-http-client/external-types.toml
+++ b/rust-runtime/aws-smithy-http-client/external-types.toml
@@ -9,6 +9,8 @@ allowed_external_types = [
     "tokio::io::async_read::AsyncRead",
     "tokio::io::async_write::AsyncWrite",
     "http::uri::Uri",
+    "http::uri::Scheme",
+    "tokio::runtime::handle::Handle",
     # Used in trait bounds for legacy hyper connector build method
     "tower_service::Service",
 

--- a/rust-runtime/aws-smithy-http-client/src/client.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client.rs
@@ -4,6 +4,7 @@
  */
 
 mod dns;
+pub mod pool;
 /// Proxy configuration
 pub mod proxy;
 mod timeout;

--- a/rust-runtime/aws-smithy-http-client/src/client/pool.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Partition-aware HTTP connection pooling.
+//!
+//! A [`Partition`] fixes where connections are established and driven. Pool
+//! state for one partition and one [`OriginKey`] meets in an `OriginCell`.
+//! Protocol-specific selection and establishment use that cell as follows:
+//!
+//! ```text
+//! request (partition P, URI)
+//!   |
+//!   | resolve canonical origin in PartitionRegistry
+//!   v
+//! OriginCell(P, origin)
+//!   |
+//!   +-- local connection available --------------------> ConnectionState -> dispatch
+//!   |
+//!   +-- unbounded miss --------------------------------> establish -> ConnectionState
+//!   |
+//!   `-- bounded miss -> local waiter -> DemandSnapshot
+//!                                      |
+//!                                      v
+//!                               OriginAdmission
+//!                          (capacity and cell order)
+//!                                      |
+//!                               CapacityDelivery
+//!                                      |
+//!                                      v
+//!                         waiter receives CapacityLease
+//!                                      |
+//!                               establish -> ConnectionState
+//! ```
+//!
+//! `OriginAdmission` exists only when an origin has a connection limit. It is
+//! not another connection cache: cells retain protocol state, while admission
+//! decides which cell may consume the next connection slot. A
+//! [`ConnectionReuseScope`] determines which cells are eligible to relieve
+//! each other's demand without moving connection I/O or its protocol driver.
+//!
+//! An installed connection tracks reuse eligibility, committed requests, and
+//! root I/O independently:
+//!
+//! ```text
+//! ConnectionState
+//!   |-- logical_close ------> stop accepting work + return bounded capacity
+//!   |-- try_commit_dispatch -> DispatchGuard -------> request completion
+//!   `-- PhysicalConnectionGuard --------------------> root I/O is gone
+//! ```
+//!
+//! Logical close releases the connection slot without waiting for committed
+//! requests or transport teardown. Those remaining lifetimes retain the
+//! shared `ConnectionState` until their own terminal transitions.
+
+// TODO(pool): Revisit this overview once protocol records and public construction are present.
+
+#![allow(
+    dead_code,
+    reason = "TODO(pool): remove when protocol paths consume the pool internals"
+)]
+
+mod admission;
+mod cell;
+mod connection;
+mod origin;
+mod partition;
+mod registry;
+
+pub use connection::{CloseReason, ConnectionId};
+pub use origin::{InvalidOrigin, OriginKey};
+#[cfg(feature = "rt-tokio")]
+pub use partition::TokioDriverSpawner;
+pub use partition::{ConnectionReuseScope, DriverSpawner, Partition, PartitionId};

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
@@ -153,12 +153,24 @@ impl OriginAdmission {
     /// Registers or returns the unique retained cell for an identity.
     pub(crate) fn register_cell(origin: &Arc<Self>, candidate: Arc<OriginCell>) -> Arc<OriginCell> {
         let id = candidate.id().clone();
-        let mut state = origin.state.lock();
-        if let Some(existing) = state.cells.get(&id).and_then(Weak::upgrade) {
-            return existing;
+        let existing = {
+            let mut state = origin.state.lock();
+            match state.cells.get(&id).and_then(Weak::upgrade) {
+                Some(existing) => Some(existing),
+                None => {
+                    state.cells.insert(id, Weak::from_arc(&candidate));
+                    None
+                }
+            }
+        };
+        if let Some(existing) = existing {
+            // Dropping the losing cell may drop a CapacityLease and re-enter
+            // this admission lock, so release the lock first.
+            drop(candidate);
+            existing
+        } else {
+            candidate
         }
-        state.cells.insert(id, Weak::from_arc(&candidate));
-        candidate
     }
 
     /// Publishes a complete demand snapshot and drives any resulting delivery.
@@ -198,7 +210,7 @@ impl OriginAdmission {
     }
 
     /// Drives sequential deliveries until no completion schedules another.
-    fn drive(mut delivery: Option<CapacityDelivery>) {
+    pub(super) fn drive(mut delivery: Option<CapacityDelivery>) {
         while let Some(current) = delivery {
             delivery = current.deliver_once();
         }
@@ -424,10 +436,9 @@ impl CapacityDelivery {
         )
     }
 
-    /// Rejects this delivery and refunnels its permit with the acknowledgement.
-    pub(crate) fn reject(self, successor: Option<DemandSnapshot>) {
-        let next = self.finish_undelivered(TargetAckResult::Rejected { successor });
-        OriginAdmission::drive(next);
+    /// Refunnels this rejected delivery and returns the next scheduled crossing.
+    pub(crate) fn reject(self, successor: Option<DemandSnapshot>) -> Option<CapacityDelivery> {
+        self.finish_undelivered(TargetAckResult::Rejected { successor })
     }
 
     /// Disarms this guard and resolves its permit and demand fence together.
@@ -1395,7 +1406,7 @@ mod tests {
             .lock()
             .publish_demand(target.id().clone(), demand(2));
         assert!(!delivery.is_current());
-        delivery.reject(None);
+        OriginAdmission::drive(delivery.reject(None));
     }
 
     #[test]
@@ -1414,7 +1425,7 @@ mod tests {
                 EligibilityGroup::Pool,
             ),
         );
-        delivery.reject(Some(demand(1)));
+        OriginAdmission::drive(delivery.reject(Some(demand(1))));
 
         assert_eq!(1, origin.counts().available);
         assert_eq!(0, origin.counts().ordered);
@@ -1449,6 +1460,35 @@ mod tests {
             .take_ready_lease(second_waiter)
             .expect("younger demand did not run after the original head");
         drop(second_lease);
+    }
+
+    #[test]
+    fn losing_registered_cell_returns_capacity_after_admission_unlocks() {
+        let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let retained = cell(&origin, 1);
+        let candidate = Arc::new(OriginCell::new(
+            retained.id().partition(),
+            retained.id().origin().clone(),
+            EligibilityGroup::Pool,
+            Some(origin.clone()),
+        ));
+        assert_eq!(retained.id(), candidate.id());
+
+        let (_waiter, snapshot) =
+            candidate.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        let delivery =
+            OriginAdmission::publish_without_driving(&origin, candidate.id().clone(), snapshot)
+                .expect("candidate demand did not reserve capacity");
+        assert!(OriginCell::receive_capacity(&candidate, delivery).is_none());
+        assert_eq!(0, origin.available_capacity_for_test());
+
+        let winner = OriginAdmission::register_cell(&origin, candidate);
+        assert!(Arc::ptr_eq(&retained, &winner));
+        assert_eq!(
+            1,
+            origin.available_capacity_for_test(),
+            "losing candidate did not return capacity after registration"
+        );
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
@@ -1,0 +1,1602 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Capacity and demand shared by the cells of one bounded origin.
+//!
+//! [`OriginAdmission`] is the authority for connection permits and cross-cell
+//! demand order. Its state lives behind one lock. Values that cross to a cell
+//! carry their own fallback so delivery and cancellation complete without
+//! nesting admission and cell locks.
+
+use super::cell::{CellId, OriginCell};
+use super::partition::EligibilityGroup;
+use crate::sync::{Arc, Mutex, Weak};
+use std::collections::HashMap;
+use std::fmt;
+use std::num::NonZeroUsize;
+
+/// Protocol capability required by the head waiter in a cell.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ProtocolRequirement {
+    /// The waiter may dispatch over HTTP/1 or HTTP/2.
+    H1Compatible,
+    /// The waiter requires HTTP/2.
+    H2Required,
+}
+
+/// Identity of one cell-local demand episode.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct DemandId(u64);
+
+impl DemandId {
+    /// Constructs an identity allocated by one cell's monotonic demand counter.
+    pub(crate) const fn from_u64(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Version of a complete snapshot for one demand identity.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct SnapshotVersion(u64);
+
+impl SnapshotVersion {
+    /// Version assigned to the first complete snapshot for a demand episode.
+    pub(crate) const INITIAL: Self = Self(0);
+
+    /// Returns the version for the next complete publication.
+    pub(crate) fn next(self) -> Self {
+        Self(
+            self.0
+                .checked_add(1)
+                .expect("demand snapshot version exhausted"),
+        )
+    }
+}
+
+/// Complete state published for one demand identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum DemandState {
+    /// The cell has a waiter that still needs a connection.
+    Active {
+        /// Protocol capability required by the cell's oldest waiter.
+        head: ProtocolRequirement,
+        /// Partitions whose connections may satisfy this demand.
+        eligibility_group: EligibilityGroup,
+    },
+    /// The demand has ended without a successor in this snapshot.
+    Inactive,
+}
+
+/// Versioned replacement state for one cell's current demand episode.
+///
+/// A publication replaces the complete previous snapshot. This prevents a
+/// delayed active publication from reviving demand retired by a newer version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DemandSnapshot {
+    /// Cell-local identity of the head-waiter episode.
+    id: DemandId,
+    /// Ordering among publications for the same demand identity.
+    version: SnapshotVersion,
+    /// Complete current state of the demand episode.
+    state: DemandState,
+}
+
+impl DemandSnapshot {
+    /// Describes the current head waiter for an active demand episode.
+    pub(crate) fn active(
+        id: DemandId,
+        version: SnapshotVersion,
+        head: ProtocolRequirement,
+        eligibility_group: EligibilityGroup,
+    ) -> Self {
+        Self {
+            id,
+            version,
+            state: DemandState::Active {
+                head,
+                eligibility_group,
+            },
+        }
+    }
+
+    /// Retires a demand episode at the supplied publication version.
+    pub(crate) fn inactive(id: DemandId, version: SnapshotVersion) -> Self {
+        Self {
+            id,
+            version,
+            state: DemandState::Inactive,
+        }
+    }
+
+    /// Returns whether this snapshot still requests capacity.
+    fn is_active(&self) -> bool {
+        matches!(self.state, DemandState::Active { .. })
+    }
+
+    /// Returns whether this snapshot may replace `current`.
+    ///
+    /// A newer demand episode supersedes every snapshot of an older episode;
+    /// publications within one episode are ordered by snapshot version.
+    fn is_newer_than(&self, current: &Self) -> bool {
+        self.id > current.id || (self.id == current.id && self.version > current.version)
+    }
+}
+
+/// Stable identity of one admitted connection slot within an origin.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct PermitId(u64);
+
+/// Stable identity of one admission-to-cell delivery.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct DeliveryId(u64);
+
+/// Shared admission authority for one bounded origin.
+///
+/// The state lock is the only authority for permit ownership while capacity
+/// resides in admission, and for demand order while no delivery is crossing
+/// to a cell. Delivery work is detached before this lock is released.
+pub(crate) struct OriginAdmission {
+    /// Permit, demand, and delivery-fence state for this origin.
+    state: Mutex<AdmissionState>,
+}
+
+impl OriginAdmission {
+    /// Creates admission for at most `limit` logically open connections.
+    pub(crate) fn new(limit: NonZeroUsize) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(AdmissionState::new(limit)),
+        })
+    }
+
+    /// Registers or returns the unique retained cell for an identity.
+    pub(crate) fn register_cell(origin: &Arc<Self>, candidate: Arc<OriginCell>) -> Arc<OriginCell> {
+        let id = candidate.id().clone();
+        let mut state = origin.state.lock();
+        if let Some(existing) = state.cells.get(&id).and_then(Weak::upgrade) {
+            return existing;
+        }
+        state.cells.insert(id, Weak::from_arc(&candidate));
+        candidate
+    }
+
+    /// Publishes a complete demand snapshot and drives any resulting delivery.
+    pub(crate) fn publish_demand(origin: &Arc<Self>, target: CellId, snapshot: DemandSnapshot) {
+        let delivery = {
+            let mut state = origin.state.lock();
+            state.publish_demand(target, snapshot);
+            Self::prepare_delivery(origin, &mut state)
+        };
+        Self::drive(delivery);
+    }
+
+    /// Extracts one permit and ordered demand into an unlocked delivery guard.
+    fn prepare_delivery(
+        origin: &Arc<Self>,
+        state: &mut AdmissionState,
+    ) -> Option<CapacityDelivery> {
+        state.schedule_one().map(|pending| CapacityDelivery {
+            origin: origin.clone(),
+            delivery: pending.delivery,
+            target: pending.target,
+            demand: pending.demand,
+            state: CapacityDeliveryState::Undelivered {
+                permit: Some(pending.permit),
+                on_drop: TargetAckResult::RetrySameResidence,
+            },
+        })
+    }
+
+    /// Upgrades a registered target without holding the admission lock.
+    fn target(&self, id: &CellId) -> Option<Arc<OriginCell>> {
+        let target = {
+            let state = self.state.lock();
+            state.cells.get(id).cloned()
+        };
+        target.and_then(|target| target.upgrade())
+    }
+
+    /// Drives sequential deliveries until no completion schedules another.
+    fn drive(mut delivery: Option<CapacityDelivery>) {
+        while let Some(current) = delivery {
+            delivery = current.deliver_once();
+        }
+    }
+
+    /// Returns whether the named delivery still owns the target's demand fence.
+    fn delivery_is_current(&self, delivery: DeliveryId, target: &CellId, demand: DemandId) -> bool {
+        self.state
+            .lock()
+            .delivery_is_current(delivery, target, demand)
+    }
+
+    /// Returns `permit` to admission and serves ordered demand when possible.
+    fn return_permit(origin: &Arc<Self>, permit: PermitId) {
+        let delivery = {
+            let mut state = origin.state.lock();
+            state.available.push(permit);
+            Self::prepare_delivery(origin, &mut state)
+        };
+        Self::drive(delivery);
+    }
+
+    /// Closes a delivery fence and prepares at most one successor.
+    ///
+    /// `permit` is present when an undelivered payload is refunnelled. A
+    /// committed delivery leaves the permit in its installed
+    /// [`CapacityLease`] and acknowledges with `None`.
+    fn finish_delivery(
+        origin: &Arc<Self>,
+        delivery: DeliveryId,
+        target: &CellId,
+        permit: Option<PermitId>,
+        result: TargetAckResult,
+    ) -> Option<CapacityDelivery> {
+        let mut state = origin.state.lock();
+        if let Some(permit) = permit {
+            state.available.push(permit);
+        }
+        state.finish_delivery(delivery, target, result);
+        Self::prepare_delivery(origin, &mut state)
+    }
+
+    #[cfg(test)]
+    pub(super) fn publish_without_driving(
+        origin: &Arc<Self>,
+        target: CellId,
+        snapshot: DemandSnapshot,
+    ) -> Option<CapacityDelivery> {
+        let mut state = origin.state.lock();
+        state.publish_demand(target, snapshot);
+        Self::prepare_delivery(origin, &mut state)
+    }
+
+    #[cfg(test)]
+    fn counts(&self) -> AdmissionCounts {
+        let state = self.state.lock();
+        AdmissionCounts {
+            limit: state.limit,
+            available: state.available_capacity(),
+            ordered: state.demand_schedule.len(),
+            queued: state.demand_schedule.queued_len(),
+            delivering: state.demand_schedule.delivering_len(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn lease_for_test(origin: &Arc<Self>) -> CapacityLease {
+        let permit = origin
+            .state
+            .lock()
+            .take_available()
+            .expect("test origin had no available capacity");
+        CapacityLease::new(origin.clone(), permit)
+    }
+
+    #[cfg(test)]
+    pub(super) fn available_capacity_for_test(&self) -> usize {
+        self.state.lock().available_capacity()
+    }
+
+    #[cfg(all(test, not(smithy_http_client_loom)))]
+    pub(super) fn ordered_demand_count_for_test(&self) -> usize {
+        self.state.lock().demand_schedule.len()
+    }
+
+    #[cfg(all(test, smithy_http_client_loom))]
+    pub(super) fn clear_modeled_cells_for_test(&self) {
+        // Loom has no modeled Weak, so its synchronization facade retains
+        // cells strongly. Explicit teardown prevents that model-only
+        // substitution from appearing as an Arc leak.
+        self.state.lock().cells.clear();
+    }
+}
+
+impl fmt::Debug for OriginAdmission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OriginAdmission")
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+/// One admitted connection slot for a bounded origin.
+///
+/// While this lease exists, one place in the origin's configured connection
+/// limit is occupied. The lease moves through capacity delivery, waiter
+/// resolution, and establishment into the installed
+/// [`super::connection::ConnectionState`]. Logical close drops the installed
+/// lease and makes that place available again.
+///
+/// Dropping a lease may synchronously deliver capacity to another waiter, so
+/// callers must move it out of protected state before drop.
+pub(crate) struct CapacityLease {
+    /// Admission state to which this slot returns when the lease ends.
+    origin: Arc<OriginAdmission>,
+    /// Internal identity of the occupied slot.
+    permit: Option<PermitId>,
+}
+
+impl CapacityLease {
+    /// Takes ownership of a permit removed from admission's available set.
+    fn new(origin: Arc<OriginAdmission>, permit: PermitId) -> Self {
+        Self {
+            origin,
+            permit: Some(permit),
+        }
+    }
+}
+
+impl fmt::Debug for CapacityLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CapacityLease")
+            .field("permit", &self.permit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CapacityLease {
+    fn drop(&mut self) {
+        if let Some(permit) = self.permit.take() {
+            OriginAdmission::return_permit(&self.origin, permit);
+        }
+    }
+}
+
+/// Admission's acknowledgement of a target-side delivery attempt.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TargetAckResult {
+    /// The target accepted the payload and optionally published its successor demand.
+    Accepted { successor: Option<DemandSnapshot> },
+    /// The same demand remains live at its existing order position.
+    RetrySameResidence,
+    /// The old demand ended and may have a successor.
+    Rejected { successor: Option<DemandSnapshot> },
+}
+
+/// An available bounded-origin slot being delivered to a waiting cell.
+///
+/// Until committed or rejected, this value owns both the permit and the
+/// delivery fence. Dropping it refunnels the permit, restores the demand's
+/// scheduling residence, and may drive the next delivery synchronously.
+pub(crate) struct CapacityDelivery {
+    /// Admission state that issued the permit.
+    origin: Arc<OriginAdmission>,
+    /// Identity of the outstanding delivery fence.
+    delivery: DeliveryId,
+    /// Cell selected while the admission lock was held.
+    target: CellId,
+    /// Demand episode the target must revalidate.
+    demand: DemandId,
+    /// Permit and fallback ownership before the terminal transition.
+    state: CapacityDeliveryState,
+}
+
+impl CapacityDelivery {
+    /// Returns the demand identity fenced by this delivery.
+    pub(crate) fn demand(&self) -> DemandId {
+        self.demand
+    }
+
+    /// Returns whether this guard still owns the target's delivery fence.
+    pub(crate) fn is_current(&self) -> bool {
+        self.origin
+            .delivery_is_current(self.delivery, &self.target, self.demand)
+    }
+
+    /// Attempts one delivery to the registered target cell.
+    ///
+    /// A live target either accepts or rejects the guard. An expired target
+    /// refunnels the permit and retires the fenced demand.
+    fn deliver_once(self) -> Option<CapacityDelivery> {
+        let target = self.origin.target(&self.target);
+        match target {
+            Some(target) => OriginCell::receive_capacity(&target, self),
+            None => self.finish_undelivered(TargetAckResult::Rejected { successor: None }),
+        }
+    }
+
+    /// Transfers the admitted slot to target-owned state.
+    ///
+    /// The returned acknowledgement keeps the scheduling fence installed
+    /// until target state contains the lease.
+    pub(crate) fn commit(
+        mut self,
+        successor: Option<DemandSnapshot>,
+    ) -> (CapacityLease, CapacityDeliveryAck) {
+        let CapacityDeliveryState::Undelivered { permit, .. } = &mut self.state else {
+            unreachable!("capacity delivery committed after terminal transition");
+        };
+        let permit = permit
+            .take()
+            .expect("capacity delivery payload moved more than once");
+        self.state = CapacityDeliveryState::Disarmed;
+
+        (
+            CapacityLease::new(self.origin.clone(), permit),
+            CapacityDeliveryAck {
+                origin: self.origin.clone(),
+                delivery: self.delivery,
+                target: self.target.clone(),
+                result: Some(TargetAckResult::Accepted { successor }),
+            },
+        )
+    }
+
+    /// Rejects this delivery and refunnels its permit with the acknowledgement.
+    pub(crate) fn reject(self, successor: Option<DemandSnapshot>) {
+        let next = self.finish_undelivered(TargetAckResult::Rejected { successor });
+        OriginAdmission::drive(next);
+    }
+
+    /// Disarms this guard and resolves its permit and demand fence together.
+    fn finish_undelivered(mut self, result: TargetAckResult) -> Option<CapacityDelivery> {
+        let permit = match &mut self.state {
+            CapacityDeliveryState::Undelivered { permit, .. } => permit.take(),
+            CapacityDeliveryState::Disarmed => None,
+        };
+        self.state = CapacityDeliveryState::Disarmed;
+        OriginAdmission::finish_delivery(&self.origin, self.delivery, &self.target, permit, result)
+    }
+}
+
+impl fmt::Debug for CapacityDelivery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CapacityDelivery")
+            .field("delivery", &self.delivery)
+            .field("target", &self.target)
+            .field("demand", &self.demand)
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+impl Drop for CapacityDelivery {
+    fn drop(&mut self) {
+        let CapacityDeliveryState::Undelivered { permit, on_drop } = &mut self.state else {
+            return;
+        };
+        let permit = permit.take();
+        let result = on_drop.clone();
+        self.state = CapacityDeliveryState::Disarmed;
+        let next = OriginAdmission::finish_delivery(
+            &self.origin,
+            self.delivery,
+            &self.target,
+            permit,
+            result,
+        );
+        OriginAdmission::drive(next);
+    }
+}
+
+/// Drop state for a permit crossing between admission and a cell.
+#[derive(Debug)]
+enum CapacityDeliveryState {
+    /// The guard still owns the permit and fallback acknowledgement.
+    Undelivered {
+        permit: Option<PermitId>,
+        on_drop: TargetAckResult,
+    },
+    /// Ownership and fallback responsibility moved to another guard.
+    Disarmed,
+}
+
+/// Target-owned acknowledgement that closes one delivery fence on completion.
+///
+/// A committed delivery has already moved its lease into target-owned state.
+/// This value is then the sole owner of fence completion; dropping it performs
+/// the acknowledgement and drives any successor delivery.
+#[derive(Debug)]
+pub(crate) struct CapacityDeliveryAck {
+    /// Admission authority that owns the fence.
+    origin: Arc<OriginAdmission>,
+    /// Identity of the outstanding fence.
+    delivery: DeliveryId,
+    /// Cell whose delivery is being acknowledged.
+    target: CellId,
+    /// Terminal result consumed by explicit completion or `Drop`.
+    result: Option<TargetAckResult>,
+}
+
+impl CapacityDeliveryAck {
+    /// Completes this delivery fence and returns the next scheduled crossing.
+    pub(super) fn finish(mut self) -> Option<CapacityDelivery> {
+        let result = self
+            .result
+            .take()
+            .expect("new capacity delivery acknowledgement had no result");
+        OriginAdmission::finish_delivery(&self.origin, self.delivery, &self.target, None, result)
+    }
+}
+
+impl Drop for CapacityDeliveryAck {
+    fn drop(&mut self) {
+        if let Some(result) = self.result.take() {
+            let next = OriginAdmission::finish_delivery(
+                &self.origin,
+                self.delivery,
+                &self.target,
+                None,
+                result,
+            );
+            OriginAdmission::drive(next);
+        }
+    }
+}
+
+/// Mutable bounded-origin state protected by one admission lock.
+#[derive(Debug)]
+struct AdmissionState {
+    /// Cells available as delivery targets, held weakly to avoid an ownership cycle.
+    cells: HashMap<CellId, Weak<OriginCell>>,
+    /// Configured number of permits for this origin.
+    limit: usize,
+    /// Issued permits returned by failed attempts or closed connections.
+    available: Vec<PermitId>,
+    /// Permits not yet materialized from the configured limit.
+    unissued: usize,
+    /// Next never-reused permit identity.
+    next_permit: u64,
+    /// Cross-cell demand records and their origin-wide scheduling order.
+    demand_schedule: DemandSchedule,
+    /// Next never-reused delivery identity.
+    next_delivery: u64,
+}
+
+impl AdmissionState {
+    /// Creates a lazy permit ledger with no materialized permit identities.
+    fn new(limit: NonZeroUsize) -> Self {
+        let limit = limit.get();
+        Self {
+            cells: HashMap::new(),
+            limit,
+            available: Vec::new(),
+            unissued: limit,
+            next_permit: 0,
+            demand_schedule: DemandSchedule::default(),
+            next_delivery: 0,
+        }
+    }
+
+    /// Removes an available permit or materializes the next configured slot.
+    fn take_available(&mut self) -> Option<PermitId> {
+        if let Some(permit) = self.available.pop() {
+            return Some(permit);
+        }
+        if self.unissued == 0 {
+            return None;
+        }
+
+        let permit = PermitId(self.next_permit);
+        self.next_permit = self
+            .next_permit
+            .checked_add(1)
+            .expect("capacity identity exhausted");
+        self.unissued -= 1;
+        Some(permit)
+    }
+
+    #[cfg(test)]
+    fn available_capacity(&self) -> usize {
+        self.unissued
+            .checked_add(self.available.len())
+            .expect("available capacity count overflowed")
+    }
+
+    /// Applies one complete cell publication to cross-cell scheduling.
+    fn publish_demand(&mut self, target: CellId, snapshot: DemandSnapshot) {
+        self.demand_schedule.publish(target, snapshot);
+    }
+
+    /// Pairs the oldest deliverable demand with one available permit.
+    fn schedule_one(&mut self) -> Option<PreparedCapacityDelivery> {
+        if !self.demand_schedule.head_is_queued() {
+            return None;
+        }
+
+        let permit = self.take_available()?;
+        let delivery = self.take_delivery_id();
+        let scheduled = self
+            .demand_schedule
+            .reserve_head(delivery)
+            .expect("queued demand head disappeared");
+        Some(PreparedCapacityDelivery {
+            permit,
+            delivery,
+            target: scheduled.target,
+            demand: scheduled.demand,
+            sequence: scheduled.sequence,
+        })
+    }
+
+    /// Delegates delivery-fence revalidation to the demand schedule.
+    fn delivery_is_current(&self, delivery: DeliveryId, target: &CellId, demand: DemandId) -> bool {
+        self.demand_schedule
+            .delivery_is_current(delivery, target, demand)
+    }
+
+    /// Applies a target acknowledgement to the demand schedule.
+    fn finish_delivery(&mut self, delivery: DeliveryId, target: &CellId, result: TargetAckResult) {
+        self.demand_schedule
+            .finish_delivery(delivery, target, result);
+    }
+
+    /// Allocates a delivery-fence identity that is never reused by this origin.
+    fn take_delivery_id(&mut self) -> DeliveryId {
+        let value = self.next_delivery;
+        self.next_delivery = value.checked_add(1).expect("delivery identity exhausted");
+        DeliveryId(value)
+    }
+}
+
+/// Cross-cell demand records and their origin-wide scheduling order.
+///
+/// At every completed transition:
+///
+/// - `records` owns the newest snapshot for every retained cell.
+/// - `DemandOrderState::Active` contains exactly the `Queued` and `Delivering`
+///   records.
+/// - Queue links live inside those ordered residence variants.
+/// - A `Delivering` record remains at the head as a scheduling fence.
+///
+/// Admission coordinates permit extraction with this schedule while holding
+/// the same origin lock.
+#[derive(Debug, Default)]
+struct DemandSchedule {
+    /// Latest demand and scheduling residence for each retained cell.
+    records: HashMap<CellId, DemandRecord>,
+    /// Origin-wide order, including an outstanding delivery fence.
+    order: DemandOrderState,
+    /// Next never-reused arrival sequence.
+    next_sequence: u64,
+}
+
+impl DemandSchedule {
+    /// Applies a complete snapshot and updates its cell's scheduling residence.
+    fn publish(&mut self, target: CellId, snapshot: DemandSnapshot) {
+        if let Some(current) = self.records.get(&target) {
+            if !snapshot.is_newer_than(&current.latest) {
+                return;
+            }
+        } else {
+            self.records.insert(
+                target.clone(),
+                DemandRecord {
+                    latest: snapshot.clone(),
+                    residence: DemandResidence::Idle,
+                },
+            );
+        }
+
+        let should_remove = matches!(
+            &self
+                .records
+                .get(&target)
+                .expect("published demand record disappeared")
+                .residence,
+            DemandResidence::Queued { demand, .. }
+                if *demand != snapshot.id || !snapshot.is_active()
+        );
+        if should_remove {
+            self.remove_from_order(&target);
+        }
+
+        self.records
+            .get_mut(&target)
+            .expect("published demand record disappeared")
+            .latest = snapshot;
+
+        let record = self
+            .records
+            .get(&target)
+            .expect("published demand record disappeared");
+        if record.latest.is_active() && matches!(&record.residence, DemandResidence::Idle) {
+            self.enqueue(target);
+        }
+        self.assert_consistent();
+    }
+
+    /// Appends an idle active demand to the origin-wide order.
+    fn enqueue(&mut self, target: CellId) {
+        let sequence = self.take_sequence();
+        let previous = match &self.order {
+            DemandOrderState::Empty => None,
+            DemandOrderState::Active { tail, .. } => Some(tail.clone()),
+        };
+        if let Some(previous) = previous.as_ref() {
+            self.records
+                .get_mut(previous)
+                .expect("order tail disappeared")
+                .residence
+                .links_mut()
+                .next = Some(target.clone());
+        }
+
+        let record = self
+            .records
+            .get_mut(&target)
+            .expect("queued demand record disappeared");
+        debug_assert!(matches!(record.residence, DemandResidence::Idle));
+        let demand = record.latest.id;
+        record.residence = DemandResidence::Queued {
+            demand,
+            links: OrderLinks {
+                previous,
+                next: None,
+                sequence,
+            },
+        };
+
+        match &mut self.order {
+            order @ DemandOrderState::Empty => {
+                *order = DemandOrderState::Active {
+                    head: target.clone(),
+                    tail: target,
+                    len: NonZeroUsize::MIN,
+                };
+            }
+            DemandOrderState::Active { tail, len, .. } => {
+                *tail = target;
+                *len = len.checked_add(1).expect("demand order length exhausted");
+            }
+        }
+    }
+
+    /// Removes an ordered demand and leaves its retained record idle.
+    fn remove_from_order(&mut self, target: &CellId) {
+        let residence = {
+            let record = self
+                .records
+                .get_mut(target)
+                .expect("removed demand record disappeared");
+            std::mem::replace(&mut record.residence, DemandResidence::Idle)
+        };
+        let links = residence
+            .into_links()
+            .expect("removed demand had no order links");
+
+        if let Some(previous) = links.previous.as_ref() {
+            self.records
+                .get_mut(previous)
+                .expect("previous demand disappeared")
+                .residence
+                .links_mut()
+                .next = links.next.clone();
+        }
+        if let Some(next) = links.next.as_ref() {
+            self.records
+                .get_mut(next)
+                .expect("next demand disappeared")
+                .residence
+                .links_mut()
+                .previous = links.previous.clone();
+        }
+
+        let order = std::mem::take(&mut self.order);
+        let DemandOrderState::Active { head, tail, len } = order else {
+            unreachable!("removed a demand from an empty order");
+        };
+        debug_assert_eq!(head == *target, links.previous.is_none());
+        debug_assert_eq!(tail == *target, links.next.is_none());
+
+        if len == NonZeroUsize::MIN {
+            debug_assert!(links.previous.is_none());
+            debug_assert!(links.next.is_none());
+            return;
+        }
+
+        self.order = DemandOrderState::Active {
+            head: if head == *target {
+                links.next.clone().expect("removed head had no successor")
+            } else {
+                head
+            },
+            tail: if tail == *target {
+                links
+                    .previous
+                    .clone()
+                    .expect("removed tail had no predecessor")
+            } else {
+                tail
+            },
+            len: NonZeroUsize::new(
+                len.get()
+                    .checked_sub(1)
+                    .expect("demand order length underflowed"),
+            )
+            .expect("nonempty demand order lost its length"),
+        };
+    }
+
+    /// Returns whether the head can begin a new one-to-one delivery.
+    fn head_is_queued(&self) -> bool {
+        let DemandOrderState::Active { head, .. } = &self.order else {
+            return false;
+        };
+        matches!(
+            &self
+                .records
+                .get(head)
+                .expect("order head disappeared")
+                .residence,
+            DemandResidence::Queued { .. }
+        )
+    }
+
+    /// Changes the queued head into a delivery fence at the same order position.
+    fn reserve_head(&mut self, delivery: DeliveryId) -> Option<ScheduledDemand> {
+        let DemandOrderState::Active { head, .. } = &self.order else {
+            return None;
+        };
+        let target = head.clone();
+        let record = self
+            .records
+            .get_mut(&target)
+            .expect("order head disappeared");
+        let residence = std::mem::replace(&mut record.residence, DemandResidence::Idle);
+        match residence {
+            DemandResidence::Queued { demand, links } => {
+                debug_assert_eq!(record.latest.id, demand);
+                debug_assert!(record.latest.is_active());
+                let sequence = links.sequence;
+                record.residence = DemandResidence::Delivering {
+                    demand,
+                    delivery,
+                    links,
+                };
+                self.assert_consistent();
+                Some(ScheduledDemand {
+                    target,
+                    demand,
+                    sequence,
+                })
+            }
+            residence => {
+                record.residence = residence;
+                None
+            }
+        }
+    }
+
+    /// Returns whether a delivery still owns the target demand's head fence.
+    ///
+    /// Cell-side reservation uses this identity check to reject a crossing
+    /// prepared for demand that was replaced while no pool lock was held.
+    fn delivery_is_current(&self, delivery: DeliveryId, target: &CellId, demand: DemandId) -> bool {
+        let Some(record) = self.records.get(target) else {
+            return false;
+        };
+        matches!(
+            &record.residence,
+            DemandResidence::Delivering {
+                demand: current_demand,
+                delivery: current_delivery,
+                ..
+            } if *current_delivery == delivery
+                && *current_demand == demand
+                && record.latest.id == demand
+                && record.latest.is_active()
+        )
+    }
+
+    /// Closes one delivery fence and resolves the demand's next residence.
+    ///
+    /// `Accepted` consumes the delivered episode and installs a newer
+    /// successor when the target supplied one. `RetrySameResidence` restores
+    /// the same episode at its existing order position when it remains live;
+    /// if it was replaced, the latest active episode is appended as new
+    /// demand. `Rejected` removes the fenced episode after its permit has
+    /// already been refunnelled and applies the same successor arbitration as
+    /// acceptance.
+    fn finish_delivery(&mut self, delivery: DeliveryId, target: &CellId, result: TargetAckResult) {
+        let Some(record) = self.records.get(target) else {
+            return;
+        };
+        let delivered_demand = match &record.residence {
+            DemandResidence::Delivering {
+                demand,
+                delivery: current,
+                ..
+            } if *current == delivery => *demand,
+            _ => return,
+        };
+
+        match result {
+            TargetAckResult::RetrySameResidence => {
+                let record = self
+                    .records
+                    .get(target)
+                    .expect("delivery demand record disappeared");
+                if record.latest.id == delivered_demand && record.latest.is_active() {
+                    let record = self
+                        .records
+                        .get_mut(target)
+                        .expect("delivery demand record disappeared");
+                    let residence = std::mem::replace(&mut record.residence, DemandResidence::Idle);
+                    let DemandResidence::Delivering {
+                        demand,
+                        delivery: current,
+                        links,
+                    } = residence
+                    else {
+                        unreachable!("delivery fence disappeared");
+                    };
+                    debug_assert_eq!(current, delivery);
+                    record.residence = DemandResidence::Queued { demand, links };
+                    self.assert_consistent();
+                    return;
+                }
+
+                self.remove_from_order(target);
+                if self
+                    .records
+                    .get(target)
+                    .expect("delivery demand record disappeared")
+                    .latest
+                    .is_active()
+                {
+                    self.enqueue(target.clone());
+                }
+            }
+            TargetAckResult::Accepted { successor } | TargetAckResult::Rejected { successor } => {
+                self.remove_from_order(target);
+
+                let install_successor = successor.as_ref().is_some_and(|successor| {
+                    successor.id > delivered_demand
+                        && successor.is_newer_than(
+                            &self
+                                .records
+                                .get(target)
+                                .expect("delivery demand record disappeared")
+                                .latest,
+                        )
+                });
+                if install_successor {
+                    self.records
+                        .get_mut(target)
+                        .expect("delivery demand record disappeared")
+                        .latest = successor.expect("validated successor disappeared");
+                } else if self
+                    .records
+                    .get(target)
+                    .expect("delivery demand record disappeared")
+                    .latest
+                    .id
+                    == delivered_demand
+                {
+                    let record = self
+                        .records
+                        .get_mut(target)
+                        .expect("delivery demand record disappeared");
+                    record.latest =
+                        DemandSnapshot::inactive(delivered_demand, record.latest.version.next());
+                }
+
+                if self
+                    .records
+                    .get(target)
+                    .expect("delivery demand record disappeared")
+                    .latest
+                    .is_active()
+                {
+                    self.enqueue(target.clone());
+                }
+            }
+        }
+        self.assert_consistent();
+    }
+
+    /// Allocates a shared arrival sequence that is never reused.
+    fn take_sequence(&mut self) -> u64 {
+        let value = self.next_sequence;
+        self.next_sequence = value.checked_add(1).expect("demand sequence exhausted");
+        value
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        match &self.order {
+            DemandOrderState::Empty => 0,
+            DemandOrderState::Active { len, .. } => len.get(),
+        }
+    }
+
+    #[cfg(test)]
+    fn queued_len(&self) -> usize {
+        self.records
+            .values()
+            .filter(|record| matches!(&record.residence, DemandResidence::Queued { .. }))
+            .count()
+    }
+
+    #[cfg(test)]
+    fn delivering_len(&self) -> usize {
+        self.records
+            .values()
+            .filter(|record| matches!(&record.residence, DemandResidence::Delivering { .. }))
+            .count()
+    }
+
+    /// Checks record residence, FIFO links, length, and head-fence relationships.
+    fn assert_consistent(&self) {
+        #[cfg(debug_assertions)]
+        self.assert_consistent_debug();
+    }
+
+    #[cfg(debug_assertions)]
+    fn assert_consistent_debug(&self) {
+        let ordered_records = self
+            .records
+            .values()
+            .filter(|record| record.residence.links().is_some())
+            .count();
+        match &self.order {
+            DemandOrderState::Empty => {
+                assert_eq!(0, ordered_records, "empty order retained ordered demand");
+            }
+            DemandOrderState::Active { head, tail, len } => {
+                let mut current = Some(head.clone());
+                let mut previous = None;
+                let mut traversed = 0;
+                let mut delivering = 0;
+                while let Some(target) = current {
+                    assert!(
+                        traversed < self.records.len(),
+                        "demand order contains a cycle"
+                    );
+                    let record = self
+                        .records
+                        .get(&target)
+                        .expect("ordered demand disappeared");
+                    let links = record
+                        .residence
+                        .links()
+                        .expect("ordered demand lost its links");
+                    assert_eq!(
+                        previous, links.previous,
+                        "demand order contains inconsistent backward links"
+                    );
+                    match &record.residence {
+                        DemandResidence::Idle => unreachable!("ordered demand became idle"),
+                        DemandResidence::Queued { demand, .. } => {
+                            assert!(record.latest.is_active(), "queued demand became inactive");
+                            assert_eq!(
+                                record.latest.id, *demand,
+                                "queued residence did not match its latest demand"
+                            );
+                        }
+                        DemandResidence::Delivering { demand, .. } => {
+                            delivering += 1;
+                            assert_eq!(
+                                target, *head,
+                                "delivery fence moved away from the order head"
+                            );
+                            assert!(
+                                record.latest.id >= *demand,
+                                "delivery fence named a future demand"
+                            );
+                        }
+                    }
+
+                    traversed += 1;
+                    previous = Some(target);
+                    current = links.next.clone();
+                }
+
+                assert!(delivering <= 1, "more than one delivery fence was active");
+                assert_eq!(Some(tail.clone()), previous, "order tail was not reachable");
+                assert_eq!(
+                    len.get(),
+                    traversed,
+                    "demand order length did not match its links"
+                );
+                assert_eq!(
+                    ordered_records, traversed,
+                    "ordered demand was not reachable from the order head"
+                );
+            }
+        }
+    }
+}
+
+/// Latest snapshot and scheduling residence for one stable cell.
+#[derive(Debug)]
+struct DemandRecord {
+    /// Newest complete publication observed for the cell.
+    latest: DemandSnapshot,
+    /// Scheduling residence, including links while ordered.
+    residence: DemandResidence,
+}
+
+/// Admission residence for one cell's latest demand.
+#[derive(Clone, Debug)]
+enum DemandResidence {
+    /// The cell has no demand represented in scheduling.
+    Idle,
+    /// The demand is waiting in origin order.
+    Queued {
+        /// Demand episode represented by this residence.
+        demand: DemandId,
+        /// Origin-wide scheduling links and arrival sequence.
+        links: OrderLinks,
+    },
+    /// One delivery guard owns capacity for this demand.
+    Delivering {
+        /// Demand episode fenced at the order head.
+        demand: DemandId,
+        /// Delivery allowed to complete this fence.
+        delivery: DeliveryId,
+        /// Origin-wide scheduling links retained until acknowledgement.
+        links: OrderLinks,
+    },
+}
+
+impl DemandResidence {
+    /// Borrows order links while this record is queued or delivering.
+    fn links(&self) -> Option<&OrderLinks> {
+        match self {
+            Self::Idle => None,
+            Self::Queued { links, .. } | Self::Delivering { links, .. } => Some(links),
+        }
+    }
+
+    /// Mutably borrows links from a record known to be ordered.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called for an idle record.
+    fn links_mut(&mut self) -> &mut OrderLinks {
+        match self {
+            Self::Idle => panic!("idle demand has no order links"),
+            Self::Queued { links, .. } | Self::Delivering { links, .. } => links,
+        }
+    }
+
+    /// Detaches links while moving a record out of origin-wide order.
+    fn into_links(self) -> Option<OrderLinks> {
+        match self {
+            Self::Idle => None,
+            Self::Queued { links, .. } | Self::Delivering { links, .. } => Some(links),
+        }
+    }
+}
+
+/// Whether origin-wide scheduling currently retains any demand.
+#[derive(Debug, Default)]
+enum DemandOrderState {
+    /// No demand is ordered.
+    #[default]
+    Empty,
+    /// A nonempty origin-wide order, possibly headed by a delivery fence.
+    Active {
+        /// Oldest ordered demand.
+        head: CellId,
+        /// Youngest ordered demand.
+        tail: CellId,
+        /// Number of records linked from `head` through `tail`.
+        len: NonZeroUsize,
+    },
+}
+
+/// Intrusive links retaining one live demand in origin order.
+#[derive(Clone, Debug)]
+struct OrderLinks {
+    /// Older demand in origin order.
+    previous: Option<CellId>,
+    /// Newer demand in origin order.
+    next: Option<CellId>,
+    /// Monotonic arrival order shared with other scheduling views.
+    sequence: u64,
+}
+
+/// Demand reserved at the order head for one capacity delivery.
+struct ScheduledDemand {
+    /// Selected destination cell.
+    target: CellId,
+    /// Demand identity current when the crossing was prepared.
+    demand: DemandId,
+    /// Demand's common arrival order for scheduling-view updates.
+    sequence: u64,
+}
+
+/// Connection capacity extracted under admission lock before crossing to a cell.
+#[derive(Debug)]
+struct PreparedCapacityDelivery {
+    /// Permit transferred into the delivery guard.
+    permit: PermitId,
+    /// Fence identity allocated for this crossing.
+    delivery: DeliveryId,
+    /// Selected destination cell.
+    target: CellId,
+    /// Demand identity current when the crossing was prepared.
+    demand: DemandId,
+    /// Demand's common arrival order for scheduling-view updates.
+    sequence: u64,
+}
+
+#[cfg(test)]
+#[derive(Debug, Eq, PartialEq)]
+struct AdmissionCounts {
+    limit: usize,
+    available: usize,
+    ordered: usize,
+    queued: usize,
+    delivering: usize,
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use crate::client::pool::origin::OriginKey;
+    use crate::client::pool::partition::PartitionId;
+    use http_1x::uri::Scheme;
+
+    fn cell(origin: &Arc<OriginAdmission>, partition: usize) -> Arc<OriginCell> {
+        let cell = Arc::new(OriginCell::new(
+            PartitionId::from_index(partition),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            Some(origin.clone()),
+        ));
+        OriginAdmission::register_cell(origin, cell)
+    }
+
+    fn demand(id: u64) -> DemandSnapshot {
+        DemandSnapshot::active(
+            DemandId::from_u64(id),
+            SnapshotVersion::INITIAL,
+            ProtocolRequirement::H1Compatible,
+            EligibilityGroup::Pool,
+        )
+    }
+
+    #[test]
+    fn configured_limit_materializes_permits_only_when_used() {
+        let limit = NonZeroUsize::new(4096).unwrap();
+        let mut state = AdmissionState::new(limit);
+
+        assert!(state.available.is_empty());
+        assert_eq!(limit.get(), state.unissued);
+        assert_eq!(PermitId(0), state.take_available().unwrap());
+        assert!(state.available.is_empty());
+        assert_eq!(limit.get() - 1, state.unissued);
+    }
+
+    #[test]
+    fn equal_or_older_snapshots_do_not_replace_current_demand() {
+        let mut state = AdmissionState::new(NonZeroUsize::new(1).unwrap());
+        let target = CellId::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+        );
+        let current = demand(2);
+        state.publish_demand(target.clone(), current.clone());
+        state.publish_demand(
+            target.clone(),
+            DemandSnapshot::inactive(DemandId::from_u64(2), SnapshotVersion::INITIAL),
+        );
+        state.publish_demand(target.clone(), demand(1));
+
+        assert_eq!(1, state.demand_schedule.len());
+        assert_eq!(
+            current,
+            state.demand_schedule.records.get(&target).unwrap().latest
+        );
+    }
+
+    #[test]
+    fn cancellation_churn_does_not_retain_order_entries() {
+        let mut state = AdmissionState::new(NonZeroUsize::new(1).unwrap());
+        let held = state.take_available().unwrap();
+        let target = CellId::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+        );
+
+        for id in 0..2_000 {
+            let id = DemandId::from_u64(id);
+            state.publish_demand(
+                target.clone(),
+                DemandSnapshot::active(
+                    id,
+                    SnapshotVersion::INITIAL,
+                    ProtocolRequirement::H1Compatible,
+                    EligibilityGroup::Pool,
+                ),
+            );
+            state.publish_demand(
+                target.clone(),
+                DemandSnapshot::inactive(id, SnapshotVersion::INITIAL.next()),
+            );
+        }
+
+        assert_eq!(0, state.demand_schedule.len());
+        assert!(matches!(
+            state.demand_schedule.order,
+            DemandOrderState::Empty
+        ));
+        state.available.push(held);
+    }
+
+    #[test]
+    fn removing_middle_and_tail_demands_repairs_order() {
+        let mut state = AdmissionState::new(NonZeroUsize::new(1).unwrap());
+        let held = state.take_available().unwrap();
+        let targets: Vec<_> = (1..=5)
+            .map(|partition| {
+                CellId::new(
+                    PartitionId::from_index(partition),
+                    OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                )
+            })
+            .collect();
+
+        for (index, target) in targets[..4].iter().enumerate() {
+            state.publish_demand(target.clone(), demand(index as u64 + 1));
+        }
+        state.publish_demand(
+            targets[1].clone(),
+            DemandSnapshot::inactive(DemandId::from_u64(2), SnapshotVersion::INITIAL.next()),
+        );
+        state.publish_demand(
+            targets[3].clone(),
+            DemandSnapshot::inactive(DemandId::from_u64(4), SnapshotVersion::INITIAL.next()),
+        );
+        state.publish_demand(targets[4].clone(), demand(5));
+        assert_eq!(3, state.demand_schedule.len());
+
+        state.available.push(held);
+        for expected in [&targets[0], &targets[2], &targets[4]] {
+            let pending = state.schedule_one().unwrap();
+            assert_eq!(expected, &pending.target);
+            state.finish_delivery(
+                pending.delivery,
+                &pending.target,
+                TargetAckResult::Accepted { successor: None },
+            );
+            state.available.push(pending.permit);
+        }
+        assert_eq!(0, state.demand_schedule.len());
+    }
+
+    #[test]
+    fn new_demand_moves_queued_cell_to_the_tail() {
+        let mut state = AdmissionState::new(NonZeroUsize::new(1).unwrap());
+        let held = state.take_available().unwrap();
+        let first = CellId::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+        );
+        let second = CellId::new(
+            PartitionId::from_index(2),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+        );
+        state.publish_demand(first.clone(), demand(1));
+        state.publish_demand(second.clone(), demand(2));
+        state.publish_demand(first, demand(3));
+        state.available.push(held);
+
+        assert_eq!(second, state.schedule_one().unwrap().target);
+    }
+
+    #[test]
+    fn delivery_currency_includes_the_demand_id() {
+        let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let target = cell(&origin, 1);
+        let delivery =
+            OriginAdmission::publish_without_driving(&origin, target.id().clone(), demand(1))
+                .unwrap();
+        assert!(delivery.is_current());
+
+        origin
+            .state
+            .lock()
+            .publish_demand(target.id().clone(), demand(2));
+        assert!(!delivery.is_current());
+        delivery.reject(None);
+    }
+
+    #[test]
+    fn stale_successor_cannot_leave_active_demand_idle() {
+        let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let target = cell(&origin, 1);
+        let delivery =
+            OriginAdmission::publish_without_driving(&origin, target.id().clone(), demand(1))
+                .unwrap();
+        origin.state.lock().publish_demand(
+            target.id().clone(),
+            DemandSnapshot::active(
+                DemandId::from_u64(1),
+                SnapshotVersion::INITIAL.next(),
+                ProtocolRequirement::H1Compatible,
+                EligibilityGroup::Pool,
+            ),
+        );
+        delivery.reject(Some(demand(1)));
+
+        assert_eq!(1, origin.counts().available);
+        assert_eq!(0, origin.counts().ordered);
+    }
+
+    #[test]
+    fn dropped_delivery_refunnels_capacity_and_preserves_order() {
+        let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let first = cell(&origin, 1);
+        let second = cell(&origin, 2);
+        let (first_waiter, first_demand) =
+            first.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        let (second_waiter, second_demand) =
+            second.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        let delivery =
+            OriginAdmission::publish_without_driving(&origin, first.id().clone(), first_demand)
+                .unwrap();
+        {
+            let mut state = origin.state.lock();
+            state.publish_demand(second.id().clone(), second_demand);
+        }
+        drop(delivery);
+
+        let first_lease = first
+            .take_ready_lease(first_waiter)
+            .expect("dropped delivery did not retry the original head");
+        assert!(second.take_ready_lease(second_waiter).is_none());
+        assert_eq!(1, origin.counts().ordered);
+
+        drop(first_lease);
+        let second_lease = second
+            .take_ready_lease(second_waiter)
+            .expect("younger demand did not run after the original head");
+        drop(second_lease);
+    }
+
+    #[test]
+    fn expired_delivery_target_refunnels_capacity() {
+        let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let target = cell(&origin, 1);
+        let target_id = target.id().clone();
+        let (_waiter, snapshot) =
+            target.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        let delivery =
+            OriginAdmission::publish_without_driving(&origin, target_id.clone(), snapshot).unwrap();
+
+        drop(target);
+        assert!(origin.target(&target_id).is_none());
+        OriginAdmission::drive(Some(delivery));
+
+        let counts = origin.counts();
+        assert_eq!(1, counts.available);
+        assert_eq!(0, counts.delivering);
+        assert_eq!(0, counts.ordered);
+    }
+
+    #[test]
+    fn separate_origins_conserve_capacity_independently() {
+        let first = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let second = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let first_cell = cell(&first, 1);
+        let second_cell = cell(&second, 1);
+
+        let first_delivery =
+            OriginAdmission::publish_without_driving(&first, first_cell.id().clone(), demand(1))
+                .unwrap();
+        let second_delivery =
+            OriginAdmission::publish_without_driving(&second, second_cell.id().clone(), demand(1))
+                .unwrap();
+        assert_eq!(
+            first_delivery
+                .state
+                .permit_id()
+                .expect("first delivery lost permit"),
+            second_delivery
+                .state
+                .permit_id()
+                .expect("second delivery lost permit")
+        );
+    }
+
+    impl CapacityDeliveryState {
+        fn permit_id(&self) -> Option<u64> {
+            match self {
+                Self::Undelivered { permit, .. } => permit.map(|permit| permit.0),
+                Self::Disarmed => None,
+            }
+        }
+    }
+}
+
+#[cfg(all(test, smithy_http_client_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::client::pool::origin::OriginKey;
+    use crate::client::pool::partition::PartitionId;
+    use http_1x::uri::Scheme;
+
+    fn id() -> CellId {
+        CellId::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+        )
+    }
+
+    fn demand() -> DemandSnapshot {
+        DemandSnapshot::active(
+            DemandId::from_u64(1),
+            SnapshotVersion::INITIAL,
+            ProtocolRequirement::H1Compatible,
+            EligibilityGroup::Pool,
+        )
+    }
+
+    #[test]
+    fn release_and_demand_publication_conserve_one_permit() {
+        loom::model(|| {
+            let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+            let permit = origin.state.lock().take_available().unwrap();
+            let lease = CapacityLease::new(origin.clone(), permit);
+
+            let release = loom::thread::spawn(move || drop(lease));
+            let publish_origin = origin.clone();
+            let publish = loom::thread::spawn(move || {
+                let delivery =
+                    OriginAdmission::publish_without_driving(&publish_origin, id(), demand());
+                drop(delivery);
+            });
+            release.join().unwrap();
+            publish.join().unwrap();
+
+            assert_eq!(1, origin.counts().available);
+            assert!(origin.counts().ordered <= 1);
+        });
+    }
+
+    #[test]
+    fn cancellation_preserves_an_outstanding_delivery_fence() {
+        loom::model(|| {
+            use loom::sync::atomic::{AtomicBool, Ordering};
+
+            let origin = OriginAdmission::new(NonZeroUsize::new(2).unwrap());
+            let target = id();
+            let delivery =
+                OriginAdmission::publish_without_driving(&origin, target.clone(), demand())
+                    .unwrap();
+            let release = Arc::new(AtomicBool::new(false));
+
+            let delivery_release = release.clone();
+            let dropped = loom::thread::spawn(move || {
+                while !delivery_release.load(Ordering::Acquire) {
+                    loom::thread::yield_now();
+                }
+                drop(delivery);
+            });
+
+            origin.state.lock().publish_demand(
+                target.clone(),
+                DemandSnapshot::inactive(DemandId::from_u64(1), SnapshotVersion::INITIAL.next()),
+            );
+            let duplicate = OriginAdmission::publish_without_driving(
+                &origin,
+                target,
+                DemandSnapshot::active(
+                    DemandId::from_u64(2),
+                    SnapshotVersion::INITIAL,
+                    ProtocolRequirement::H1Compatible,
+                    EligibilityGroup::Pool,
+                ),
+            );
+
+            release.store(true, Ordering::Release);
+            dropped.join().unwrap();
+            assert!(
+                duplicate.is_none(),
+                "outstanding delivery fence admitted a second delivery"
+            );
+
+            let counts = origin.counts();
+            assert_eq!(2, counts.available);
+            assert_eq!(0, counts.delivering);
+            assert_eq!(0, counts.ordered);
+        });
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
@@ -153,8 +153,7 @@ impl OriginCell {
         };
 
         let DeliveryReservation::Reserved { waiter, successor } = reservation else {
-            delivery.reject(None);
-            return None;
+            return delivery.reject(None);
         };
 
         let (lease, acknowledgement) = delivery.commit(successor);
@@ -418,12 +417,67 @@ mod tests {
                 .expect("first demand did not reserve capacity");
 
         assert!(cell.cancel_waiter(first));
-        assert!(OriginCell::receive_capacity(&cell, stale).is_none());
+        OriginAdmission::drive(OriginCell::receive_capacity(&cell, stale));
 
         let lease = cell
             .take_ready_lease(second)
             .expect("replacement demand did not receive refunnelled capacity");
         drop(lease);
+    }
+
+    #[test]
+    fn stale_delivery_returns_its_successor_to_the_driver() {
+        let admission = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let stale = OriginAdmission::register_cell(
+            &admission,
+            Arc::new(OriginCell::new(
+                PartitionId::from_index(1),
+                OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                EligibilityGroup::Pool,
+                Some(admission.clone()),
+            )),
+        );
+        let target = OriginAdmission::register_cell(
+            &admission,
+            Arc::new(OriginCell::new(
+                PartitionId::from_index(2),
+                OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                EligibilityGroup::Pool,
+                Some(admission.clone()),
+            )),
+        );
+
+        let (stale_waiter, stale_demand) =
+            stale.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        let delivery =
+            OriginAdmission::publish_without_driving(&admission, stale.id().clone(), stale_demand)
+                .expect("stale demand did not reserve capacity");
+        let (target_waiter, target_demand) =
+            target.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        OriginAdmission::publish_demand(&admission, target.id().clone(), target_demand);
+
+        // Model cancellation winning in the cell before its retirement
+        // publication reaches admission.
+        let cancelled = stale
+            .state
+            .lock()
+            .cancel_waiter(stale_waiter, &stale.eligibility_group)
+            .expect("stale waiter was not cancelled");
+        drop(cancelled.returned_lease);
+
+        let next = OriginCell::receive_capacity(&stale, delivery)
+            .expect("stale rejection did not return the successor delivery");
+        assert!(
+            target.take_ready_lease(target_waiter).is_none(),
+            "stale rejection recursively drove its successor"
+        );
+
+        OriginAdmission::drive(Some(next));
+        drop(
+            target
+                .take_ready_lease(target_waiter)
+                .expect("existing driver did not deliver the successor"),
+        );
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
@@ -1,0 +1,543 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! State local to one partition and origin.
+//!
+//! An [`OriginCell`] owns its waiter order and delivered results. A bounded
+//! cell publishes aggregate demand to [`OriginAdmission`] after releasing its
+//! lock, and admission returns capacity through the same unlocked boundary.
+//!
+//! Each waiter follows one cell-local ownership path:
+//!
+//! ```text
+//! Waiting --delivery reserved--> Receiving --delivery lands--> Ready --poll--> consumed
+//!    |                              |                           |
+//!    | cancel                       | cancel                    | cancel
+//!    v                              v                           v
+//! removed                 CancelledReceiving          removed + lease refunnelled
+//!   |                              |
+//!   | head: retire/replace demand  | delivery lands
+//!   | non-head: demand unchanged   v
+//!   `----------------------> removed + lease refunnelled
+//! ```
+
+mod waiters;
+
+#[cfg(test)]
+use self::waiters::CellSnapshot;
+use self::waiters::{DeliveryReservation, LeaseInstallError, WaiterId, WaiterQueue};
+#[cfg(test)]
+use super::admission::DemandSnapshot;
+use super::admission::{CapacityDelivery, CapacityLease, OriginAdmission, ProtocolRequirement};
+use super::origin::OriginKey;
+use super::partition::{EligibilityGroup, PartitionId};
+use crate::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+/// Stable state shared by requests for one partition and canonical origin.
+pub(crate) struct OriginCell {
+    /// Complete identity used by partition and admission indexes.
+    id: CellId,
+    /// Partitions whose connections may satisfy this cell's demand.
+    eligibility_group: EligibilityGroup,
+    /// Origin-wide authority present only when capacity is bounded.
+    admission: Option<Arc<OriginAdmission>>,
+    /// Waiter order, aggregate demand, and delivered results.
+    state: Mutex<WaiterQueue>,
+}
+
+impl OriginCell {
+    /// Creates a cell before its one-time publication in a partition registry.
+    pub(super) fn new(
+        partition: PartitionId,
+        origin: OriginKey,
+        eligibility_group: EligibilityGroup,
+        admission: Option<Arc<OriginAdmission>>,
+    ) -> Self {
+        Self {
+            id: CellId::new(partition, origin),
+            eligibility_group,
+            admission,
+            state: Mutex::new(WaiterQueue::default()),
+        }
+    }
+
+    /// Returns this cell's stable partition-and-origin identity.
+    pub(crate) fn id(&self) -> &CellId {
+        &self.id
+    }
+
+    /// Returns the set of partitions eligible to use this cell's connections.
+    pub(crate) fn eligibility_group(&self) -> &EligibilityGroup {
+        &self.eligibility_group
+    }
+
+    /// Returns this cell's origin-wide admission authority, when bounded.
+    pub(crate) fn admission(&self) -> Option<&Arc<OriginAdmission>> {
+        self.admission.as_ref()
+    }
+
+    /// Registers one bounded-capacity waiter in cell-local arrival order.
+    ///
+    /// The waiter and its demand snapshot are committed under the cell lock.
+    /// Publication to origin admission happens only after that lock is
+    /// released.
+    pub(super) fn register_waiter(&self, requirement: ProtocolRequirement) -> WaiterId {
+        let admission = self
+            .admission
+            .as_ref()
+            .expect("capacity waiter registered for an unbounded origin");
+        let (waiter, snapshot) = {
+            let mut state = self.state.lock();
+            state.register_waiter(requirement, &self.eligibility_group)
+        };
+
+        if let Some(snapshot) = snapshot {
+            OriginAdmission::publish_demand(admission, self.id.clone(), snapshot);
+        }
+        waiter
+    }
+
+    /// Cancels a waiter and refunnels any capacity already delivered to it.
+    pub(super) fn cancel_waiter(&self, waiter: WaiterId) -> bool {
+        let admission = self
+            .admission
+            .as_ref()
+            .expect("capacity waiter cancelled for an unbounded origin");
+        let Some(cancelled) = ({
+            let mut state = self.state.lock();
+            state.cancel_waiter(waiter, &self.eligibility_group)
+        }) else {
+            return false;
+        };
+
+        for snapshot in cancelled.demand_updates.into_iter().flatten() {
+            OriginAdmission::publish_demand(admission, self.id.clone(), snapshot);
+        }
+
+        // A ready waiter owns its lease in cell state. Cancellation transfers
+        // that ownership here so dropping it cannot nest cell and admission
+        // locks.
+        drop(cancelled.returned_lease);
+        true
+    }
+
+    /// Polls the capacity reserved for one waiter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `waiter` is unknown, was cancelled, or is polled again after
+    /// its ready lease was consumed.
+    pub(super) fn poll_waiter(
+        &self,
+        waiter: WaiterId,
+        cx: &mut Context<'_>,
+    ) -> Poll<CapacityLease> {
+        let mut state = self.state.lock();
+        state.poll_waiter(waiter, cx)
+    }
+
+    /// Applies a capacity delivery after the admission-to-cell lock crossing.
+    ///
+    /// The returned action is driven by admission after this method has
+    /// released the cell lock. No cell and admission locks are nested.
+    pub(super) fn receive_capacity(
+        cell: &Arc<Self>,
+        delivery: CapacityDelivery,
+    ) -> Option<CapacityDelivery> {
+        let reservation = {
+            let mut state = cell.state.lock();
+            state.reserve_delivery_target(delivery.demand(), &cell.eligibility_group)
+        };
+
+        let DeliveryReservation::Reserved { waiter, successor } = reservation else {
+            delivery.reject(None);
+            return None;
+        };
+
+        let (lease, acknowledgement) = delivery.commit(successor);
+        let installation = {
+            let mut state = cell.state.lock();
+            state.install_delivered_lease(waiter, lease)
+        };
+
+        // Cancellation may win after the delivery was reserved but before its
+        // lease was installed. Return that lease before closing the fence so a
+        // successor is scheduled by the fence acknowledgement.
+        drop(installation.returned_lease);
+        let next = acknowledgement.finish();
+        if let Some(waker) = installation.waker {
+            waker.wake();
+        }
+        if let Some(error) = installation.error {
+            match error {
+                LeaseInstallError::MissingWaiter => {
+                    panic!("reserved waiter disappeared before capacity delivery")
+                }
+                LeaseInstallError::UnexpectedState => {
+                    panic!("reserved waiter entered an invalid capacity-delivery state")
+                }
+            }
+        }
+        next
+    }
+
+    #[cfg(test)]
+    pub(super) fn take_ready_lease(&self, waiter: WaiterId) -> Option<CapacityLease> {
+        self.state.lock().take_ready_lease(waiter)
+    }
+
+    #[cfg(test)]
+    pub(super) fn register_waiter_without_publish(
+        &self,
+        requirement: ProtocolRequirement,
+    ) -> (WaiterId, DemandSnapshot) {
+        let (waiter, snapshot) = self
+            .state
+            .lock()
+            .register_waiter(requirement, &self.eligibility_group);
+        (
+            waiter,
+            snapshot.expect("first unpublished waiter did not create demand"),
+        )
+    }
+
+    #[cfg(test)]
+    fn snapshot(&self) -> CellSnapshot {
+        self.state.lock().snapshot()
+    }
+}
+
+impl std::fmt::Debug for OriginCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OriginCell")
+            .field("id", &self.id)
+            .field("eligibility_group", &self.eligibility_group)
+            .field("admission", &self.admission)
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+/// Stable identity of an [`OriginCell`].
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct CellId {
+    partition: PartitionId,
+    origin: OriginKey,
+}
+
+impl CellId {
+    /// Creates an identity from its complete partition and origin axes.
+    pub(super) fn new(partition: PartitionId, origin: OriginKey) -> Self {
+        Self { partition, origin }
+    }
+
+    /// Returns the partition axis.
+    pub(crate) fn partition(&self) -> PartitionId {
+        self.partition
+    }
+
+    /// Returns the canonical origin axis.
+    pub(crate) fn origin(&self) -> &OriginKey {
+        &self.origin
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use http_1x::uri::Scheme;
+    use std::num::NonZeroUsize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc as StdArc;
+    use std::task::{Wake, Waker};
+
+    struct WakeCounter(AtomicUsize);
+
+    impl Wake for WakeCounter {
+        fn wake(self: StdArc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn wake_by_ref(self: &StdArc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn bounded_cell() -> (Arc<OriginAdmission>, Arc<OriginCell>) {
+        let admission = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let candidate = Arc::new(OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            Some(admission.clone()),
+        ));
+        let cell = OriginAdmission::register_cell(&admission, candidate);
+        (admission, cell)
+    }
+
+    fn saturated_bounded_cell() -> (Arc<OriginAdmission>, Arc<OriginCell>, CapacityLease) {
+        let (admission, cell) = bounded_cell();
+        let lease = OriginAdmission::lease_for_test(&admission);
+        (admission, cell, lease)
+    }
+
+    #[test]
+    fn three_waiters_receive_capacity_in_fifo_order() {
+        let (_admission, cell) = bounded_cell();
+        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let third = cell.register_waiter(ProtocolRequirement::H1Compatible);
+
+        let first_lease = cell.take_ready_lease(first).unwrap();
+        assert!(cell.take_ready_lease(second).is_none());
+        assert!(cell.take_ready_lease(third).is_none());
+
+        drop(first_lease);
+        let second_lease = cell.take_ready_lease(second).unwrap();
+        assert!(cell.take_ready_lease(third).is_none());
+
+        drop(second_lease);
+        let third_lease = cell.take_ready_lease(third).unwrap();
+        drop(third_lease);
+        assert_eq!(0, cell.snapshot().retained);
+    }
+
+    #[test]
+    fn cancelling_middle_and_tail_waiters_repairs_fifo_links() {
+        let (_admission, cell, held) = saturated_bounded_cell();
+        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let second = cell.register_waiter(ProtocolRequirement::H2Required);
+        let third = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let fourth = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let demand = cell.snapshot().demand;
+
+        assert!(cell.cancel_waiter(second));
+        assert!(cell.cancel_waiter(fourth));
+        assert_eq!(demand, cell.snapshot().demand);
+        assert_eq!(2, cell.snapshot().waiting);
+        let fifth = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        assert_eq!(3, cell.snapshot().waiting);
+
+        drop(held);
+        let first_lease = cell.take_ready_lease(first).unwrap();
+        assert!(cell.take_ready_lease(third).is_none());
+        assert!(cell.take_ready_lease(fifth).is_none());
+        drop(first_lease);
+
+        let third_lease = cell.take_ready_lease(third).unwrap();
+        assert!(cell.take_ready_lease(fifth).is_none());
+        drop(third_lease);
+
+        drop(cell.take_ready_lease(fifth).unwrap());
+        assert_eq!(0, cell.snapshot().retained);
+    }
+
+    #[test]
+    fn cancelling_head_waiter_preserves_remaining_fifo_order() {
+        let (_admission, cell, held) = saturated_bounded_cell();
+        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let third = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let fourth = cell.register_waiter(ProtocolRequirement::H1Compatible);
+
+        assert!(cell.cancel_waiter(first));
+        drop(held);
+
+        let second_lease = cell.take_ready_lease(second).unwrap();
+        assert!(cell.take_ready_lease(third).is_none());
+        assert!(cell.take_ready_lease(fourth).is_none());
+        drop(second_lease);
+
+        let third_lease = cell.take_ready_lease(third).unwrap();
+        assert!(cell.take_ready_lease(fourth).is_none());
+        drop(third_lease);
+
+        drop(cell.take_ready_lease(fourth).unwrap());
+        assert_eq!(0, cell.snapshot().retained);
+    }
+
+    #[test]
+    fn cancelling_ready_waiter_refunnels_capacity() {
+        let (_admission, cell) = bounded_cell();
+        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
+
+        assert!(cell.cancel_waiter(first));
+        let lease = cell.take_ready_lease(second).unwrap();
+        drop(lease);
+    }
+
+    #[test]
+    fn cancelling_during_delivery_refunnels_capacity_after_unlock() {
+        let (admission, cell) = bounded_cell();
+        let (waiter, demand) =
+            cell.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+        let delivery =
+            OriginAdmission::publish_without_driving(&admission, cell.id().clone(), demand)
+                .expect("published demand did not reserve capacity");
+        let reservation = {
+            let mut state = cell.state.lock();
+            state.reserve_delivery_target(delivery.demand(), &cell.eligibility_group)
+        };
+        let DeliveryReservation::Reserved {
+            waiter: reserved,
+            successor,
+        } = reservation
+        else {
+            panic!("current delivery was rejected");
+        };
+        assert_eq!(waiter, reserved);
+        let (lease, acknowledgement) = delivery.commit(successor);
+
+        assert!(cell.cancel_waiter(waiter));
+        let installation = {
+            let mut state = cell.state.lock();
+            state.install_delivered_lease(waiter, lease)
+        };
+        assert!(installation.returned_lease.is_some());
+        assert!(installation.error.is_none());
+        assert_eq!(0, cell.snapshot().retained);
+
+        drop(installation.returned_lease);
+        assert_eq!(1, admission.available_capacity_for_test());
+        assert!(acknowledgement.finish().is_none());
+        assert_eq!(1, admission.available_capacity_for_test());
+    }
+
+    #[test]
+    fn stale_delivery_is_rejected_after_head_cancellation() {
+        let (admission, cell) = bounded_cell();
+        let (first, first_demand) =
+            cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let stale =
+            OriginAdmission::publish_without_driving(&admission, cell.id().clone(), first_demand)
+                .expect("first demand did not reserve capacity");
+
+        assert!(cell.cancel_waiter(first));
+        assert!(OriginCell::receive_capacity(&cell, stale).is_none());
+
+        let lease = cell
+            .take_ready_lease(second)
+            .expect("replacement demand did not receive refunnelled capacity");
+        drop(lease);
+    }
+
+    #[test]
+    fn cancelling_the_only_waiter_retires_admission_demand() {
+        let (admission, cell, held) = saturated_bounded_cell();
+        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        assert_eq!(1, admission.ordered_demand_count_for_test());
+
+        assert!(cell.cancel_waiter(waiter));
+        assert_eq!(0, admission.ordered_demand_count_for_test());
+        drop(held);
+    }
+
+    #[test]
+    fn unknown_waiter_cancellation_is_a_noop() {
+        let (_admission, cell) = bounded_cell();
+        assert!(!cell.cancel_waiter(WaiterId(99)));
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity waiter registered for an unbounded origin")]
+    fn capacity_waiter_requires_bounded_admission() {
+        let cell = OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            None,
+        );
+
+        cell.register_waiter(ProtocolRequirement::H1Compatible);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity waiter cancelled for an unbounded origin")]
+    fn capacity_waiter_cancellation_requires_bounded_admission() {
+        let cell = OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            None,
+        );
+
+        cell.cancel_waiter(WaiterId(0));
+    }
+
+    #[test]
+    fn polling_waiter_records_a_waker() {
+        let (_admission, cell, _held) = saturated_bounded_cell();
+        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+
+        assert!(cell.poll_waiter(waiter, &mut context).is_pending());
+        assert!(cell.cancel_waiter(waiter));
+    }
+
+    #[test]
+    fn delivered_waiter_is_woken_once() {
+        let (_admission, cell, held) = saturated_bounded_cell();
+        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let counter = StdArc::new(WakeCounter(AtomicUsize::new(0)));
+        let waker = Waker::from(counter.clone());
+        let mut context = Context::from_waker(&waker);
+        assert!(cell.poll_waiter(waiter, &mut context).is_pending());
+
+        drop(held);
+        assert_eq!(1, counter.0.load(Ordering::Relaxed));
+        drop(
+            cell.take_ready_lease(waiter)
+                .expect("woken waiter had no capacity"),
+        );
+        assert_eq!(1, counter.0.load(Ordering::Relaxed));
+    }
+}
+
+#[cfg(all(test, smithy_http_client_loom))]
+mod loom_tests {
+    use super::*;
+    use http_1x::uri::Scheme;
+    use std::num::NonZeroUsize;
+
+    fn bounded_cell() -> (Arc<OriginAdmission>, Arc<OriginCell>) {
+        let admission = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let candidate = Arc::new(OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            Some(admission.clone()),
+        ));
+        let cell = OriginAdmission::register_cell(&admission, candidate);
+        (admission, cell)
+    }
+
+    #[test]
+    fn delivery_and_cancellation_race_refunnels_capacity() {
+        loom::model(|| {
+            let (admission, cell) = bounded_cell();
+            let (first, demand) =
+                cell.register_waiter_without_publish(ProtocolRequirement::H1Compatible);
+            let delivery =
+                OriginAdmission::publish_without_driving(&admission, cell.id().clone(), demand)
+                    .unwrap();
+
+            let delivery_cell = cell.clone();
+            let deliver = loom::thread::spawn(move || {
+                drop(OriginCell::receive_capacity(&delivery_cell, delivery));
+            });
+            let cancel_cell = cell.clone();
+            let cancel = loom::thread::spawn(move || cancel_cell.cancel_waiter(first));
+            deliver.join().unwrap();
+            cancel.join().unwrap();
+
+            assert_eq!(1, admission.available_capacity_for_test());
+            admission.clear_modeled_cells_for_test();
+        });
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/waiters.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/waiters.rs
@@ -1,0 +1,756 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Cell-local waiter order and delivered-capacity ownership.
+//!
+//! [`WaiterQueue`] is the complete mutable state behind an origin cell's lock.
+//! It keeps the request FIFO, aggregate head demand, delivery crossing state,
+//! and any delivered lease in one invariant domain. Values that require
+//! admission locking or task wakeup are detached for the caller to process
+//! only after releasing the cell lock.
+
+use super::super::admission::{
+    CapacityLease, DemandId, DemandSnapshot, ProtocolRequirement, SnapshotVersion,
+};
+use super::super::partition::EligibilityGroup;
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::task::{Context, Poll, Waker};
+
+/// Local waiter identity within one cell.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(in crate::client::pool) struct WaiterId(pub(in crate::client::pool) u64);
+
+/// Cell-local acquisition waiters, their FIFO order, and aggregate demand.
+///
+/// At every completed transition:
+///
+/// - `records` owns every retained waiter.
+/// - [`WaitingQueueState::Active`] contains exactly the [`WaiterState::Waiting`]
+///   records.
+/// - The active queue's demand describes its head waiter.
+/// - Receiving, cancelled-receiving, and ready waiters remain in `records` but
+///   not in the FIFO.
+///
+/// The queue never invokes admission or wakes a task. Transition results carry
+/// that work across the cell lock boundary.
+#[derive(Debug, Default)]
+pub(super) struct WaiterQueue {
+    /// Every waiter still queued, receiving, or holding delivered capacity.
+    records: HashMap<WaiterId, WaiterRecord>,
+    /// FIFO endpoints and demand for the records currently waiting.
+    waiting: WaitingQueueState,
+    /// Next cell-local waiter identity.
+    next_waiter: u64,
+    /// Next identity for a head-waiter demand episode.
+    next_demand_id: u64,
+}
+
+impl WaiterQueue {
+    /// Appends a waiter and returns demand when an empty queue becomes active.
+    pub(super) fn register_waiter(
+        &mut self,
+        requirement: ProtocolRequirement,
+        eligibility_group: &EligibilityGroup,
+    ) -> (WaiterId, Option<DemandSnapshot>) {
+        let waiter = self.take_waiter_id();
+        let previous = match &self.waiting {
+            WaitingQueueState::Empty => None,
+            WaitingQueueState::Active { tail, .. } => Some(*tail),
+        };
+        let initial_demand = previous.is_none().then(|| self.new_demand(requirement));
+
+        if let Some(previous) = previous {
+            let previous = self
+                .records
+                .get_mut(&previous)
+                .expect("waiting tail disappeared");
+            let WaiterState::Waiting { next, .. } = &mut previous.state else {
+                unreachable!("waiting tail left the waiting state");
+            };
+            debug_assert!(next.is_none());
+            *next = Some(waiter);
+        }
+
+        let replaced = self.records.insert(
+            waiter,
+            WaiterRecord {
+                requirement,
+                state: WaiterState::Waiting {
+                    previous,
+                    next: None,
+                    waker: None,
+                },
+            },
+        );
+        debug_assert!(replaced.is_none());
+
+        let snapshot = match (&mut self.waiting, initial_demand) {
+            (waiting @ WaitingQueueState::Empty, Some(demand)) => {
+                let snapshot = demand.snapshot(eligibility_group);
+                *waiting = WaitingQueueState::Active {
+                    head: waiter,
+                    tail: waiter,
+                    len: NonZeroUsize::MIN,
+                    demand,
+                };
+                Some(snapshot)
+            }
+            (WaitingQueueState::Active { tail, len, .. }, None) => {
+                *tail = waiter;
+                *len = len.checked_add(1).expect("waiter queue length exhausted");
+                None
+            }
+            _ => unreachable!("waiter queue occupancy changed during registration"),
+        };
+        self.assert_consistent();
+        (waiter, snapshot)
+    }
+
+    /// Cancels one waiter and detaches all cross-lock cleanup work.
+    ///
+    /// Removing the head retires its demand and starts a successor episode.
+    /// Removing another waiting record leaves the active demand unchanged.
+    /// Cancellation during delivery leaves a marker for lease installation to
+    /// observe. A ready lease is returned to the caller for drop after unlock.
+    pub(super) fn cancel_waiter(
+        &mut self,
+        waiter: WaiterId,
+        eligibility_group: &EligibilityGroup,
+    ) -> Option<WaiterCancellation> {
+        let state = &self.records.get(&waiter)?.state;
+        let cancellation = if matches!(state, WaiterState::Waiting { .. }) {
+            let is_head = matches!(
+                self.waiting,
+                WaitingQueueState::Active { head, .. } if head == waiter
+            );
+            let demand_updates = if is_head {
+                let removed = self.pop_head(eligibility_group);
+                debug_assert_eq!(waiter, removed.waiter);
+                let record = self
+                    .records
+                    .remove(&waiter)
+                    .expect("cancelled head waiter disappeared");
+                debug_assert!(matches!(record.state, WaiterState::Waiting { .. }));
+                let retired =
+                    DemandSnapshot::inactive(removed.demand.id, removed.demand.version.next());
+                [Some(retired), removed.successor]
+            } else {
+                self.remove_non_head(waiter);
+                [None, None]
+            };
+            WaiterCancellation {
+                demand_updates,
+                returned_lease: None,
+            }
+        } else if matches!(state, WaiterState::Receiving { .. }) {
+            let record = self
+                .records
+                .get_mut(&waiter)
+                .expect("receiving waiter disappeared");
+            let WaiterState::Receiving { waker } = &mut record.state else {
+                unreachable!("receiving waiter changed state under the cell lock");
+            };
+            let waker = waker.take();
+            record.state = WaiterState::CancelledReceiving { waker };
+            WaiterCancellation {
+                demand_updates: [None, None],
+                returned_lease: None,
+            }
+        } else if matches!(state, WaiterState::Ready(_)) {
+            // Validate before detaching the lease. Once the lease is local,
+            // this method must return without another panic-capable check.
+            self.assert_consistent();
+            let record = self.records.remove(&waiter)?;
+            let WaiterState::Ready(lease) = record.state else {
+                unreachable!("ready waiter changed state under the cell lock");
+            };
+            return Some(WaiterCancellation {
+                demand_updates: [None, None],
+                returned_lease: Some(lease),
+            });
+        } else {
+            debug_assert!(matches!(state, WaiterState::CancelledReceiving { .. }));
+            return None;
+        };
+
+        self.assert_consistent();
+        Some(cancellation)
+    }
+
+    /// Returns a ready lease or records the latest waker for a pending waiter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `waiter` is unknown, was cancelled, or was already consumed
+    /// by an earlier ready poll.
+    pub(super) fn poll_waiter(
+        &mut self,
+        waiter: WaiterId,
+        cx: &mut Context<'_>,
+    ) -> Poll<CapacityLease> {
+        if matches!(
+            self.records.get(&waiter).map(|record| &record.state),
+            Some(WaiterState::Ready(_))
+        ) {
+            return Poll::Ready(
+                self.take_ready_lease(waiter)
+                    .expect("ready waiter lost its capacity lease"),
+            );
+        }
+
+        let record = self
+            .records
+            .get_mut(&waiter)
+            .expect("polled a cancelled, consumed, or unknown capacity waiter");
+        let waker = match &mut record.state {
+            WaiterState::Waiting { waker, .. } | WaiterState::Receiving { waker } => waker,
+            WaiterState::CancelledReceiving { .. } => panic!("polled a cancelled capacity waiter"),
+            WaiterState::Ready(_) => {
+                unreachable!("ready waiter changed state under the cell lock")
+            }
+        };
+        if waker
+            .as_ref()
+            .is_none_or(|waker| !waker.will_wake(cx.waker()))
+        {
+            *waker = Some(cx.waker().clone());
+        }
+        Poll::Pending
+    }
+
+    /// Reserves the current head when a delivery still names its demand episode.
+    ///
+    /// The reserved waiter leaves the FIFO and changes in place to
+    /// [`WaiterState::Receiving`]. Any remaining head receives a new demand
+    /// episode returned for admission acknowledgement.
+    pub(super) fn reserve_delivery_target(
+        &mut self,
+        demand: DemandId,
+        eligibility_group: &EligibilityGroup,
+    ) -> DeliveryReservation {
+        let current = matches!(
+            &self.waiting,
+            WaitingQueueState::Active {
+                demand: current,
+                ..
+            } if current.id == demand
+        );
+        if !current {
+            return DeliveryReservation::Rejected;
+        }
+
+        let removed = self.pop_head(eligibility_group);
+        debug_assert_eq!(removed.demand.id, demand);
+        let record = self
+            .records
+            .get_mut(&removed.waiter)
+            .expect("reserved queue head disappeared");
+        let WaiterState::Waiting { waker, .. } = &mut record.state else {
+            unreachable!("reserved queue head left the waiting state");
+        };
+        let waker = waker.take();
+        record.state = WaiterState::Receiving { waker };
+
+        self.assert_consistent();
+        DeliveryReservation::Reserved {
+            waiter: removed.waiter,
+            successor: removed.successor,
+        }
+    }
+
+    /// Completes the unlocked delivery crossing without panicking while the
+    /// incoming lease remains a droppable local.
+    ///
+    /// A live receiver takes ownership of the lease in [`WaiterState::Ready`]
+    /// before its state is checked. If cancellation won, or the reserved
+    /// record is invalid, the lease is returned without another panic-capable
+    /// operation. The caller refunnels it and reports invalid state only after
+    /// unlocking.
+    pub(super) fn install_delivered_lease(
+        &mut self,
+        waiter: WaiterId,
+        lease: CapacityLease,
+    ) -> LeaseInstallResult {
+        let Some(record) = self.records.get_mut(&waiter) else {
+            return LeaseInstallResult::invalid(lease, LeaseInstallError::MissingWaiter);
+        };
+
+        match &mut record.state {
+            WaiterState::Receiving { waker } => {
+                let waker = waker.take();
+                record.state = WaiterState::Ready(lease);
+                // The lease is state-owned before this check can panic.
+                self.assert_consistent();
+                LeaseInstallResult {
+                    returned_lease: None,
+                    waker,
+                    error: None,
+                }
+            }
+            WaiterState::CancelledReceiving { waker } => {
+                let waker = waker.take();
+                // The state was revalidated above while the same cell lock was
+                // held, so removal cannot fail. Avoid an assertion here:
+                // `lease` must cross the lock boundary even if state is broken.
+                self.records.remove(&waiter);
+                LeaseInstallResult {
+                    returned_lease: Some(lease),
+                    waker,
+                    error: None,
+                }
+            }
+            WaiterState::Waiting { .. } | WaiterState::Ready(_) => {
+                LeaseInstallResult::invalid(lease, LeaseInstallError::UnexpectedState)
+            }
+        }
+    }
+
+    /// Removes a ready waiter and transfers ownership of its lease.
+    pub(super) fn take_ready_lease(&mut self, waiter: WaiterId) -> Option<CapacityLease> {
+        if !matches!(
+            self.records.get(&waiter).map(|record| &record.state),
+            Some(WaiterState::Ready(_))
+        ) {
+            return None;
+        }
+
+        // Validate before detaching the lease. Returning it must be the last
+        // operation performed while the cell lock is held.
+        self.assert_consistent();
+        let record = self.records.remove(&waiter)?;
+        let WaiterState::Ready(lease) = record.state else {
+            unreachable!("ready waiter changed state under the cell lock");
+        };
+        Some(lease)
+    }
+
+    /// Unlinks the FIFO head and installs any successor demand.
+    ///
+    /// The head record remains in `records`; the caller either changes it to
+    /// `Receiving` or removes it for cancellation.
+    fn pop_head(&mut self, eligibility_group: &EligibilityGroup) -> RemovedHead {
+        let waiting = std::mem::take(&mut self.waiting);
+        let WaitingQueueState::Active {
+            head,
+            tail,
+            len,
+            demand,
+        } = waiting
+        else {
+            unreachable!("removed a head from an empty waiter queue");
+        };
+        let next = match &self
+            .records
+            .get(&head)
+            .expect("waiting head disappeared")
+            .state
+        {
+            WaiterState::Waiting { previous, next, .. } => {
+                debug_assert!(previous.is_none());
+                *next
+            }
+            _ => unreachable!("waiting head left the waiting state"),
+        };
+
+        let successor = match next {
+            Some(next) => {
+                let requirement = {
+                    let next_record = self
+                        .records
+                        .get_mut(&next)
+                        .expect("next waiter disappeared");
+                    let WaiterState::Waiting { previous, .. } = &mut next_record.state else {
+                        unreachable!("next waiter left the waiting state");
+                    };
+                    debug_assert_eq!(*previous, Some(head));
+                    *previous = None;
+                    next_record.requirement
+                };
+
+                let next_demand = self.new_demand(requirement);
+                let snapshot = next_demand.snapshot(eligibility_group);
+                let len = NonZeroUsize::new(
+                    len.get()
+                        .checked_sub(1)
+                        .expect("waiter queue length underflowed"),
+                )
+                .expect("nonempty waiter queue lost its length");
+                self.waiting = WaitingQueueState::Active {
+                    head: next,
+                    tail,
+                    len,
+                    demand: next_demand,
+                };
+                Some(snapshot)
+            }
+            None => {
+                debug_assert_eq!(head, tail);
+                debug_assert_eq!(len, NonZeroUsize::MIN);
+                None
+            }
+        };
+
+        RemovedHead {
+            waiter: head,
+            demand,
+            successor,
+        }
+    }
+
+    /// Removes a non-head waiting record without changing aggregate demand.
+    fn remove_non_head(&mut self, waiter: WaiterId) -> WaiterRecord {
+        let record = self
+            .records
+            .remove(&waiter)
+            .expect("removed waiter disappeared");
+        let (previous, next) = match &record.state {
+            WaiterState::Waiting { previous, next, .. } => (*previous, *next),
+            _ => unreachable!("removed waiter left the waiting state"),
+        };
+        let previous = previous.expect("non-head waiter had no predecessor");
+
+        let previous_record = self
+            .records
+            .get_mut(&previous)
+            .expect("previous waiter disappeared");
+        let WaiterState::Waiting {
+            next: previous_next,
+            ..
+        } = &mut previous_record.state
+        else {
+            unreachable!("previous waiter left the waiting state");
+        };
+        debug_assert_eq!(*previous_next, Some(waiter));
+        *previous_next = next;
+
+        if let Some(next) = next {
+            let next_record = self
+                .records
+                .get_mut(&next)
+                .expect("next waiter disappeared");
+            let WaiterState::Waiting {
+                previous: next_previous,
+                ..
+            } = &mut next_record.state
+            else {
+                unreachable!("next waiter left the waiting state");
+            };
+            debug_assert_eq!(*next_previous, Some(waiter));
+            *next_previous = Some(previous);
+        }
+
+        let WaitingQueueState::Active {
+            head, tail, len, ..
+        } = &mut self.waiting
+        else {
+            unreachable!("removed a waiter from an empty queue");
+        };
+        debug_assert_ne!(*head, waiter);
+        if next.is_none() {
+            debug_assert_eq!(*tail, waiter);
+            *tail = previous;
+        }
+        *len = NonZeroUsize::new(
+            len.get()
+                .checked_sub(1)
+                .expect("waiter queue length underflowed"),
+        )
+        .expect("removing a non-head waiter emptied the queue");
+        record
+    }
+
+    /// Allocates an identity that is never reused within this cell.
+    fn take_waiter_id(&mut self) -> WaiterId {
+        let value = self.next_waiter;
+        self.next_waiter = value.checked_add(1).expect("waiter identity exhausted");
+        WaiterId(value)
+    }
+
+    /// Starts a demand episode for a waiter that became the FIFO head.
+    fn new_demand(&mut self, requirement: ProtocolRequirement) -> DemandTicket {
+        let value = self.next_demand_id;
+        self.next_demand_id = value.checked_add(1).expect("demand identity exhausted");
+        DemandTicket {
+            id: DemandId::from_u64(value),
+            version: SnapshotVersion::INITIAL,
+            requirement,
+        }
+    }
+
+    /// Checks map, FIFO, and demand relationships in debug and test builds.
+    pub(super) fn assert_consistent(&self) {
+        #[cfg(debug_assertions)]
+        self.assert_consistent_debug();
+    }
+
+    #[cfg(debug_assertions)]
+    fn assert_consistent_debug(&self) {
+        let waiting_records = self
+            .records
+            .values()
+            .filter(|record| matches!(record.state, WaiterState::Waiting { .. }))
+            .count();
+        match &self.waiting {
+            WaitingQueueState::Empty => {
+                assert_eq!(0, waiting_records, "empty queue retained waiting records");
+            }
+            WaitingQueueState::Active {
+                head,
+                tail,
+                len,
+                demand,
+            } => {
+                let head_record = self.records.get(head).expect("waiting head disappeared");
+                assert_eq!(
+                    demand.requirement, head_record.requirement,
+                    "aggregate demand did not describe the waiting head"
+                );
+
+                let mut current = Some(*head);
+                let mut previous = None;
+                let mut traversed = 0;
+                while let Some(waiter) = current {
+                    assert!(
+                        traversed < self.records.len(),
+                        "waiter queue contains a cycle"
+                    );
+                    let record = self
+                        .records
+                        .get(&waiter)
+                        .expect("linked waiter disappeared");
+                    let WaiterState::Waiting {
+                        previous: linked_previous,
+                        next,
+                        ..
+                    } = &record.state
+                    else {
+                        panic!("linked waiter left the waiting state");
+                    };
+                    assert_eq!(
+                        previous, *linked_previous,
+                        "waiter queue contains inconsistent backward links"
+                    );
+                    traversed += 1;
+                    previous = Some(waiter);
+                    current = *next;
+                }
+
+                assert_eq!(Some(*tail), previous, "waiting tail was not reachable");
+                assert_eq!(
+                    len.get(),
+                    traversed,
+                    "waiter queue length did not match its links"
+                );
+                assert_eq!(
+                    waiting_records, traversed,
+                    "waiting record was not reachable from the queue head"
+                );
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshot(&self) -> CellSnapshot {
+        let (waiting, demand) = match &self.waiting {
+            WaitingQueueState::Empty => (0, None),
+            WaitingQueueState::Active { len, demand, .. } => (len.get(), Some(demand.id)),
+        };
+        CellSnapshot {
+            waiting,
+            retained: self.records.len(),
+            demand,
+        }
+    }
+}
+
+/// Whether the cell has an active FIFO and aggregate head demand.
+#[derive(Debug, Default)]
+enum WaitingQueueState {
+    /// No waiter is linked and no demand is active.
+    #[default]
+    Empty,
+    /// A nonempty FIFO represented by its endpoints, length, and head demand.
+    Active {
+        /// Oldest waiting record.
+        head: WaiterId,
+        /// Youngest waiting record.
+        tail: WaiterId,
+        /// Number of records linked from `head` through `tail`.
+        len: NonZeroUsize,
+        /// Demand episode representing `head`.
+        demand: DemandTicket,
+    },
+}
+
+/// One request retained while waiting for or owning delivered capacity.
+#[derive(Debug)]
+struct WaiterRecord {
+    /// Protocol requirement published while this waiter is the head.
+    requirement: ProtocolRequirement,
+    /// Queue residence, delivery state, and any owned lease.
+    state: WaiterState,
+}
+
+/// Authoritative cell-local ownership state for one waiter.
+#[derive(Debug)]
+enum WaiterState {
+    /// The waiter is linked in the cell-local FIFO.
+    Waiting {
+        /// Older waiting record, or `None` at the head.
+        previous: Option<WaiterId>,
+        /// Newer waiting record, or `None` at the tail.
+        next: Option<WaiterId>,
+        /// Latest task waiting for capacity.
+        waker: Option<Waker>,
+    },
+    /// A delivery selected the waiter but has not installed its lease.
+    Receiving {
+        /// Latest task waiting for the crossing delivery.
+        waker: Option<Waker>,
+    },
+    /// Cancellation won while a delivery was crossing without locks held.
+    CancelledReceiving {
+        /// Task detached for wake after the delivery is refunnelled.
+        waker: Option<Waker>,
+    },
+    /// The waiter owns a delivered capacity lease.
+    Ready(CapacityLease),
+}
+
+/// Cell-local ownership of the aggregate head demand.
+#[derive(Debug)]
+struct DemandTicket {
+    /// Identity of this head-waiter episode.
+    id: DemandId,
+    /// Version of the next complete publication.
+    version: SnapshotVersion,
+    /// Protocol capability required by this head waiter.
+    requirement: ProtocolRequirement,
+}
+
+impl DemandTicket {
+    /// Creates the complete active state published for this head episode.
+    fn snapshot(&self, eligibility_group: &EligibilityGroup) -> DemandSnapshot {
+        DemandSnapshot::active(
+            self.id,
+            self.version,
+            self.requirement,
+            eligibility_group.clone(),
+        )
+    }
+}
+
+/// Result of reserving a target for one unlocked capacity delivery.
+pub(super) enum DeliveryReservation {
+    /// The current head was reserved and may have a successor demand.
+    Reserved {
+        waiter: WaiterId,
+        successor: Option<DemandSnapshot>,
+    },
+    /// The delivery no longer matches live cell demand.
+    Rejected,
+}
+
+/// Values detached from cell state by cancellation.
+pub(super) struct WaiterCancellation {
+    /// Demand retirement and optional successor published after unlocking.
+    pub(super) demand_updates: [Option<DemandSnapshot>; 2],
+    /// Delivered capacity returned after unlocking.
+    pub(super) returned_lease: Option<CapacityLease>,
+}
+
+/// Invalid state observed while a committed lease was crossing to the cell.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum LeaseInstallError {
+    /// The waiter reserved for the delivery no longer exists.
+    MissingWaiter,
+    /// The waiter exists but cannot receive the reserved delivery.
+    UnexpectedState,
+}
+
+/// Values produced after installing or refunnelling a committed delivery.
+pub(super) struct LeaseInstallResult {
+    /// Capacity rejected by cancellation and returned after unlocking.
+    pub(super) returned_lease: Option<CapacityLease>,
+    /// Waiting task woken after the delivery fence closes.
+    pub(super) waker: Option<Waker>,
+    /// Invalid state reported only after the returned lease is refunnelled.
+    pub(super) error: Option<LeaseInstallError>,
+}
+
+impl LeaseInstallResult {
+    /// Preserves the incoming lease for unlocked cleanup after invalid state.
+    fn invalid(lease: CapacityLease, error: LeaseInstallError) -> Self {
+        Self {
+            returned_lease: Some(lease),
+            waker: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// FIFO state detached while advancing the active head.
+struct RemovedHead {
+    /// Identity of the unlinked waiter.
+    waiter: WaiterId,
+    /// Retired demand episode that represented this head.
+    demand: DemandTicket,
+    /// New demand published if another waiter became the head.
+    successor: Option<DemandSnapshot>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(super) struct CellSnapshot {
+    pub(super) waiting: usize,
+    pub(super) retained: usize,
+    pub(super) demand: Option<DemandId>,
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn head_cancellation_uses_the_successors_protocol_requirement() {
+        let mut queue = WaiterQueue::default();
+        let (head, initial) =
+            queue.register_waiter(ProtocolRequirement::H2Required, &EligibilityGroup::Pool);
+        let (_successor, no_new_demand) =
+            queue.register_waiter(ProtocolRequirement::H1Compatible, &EligibilityGroup::Pool);
+        assert!(initial.is_some());
+        assert!(no_new_demand.is_none());
+
+        let cancelled = queue
+            .cancel_waiter(head, &EligibilityGroup::Pool)
+            .expect("head waiter was not cancelled");
+        assert_eq!(
+            Some(DemandSnapshot::active(
+                DemandId::from_u64(1),
+                SnapshotVersion::INITIAL,
+                ProtocolRequirement::H1Compatible,
+                EligibilityGroup::Pool,
+            )),
+            cancelled.demand_updates[1]
+        );
+    }
+
+    #[test]
+    fn retired_demand_cannot_reserve_the_successor() {
+        let mut queue = WaiterQueue::default();
+        let (head, _initial) =
+            queue.register_waiter(ProtocolRequirement::H1Compatible, &EligibilityGroup::Pool);
+        queue.register_waiter(ProtocolRequirement::H1Compatible, &EligibilityGroup::Pool);
+        queue
+            .cancel_waiter(head, &EligibilityGroup::Pool)
+            .expect("head waiter was not cancelled");
+
+        assert!(matches!(
+            queue.reserve_delivery_target(DemandId::from_u64(0), &EligibilityGroup::Pool),
+            DeliveryReservation::Rejected
+        ));
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
@@ -1,0 +1,412 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Protocol-independent connection lifetime.
+//!
+//! [`ConnectionState`] serializes dispatch commitment with logical close.
+//! [`DispatchGuard`] accounts for accepted requests, while
+//! [`PhysicalConnectionGuard`] follows root I/O until the transport is gone.
+//! Logical close returns bounded capacity without waiting for either lifetime
+//! to finish.
+
+use super::admission::CapacityLease;
+use super::partition::PartitionId;
+use crate::sync::{Arc, Mutex};
+pub use aws_smithy_runtime_api::client::connection::ConnectionId;
+use std::fmt;
+
+/// Why a connection stopped accepting new work.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum CloseReason {
+    /// The connection exceeded its configured idle timeout.
+    IdleTimeout,
+    /// The connection was explicitly marked unsafe for reuse.
+    Poisoned,
+    /// The protocol driver or peer closed the connection.
+    ProtocolClosed,
+    /// HTTP/1 did not prove a complete reusable message boundary.
+    IncompleteH1Exchange,
+    /// The transport left HTTP/1 pool ownership through an upgrade.
+    Upgraded,
+    /// The connection closed to move bounded capacity to another cell.
+    Reclaimed,
+    /// The connection pool was dropped.
+    PoolDropped,
+    /// The runtime driving the connection shut down.
+    OwnerRuntimeShutdown,
+}
+
+/// Shared protocol-independent ownership for one installed connection.
+pub(super) struct ConnectionState {
+    /// Stable identity shared with metadata and lifecycle events.
+    id: ConnectionId,
+    /// Partition that retains the connection's I/O and protocol driver.
+    owner_partition: PartitionId,
+    /// Dispatch, logical-close, and root-I/O completion state.
+    lifecycle: Mutex<LifecycleState>,
+}
+
+impl ConnectionState {
+    /// Creates a connection whose origin has no admission bound.
+    ///
+    /// The returned guard is the unique physical-lifetime owner and must move
+    /// with the root I/O task.
+    pub(super) fn unbounded(
+        id: ConnectionId,
+        owner_partition: PartitionId,
+    ) -> (Arc<Self>, PhysicalConnectionGuard) {
+        Self::new(id, owner_partition, None)
+    }
+
+    /// Creates a connection that takes ownership of one bounded-origin slot.
+    ///
+    /// The returned guard is the unique physical-lifetime owner and must move
+    /// with the root I/O task. Logical close returns `lease` independently of
+    /// that guard.
+    pub(super) fn bounded(
+        id: ConnectionId,
+        owner_partition: PartitionId,
+        lease: CapacityLease,
+    ) -> (Arc<Self>, PhysicalConnectionGuard) {
+        Self::new(id, owner_partition, Some(lease))
+    }
+
+    /// Builds shared connection state and its unique physical-lifetime guard.
+    fn new(
+        id: ConnectionId,
+        owner_partition: PartitionId,
+        lease: Option<CapacityLease>,
+    ) -> (Arc<Self>, PhysicalConnectionGuard) {
+        let connection = Arc::new(Self {
+            id,
+            owner_partition,
+            lifecycle: Mutex::new(LifecycleState {
+                logical: LogicalState::Open { lease },
+                in_flight: 0,
+                physical_complete: false,
+            }),
+        });
+        let physical = PhysicalConnectionGuard {
+            connection: connection.clone(),
+            active: true,
+        };
+        (connection, physical)
+    }
+
+    /// Returns this connection's stable identity.
+    pub(super) fn id(&self) -> ConnectionId {
+        self.id
+    }
+
+    /// Returns the partition that owns this connection's I/O and driver.
+    pub(super) fn owner_partition(&self) -> PartitionId {
+        self.owner_partition
+    }
+
+    /// Attempts to commit one request against logical close.
+    ///
+    /// Returns a guard and increments the in-flight count while the connection
+    /// is open. Returns `None` without changing state after logical close.
+    pub(super) fn try_commit_dispatch(connection: &Arc<Self>) -> Option<DispatchGuard> {
+        let mut lifecycle = connection.lifecycle.lock();
+        if !matches!(lifecycle.logical, LogicalState::Open { .. }) {
+            return None;
+        }
+        lifecycle.in_flight = lifecycle
+            .in_flight
+            .checked_add(1)
+            .expect("in-flight dispatch count exhausted");
+        drop(lifecycle);
+
+        Some(DispatchGuard {
+            connection: connection.clone(),
+            active: true,
+        })
+    }
+
+    /// Performs the first logical-close transition.
+    ///
+    /// Returns `true` when this call closes the connection and records
+    /// `reason`. Returns `false` when another close already won; the original
+    /// reason remains unchanged.
+    ///
+    /// The detached lease is dropped only after the connection lock is
+    /// released, so admission and connection locks are never nested.
+    pub(super) fn logical_close(&self, reason: CloseReason) -> bool {
+        let lease = {
+            let mut lifecycle = self.lifecycle.lock();
+            let LogicalState::Open { lease } = &mut lifecycle.logical else {
+                return false;
+            };
+            let lease = lease.take();
+            lifecycle.logical = LogicalState::Closed { reason };
+            lease
+        };
+        drop(lease);
+        true
+    }
+
+    /// Removes one dispatch previously committed by [`Self::try_commit_dispatch`].
+    fn finish_dispatch(&self) {
+        let mut lifecycle = self.lifecycle.lock();
+        lifecycle.in_flight = lifecycle
+            .in_flight
+            .checked_sub(1)
+            .expect("completed a dispatch that was not in flight");
+    }
+
+    /// Records that the connection's root I/O is no longer live.
+    ///
+    /// # Panics
+    ///
+    /// Panics if physical ownership completes more than once.
+    fn finish_physical(&self) {
+        let mut lifecycle = self.lifecycle.lock();
+        assert!(
+            !lifecycle.physical_complete,
+            "physical connection ownership completed more than once"
+        );
+        lifecycle.physical_complete = true;
+    }
+
+    /// Returns a consistent lifecycle snapshot.
+    pub(super) fn snapshot(&self) -> ConnectionSnapshot {
+        let lifecycle = self.lifecycle.lock();
+        ConnectionSnapshot {
+            close_reason: match lifecycle.logical {
+                LogicalState::Open { .. } => None,
+                LogicalState::Closed { reason } => Some(reason),
+            },
+            in_flight: lifecycle.in_flight,
+            physical_complete: lifecycle.physical_complete,
+        }
+    }
+}
+
+impl fmt::Debug for ConnectionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionState")
+            .field("id", &self.id)
+            .field("owner_partition", &self.owner_partition)
+            .field("lifecycle", &self.lifecycle)
+            .finish()
+    }
+}
+
+/// Connection lifetime state serialized with dispatch commitment and close.
+#[derive(Debug)]
+struct LifecycleState {
+    /// Dispatch eligibility and ownership of bounded capacity.
+    logical: LogicalState,
+    /// Requests that committed before logical close.
+    in_flight: usize,
+    /// Whether ownership of root transport I/O has ended.
+    physical_complete: bool,
+}
+
+/// Whether a connection may accept dispatch and still owns bounded capacity.
+#[derive(Debug)]
+enum LogicalState {
+    /// Dispatch may commit; the optional lease is released by logical close.
+    Open { lease: Option<CapacityLease> },
+    /// New dispatch is rejected while existing work may still drain.
+    Closed { reason: CloseReason },
+}
+
+/// Observable lifecycle state used by protocol coordination and focused tests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ConnectionSnapshot {
+    /// Reason logical close won, or `None` while dispatch is accepted.
+    pub(super) close_reason: Option<CloseReason>,
+    /// Number of dispatches that have not completed.
+    pub(super) in_flight: usize,
+    /// Whether root-I/O ownership has completed.
+    pub(super) physical_complete: bool,
+}
+
+/// One dispatch that committed before logical close.
+///
+/// Dropping the guard records request completion exactly once.
+#[derive(Debug)]
+pub(super) struct DispatchGuard {
+    /// Shared state whose in-flight count this guard owns.
+    connection: Arc<ConnectionState>,
+    /// Whether `Drop` still owes request completion.
+    active: bool,
+}
+
+impl DispatchGuard {
+    /// Returns the identity of the connection carrying this dispatch.
+    pub(super) fn connection_id(&self) -> ConnectionId {
+        self.connection.id
+    }
+
+    /// Consumes the guard and records request completion immediately.
+    ///
+    /// Dropping an uncompleted guard performs the same accounting as a
+    /// cancellation fallback.
+    pub(super) fn complete(mut self) {
+        self.active = false;
+        self.connection.finish_dispatch();
+    }
+}
+
+impl Drop for DispatchGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.connection.finish_dispatch();
+        }
+    }
+}
+
+/// Unique root-I/O ownership whose drop records physical completion.
+///
+/// The guard is created with the connection and moves with root I/O through
+/// protocol drain or upgrade.
+#[derive(Debug)]
+pub(super) struct PhysicalConnectionGuard {
+    /// Shared state whose physical lifetime this guard owns.
+    connection: Arc<ConnectionState>,
+    /// Whether `Drop` still owes physical completion.
+    active: bool,
+}
+
+impl PhysicalConnectionGuard {
+    /// Consumes the guard and records root-I/O completion immediately.
+    ///
+    /// Dropping an uncompleted guard performs the same transition during task
+    /// cancellation or runtime shutdown.
+    pub(super) fn complete(mut self) {
+        self.active = false;
+        self.connection.finish_physical();
+    }
+}
+
+impl Drop for PhysicalConnectionGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.connection.finish_physical();
+        }
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use crate::client::pool::admission::OriginAdmission;
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn logical_close_releases_capacity_before_physical_completion() {
+        let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+        let lease = OriginAdmission::lease_for_test(&origin);
+        let (connection, physical) =
+            ConnectionState::bounded(ConnectionId::new(1), PartitionId::from_index(0), lease);
+
+        assert!(connection.logical_close(CloseReason::Reclaimed));
+        assert!(!connection.logical_close(CloseReason::PoolDropped));
+        assert_eq!(1, origin.available_capacity_for_test());
+        assert!(!connection.snapshot().physical_complete);
+        assert_eq!(
+            Some(CloseReason::Reclaimed),
+            connection.snapshot().close_reason
+        );
+
+        drop(physical);
+        assert!(connection.snapshot().physical_complete);
+    }
+
+    #[test]
+    fn committed_dispatch_drains_after_logical_close() {
+        let (connection, _physical) =
+            ConnectionState::unbounded(ConnectionId::new(1), PartitionId::from_index(0));
+        let dispatch = ConnectionState::try_commit_dispatch(&connection).unwrap();
+        assert_eq!(ConnectionId::new(1), dispatch.connection_id());
+
+        assert!(connection.logical_close(CloseReason::ProtocolClosed));
+        assert!(ConnectionState::try_commit_dispatch(&connection).is_none());
+        assert_eq!(1, connection.snapshot().in_flight);
+
+        dispatch.complete();
+        assert_eq!(0, connection.snapshot().in_flight);
+    }
+
+    #[test]
+    fn physical_guard_is_created_once_with_the_connection() {
+        let (connection, physical) =
+            ConnectionState::unbounded(ConnectionId::new(1), PartitionId::from_index(0));
+        assert_eq!(ConnectionId::new(1), connection.id());
+        assert_eq!(PartitionId::from_index(0), connection.owner_partition());
+        assert!(!connection.snapshot().physical_complete);
+        physical.complete();
+        assert!(connection.snapshot().physical_complete);
+    }
+}
+
+#[cfg(all(test, smithy_http_client_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::client::pool::admission::OriginAdmission;
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn dispatch_commit_linearizes_against_close() {
+        loom::model(|| {
+            let (connection, _physical) =
+                ConnectionState::unbounded(ConnectionId::new(1), PartitionId::from_index(0));
+
+            let dispatch_connection = connection.clone();
+            let dispatch = loom::thread::spawn(move || {
+                ConnectionState::try_commit_dispatch(&dispatch_connection)
+            });
+            let close_connection = connection.clone();
+            let close = loom::thread::spawn(move || {
+                close_connection.logical_close(CloseReason::ProtocolClosed)
+            });
+
+            let dispatch = dispatch.join().unwrap();
+            assert!(close.join().unwrap());
+            let snapshot = connection.snapshot();
+            assert_eq!(Some(CloseReason::ProtocolClosed), snapshot.close_reason);
+            assert!(ConnectionState::try_commit_dispatch(&connection).is_none());
+            match dispatch {
+                Some(dispatch) => {
+                    assert_eq!(1, snapshot.in_flight);
+                    drop(dispatch);
+                    assert_eq!(0, connection.snapshot().in_flight);
+                }
+                None => assert_eq!(0, snapshot.in_flight),
+            }
+        });
+    }
+
+    #[test]
+    fn concurrent_logical_close_releases_one_capacity_lease() {
+        loom::model(|| {
+            let origin = OriginAdmission::new(NonZeroUsize::new(1).unwrap());
+            let lease = OriginAdmission::lease_for_test(&origin);
+            let (connection, _physical) =
+                ConnectionState::bounded(ConnectionId::new(1), PartitionId::from_index(0), lease);
+            let first_connection = connection.clone();
+            let first =
+                loom::thread::spawn(move || first_connection.logical_close(CloseReason::Poisoned));
+            let second_connection = connection.clone();
+            let second = loom::thread::spawn(move || {
+                second_connection.logical_close(CloseReason::PoolDropped)
+            });
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            assert_ne!(first, second);
+            assert_eq!(1, origin.available_capacity_for_test());
+            let reason = connection.snapshot().close_reason.unwrap();
+            assert!(matches!(
+                reason,
+                CloseReason::Poisoned | CloseReason::PoolDropped
+            ));
+        });
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/origin.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/origin.rs
@@ -1,0 +1,500 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Canonical HTTP origin identity.
+//!
+//! [`OriginLookup`] borrows canonical URI host text when possible. A miss
+//! materializes an owned [`OriginKey`] for retained pool state; a canonical
+//! lookup hit does not allocate host storage.
+
+use http_1x::uri::{Authority, Scheme};
+use http_1x::Uri;
+use std::borrow::Cow;
+#[cfg(test)]
+use std::cell::Cell;
+use std::error::Error;
+use std::fmt;
+use std::net::Ipv6Addr;
+use std::num::NonZeroU16;
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[cfg(test)]
+std::thread_local! {
+    static OWNED_ORIGIN_KEY_MATERIALIZATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+/// An owned, canonical HTTP or HTTPS origin.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct OriginKey {
+    scheme: SchemeKey,
+    host: Arc<str>,
+    port: Option<NonZeroU16>,
+}
+
+impl OriginKey {
+    /// Creates an origin from an absolute HTTP or HTTPS URI.
+    pub fn from_uri(uri: &Uri) -> Result<Self, InvalidOrigin> {
+        OriginLookup::from_uri(uri).map(OriginLookup::into_owned)
+    }
+
+    /// Creates an origin from structured scheme, host, and port parts.
+    ///
+    /// The `host` must not contain user information or a port. IPv6 literals
+    /// use the bracketed authority form, for example `[::1]`.
+    pub fn from_parts(
+        scheme: Scheme,
+        host: impl AsRef<str>,
+        port: Option<u16>,
+    ) -> Result<Self, InvalidOrigin> {
+        let scheme = SchemeKey::from_scheme(&scheme)?;
+        let host = host.as_ref();
+        let authority = Authority::from_str(host).map_err(|source| {
+            InvalidOrigin::with_source(format!("invalid origin host {host:?}"), source)
+        })?;
+
+        if authority.as_str().contains('@') || authority_port_text(&authority).is_some() {
+            return Err(InvalidOrigin::new(
+                "origin host must not contain user information or a port",
+            ));
+        }
+
+        let host = authority.host();
+        if host.is_empty() {
+            return Err(InvalidOrigin::new("origin host must not be empty"));
+        }
+
+        Ok(OriginLookup {
+            scheme,
+            host: canonical_host(host),
+            port: canonical_port(scheme, port)?,
+        }
+        .into_owned())
+    }
+
+    /// Returns this origin's HTTP or HTTPS scheme.
+    pub fn scheme(&self) -> &Scheme {
+        self.scheme.as_scheme()
+    }
+
+    /// Returns this origin's canonical host.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Returns the non-default port, if one was specified.
+    pub fn port(&self) -> Option<u16> {
+        self.port.map(NonZeroU16::get)
+    }
+
+    /// Clones the shared host pointer for use as an index key.
+    pub(super) fn shared_host(&self) -> Arc<str> {
+        self.host.clone()
+    }
+}
+
+/// Error returned when a URI or set of parts does not name an HTTP origin.
+#[derive(Debug)]
+pub struct InvalidOrigin {
+    message: String,
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl InvalidOrigin {
+    /// Creates an origin error with no lower-level cause.
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Creates an origin error that preserves the parsing failure as its source.
+    fn with_source(message: impl Into<String>, source: impl Error + Send + Sync + 'static) -> Self {
+        Self {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl fmt::Display for InvalidOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for InvalidOrigin {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn Error + 'static))
+    }
+}
+
+/// Compact HTTP or HTTPS scheme identity.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) enum SchemeKey {
+    Http,
+    Https,
+}
+
+impl SchemeKey {
+    /// Accepts HTTP or HTTPS case-insensitively and rejects every other scheme.
+    fn from_scheme(scheme: &Scheme) -> Result<Self, InvalidOrigin> {
+        if scheme.as_str().eq_ignore_ascii_case("http") {
+            Ok(Self::Http)
+        } else if scheme.as_str().eq_ignore_ascii_case("https") {
+            Ok(Self::Https)
+        } else {
+            Err(InvalidOrigin::new(format!(
+                "unsupported origin scheme {:?}; expected http or https",
+                scheme.as_str()
+            )))
+        }
+    }
+
+    /// Returns the canonical static `http` or `https` scheme.
+    fn as_scheme(self) -> &'static Scheme {
+        match self {
+            Self::Http => &Scheme::HTTP,
+            Self::Https => &Scheme::HTTPS,
+        }
+    }
+}
+
+/// Borrowed canonical origin used to probe retained cells.
+///
+/// A lowercase URI host remains borrowed on a lookup hit. After a cell miss,
+/// converting it into an [`OriginKey`] allocates the host retained by the new
+/// cell.
+pub(super) struct OriginLookup<'a> {
+    scheme: SchemeKey,
+    host: Cow<'a, str>,
+    port: Option<NonZeroU16>,
+}
+
+impl<'a> OriginLookup<'a> {
+    /// Borrows every identity component from an already-owned origin.
+    pub(super) fn from_origin(origin: &'a OriginKey) -> Self {
+        Self {
+            scheme: origin.scheme,
+            host: Cow::Borrowed(&origin.host),
+            port: origin.port,
+        }
+    }
+
+    /// Canonicalizes an absolute HTTP or HTTPS URI for retained-state lookup.
+    ///
+    /// Host storage remains borrowed when the URI already uses its canonical
+    /// spelling.
+    pub(super) fn from_uri(uri: &'a Uri) -> Result<Self, InvalidOrigin> {
+        let scheme = uri
+            .scheme()
+            .ok_or_else(|| InvalidOrigin::new("origin URI is missing a scheme"))
+            .and_then(SchemeKey::from_scheme)?;
+        let authority = uri
+            .authority()
+            .ok_or_else(|| InvalidOrigin::new("origin URI is missing an authority"))?;
+        let host = authority.host();
+        if host.is_empty() {
+            return Err(InvalidOrigin::new("origin URI is missing a host"));
+        }
+
+        Ok(Self {
+            scheme,
+            host: canonical_host(host),
+            port: canonical_port(scheme, parse_authority_port(authority)?)?,
+        })
+    }
+
+    /// Returns the compact canonical scheme used by the first-level index.
+    pub(super) fn scheme(&self) -> SchemeKey {
+        self.scheme
+    }
+
+    /// Returns the canonical host without materializing owned storage.
+    pub(super) fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Returns the canonical non-default port used by the first-level index.
+    pub(super) fn port(&self) -> Option<NonZeroU16> {
+        self.port
+    }
+
+    /// Materializes the stable identity retained after a lookup miss.
+    pub(super) fn into_owned(self) -> OriginKey {
+        #[cfg(test)]
+        OWNED_ORIGIN_KEY_MATERIALIZATIONS.with(|count| count.set(count.get() + 1));
+        OriginKey {
+            scheme: self.scheme,
+            host: Arc::from(self.host),
+            port: self.port,
+        }
+    }
+
+    #[cfg(test)]
+    /// Returns the number of lookup values converted into retained identities.
+    pub(super) fn owned_origin_key_materializations_for_test() -> usize {
+        OWNED_ORIGIN_KEY_MATERIALIZATIONS.with(Cell::get)
+    }
+}
+
+/// Returns a non-default port, omitting scheme defaults and rejecting zero.
+fn canonical_port(
+    scheme: SchemeKey,
+    port: Option<u16>,
+) -> Result<Option<NonZeroU16>, InvalidOrigin> {
+    match (scheme, port) {
+        (_, Some(0)) => Err(InvalidOrigin::new("origin port must not be zero")),
+        (SchemeKey::Http, Some(80)) | (SchemeKey::Https, Some(443)) | (_, None) => Ok(None),
+        (_, Some(port)) => Ok(NonZeroU16::new(port)),
+    }
+}
+
+/// Parses an explicitly written authority port.
+///
+/// Invalid and absent ports remain distinct so malformed origins cannot alias
+/// an origin with the scheme's default port.
+fn parse_authority_port(authority: &Authority) -> Result<Option<u16>, InvalidOrigin> {
+    let Some(port) = authority_port_text(authority) else {
+        return Ok(None);
+    };
+
+    port.parse().map(Some).map_err(|source| {
+        InvalidOrigin::with_source(format!("invalid origin port {port:?}"), source)
+    })
+}
+
+/// Returns the port text following an authority host, if one was written.
+///
+/// This reads the authority source because `Authority::port_u16` returns
+/// `None` for both an absent port and a malformed or out-of-range port.
+fn authority_port_text(authority: &Authority) -> Option<&str> {
+    let host_and_port = authority
+        .as_str()
+        .rsplit_once('@')
+        .map_or(authority.as_str(), |(_, host_and_port)| host_and_port);
+
+    if host_and_port.starts_with('[') {
+        let close = host_and_port.find(']')?;
+        host_and_port[close + 1..].strip_prefix(':')
+    } else {
+        host_and_port.rsplit_once(':').map(|(_, port)| port)
+    }
+}
+
+/// Canonicalizes DNS names and recognized IPv6 literals, borrowing when unchanged.
+///
+/// DNS names are ASCII-lowercased. IPv6 addresses use the standard compressed
+/// spelling while retaining the zone identifier's case. Unknown IP-literal
+/// forms remain byte-distinct because their case semantics are not known.
+fn canonical_host(host: &str) -> Cow<'_, str> {
+    if let Some(inner) = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+    {
+        let (address, zone) = inner
+            .split_once("%25")
+            .map_or((inner, None), |(address, zone)| (address, Some(zone)));
+        if let Ok(address) = address.parse::<Ipv6Addr>() {
+            return if canonical_ipv6_matches(host, address, zone) {
+                Cow::Borrowed(host)
+            } else {
+                Cow::Owned(match zone {
+                    Some(zone) => format!("[{address}%25{zone}]"),
+                    None => format!("[{address}]"),
+                })
+            };
+        }
+
+        return Cow::Borrowed(host);
+    }
+
+    if host.as_bytes().iter().any(u8::is_ascii_uppercase) {
+        let mut canonical = host.to_owned();
+        canonical.make_ascii_lowercase();
+        Cow::Owned(canonical)
+    } else {
+        Cow::Borrowed(host)
+    }
+}
+
+/// Compares an IPv6 literal with its canonical formatting without allocating.
+fn canonical_ipv6_matches(host: &str, address: Ipv6Addr, zone: Option<&str>) -> bool {
+    struct CompareWriter<'a> {
+        expected: &'a [u8],
+        offset: usize,
+        matches: bool,
+    }
+
+    impl fmt::Write for CompareWriter<'_> {
+        fn write_str(&mut self, value: &str) -> fmt::Result {
+            let end = self.offset.saturating_add(value.len());
+            if self.expected.get(self.offset..end) != Some(value.as_bytes()) {
+                self.matches = false;
+            }
+            self.offset = end;
+            Ok(())
+        }
+    }
+
+    let mut writer = CompareWriter {
+        expected: host.as_bytes(),
+        offset: 0,
+        matches: true,
+    };
+    let result = match zone {
+        Some(zone) => fmt::write(&mut writer, format_args!("[{address}%25{zone}]")),
+        None => fmt::write(&mut writer, format_args!("[{address}]")),
+    };
+    result.is_ok() && writer.matches && writer.offset == writer.expected.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_host_borrows_common_case() {
+        assert!(matches!(canonical_host("example.com"), Cow::Borrowed(_)));
+        assert!(matches!(
+            canonical_host("EXAMPLE.com"),
+            Cow::Owned(host) if host == "example.com"
+        ));
+    }
+
+    #[test]
+    fn canonicalizes_host_and_default_port() {
+        let a = OriginKey::from_uri(&"https://EXAMPLE.com:443/a".parse().unwrap()).unwrap();
+        let b = OriginKey::from_uri(&"https://example.com/b".parse().unwrap()).unwrap();
+
+        assert_eq!(a, b);
+        assert_eq!("example.com", a.host());
+        assert_eq!(None, a.port());
+    }
+
+    #[test]
+    fn non_default_port_and_scheme_remain_identity() {
+        let base = OriginKey::from_uri(&"https://example.com/".parse().unwrap()).unwrap();
+        let port = OriginKey::from_uri(&"https://example.com:8443/".parse().unwrap()).unwrap();
+        let clear = OriginKey::from_uri(&"http://example.com/".parse().unwrap()).unwrap();
+
+        assert_ne!(base, port);
+        assert_ne!(base, clear);
+        assert_eq!(Some(8443), port.port());
+    }
+
+    #[test]
+    fn rejects_invalid_and_zero_ports() {
+        for uri in [
+            "https://example.com:/",
+            "https://example.com:abc/",
+            "https://example.com:99999/",
+            "https://example.com:0/",
+        ] {
+            let uri: Uri = uri.parse().unwrap();
+            assert!(OriginKey::from_uri(&uri).is_err(), "{uri}");
+        }
+
+        assert!(OriginKey::from_parts(Scheme::HTTPS, "example.com", Some(0)).is_err());
+        assert!(OriginKey::from_parts(Scheme::HTTPS, "example.com:abc", None).is_err());
+        assert!(OriginKey::from_parts(Scheme::HTTPS, "example.com:99999", None).is_err());
+    }
+
+    #[test]
+    fn trailing_dot_remains_distinct() {
+        let plain = OriginKey::from_uri(&"https://example.com/".parse().unwrap()).unwrap();
+        let dotted = OriginKey::from_uri(&"https://example.com./".parse().unwrap()).unwrap();
+        assert_ne!(plain, dotted);
+    }
+
+    #[test]
+    fn parts_and_uri_canonicalize_identically() {
+        let from_parts = OriginKey::from_parts(Scheme::HTTPS, "EXAMPLE.com", Some(443)).unwrap();
+        let from_uri = OriginKey::from_uri(&"https://example.com/".parse().unwrap()).unwrap();
+        assert_eq!(from_parts, from_uri);
+    }
+
+    #[test]
+    fn parts_accept_mixed_case_http_scheme() {
+        let scheme = Scheme::from_str("HTTPS").unwrap();
+        let origin = OriginKey::from_parts(scheme, "example.com", None).unwrap();
+        assert_eq!(&Scheme::HTTPS, origin.scheme());
+    }
+
+    #[test]
+    fn uri_userinfo_is_not_part_of_the_origin() {
+        let with_userinfo =
+            OriginKey::from_uri(&"https://user:password@example.com/".parse().unwrap()).unwrap();
+        let plain = OriginKey::from_uri(&"https://example.com/".parse().unwrap()).unwrap();
+        assert_eq!(plain, with_userinfo);
+    }
+
+    #[test]
+    fn ipv6_parts_and_uri_canonicalize_identically() {
+        let from_parts =
+            OriginKey::from_parts(Scheme::HTTPS, "[2001:0db8:0:0:0:0:0:1]", Some(443)).unwrap();
+        let from_uri = OriginKey::from_uri(&"https://[2001:db8::1]:443/".parse().unwrap()).unwrap();
+
+        assert_eq!(from_parts, from_uri);
+        assert_eq!("[2001:db8::1]", from_parts.host());
+        assert_eq!(None, from_parts.port());
+    }
+
+    #[test]
+    fn canonical_ipv6_lookup_remains_borrowed() {
+        assert!(matches!(canonical_host("[2001:db8::1]"), Cow::Borrowed(_)));
+        assert!(matches!(
+            canonical_host("[fe80::1%25ETH0]"),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn ipv6_zone_identifier_case_remains_distinct() {
+        let upper =
+            OriginKey::from_uri(&"https://[fe80:0:0:0::1%25ETH0]/".parse().unwrap()).unwrap();
+        let lower = OriginKey::from_uri(&"https://[fe80::1%25eth0]/".parse().unwrap()).unwrap();
+
+        assert_eq!("[fe80::1%25ETH0]", upper.host());
+        assert_ne!(upper, lower);
+    }
+
+    #[test]
+    fn invalid_origin_preserves_diagnostic_source() {
+        let error = OriginKey::from_parts(Scheme::HTTPS, "not a host", None).unwrap_err();
+        assert!(error.to_string().contains("invalid origin host"));
+        assert!(error.source().is_some());
+
+        let uri: Uri = "https://example.com:abc/".parse().unwrap();
+        let error = OriginKey::from_uri(&uri).unwrap_err();
+        assert_eq!("invalid origin port \"abc\"", error.to_string());
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn rejects_non_origins() {
+        let relative: Uri = "/path".parse().unwrap();
+        assert_eq!(
+            "origin URI is missing a scheme",
+            OriginKey::from_uri(&relative).unwrap_err().to_string()
+        );
+
+        let ftp: Uri = "ftp://example.com/".parse().unwrap();
+        assert!(OriginKey::from_uri(&ftp)
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported origin scheme"));
+
+        assert_eq!(
+            "origin host must not contain user information or a port",
+            OriginKey::from_parts(Scheme::HTTPS, "example.com:443", None)
+                .unwrap_err()
+                .to_string()
+        );
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/partition.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/partition.rs
@@ -1,0 +1,246 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Connection placement declarations.
+//!
+//! A [`Partition`] combines stable identity, driver placement, and an optional
+//! network-interface binding. It declares where connections live; sharing a
+//! connection never moves that connection's I/O or driver.
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Declares where a client's connections are established and driven.
+#[derive(Clone)]
+pub struct Partition {
+    id: PartitionId,
+    spawner: Arc<dyn DriverSpawner>,
+    interface: Option<Arc<str>>,
+}
+
+impl Partition {
+    /// Creates a partition with a stable identity and driver spawner.
+    pub fn new<S>(id: PartitionId, spawner: S) -> Self
+    where
+        S: DriverSpawner,
+    {
+        Self {
+            id,
+            spawner: Arc::new(spawner),
+            interface: None,
+        }
+    }
+
+    /// Binds connections established by this partition to an interface.
+    ///
+    /// The binding is applied before connect. On Linux, using this setting
+    /// may require `CAP_NET_RAW` or root privileges.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "solaris",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    pub fn interface(mut self, interface: impl Into<String>) -> Self {
+        self.interface = Some(Arc::from(interface.into()));
+        self
+    }
+
+    /// Returns this partition's declared identity.
+    pub(super) fn id(&self) -> PartitionId {
+        self.id
+    }
+
+    /// Decomposes this declaration for immutable registry storage.
+    pub(super) fn into_parts(self) -> (PartitionId, Arc<dyn DriverSpawner>, Option<Arc<str>>) {
+        (self.id, self.spawner, self.interface)
+    }
+}
+
+impl fmt::Debug for Partition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Partition")
+            .field("id", &self.id)
+            .field("spawner", &self.spawner)
+            .field("interface", &self.interface)
+            .finish()
+    }
+}
+
+/// Identifies one declared connection partition.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct PartitionId(usize);
+
+impl PartitionId {
+    /// Reserved identity for the implicit default partition.
+    pub const ANONYMOUS: Self = Self(usize::MAX);
+
+    /// Creates a partition identity from a caller-owned index.
+    ///
+    /// `usize::MAX` is reserved for [`Self::ANONYMOUS`] and is rejected when
+    /// used in an explicit partition declaration.
+    pub const fn from_index(index: usize) -> Self {
+        Self(index)
+    }
+
+    /// Returns whether this is the reserved anonymous partition identity.
+    pub const fn is_anonymous(self) -> bool {
+        self.0 == Self::ANONYMOUS.0
+    }
+}
+
+/// Spawns protocol drivers on a partition's owning runtime.
+pub trait DriverSpawner: fmt::Debug + Send + Sync + 'static {
+    /// Spawns a protocol driver future.
+    fn spawn(&self, driver: Pin<Box<dyn Future<Output = ()> + Send + 'static>>);
+}
+
+/// A driver spawner backed by a captured Tokio runtime handle.
+#[cfg(feature = "rt-tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rt-tokio")))]
+#[derive(Clone, Debug)]
+pub struct TokioDriverSpawner {
+    handle: tokio::runtime::Handle,
+}
+
+#[cfg(feature = "rt-tokio")]
+impl TokioDriverSpawner {
+    /// Captures the current Tokio runtime.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called outside a Tokio runtime context.
+    pub fn current() -> Self {
+        Self::from_handle(tokio::runtime::Handle::current())
+    }
+
+    /// Uses a specific Tokio runtime handle.
+    pub fn from_handle(handle: tokio::runtime::Handle) -> Self {
+        Self { handle }
+    }
+}
+
+#[cfg(feature = "rt-tokio")]
+impl DriverSpawner for TokioDriverSpawner {
+    fn spawn(&self, driver: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+        debug_assert_eq!(
+            tokio::runtime::Handle::try_current()
+                .ok()
+                .map(|current| current.id()),
+            Some(self.handle.id()),
+            "driver spawned outside the partition's declared runtime"
+        );
+        drop(self.handle.spawn(driver));
+    }
+}
+
+/// Controls which partitions may dispatch through each other's connections.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectionReuseScope {
+    /// A connection serves only requests from its owning partition.
+    Partition,
+    /// Partitions with the same interface binding may share connections.
+    #[default]
+    NetworkInterface,
+    /// Every partition in the pool may share connections.
+    Pool,
+}
+
+/// Identifies the exact set of partitions eligible to reuse a connection.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum EligibilityGroup {
+    /// Only the partition with this identity is eligible.
+    Partition(PartitionId),
+    /// Partitions with this exact interface binding are eligible.
+    NetworkInterface(Option<Arc<str>>),
+    /// Every partition in the pool is eligible.
+    Pool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "rt-tokio")]
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Debug)]
+    struct TestSpawner;
+
+    impl DriverSpawner for TestSpawner {
+        fn spawn(&self, driver: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            drop(driver);
+        }
+    }
+
+    #[test]
+    fn anonymous_identity_is_reserved() {
+        assert!(PartitionId::ANONYMOUS.is_anonymous());
+        assert!(PartitionId::from_index(usize::MAX).is_anonymous());
+        assert!(!PartitionId::from_index(0).is_anonymous());
+    }
+
+    #[test]
+    fn partition_retains_placement() {
+        let partition = Partition::new(PartitionId::from_index(7), TestSpawner);
+        let (id, spawner, interface) = partition.into_parts();
+        assert_eq!(PartitionId::from_index(7), id);
+        assert_eq!(None, interface);
+
+        let driver = Box::pin(async {});
+        spawner.spawn(driver);
+    }
+
+    #[cfg(feature = "rt-tokio")]
+    #[test]
+    fn tokio_spawner_uses_captured_runtime() {
+        let owner = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let owner_id = owner.handle().id();
+        let ran = Arc::new(AtomicBool::new(false));
+        let task_ran = ran.clone();
+        let spawner = TokioDriverSpawner::from_handle(owner.handle().clone());
+
+        owner.block_on(async {
+            spawner.spawn(Box::pin(async move {
+                assert_eq!(owner_id, tokio::runtime::Handle::current().id());
+                task_ran.store(true, Ordering::SeqCst);
+            }));
+            for _ in 0..10 {
+                if ran.load(Ordering::SeqCst) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[cfg(all(feature = "rt-tokio", debug_assertions))]
+    #[test]
+    #[should_panic(expected = "driver spawned outside the partition's declared runtime")]
+    fn tokio_spawner_diagnoses_foreign_runtime_use() {
+        let owner = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let foreign = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let spawner = TokioDriverSpawner::from_handle(owner.handle().clone());
+
+        foreign.block_on(async {
+            spawner.spawn(Box::pin(async {}));
+        });
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
@@ -1,0 +1,701 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Pool topology and stable origin-cell publication.
+//!
+//! [`PartitionRegistry`] retains the fixed partition set and one shared
+//! [`OriginAdmission`] for each bounded origin. Each [`PartitionState`] owns
+//! runtime placement and lazily retains one [`OriginCell`] per canonical
+//! origin.
+
+use super::admission::OriginAdmission;
+use super::cell::OriginCell;
+use super::origin::{InvalidOrigin, OriginKey, OriginLookup, SchemeKey};
+use super::partition::{
+    ConnectionReuseScope, DriverSpawner, EligibilityGroup, Partition, PartitionId,
+};
+use crate::sync::{Arc, Mutex, RwLock};
+use http_1x::Uri;
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::num::{NonZeroU16, NonZeroUsize};
+use std::sync::Arc as StdArc;
+
+/// Fixed partition set and the origin-wide admission states it shares.
+#[derive(Debug)]
+pub(crate) struct PartitionRegistry {
+    /// Immutable partition identities resolved when a client is built.
+    partitions: HashMap<PartitionId, Arc<PartitionState>>,
+    /// Policy used to derive a new cell's eligibility group.
+    reuse_scope: ConnectionReuseScope,
+    /// Optional origin-wide bound used when admission is first created.
+    max_connections_per_host: Option<NonZeroUsize>,
+    /// Admission authorities retained by canonical origin.
+    bounded_origins: Mutex<HashMap<OriginKey, Arc<OriginAdmission>>>,
+}
+
+impl PartitionRegistry {
+    /// Creates a registry containing its implicit anonymous partition.
+    pub(crate) fn anonymous(
+        reuse_scope: ConnectionReuseScope,
+        max_connections_per_host: Option<NonZeroUsize>,
+    ) -> Self {
+        let partition = Arc::new(PartitionState::anonymous());
+        let mut partitions = HashMap::new();
+        partitions.insert(PartitionId::ANONYMOUS, partition.clone());
+        Self {
+            partitions,
+            reuse_scope,
+            max_connections_per_host,
+            bounded_origins: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Creates a registry from a nonempty set of explicit partitions.
+    pub(crate) fn explicit(
+        partitions: impl IntoIterator<Item = Partition>,
+        reuse_scope: ConnectionReuseScope,
+        max_connections_per_host: Option<NonZeroUsize>,
+    ) -> Result<Self, PartitionRegistryError> {
+        let mut by_id = HashMap::new();
+        for partition in partitions {
+            let id = partition.id();
+            if id.is_anonymous() {
+                return Err(PartitionRegistryError::ReservedAnonymousPartition);
+            }
+            if by_id
+                .insert(id, Arc::new(PartitionState::explicit(partition)))
+                .is_some()
+            {
+                return Err(PartitionRegistryError::DuplicatePartition(id));
+            }
+        }
+
+        if by_id.is_empty() {
+            return Err(PartitionRegistryError::EmptyExplicitPartitionSet);
+        }
+
+        Ok(Self {
+            partitions: by_id,
+            reuse_scope,
+            max_connections_per_host,
+            bounded_origins: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Resolves a declared partition once during client construction.
+    pub(crate) fn partition(&self, id: PartitionId) -> Option<Arc<PartitionState>> {
+        self.partitions.get(&id).cloned()
+    }
+
+    /// Resolves the stable cell for an already-resolved partition and URI.
+    pub(crate) fn resolve_cell(
+        &self,
+        partition: &PartitionState,
+        uri: &Uri,
+    ) -> Result<Arc<OriginCell>, InvalidOrigin> {
+        let lookup = OriginLookup::from_uri(uri)?;
+        if let Some(cell) = partition.find_cell(&lookup) {
+            return Ok(cell);
+        }
+
+        let eligibility_group = self.eligibility_group(partition);
+        let origin = lookup.into_owned();
+        let admission = self.origin_admission(&origin);
+        let candidate = Arc::new(OriginCell::new(
+            partition.id(),
+            origin,
+            eligibility_group,
+            admission.clone(),
+        ));
+        let cell = match admission {
+            Some(admission) => OriginAdmission::register_cell(&admission, candidate),
+            None => candidate,
+        };
+        Ok(partition.publish_cell(cell))
+    }
+
+    /// Returns the shared admission authority for a bounded origin.
+    ///
+    /// Unbounded registries return `None`. Concurrent first use of a bounded
+    /// origin converges on one retained authority.
+    fn origin_admission(&self, origin: &OriginKey) -> Option<Arc<OriginAdmission>> {
+        let limit = self.max_connections_per_host?;
+        let admission = {
+            let mut origins = self.bounded_origins.lock();
+            origins
+                .entry(origin.clone())
+                .or_insert_with(|| OriginAdmission::new(limit))
+                .clone()
+        };
+        Some(admission)
+    }
+
+    /// Derives which partitions may relieve a new cell's bounded demand.
+    fn eligibility_group(&self, partition: &PartitionState) -> EligibilityGroup {
+        match self.reuse_scope {
+            ConnectionReuseScope::Partition => EligibilityGroup::Partition(partition.id()),
+            ConnectionReuseScope::NetworkInterface => {
+                EligibilityGroup::NetworkInterface(partition.interface().cloned())
+            }
+            ConnectionReuseScope::Pool => EligibilityGroup::Pool,
+        }
+    }
+}
+
+/// Runtime placement and retained origin cells for one partition.
+#[derive(Debug)]
+pub(crate) struct PartitionState {
+    /// Stable identity copied into every cell and owned connection.
+    id: PartitionId,
+    /// Declared spawner, or the first spawner published for the anonymous partition.
+    spawner: Mutex<Option<StdArc<dyn DriverSpawner>>>,
+    /// Network interface used for placement and reuse eligibility.
+    interface: Option<StdArc<str>>,
+    /// Cells retained for the lifetime of this partition.
+    origins: RwLock<OriginMap>,
+}
+
+impl PartitionState {
+    /// Creates the implicit partition whose spawner is published on first use.
+    fn anonymous() -> Self {
+        Self {
+            id: PartitionId::ANONYMOUS,
+            spawner: Mutex::new(None),
+            interface: None,
+            origins: RwLock::new(OriginMap::default()),
+        }
+    }
+
+    /// Moves one validated explicit declaration into retained partition state.
+    fn explicit(partition: Partition) -> Self {
+        let (id, spawner, interface) = partition.into_parts();
+        Self {
+            id,
+            spawner: Mutex::new(Some(spawner)),
+            interface,
+            origins: RwLock::new(OriginMap::default()),
+        }
+    }
+
+    /// Returns this partition's stable identity.
+    pub(crate) fn id(&self) -> PartitionId {
+        self.id
+    }
+
+    /// Returns this partition's optional network-interface binding.
+    pub(crate) fn interface(&self) -> Option<&StdArc<str>> {
+        self.interface.as_ref()
+    }
+
+    /// Returns the declared spawner or lazily publishes an anonymous spawner.
+    ///
+    /// Candidate construction and destruction both happen without the
+    /// spawner lock held. Concurrent callers receive the one published value.
+    pub(crate) fn driver_spawner_with(
+        &self,
+        make_anonymous: impl FnOnce() -> StdArc<dyn DriverSpawner>,
+    ) -> StdArc<dyn DriverSpawner> {
+        if let Some(spawner) = self.spawner.lock().as_ref() {
+            return spawner.clone();
+        }
+
+        debug_assert!(self.id.is_anonymous());
+        let candidate = make_anonymous();
+        let selected = {
+            let mut spawner = self.spawner.lock();
+            if let Some(spawner) = spawner.as_ref() {
+                spawner.clone()
+            } else {
+                *spawner = Some(candidate.clone());
+                candidate.clone()
+            }
+        };
+        drop(candidate);
+        selected
+    }
+
+    /// Looks up a cell without materializing an owned origin key.
+    fn find_cell(&self, lookup: &OriginLookup<'_>) -> Option<Arc<OriginCell>> {
+        self.origins.read().get(lookup)
+    }
+
+    /// Publishes `cell` or returns the value that won concurrent publication.
+    fn publish_cell(&self, cell: Arc<OriginCell>) -> Arc<OriginCell> {
+        self.origins.write().get_or_insert(cell)
+    }
+
+    /// Returns the number of cells retained by this partition.
+    pub(crate) fn cell_count(&self) -> usize {
+        self.origins.read().len()
+    }
+}
+
+/// Retained origin cells owned by one partition.
+#[derive(Default, Debug)]
+struct OriginMap {
+    /// Host maps grouped by scheme and non-default port for borrowed lookup.
+    indexes: HashMap<SchemePortKey, HashMap<StdArc<str>, Arc<OriginCell>>>,
+    /// Cached cell total, avoiding a scan across every first-level bucket.
+    cell_count: usize,
+}
+
+impl OriginMap {
+    /// Resolves a cell through borrowed scheme, port, and host components.
+    fn get(&self, lookup: &OriginLookup<'_>) -> Option<Arc<OriginCell>> {
+        self.indexes
+            .get(&SchemePortKey::from_lookup(lookup))?
+            .get(lookup.host())
+            .cloned()
+    }
+
+    /// Publishes one stable cell and returns an existing concurrent winner.
+    fn get_or_insert(&mut self, cell: Arc<OriginCell>) -> Arc<OriginCell> {
+        let lookup = OriginLookup::from_origin(cell.id().origin());
+        if let Some(existing) = self.get(&lookup) {
+            return existing;
+        }
+
+        let index = SchemePortKey::from_lookup(&lookup);
+        let host = cell.id().origin().shared_host();
+        self.indexes
+            .entry(index)
+            .or_default()
+            .insert(host, cell.clone());
+        self.cell_count = self
+            .cell_count
+            .checked_add(1)
+            .expect("origin cell count exhausted");
+        cell
+    }
+
+    /// Returns the cached number of cells across every scheme-port bucket.
+    fn len(&self) -> usize {
+        self.cell_count
+    }
+}
+
+/// Scheme and non-default port used for the first level of origin lookup.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct SchemePortKey {
+    /// Canonical HTTP or HTTPS scheme.
+    scheme: SchemeKey,
+    /// Canonical non-default port.
+    port: Option<NonZeroU16>,
+}
+
+impl SchemePortKey {
+    /// Extracts the first-level index from a canonical borrowed lookup.
+    fn from_lookup(lookup: &OriginLookup<'_>) -> Self {
+        Self {
+            scheme: lookup.scheme(),
+            port: lookup.port(),
+        }
+    }
+}
+
+/// Error returned for an invalid explicit partition set.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PartitionRegistryError {
+    /// No partitions were declared.
+    EmptyExplicitPartitionSet,
+    /// More than one partition used the same identity.
+    DuplicatePartition(PartitionId),
+    /// An explicit partition used the identity reserved for the default.
+    ReservedAnonymousPartition,
+}
+
+impl fmt::Display for PartitionRegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyExplicitPartitionSet => {
+                f.write_str("explicit partition set must not be empty")
+            }
+            Self::DuplicatePartition(id) => write!(f, "duplicate partition identifier: {id:?}"),
+            Self::ReservedAnonymousPartition => {
+                f.write_str("the anonymous partition identifier is reserved")
+            }
+        }
+    }
+}
+
+impl Error for PartitionRegistryError {}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use crate::client::pool::admission::ProtocolRequirement;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Barrier;
+
+    #[derive(Debug)]
+    struct TestSpawner;
+
+    impl DriverSpawner for TestSpawner {
+        fn spawn(&self, driver: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            drop(driver);
+        }
+    }
+
+    fn partition(index: usize) -> Partition {
+        Partition::new(PartitionId::from_index(index), TestSpawner)
+    }
+
+    fn explicit_partition(registry: &PartitionRegistry, index: usize) -> Arc<PartitionState> {
+        registry
+            .partition(PartitionId::from_index(index))
+            .expect("test partition was not registered")
+    }
+
+    #[test]
+    fn anonymous_partition_publishes_one_spawner() {
+        const THREADS: usize = 8;
+        let registry = Arc::new(PartitionRegistry::anonymous(
+            ConnectionReuseScope::NetworkInterface,
+            None,
+        ));
+        let partition = registry.partition(PartitionId::ANONYMOUS).unwrap();
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut threads = Vec::new();
+
+        for _ in 0..THREADS {
+            let partition = partition.clone();
+            let barrier = barrier.clone();
+            let calls = calls.clone();
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                partition.driver_spawner_with(|| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Arc::new(TestSpawner)
+                })
+            }));
+        }
+
+        let spawners: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect();
+        assert!(spawners
+            .iter()
+            .skip(1)
+            .all(|spawner| Arc::ptr_eq(&spawners[0], spawner)));
+        assert!((1..=THREADS).contains(&calls.load(Ordering::SeqCst)));
+    }
+
+    #[test]
+    fn losing_spawner_is_dropped_without_the_registry_lock() {
+        #[derive(Debug)]
+        struct DropChecksLock {
+            other_lock: Arc<Mutex<()>>,
+        }
+
+        impl DriverSpawner for DropChecksLock {
+            fn spawn(&self, driver: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+                drop(driver);
+            }
+        }
+
+        impl Drop for DropChecksLock {
+            fn drop(&mut self) {
+                drop(self.other_lock.lock());
+            }
+        }
+
+        let registry = PartitionRegistry::anonymous(ConnectionReuseScope::default(), None);
+        let partition = registry.partition(PartitionId::ANONYMOUS).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let other_lock = Arc::new(Mutex::new(()));
+        let mut threads = Vec::new();
+        for _ in 0..2 {
+            let partition = partition.clone();
+            let barrier = barrier.clone();
+            let other_lock = other_lock.clone();
+            threads.push(std::thread::spawn(move || {
+                partition.driver_spawner_with(|| {
+                    barrier.wait();
+                    Arc::new(DropChecksLock { other_lock })
+                })
+            }));
+        }
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn explicit_registry_rejects_invalid_partition_sets() {
+        assert_eq!(
+            PartitionRegistryError::EmptyExplicitPartitionSet,
+            PartitionRegistry::explicit(Vec::new(), ConnectionReuseScope::default(), None)
+                .unwrap_err()
+        );
+        assert_eq!(
+            PartitionRegistryError::ReservedAnonymousPartition,
+            PartitionRegistry::explicit(
+                [Partition::new(PartitionId::ANONYMOUS, TestSpawner)],
+                ConnectionReuseScope::default(),
+                None,
+            )
+            .unwrap_err()
+        );
+        assert_eq!(
+            PartitionRegistryError::DuplicatePartition(PartitionId::from_index(1)),
+            PartitionRegistry::explicit(
+                [partition(1), partition(1)],
+                ConnectionReuseScope::default(),
+                None,
+            )
+            .unwrap_err()
+        );
+    }
+
+    #[test]
+    fn canonical_spellings_resolve_one_stable_cell() {
+        let registry =
+            PartitionRegistry::explicit([partition(1)], ConnectionReuseScope::default(), None)
+                .unwrap();
+        let partition = explicit_partition(&registry, 1);
+        let first = registry
+            .resolve_cell(&partition, &"https://EXAMPLE.com:443/a".parse().unwrap())
+            .unwrap();
+        let owned_origin_keys = OriginLookup::owned_origin_key_materializations_for_test();
+        let second = registry
+            .resolve_cell(&partition, &"https://example.com/b".parse().unwrap())
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            owned_origin_keys,
+            OriginLookup::owned_origin_key_materializations_for_test(),
+            "canonical cell hit materialized a new OriginKey"
+        );
+        assert_eq!(PartitionId::from_index(1), first.id().partition());
+        assert_eq!("example.com", first.id().origin().host());
+        assert_eq!(1, partition.cell_count());
+    }
+
+    #[test]
+    fn scheme_origin_and_partition_form_cell_identity() {
+        let registry = PartitionRegistry::explicit(
+            [partition(1), partition(2)],
+            ConnectionReuseScope::Pool,
+            None,
+        )
+        .unwrap();
+        let partition_1 = explicit_partition(&registry, 1);
+        let partition_2 = explicit_partition(&registry, 2);
+        let https: Uri = "https://example.com/".parse().unwrap();
+        let http: Uri = "http://example.com/".parse().unwrap();
+        let other_port: Uri = "https://example.com:8443/".parse().unwrap();
+
+        let p1 = registry.resolve_cell(&partition_1, &https).unwrap();
+        let p2 = registry.resolve_cell(&partition_2, &https).unwrap();
+        let p1_http = registry.resolve_cell(&partition_1, &http).unwrap();
+        let p1_other = registry.resolve_cell(&partition_1, &other_port).unwrap();
+
+        assert!(!Arc::ptr_eq(&p1, &p2));
+        assert!(!Arc::ptr_eq(&p1, &p1_http));
+        assert!(!Arc::ptr_eq(&p1, &p1_other));
+        assert_eq!(p1.eligibility_group(), p2.eligibility_group());
+    }
+
+    #[test]
+    fn every_reuse_scope_forms_expected_groups() {
+        assert_eq!(
+            ConnectionReuseScope::NetworkInterface,
+            ConnectionReuseScope::default()
+        );
+        let uri: Uri = "https://example.com/".parse().unwrap();
+        let resolve = |scope| {
+            let registry =
+                PartitionRegistry::explicit([partition(1), partition(2)], scope, None).unwrap();
+            let first_partition = explicit_partition(&registry, 1);
+            let second_partition = explicit_partition(&registry, 2);
+            let first = registry.resolve_cell(&first_partition, &uri).unwrap();
+            let second = registry.resolve_cell(&second_partition, &uri).unwrap();
+            (
+                first.eligibility_group().clone(),
+                second.eligibility_group().clone(),
+            )
+        };
+
+        let (first, second) = resolve(ConnectionReuseScope::Partition);
+        assert_ne!(first, second);
+        let (first, second) = resolve(ConnectionReuseScope::NetworkInterface);
+        assert_eq!(first, second);
+        let (first, second) = resolve(ConnectionReuseScope::Pool);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "solaris",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    fn network_interface_scope_forms_exact_groups() {
+        let registry = PartitionRegistry::explicit(
+            [
+                partition(1).interface("eth0"),
+                partition(2).interface("eth0"),
+                partition(3).interface("eth1"),
+                partition(4),
+            ],
+            ConnectionReuseScope::NetworkInterface,
+            None,
+        )
+        .unwrap();
+        let uri: Uri = "https://example.com/".parse().unwrap();
+        let cell = |id| {
+            let partition = explicit_partition(&registry, id);
+            registry.resolve_cell(&partition, &uri).unwrap()
+        };
+
+        assert_eq!(cell(1).eligibility_group(), cell(2).eligibility_group());
+        assert_ne!(cell(1).eligibility_group(), cell(3).eligibility_group());
+        assert_ne!(cell(1).eligibility_group(), cell(4).eligibility_group());
+    }
+
+    #[test]
+    fn bounded_origins_share_one_admission_across_partitions() {
+        let registry = PartitionRegistry::explicit(
+            [partition(1), partition(2)],
+            ConnectionReuseScope::Pool,
+            NonZeroUsize::new(1),
+        )
+        .unwrap();
+        let partition_1 = explicit_partition(&registry, 1);
+        let partition_2 = explicit_partition(&registry, 2);
+        let uri: Uri = "https://example.com/".parse().unwrap();
+        let other: Uri = "https://other.example.com/".parse().unwrap();
+
+        let first = registry.resolve_cell(&partition_1, &uri).unwrap();
+        let second = registry.resolve_cell(&partition_2, &uri).unwrap();
+        let other = registry.resolve_cell(&partition_1, &other).unwrap();
+
+        let admission = first.admission().unwrap();
+        assert!(Arc::ptr_eq(admission, second.admission().unwrap()));
+        assert!(!Arc::ptr_eq(admission, other.admission().unwrap()));
+    }
+
+    #[test]
+    fn unbounded_origins_construct_no_admission_state() {
+        let registry =
+            PartitionRegistry::explicit([partition(1)], ConnectionReuseScope::Pool, None).unwrap();
+        let partition = explicit_partition(&registry, 1);
+        let cell = registry
+            .resolve_cell(&partition, &"https://example.com/".parse().unwrap())
+            .unwrap();
+
+        assert!(cell.admission().is_none());
+        assert!(registry.bounded_origins.lock().is_empty());
+    }
+
+    #[test]
+    fn first_cell_publication_is_stable_under_contention() {
+        const THREADS: usize = 8;
+        let registry = Arc::new(
+            PartitionRegistry::explicit(
+                [partition(1)],
+                ConnectionReuseScope::default(),
+                NonZeroUsize::new(1),
+            )
+            .unwrap(),
+        );
+        let partition = explicit_partition(&registry, 1);
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut threads = Vec::new();
+
+        for _ in 0..THREADS {
+            let registry = registry.clone();
+            let partition = partition.clone();
+            let barrier = barrier.clone();
+            threads.push(std::thread::spawn(move || {
+                let uri: Uri = "https://example.com/".parse().unwrap();
+                barrier.wait();
+                registry.resolve_cell(&partition, &uri).unwrap()
+            }));
+        }
+
+        let cells: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect();
+        assert!(cells
+            .iter()
+            .skip(1)
+            .all(|cell| Arc::ptr_eq(&cells[0], cell)));
+        assert_eq!(1, partition.cell_count());
+
+        let waiter = cells[0].register_waiter(ProtocolRequirement::H1Compatible);
+        let lease = cells[0]
+            .take_ready_lease(waiter)
+            .expect("admission targeted a different cell than the registry retained");
+        drop(lease);
+    }
+}
+
+#[cfg(all(test, smithy_http_client_loom))]
+mod loom_tests {
+    use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
+
+    #[derive(Debug)]
+    struct TestSpawner;
+
+    impl DriverSpawner for TestSpawner {
+        fn spawn(&self, driver: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            drop(driver);
+        }
+    }
+
+    #[test]
+    fn first_cell_publication_is_stable_under_contention() {
+        loom::model(|| {
+            let registry = Arc::new(
+                PartitionRegistry::explicit(
+                    [Partition::new(PartitionId::from_index(1), TestSpawner)],
+                    ConnectionReuseScope::default(),
+                    None,
+                )
+                .unwrap(),
+            );
+            let partition = registry.partition(PartitionId::from_index(1)).unwrap();
+
+            let first_registry = registry.clone();
+            let first_partition = partition.clone();
+            let first = loom::thread::spawn(move || {
+                let uri: Uri = "https://example.com/".parse().unwrap();
+                first_registry.resolve_cell(&first_partition, &uri).unwrap()
+            });
+            let second_registry = registry.clone();
+            let second_partition = partition.clone();
+            let second = loom::thread::spawn(move || {
+                let uri: Uri = "https://example.com/".parse().unwrap();
+                second_registry
+                    .resolve_cell(&second_partition, &uri)
+                    .unwrap()
+            });
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            assert!(Arc::ptr_eq(&first, &second));
+            assert_eq!(1, partition.cell_count());
+        });
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-client/src/lib.rs
@@ -12,6 +12,7 @@
 //! # Crate Features
 //!
 //! - `default-client`: Enable default HTTP client implementation (based on hyper 1.x).
+//! - `rt-tokio`: Enable Tokio-specific runtime adapters for the default client.
 //! - `rustls-ring`: Enable TLS provider based on `rustls` using `ring` as the crypto provider
 //! - `rustls-aws-lc`: Enable TLS provider based on `rustls` using `aws-lc` as the crypto provider
 //! - `rustls-aws-lc-fips`: Same as `rustls-aws-lc` feature but using a FIPS compliant version of `aws-lc`
@@ -42,7 +43,9 @@ pub mod hyper_014 {
 #[cfg(feature = "default-client")]
 pub(crate) mod client;
 #[cfg(feature = "default-client")]
-pub use client::{default_connector, proxy, tls, Builder, Connector, ConnectorBuilder};
+mod sync;
+#[cfg(feature = "default-client")]
+pub use client::{default_connector, pool, proxy, tls, Builder, Connector, ConnectorBuilder};
 
 #[cfg(feature = "test-util")]
 pub mod test_util;

--- a/rust-runtime/aws-smithy-http-client/src/sync/loom.rs
+++ b/rust-runtime/aws-smithy-http-client/src/sync/loom.rs
@@ -1,0 +1,168 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Loom-backed synchronization primitives used by focused model tests.
+
+use ::std::ops::{Deref, DerefMut};
+
+pub(crate) use loom::sync::Arc;
+
+loom::thread_local! {
+    static HELD_POOL_LOCKS: ::std::cell::Cell<usize> = ::std::cell::Cell::new(0);
+}
+
+struct LockDepth;
+
+impl LockDepth {
+    fn enter() -> Self {
+        HELD_POOL_LOCKS.with(|depth| {
+            assert_eq!(
+                0,
+                depth.get(),
+                "pool coordination locks must never be nested"
+            );
+            depth.set(1);
+        });
+        Self
+    }
+}
+
+impl Drop for LockDepth {
+    fn drop(&mut self) {
+        HELD_POOL_LOCKS.with(|depth| {
+            assert_eq!(1, depth.get(), "pool lock-depth tracking became unbalanced");
+            depth.set(0);
+        });
+    }
+}
+
+/// Loom substitute for a non-owning registry reference.
+///
+/// Loom's modeled `Arc` has no weak-reference API. Keeping a strong reference
+/// in model tests preserves lookup behavior but cannot model target expiry.
+/// Ordinary tests cover the expired-target delivery fallback.
+#[derive(Debug)]
+pub(crate) struct Weak<T>(Arc<T>);
+
+impl<T> Weak<T> {
+    /// Creates the modeled registry reference.
+    pub(crate) fn from_arc(value: &Arc<T>) -> Self {
+        Self(value.clone())
+    }
+
+    /// Acquires an owning reference.
+    pub(crate) fn upgrade(&self) -> Option<Arc<T>> {
+        Some(self.0.clone())
+    }
+}
+
+impl<T> Clone for Weak<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+/// Loom-backed mutex.
+#[derive(Debug)]
+pub(crate) struct Mutex<T>(loom::sync::Mutex<T>);
+
+impl<T> Mutex<T> {
+    /// Creates a mutex containing `value`.
+    pub(crate) fn new(value: T) -> Self {
+        Self(loom::sync::Mutex::new(value))
+    }
+
+    /// Locks the mutex.
+    pub(crate) fn lock(&self) -> MutexGuard<'_, T> {
+        let depth = LockDepth::enter();
+        MutexGuard {
+            inner: self.0.lock().expect("Loom mutex poisoned"),
+            _depth: depth,
+        }
+    }
+}
+
+/// Exclusive access returned by [`Mutex::lock`].
+pub(crate) struct MutexGuard<'a, T> {
+    inner: loom::sync::MutexGuard<'a, T>,
+    _depth: LockDepth,
+}
+
+impl<T> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// Loom-backed reader-writer lock.
+#[derive(Debug)]
+pub(crate) struct RwLock<T>(loom::sync::RwLock<T>);
+
+impl<T> RwLock<T> {
+    /// Creates a reader-writer lock containing `value`.
+    pub(crate) fn new(value: T) -> Self {
+        Self(loom::sync::RwLock::new(value))
+    }
+
+    /// Locks with shared read access.
+    pub(crate) fn read(&self) -> RwLockReadGuard<'_, T> {
+        let depth = LockDepth::enter();
+        RwLockReadGuard {
+            inner: self.0.read().expect("Loom RwLock poisoned"),
+            _depth: depth,
+        }
+    }
+
+    /// Locks with exclusive write access.
+    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, T> {
+        let depth = LockDepth::enter();
+        RwLockWriteGuard {
+            inner: self.0.write().expect("Loom RwLock poisoned"),
+            _depth: depth,
+        }
+    }
+}
+
+/// Shared access returned by [`RwLock::read`].
+pub(crate) struct RwLockReadGuard<'a, T> {
+    inner: loom::sync::RwLockReadGuard<'a, T>,
+    _depth: LockDepth,
+}
+
+impl<T> Deref for RwLockReadGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Exclusive access returned by [`RwLock::write`].
+pub(crate) struct RwLockWriteGuard<'a, T> {
+    inner: loom::sync::RwLockWriteGuard<'a, T>,
+    _depth: LockDepth,
+}
+
+impl<T> Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for RwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/sync/mod.rs
+++ b/rust-runtime/aws-smithy-http-client/src/sync/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Synchronization primitives with standard-library and Loom backends.
+
+#[cfg(all(test, smithy_http_client_loom))]
+mod loom;
+#[cfg(not(all(test, smithy_http_client_loom)))]
+mod std;
+
+#[cfg(all(test, smithy_http_client_loom))]
+pub(crate) use self::loom::*;
+#[cfg(not(all(test, smithy_http_client_loom)))]
+pub(crate) use self::std::*;

--- a/rust-runtime/aws-smithy-http-client/src/sync/std.rs
+++ b/rust-runtime/aws-smithy-http-client/src/sync/std.rs
@@ -1,0 +1,223 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Production synchronization primitives backed by the standard library.
+
+use ::std::ops::{Deref, DerefMut};
+
+pub(crate) use ::std::sync::Arc;
+
+/// Non-owning reference used by coordination registries.
+#[derive(Debug)]
+pub(crate) struct Weak<T>(::std::sync::Weak<T>);
+
+impl<T> Weak<T> {
+    /// Creates a non-owning reference to `value`.
+    pub(crate) fn from_arc(value: &Arc<T>) -> Self {
+        Self(Arc::downgrade(value))
+    }
+
+    /// Attempts to acquire an owning reference.
+    pub(crate) fn upgrade(&self) -> Option<Arc<T>> {
+        self.0.upgrade()
+    }
+}
+
+impl<T> Clone for Weak<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+#[cfg(test)]
+::std::thread_local! {
+    static HELD_POOL_LOCKS: ::std::cell::Cell<usize> = const { ::std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+struct LockDepth;
+
+#[cfg(test)]
+impl LockDepth {
+    fn enter() -> Self {
+        HELD_POOL_LOCKS.with(|depth| {
+            assert_eq!(
+                0,
+                depth.get(),
+                "pool coordination locks must never be nested"
+            );
+            depth.set(1);
+        });
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for LockDepth {
+    fn drop(&mut self) {
+        HELD_POOL_LOCKS.with(|depth| {
+            assert_eq!(1, depth.get(), "pool lock-depth tracking became unbalanced");
+            depth.set(0);
+        });
+    }
+}
+
+/// A mutex that retains access to protected state after poisoning.
+#[derive(Debug)]
+pub(crate) struct Mutex<T>(::std::sync::Mutex<T>);
+
+impl<T> Mutex<T> {
+    /// Creates a mutex containing `value`.
+    pub(crate) fn new(value: T) -> Self {
+        Self(::std::sync::Mutex::new(value))
+    }
+
+    /// Locks the mutex.
+    pub(crate) fn lock(&self) -> MutexGuard<'_, T> {
+        #[cfg(test)]
+        let depth = LockDepth::enter();
+        let inner = self
+            .0
+            .lock()
+            .unwrap_or_else(::std::sync::PoisonError::into_inner);
+        MutexGuard {
+            inner,
+            #[cfg(test)]
+            _depth: depth,
+        }
+    }
+}
+
+/// Exclusive access returned by [`Mutex::lock`].
+pub(crate) struct MutexGuard<'a, T> {
+    inner: ::std::sync::MutexGuard<'a, T>,
+    #[cfg(test)]
+    _depth: LockDepth,
+}
+
+impl<T> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// A reader-writer lock that retains access to protected state after poisoning.
+#[derive(Debug)]
+pub(crate) struct RwLock<T>(::std::sync::RwLock<T>);
+
+impl<T> RwLock<T> {
+    /// Creates a reader-writer lock containing `value`.
+    pub(crate) fn new(value: T) -> Self {
+        Self(::std::sync::RwLock::new(value))
+    }
+
+    /// Locks with shared read access.
+    pub(crate) fn read(&self) -> RwLockReadGuard<'_, T> {
+        #[cfg(test)]
+        let depth = LockDepth::enter();
+        let inner = self
+            .0
+            .read()
+            .unwrap_or_else(::std::sync::PoisonError::into_inner);
+        RwLockReadGuard {
+            inner,
+            #[cfg(test)]
+            _depth: depth,
+        }
+    }
+
+    /// Locks with exclusive write access.
+    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, T> {
+        #[cfg(test)]
+        let depth = LockDepth::enter();
+        let inner = self
+            .0
+            .write()
+            .unwrap_or_else(::std::sync::PoisonError::into_inner);
+        RwLockWriteGuard {
+            inner,
+            #[cfg(test)]
+            _depth: depth,
+        }
+    }
+}
+
+/// Shared access returned by [`RwLock::read`].
+pub(crate) struct RwLockReadGuard<'a, T> {
+    inner: ::std::sync::RwLockReadGuard<'a, T>,
+    #[cfg(test)]
+    _depth: LockDepth,
+}
+
+impl<T> Deref for RwLockReadGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Exclusive access returned by [`RwLock::write`].
+pub(crate) struct RwLockWriteGuard<'a, T> {
+    inner: ::std::sync::RwLockWriteGuard<'a, T>,
+    #[cfg(test)]
+    _depth: LockDepth,
+}
+
+impl<T> Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for RwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutex_retains_state_after_poisoning() {
+        let mutex = Arc::new(Mutex::new(7));
+        let panicking = mutex.clone();
+        let thread = ::std::thread::spawn(move || {
+            let _guard = panicking.lock();
+            panic!("poison the mutex");
+        });
+
+        assert!(thread.join().is_err());
+        assert_eq!(7, *mutex.lock());
+    }
+
+    #[test]
+    fn rw_lock_retains_state_after_poisoning() {
+        let lock = Arc::new(RwLock::new(7));
+        let panicking = lock.clone();
+        let thread = ::std::thread::spawn(move || {
+            let mut guard = panicking.write();
+            *guard = 8;
+            panic!("poison the reader-writer lock");
+        });
+
+        assert!(thread.join().is_err());
+        assert_eq!(8, *lock.read());
+        *lock.write() = 9;
+        assert_eq!(9, *lock.read());
+    }
+}

--- a/rust-runtime/aws-smithy-runtime-api/src/client/connection.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/connection.rs
@@ -10,6 +10,26 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
+/// Opaque identifier for a physical HTTP connection.
+///
+/// The assigning HTTP client defines the scope of an ID. IDs from different
+/// clients or pools are not comparable.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ConnectionId(u64);
+
+impl ConnectionId {
+    /// Creates an ID from a value assigned by an HTTP client.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for ConnectionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// Metadata that tracks the state of an active connection.
 #[derive(Clone)]
 pub struct ConnectionMetadata {
@@ -17,6 +37,7 @@ pub struct ConnectionMetadata {
     remote_addr: Option<SocketAddr>,
     local_addr: Option<SocketAddr>,
     poison_fn: Arc<dyn Fn() + Send + Sync>,
+    connection_id: Option<ConnectionId>,
 }
 
 impl ConnectionMetadata {
@@ -45,6 +66,7 @@ impl ConnectionMetadata {
             // need to use builder to set this field
             local_addr: None,
             poison_fn: Arc::new(poison),
+            connection_id: None,
         }
     }
 
@@ -62,6 +84,13 @@ impl ConnectionMetadata {
     pub fn local_addr(&self) -> Option<SocketAddr> {
         self.local_addr
     }
+
+    /// Get the ID assigned to this connection, if the HTTP client provides one.
+    ///
+    /// Clients that do not track physical connection identity leave this unset.
+    pub fn connection_id(&self) -> Option<ConnectionId> {
+        self.connection_id
+    }
 }
 
 impl fmt::Debug for ConnectionMetadata {
@@ -70,6 +99,7 @@ impl fmt::Debug for ConnectionMetadata {
             .field("is_proxied", &self.is_proxied)
             .field("remote_addr", &self.remote_addr)
             .field("local_addr", &self.local_addr)
+            .field("connection_id", &self.connection_id)
             .finish()
     }
 }
@@ -81,6 +111,7 @@ pub struct ConnectionMetadataBuilder {
     remote_addr: Option<SocketAddr>,
     local_addr: Option<SocketAddr>,
     poison_fn: Option<Arc<dyn Fn() + Send + Sync>>,
+    connection_id: Option<ConnectionId>,
 }
 
 impl fmt::Debug for ConnectionMetadataBuilder {
@@ -89,6 +120,7 @@ impl fmt::Debug for ConnectionMetadataBuilder {
             .field("is_proxied", &self.is_proxied)
             .field("remote_addr", &self.remote_addr)
             .field("local_addr", &self.local_addr)
+            .field("connection_id", &self.connection_id)
             .finish()
     }
 }
@@ -135,6 +167,18 @@ impl ConnectionMetadataBuilder {
         self
     }
 
+    /// Set the [`ConnectionId`] assigned by the HTTP client.
+    pub fn connection_id(mut self, connection_id: ConnectionId) -> Self {
+        self.set_connection_id(Some(connection_id));
+        self
+    }
+
+    /// Set the [`ConnectionId`] assigned by the HTTP client.
+    pub fn set_connection_id(&mut self, connection_id: Option<ConnectionId>) -> &mut Self {
+        self.connection_id = connection_id;
+        self
+    }
+
     /// Set a closure which will poison the associated connection.
     ///
     /// A poisoned connection will not be reused for subsequent requests by the pool
@@ -170,6 +214,7 @@ impl ConnectionMetadataBuilder {
             poison_fn: self
                 .poison_fn
                 .expect("poison_fn should be set for ConnectionMetadata"),
+            connection_id: self.connection_id,
         }
     }
 }
@@ -259,6 +304,7 @@ mod tests {
             .proxied(true)
             .local_addr(TEST_SOCKET_ADDR)
             .remote_addr(TEST_SOCKET_ADDR)
+            .connection_id(ConnectionId::new(17))
             .poison_fn({
                 let mutable_flag = Arc::clone(&mutable_flag);
                 move || {
@@ -271,6 +317,11 @@ mod tests {
         assert!(connection_metadata.is_proxied);
         assert_eq!(connection_metadata.remote_addr(), Some(TEST_SOCKET_ADDR));
         assert_eq!(connection_metadata.local_addr(), Some(TEST_SOCKET_ADDR));
+        assert_eq!(
+            connection_metadata.connection_id(),
+            Some(ConnectionId::new(17))
+        );
+        assert_eq!("17", ConnectionId::new(17).to_string());
         assert!(!(*mutable_flag.lock().unwrap()));
         connection_metadata.poison();
         assert!(*mutable_flag.lock().unwrap());
@@ -285,6 +336,7 @@ mod tests {
 
         assert_eq!(metadata1.local_addr(), None);
         assert_eq!(metadata1.remote_addr(), None);
+        assert_eq!(metadata1.connection_id(), None);
 
         let metadata2 = ConnectionMetadataBuilder::new()
             .proxied(true)


### PR DESCRIPTION
## Summary

This is the first of five planned implementation PRs for the [connection-pool design](https://github.com/smithy-lang/smithy-rs/blob/d2b71340e/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md). It adds the topology, origin identity, bounded admission, waiter delivery, and connection-lifetime foundation for the new `aws-smithy-http-client` connection pool. It exposes partition declarations and adds optional connection identity to `ConnectionMetadata` in `aws-smithy-runtime-api`, but it does not add a usable pool client, execute a connector, or dispatch requests through Hyper. The existing default client remains unchanged.

The implementation series is:

1. **This PR: Partition-aware ownership and coordination foundation**
2. Public HTTP/1 vertical slice
3. HTTP/2, automatic ALPN, and peer publication
4. Smithy integration, telemetry, and configuration completion
5. Correctness completion and hardening

The design is already committed on `connection-pool-main`, which is the integration target for this series. Its sections "Topology and identity," "Bounded-capacity coordination," and "Connection retirement and maintenance" define the corresponding architecture. This PR includes the supporting origin canonicalization, Tokio runtime diagnostics, synchronization facade, and private module ownership.

## Why

The pool must enforce one optional connection limit per origin across connections placed on different runtimes or network interfaces. A connection's socket and protocol driver must remain on the partition that established them even when another eligible partition later uses its dispatch handle. Per-partition caches or limits cannot provide both properties because each partition could admit the full origin limit independently.

The foundation separates placement, origin-wide admission, and connection lifetime so later HTTP/1 and HTTP/2 paths share the final partition-aware ownership model.

## Overview

### Composition and identity

`PartitionRegistry` retains the fixed partition set. Each `PartitionState` owns runtime placement and one stable `OriginCell` for every canonical origin used on that partition. Bounded origins also have one `OriginAdmission` shared across their cells.

```text
request (partition, URI)
  |
  `-- PartitionRegistry::resolve_cell
        |
        `-- OriginCell(partition, canonical origin)
              |
              +-- protocol-local hit -> ConnectionState::try_commit_dispatch -> Hyper
              |
              +-- unbounded miss -> establish connection -> ConnectionState
              |
              `-- bounded miss -> WaiterQueue -> OriginAdmission
                                                |
                                         CapacityDelivery
                                                |
                                         CapacityLease
                                                |
                                  establish connection -> ConnectionState
```

This PR implements the registry, cell, bounded-miss handoff, and connection-lifetime endpoints in that flow. The protocol-local selection, connector, Hyper handshake, and dispatch boxes are the HTTP/1 and HTTP/2 work that consumes this foundation in the next PRs. That boundary is also why the types can be exercised for capacity and cancellation here without forming a usable HTTP client.

`OriginKey` canonicalizes HTTP and HTTPS scheme, host, and non-default port. During cell resolution, `OriginLookup` borrows canonical host text so a hit does not materialize another owned key; a miss converts the lookup into the identity retained by the new cell. `ConnectionReuseScope` maps each partition to the eligibility group that later cross-partition reuse may serve without moving connection I/O.

`ConnectionId` lives in `aws-smithy-runtime-api`, and both pool connection state and `ConnectionMetadata` use it. Existing clients may leave `ConnectionMetadata::connection_id` unset.

### Bounded capacity

`OriginAdmission` is the authority for one bounded origin's permits and cross-cell demand order. A cell commits its local waiter and publishes a complete, versioned `DemandSnapshot` after releasing the cell lock. Admission lazily materializes permits up to the configured limit and keeps active cell demand in FIFO order.

`WaiterQueue` selects the next request within one cell. `DemandSchedule` separately orders the cells competing for origin-wide capacity and retains an outstanding delivery at the head until the target acknowledges it.

An available permit crosses to one cell in a `CapacityDelivery` fenced by delivery, cell, and demand identity. The target revalidates the demand under its own lock before moving the resulting `CapacityLease` into the reserved waiter. `CapacityDeliveryAck` keeps the admission fence open until the target has either installed or refunnelled that lease.

`CapacityLease`, `CapacityDelivery`, and `CapacityDeliveryAck` each retain the fallback for the ownership transition they represent. Cancellation or drop returns capacity and completes the delivery fence after releasing cell state. No pool lock nests another pool lock, and no wake or callback runs while one is held.

```text
AdmissionState::available
  `-- CapacityDelivery::commit
      |-- CapacityLease --> OriginCell waiter --> establishment --> ConnectionState
      |                                                        `--> logical close --> admission
      `-- CapacityDeliveryAck --> closes the delivery fence

ConnectionState
  |-- DispatchGuard[]            request lifetimes
  `-- PhysicalConnectionGuard    root-I/O lifetime
```

### Connection lifetime

`ConnectionState` serializes dispatch commitment with logical close. A successful dispatch owns a `DispatchGuard`; logical close rejects new dispatches, detaches the optional bounded-capacity lease, and returns that lease after unlocking while committed dispatches drain.

Connection construction creates the only `PhysicalConnectionGuard`. That guard follows root I/O through protocol drain or upgrade, so physical completion remains distinct from logical close and permit release.

Focused Loom models cover the races between first-cell publication, capacity release and demand publication, delivery and waiter cancellation, dispatch commitment and logical close, and two concurrent close attempts on one bounded connection. Both synchronization backends also reject nested pool-lock acquisition in tests, making the lock-order rule executable in the ordinary and modeled paths.

## How to review

1. Start with `pool/partition.rs`, `pool/origin.rs`, and `PartitionRegistry` in `pool/registry.rs` for placement, canonical identity, and stable cell publication.
2. Continue with `OriginCell` in `pool/cell.rs` for the admission crossing, then `WaiterQueue` in
   `pool/cell/waiters.rs` for local order, cancellation, and delivered-capacity ownership.
3. Read `OriginAdmission`, `AdmissionState`, `DemandSchedule`, `CapacityDelivery`, and
   `CapacityDeliveryAck` in `pool/admission.rs` for permit conservation, cross-cell order, and drop fallback.
4. Read `ConnectionState`, `DispatchGuard`, and `PhysicalConnectionGuard` in `pool/connection.rs` for dispatch versus close and logical versus physical lifetime.
5. Finish with `sync/` and the colocated Loom models for the lock boundaries and races above.

## Scope

This PR contains no connector execution, Hyper sender, response ownership, HTTP/1 residence or return claim, HTTP/2 flight or generation, or supported public construction path for a pooled client. The HTTP/1 vertical slice will connect these foundations to real requests and add the public client builder without replacing the partition-aware core.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._