### PR TITLE
Add configurable Serde deserialization to generated model types

### DIFF
--- a/.changelog/codegen-serde-deserialization.md
+++ b/.changelog/codegen-serde-deserialization.md
@@ -1,6 +1,7 @@
 ---
 applies_to: ["client", "server"]
 authors: ["rcoh"]
+references: ["smithy-rs#4812"]
 breaking: false
 new_feature: true
 bug_fix: false

--- a/.changelog/codegen-serde-deserialization.md
+++ b/.changelog/codegen-serde-deserialization.md
@@ -1,0 +1,8 @@
+---
+applies_to: ["client", "server"]
+authors: ["rcoh"]
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add configurable Serde deserialization for generated model types in `codegen-serde`.

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/DeserializeImplGenerator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/DeserializeImplGenerator.kt
@@ -44,6 +44,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.contextName
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.isRustBoxed
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.ReturnSymbolToParse
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.shapeFunctionName
@@ -67,9 +68,8 @@ import software.amazon.smithy.rust.codegen.server.smithy.traits.isReachableFromO
 /**
  * Generates ordinary `Deserialize` implementations for nominal model types.
  *
- * Serde formats are first decoded into a private value tree. Shape-specific parsers then convert that tree into
- * generated model types. This preserves duplicate map entries and lets server input shapes flow through their
- * unconstrained representations before constraints are enforced at the root.
+ * Each shape is deserialized by a typed visitor. Aggregate visitors pass shape-specific seeds directly to Serde and
+ * structures populate their generated builders as fields arrive.
  */
 class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
     private val model = codegenContext.model
@@ -107,20 +107,20 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
                 if (shape.isEventStream()) {
                     writable { }
                 } else {
-                    writable { addDependency(parser(shape).toSymbol()) }
+                    writable { addDependency(seed(shape).toSymbol()) }
                 }
 
             is StructureShape ->
                 if (shape.hasEventStreamMember(model)) {
                     writable { }
                 } else {
-                    writable { addDependency(parser(shape).toSymbol()) }
+                    writable { addDependency(seed(shape).toSymbol()) }
                 }
 
-            is EnumShape -> writable { addDependency(parser(shape).toSymbol()) }
+            is EnumShape -> writable { addDependency(seed(shape).toSymbol()) }
             is StringShape ->
                 if (shape.hasTrait<EnumTrait>()) {
-                    writable { addDependency(parser(shape).toSymbol()) }
+                    writable { addDependency(seed(shape).toSymbol()) }
                 } else {
                     writable { }
                 }
@@ -128,13 +128,22 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             else -> writable { }
         }
 
-    private fun parser(shape: Shape): RuntimeType =
-        RuntimeType.forInlineFun(parseFunctionName(shape), DeserializerModule) {
-            renderParser(shape)(this)
+    private fun seed(shape: Shape): RuntimeType =
+        RuntimeType.forInlineFun(seedName(shape), DeserializerModule) {
+            renderSeed(shape)(this)
         }
 
-    private fun parseFunctionName(shape: Shape): String =
-        symbolProvider.shapeFunctionName(codegenContext.serviceShape, shape) + "_serde_deserialize"
+    private fun seedName(shape: Shape): String =
+        (
+            symbolProvider.shapeFunctionName(codegenContext.serviceShape, shape) +
+                "_serde_deserialize_seed"
+        ).toPascalCase()
+
+    private fun visitorName(shape: Shape): String = seedName(shape) + "Visitor"
+
+    private fun fieldName(shape: Shape): String = seedName(shape) + "Field"
+
+    private fun fieldVisitorName(shape: Shape): String = fieldName(shape) + "Visitor"
 
     private fun parseInfo(shape: Shape): ReturnSymbolToParse {
         if (shape is BlobShape && shape.hasTrait<StreamingTrait>()) {
@@ -154,24 +163,36 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
         }
     }
 
-    private fun renderParser(shape: Shape): Writable =
+    private fun renderSeed(shape: Shape): Writable =
         writable {
             val info = parseInfo(shape)
+            renderVisitor(shape, info)(this)
             rustTemplate(
                 """
-                ##[allow(unused_mut, unused_variables)]
-                ##[allow(clippy::match_single_binding, clippy::single_match)]
-                fn ${parseFunctionName(shape)}(
-                    value: #{Value},
-                    settings: &#{DeserializationSettings},
-                ) -> #{Result}<#{Return}, #{String}> {
-                    let _ = settings;
-                    #{Body}
+                ##[allow(dead_code)]
+                struct ${seedName(shape)}<'a> {
+                    settings: &'a #{DeserializationSettings},
+                    depth: usize,
+                }
+
+                impl<'de> #{serde}::de::DeserializeSeed<'de> for ${seedName(shape)}<'_> {
+                    type Value = #{Return};
+
+                    fn deserialize<D>(self, deserializer: D) -> #{Result}<Self::Value, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        let depth = self.depth.checked_sub(1).ok_or_else(|| {
+                            <D::Error as #{serde}::de::Error>::custom(
+                                "maximum deserialization depth exceeded"
+                            )
+                        })?;
+                        #{Dispatch}
+                    }
                 }
                 """,
-                "Value" to dynamicValue(),
                 "Return" to info.symbol,
-                "Body" to parserBody(shape, info),
+                "Dispatch" to deserializeDispatch(shape),
                 *SupportStructures.codegenScope,
                 *RuntimeType.preludeScope,
             )
@@ -186,184 +207,450 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             shape is EnumShape ||
             (shape is StringShape && shape.hasTrait<EnumTrait>())
 
-    private fun parserBody(
+    private fun renderVisitor(
         shape: Shape,
         info: ReturnSymbolToParse,
     ): Writable =
         when (shape) {
-            is StructureShape -> parseStructure(shape, info)
-            is UnionShape -> parseUnion(shape, info)
-            is EnumShape -> parseEnum(shape, info)
+            is StructureShape -> renderStructureVisitor(shape, info)
+            is UnionShape -> renderUnionVisitor(shape, info)
+            is EnumShape -> renderEnumVisitor(shape, info)
             is StringShape ->
                 if (shape.hasTrait<EnumTrait>()) {
-                    parseEnum(shape, info)
+                    renderEnumVisitor(shape, info)
                 } else {
-                    parseString()
+                    renderStringVisitor(shape, info)
                 }
 
-            is BooleanShape -> parseBoolean()
-            is NumberShape -> parseNumber(shape)
-            is BlobShape -> parseBlob(shape)
-            is TimestampShape -> parseTimestamp()
-            is DocumentShape -> parseDocument(shape)
-            is CollectionShape -> parseCollection(shape, info)
-            is MapShape -> parseMap(shape, info)
-            else -> writable { rust("Err(\"unsupported shape for deserialization\".to_string())") }
+            is BooleanShape -> renderBooleanVisitor(shape, info)
+            is NumberShape -> renderNumberVisitor(shape, info)
+            is BlobShape -> renderBlobVisitor(shape, info)
+            is TimestampShape -> renderTimestampVisitor(shape, info)
+            is DocumentShape -> renderDocumentVisitor(shape, info)
+            is CollectionShape -> renderCollectionVisitor(shape, info)
+            is MapShape -> renderMapVisitor(shape, info)
+            else -> writable { rust("// unsupported shape for deserialization") }
         }
 
-    private fun parseBoolean(): Writable =
+    private fun deserializeDispatch(shape: Shape): Writable =
         writable {
-            rustTemplate(
-                """
-                match value {
-                    #{Value}::Bool(value) => #{Ok}(value),
-                    _ => #{Err}("expected a boolean".to_string()),
+            val visitor =
+                writable {
+                    rustTemplate(
+                        "${visitorName(shape)} { settings: self.settings, depth }",
+                    )
                 }
-                """,
-                "Value" to dynamicValue(),
-                *RuntimeType.preludeScope,
-            )
+            when (shape) {
+                is StructureShape ->
+                    rustTemplate(
+                        """
+                        deserializer.deserialize_struct(
+                            ${shape.contextName(codegenContext.serviceShape).dq()},
+                            &[#{Fields}],
+                            #{Visitor},
+                        )
+                        """,
+                        "Fields" to
+                            writable {
+                                rust(shape.members().joinToString(", ") { it.memberName.dq() })
+                            },
+                        "Visitor" to visitor,
+                    )
+
+                is UnionShape ->
+                    rustTemplate(
+                        """
+                        deserializer.deserialize_enum(
+                            ${shape.contextName(codegenContext.serviceShape).dq()},
+                            &[#{Variants}],
+                            #{Visitor},
+                        )
+                        """,
+                        "Variants" to
+                            writable {
+                                rust(shape.members().joinToString(", ") { it.memberName.dq() })
+                            },
+                        "Visitor" to visitor,
+                    )
+
+                is EnumShape, is StringShape -> rustTemplate("deserializer.deserialize_string(#{Visitor})", "Visitor" to visitor)
+                is BooleanShape -> rustTemplate("deserializer.deserialize_bool(#{Visitor})", "Visitor" to visitor)
+                is ByteShape -> rustTemplate("deserializer.deserialize_i8(#{Visitor})", "Visitor" to visitor)
+                is ShortShape -> rustTemplate("deserializer.deserialize_i16(#{Visitor})", "Visitor" to visitor)
+                is IntegerShape -> rustTemplate("deserializer.deserialize_i32(#{Visitor})", "Visitor" to visitor)
+                is LongShape -> rustTemplate("deserializer.deserialize_i64(#{Visitor})", "Visitor" to visitor)
+                is FloatShape ->
+                    rustTemplate(
+                        """
+                        if self.settings.allow_non_finite_float_strings {
+                            deserializer.deserialize_any(#{Visitor})
+                        } else {
+                            deserializer.deserialize_f32(#{Visitor})
+                        }
+                        """,
+                        "Visitor" to visitor,
+                    )
+
+                is DoubleShape ->
+                    rustTemplate(
+                        """
+                        if self.settings.allow_non_finite_float_strings {
+                            deserializer.deserialize_any(#{Visitor})
+                        } else {
+                            deserializer.deserialize_f64(#{Visitor})
+                        }
+                        """,
+                        "Visitor" to visitor,
+                    )
+
+                is BigIntegerShape, is BigDecimalShape ->
+                    rustTemplate("deserializer.deserialize_any(#{Visitor})", "Visitor" to visitor)
+
+                is BlobShape ->
+                    rustTemplate("deserializer.deserialize_any(#{Visitor})", "Visitor" to visitor)
+
+                is TimestampShape -> rustTemplate("deserializer.deserialize_string(#{Visitor})", "Visitor" to visitor)
+                is DocumentShape -> rustTemplate("deserializer.deserialize_any(#{Visitor})", "Visitor" to visitor)
+                is CollectionShape -> rustTemplate("deserializer.deserialize_seq(#{Visitor})", "Visitor" to visitor)
+                is MapShape -> rustTemplate("deserializer.deserialize_map(#{Visitor})", "Visitor" to visitor)
+                else ->
+                    rustTemplate(
+                        "#{Err}(<D::Error as #{serde}::de::Error>::custom(\"unsupported shape for deserialization\"))",
+                        *SupportStructures.codegenScope,
+                        *RuntimeType.preludeScope,
+                    )
+            }
         }
 
-    private fun parseString(): Writable =
-        writable {
-            rustTemplate(
-                """
-                match value {
-                    #{Value}::String(value) => #{Ok}(value),
-                    _ => #{Err}("expected a string".to_string()),
-                }
-                """,
-                "Value" to dynamicValue(),
-                *RuntimeType.preludeScope,
-            )
-        }
-
-    private fun parseEnum(
+    private fun visitorHeader(
         shape: Shape,
         info: ReturnSymbolToParse,
+        expecting: String,
+        body: Writable,
     ): Writable =
         writable {
             rustTemplate(
                 """
-                let text = match value {
-                    #{Value}::String(value) => value,
-                    _ => return #{Err}("expected an enum string".to_string()),
-                };
+                ##[allow(dead_code)]
+                struct ${visitorName(shape)}<'a> {
+                    settings: &'a #{DeserializationSettings},
+                    depth: usize,
+                }
+
+                ##[allow(unused_mut, unused_variables)]
+                ##[allow(
+                    clippy::match_single_binding,
+                    clippy::unnecessary_cast,
+                    clippy::unnecessary_fallible_conversions,
+                )]
+                impl<'de> #{serde}::de::Visitor<'de> for ${visitorName(shape)}<'_> {
+                    type Value = #{Return};
+
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        formatter.write_str(${expecting.dq()})
+                    }
+
+                    #{Body}
+                }
                 """,
-                "Value" to dynamicValue(),
-                *RuntimeType.preludeScope,
+                "Return" to info.symbol,
+                "Body" to body,
+                *SupportStructures.codegenScope,
             )
+        }
+
+    private fun renderBooleanVisitor(
+        shape: BooleanShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "a boolean",
+            writable {
+                rustTemplate(
+                    """
+                    fn visit_bool<E>(self, value: bool) -> #{Result}<Self::Value, E> {
+                        #{Ok}(value)
+                    }
+                    """,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
+
+    private fun renderStringVisitor(
+        shape: StringShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "a string",
+            writable {
+                rustTemplate(
+                    """
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E> {
+                        #{Ok}(value.to_string())
+                    }
+
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E> {
+                        #{Ok}(value)
+                    }
+                    """,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
+
+    private fun renderEnumVisitor(
+        shape: Shape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "an enum string",
+            writable {
+                rustTemplate(
+                    """
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        self.visit_string(value.to_string())
+                    }
+
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        #{Parse}
+                    }
+                    """,
+                    "Parse" to enumFromString(info),
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
+
+    private fun enumFromString(info: ReturnSymbolToParse): Writable =
+        writable {
             when {
                 codegenContext.target == CodegenTarget.SERVER && info.isUnconstrained ->
-                    rustTemplate("#{Ok}(text)", *RuntimeType.preludeScope)
+                    rustTemplate("#{Ok}(value)", *RuntimeType.preludeScope)
 
                 codegenContext.target == CodegenTarget.SERVER ->
                     rustTemplate(
-                        "#{Return}::try_from(text).map_err(|err| err.to_string())",
+                        "<#{Return} as #{TryFrom}<#{String}>>::try_from(value).map_err(E::custom)",
                         "Return" to info.symbol,
+                        *RuntimeType.preludeScope,
                     )
 
                 else ->
                     rustTemplate(
-                        "#{Ok}(#{Return}::from(text.as_str()))",
+                        "#{Ok}(#{Return}::from(value.as_str()))",
                         "Return" to info.symbol,
                         *RuntimeType.preludeScope,
                     )
             }
         }
 
-    private fun parseNumber(shape: NumberShape): Writable =
+    private fun renderNumberVisitor(
+        shape: NumberShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
         when (shape) {
-            is FloatShape -> parseFloat("f32")
-            is DoubleShape -> parseFloat("f64")
-            is BigIntegerShape -> parseBigNumber(RuntimeType.bigInteger(codegenContext.runtimeConfig))
-            is BigDecimalShape -> parseBigNumber(RuntimeType.bigDecimal(codegenContext.runtimeConfig))
-            is ByteShape -> parseInteger("i8")
-            is ShortShape -> parseInteger("i16")
-            is IntegerShape -> parseInteger("i32")
-            is LongShape -> parseInteger("i64")
-            else -> writable { rust("Err(\"unsupported number shape\".to_string())") }
+            is FloatShape -> renderFloatVisitor(shape, info, "f32")
+            is DoubleShape -> renderFloatVisitor(shape, info, "f64")
+            is BigIntegerShape -> renderBigNumberVisitor(shape, info, RuntimeType.bigInteger(codegenContext.runtimeConfig))
+            is BigDecimalShape -> renderBigNumberVisitor(shape, info, RuntimeType.bigDecimal(codegenContext.runtimeConfig))
+            is ByteShape -> renderIntegerVisitor(shape, info, "i8")
+            is ShortShape -> renderIntegerVisitor(shape, info, "i16")
+            is IntegerShape -> renderIntegerVisitor(shape, info, "i32")
+            is LongShape -> renderIntegerVisitor(shape, info, "i64")
+            else -> writable { rust("// unsupported number shape") }
         }
 
-    private fun parseInteger(rustType: String): Writable =
-        writable {
-            rustTemplate(
-                """
-                match value {
-                    #{Value}::I64(value) => <$rustType as #{TryFrom}<i64>>::try_from(value)
-                        .map_err(|_| "integer is out of range".to_string()),
-                    #{Value}::U64(value) => <$rustType as #{TryFrom}<u64>>::try_from(value)
-                        .map_err(|_| "integer is out of range".to_string()),
-                    _ => #{Err}("expected an integer".to_string()),
-                }
-                """,
-                "Value" to dynamicValue(),
-                *RuntimeType.preludeScope,
-            )
-        }
-
-    private fun parseFloat(rustType: String): Writable =
-        writable {
-            val parsedF64 = if (rustType == "f64") "value" else "value as $rustType"
-            rustTemplate(
-                """
-                match value {
-                    #{Value}::F64(value) => #{Ok}($parsedF64),
-                    #{Value}::I64(value) => #{Ok}(value as $rustType),
-                    #{Value}::U64(value) => #{Ok}(value as $rustType),
-                    #{Value}::String(value) if settings.allow_non_finite_float_strings => match value.as_str() {
-                        "NaN" => #{Ok}($rustType::NAN),
-                        "Infinity" => #{Ok}($rustType::INFINITY),
-                        "-Infinity" => #{Ok}($rustType::NEG_INFINITY),
-                        _ => #{Err}("expected a floating-point number".to_string()),
-                    },
-                    _ => #{Err}("expected a floating-point number".to_string()),
-                }
-                """,
-                "Value" to dynamicValue(),
-                *RuntimeType.preludeScope,
-            )
-        }
-
-    private fun parseBigNumber(type: RuntimeType): Writable =
-        writable {
-            rustTemplate(
-                """
-                let text = match value {
-                    #{Value}::String(value) => value,
-                    #{Value}::I64(value) => value.to_string(),
-                    #{Value}::U64(value) => value.to_string(),
-                    #{Value}::F64(value) => value.to_string(),
-                    _ => return #{Err}("expected a number".to_string()),
-                };
-                <#{Type} as ::std::str::FromStr>::from_str(&text).map_err(|err| err.to_string())
-                """,
-                "Value" to dynamicValue(),
-                "Type" to type,
-                *RuntimeType.preludeScope,
-            )
-        }
-
-    private fun parseBlob(shape: BlobShape): Writable =
-        writable {
-            rustTemplate(
-                """
-                let bytes = match value {
-                    #{Value}::Bytes(value) => value,
-                    #{Value}::String(value) => {
-                        if value == "streaming data" {
-                            return #{Err}("the streaming data placeholder cannot be deserialized".to_string());
+    private fun renderIntegerVisitor(
+        shape: NumberShape,
+        info: ReturnSymbolToParse,
+        rustType: String,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "an integer",
+            writable {
+                listOf("i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64").forEach { source ->
+                    rustTemplate(
+                        """
+                        fn visit_$source<E>(self, value: $source) -> #{Result}<Self::Value, E>
+                        where
+                            E: #{serde}::de::Error,
+                        {
+                            <$rustType as #{TryFrom}<$source>>::try_from(value)
+                                .map_err(|_| E::custom("integer is out of range"))
                         }
-                        #{base64_decode}(value).map_err(|_| "invalid base64 blob".to_string())?
-                    },
-                    _ => return #{Err}("expected a base64 string or bytes".to_string()),
-                };
-                """,
-                "Value" to dynamicValue(),
-                "base64_decode" to RuntimeType.base64Decode(codegenContext.runtimeConfig),
-                *RuntimeType.preludeScope,
-            )
+                        """,
+                        *SupportStructures.codegenScope,
+                        *RuntimeType.preludeScope,
+                    )
+                }
+            },
+        )
+
+    private fun renderFloatVisitor(
+        shape: NumberShape,
+        info: ReturnSymbolToParse,
+        rustType: String,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "a floating-point number",
+            writable {
+                listOf("i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64").forEach { source ->
+                    rustTemplate(
+                        """
+                        fn visit_$source<E>(self, value: $source) -> #{Result}<Self::Value, E> {
+                            #{Ok}(value as $rustType)
+                        }
+                        """,
+                        *RuntimeType.preludeScope,
+                    )
+                }
+                rustTemplate(
+                    """
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        if !self.settings.allow_non_finite_float_strings {
+                            return #{Err}(E::custom("expected a floating-point number"));
+                        }
+                        match value {
+                            "NaN" => #{Ok}($rustType::NAN),
+                            "Infinity" => #{Ok}($rustType::INFINITY),
+                            "-Infinity" => #{Ok}($rustType::NEG_INFINITY),
+                            _ => #{Err}(E::custom("expected a floating-point number")),
+                        }
+                    }
+
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        self.visit_str(value.as_str())
+                    }
+                    """,
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
+
+    private fun renderBigNumberVisitor(
+        shape: NumberShape,
+        info: ReturnSymbolToParse,
+        type: RuntimeType,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "a number",
+            writable {
+                rustTemplate(
+                    """
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        <#{Type} as ::std::str::FromStr>::from_str(value).map_err(E::custom)
+                    }
+
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        self.visit_str(value.as_str())
+                    }
+                    """,
+                    "Type" to type,
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+                listOf("i64", "u64", "f64").forEach { source ->
+                    rustTemplate(
+                        """
+                        fn visit_$source<E>(self, value: $source) -> #{Result}<Self::Value, E>
+                        where
+                            E: #{serde}::de::Error,
+                        {
+                            self.visit_string(value.to_string())
+                        }
+                        """,
+                        *SupportStructures.codegenScope,
+                        *RuntimeType.preludeScope,
+                    )
+                }
+            },
+        )
+
+    private fun renderBlobVisitor(
+        shape: BlobShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            visitorHeader(
+                shape,
+                info,
+                "a base64 string or bytes",
+                writable {
+                    rustTemplate(
+                        """
+                        fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                        where
+                            E: #{serde}::de::Error,
+                        {
+                            if value == "streaming data" {
+                                return #{Err}(E::custom(
+                                    "the streaming data placeholder cannot be deserialized"
+                                ));
+                            }
+                            let bytes = #{base64_decode}(value)
+                                .map_err(|_| E::custom("invalid base64 blob"))?;
+                            #{Finish}
+                        }
+
+                        fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E>
+                        where
+                            E: #{serde}::de::Error,
+                        {
+                            self.visit_str(value.as_str())
+                        }
+
+                        fn visit_bytes<E>(self, value: &[u8]) -> #{Result}<Self::Value, E> {
+                            let bytes = value.to_vec();
+                            #{Finish}
+                        }
+
+                        fn visit_byte_buf<E>(self, bytes: #{Vec}<u8>) -> #{Result}<Self::Value, E> {
+                            #{Finish}
+                        }
+                        """,
+                        "base64_decode" to RuntimeType.base64Decode(codegenContext.runtimeConfig),
+                        "Finish" to finishBlob(shape),
+                        *SupportStructures.codegenScope,
+                        *RuntimeType.preludeScope,
+                    )
+                },
+            )(this)
+        }
+
+    private fun finishBlob(shape: BlobShape): Writable =
+        writable {
             if (shape.hasTrait<StreamingTrait>()) {
                 rustTemplate(
                     "#{Ok}(#{ByteStream}::from(bytes))",
@@ -379,166 +666,276 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             }
         }
 
-    private fun parseTimestamp(): Writable =
-        writable {
-            rustTemplate(
-                """
-                let text = match value {
-                    #{Value}::String(value) => value,
-                    _ => return #{Err}("expected a timestamp string".to_string()),
-                };
-                #{DateTime}::from_str(&text, #{Format}::DateTime).map_err(|err| err.to_string())
-                """,
-                "Value" to dynamicValue(),
-                "DateTime" to RuntimeType.dateTime(codegenContext.runtimeConfig),
-                "Format" to RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("date_time::Format"),
-                *RuntimeType.preludeScope,
-            )
-        }
+    private fun renderTimestampVisitor(
+        shape: TimestampShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "a timestamp string",
+            writable {
+                rustTemplate(
+                    """
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        #{DateTime}::from_str(value, #{Format}::DateTime).map_err(E::custom)
+                    }
 
-    private fun parseDocument(shape: DocumentShape): Writable =
-        writable {
-            val parseName = parseFunctionName(shape)
-            rustTemplate(
-                """
-                let document = match value {
-                    #{Value}::Null => #{Document}::Null,
-                    #{Value}::Bool(value) => #{Document}::Bool(value),
-                    #{Value}::String(value) => #{Document}::String(value),
-                    #{Value}::I64(value) if value < 0 => #{Document}::Number(#{Number}::NegInt(value)),
-                    #{Value}::I64(value) => #{Document}::Number(#{Number}::PosInt(value as u64)),
-                    #{Value}::U64(value) => #{Document}::Number(#{Number}::PosInt(value)),
-                    #{Value}::F64(value) => #{Document}::Number(#{Number}::Float(value)),
-                    #{Value}::Seq(values) => {
-                        let mut result = #{Vec}::with_capacity(values.len());
-                        for value in values {
-                            result.push($parseName(value, settings)?);
-                        }
-                        #{Document}::Array(result)
-                    },
-                    #{Value}::Map(entries) => {
-                        let mut result = #{HashMap}::with_capacity(entries.len());
-                        for (key, value) in entries {
-                            let key = match key {
-                                #{Value}::String(key) => key,
-                                _ => return #{Err}("document object keys must be strings".to_string()),
-                            };
-                            result.insert(key, $parseName(value, settings)?);
-                        }
-                        #{Document}::Object(result)
-                    },
-                    #{Value}::Bytes(_) => return #{Err}("documents cannot contain raw bytes".to_string()),
-                };
-                #{Ok}(document)
-                """,
-                "Value" to dynamicValue(),
-                "Document" to RuntimeType.document(codegenContext.runtimeConfig),
-                "Number" to RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("Number"),
-                "HashMap" to RuntimeType.HashMap,
-                *RuntimeType.preludeScope,
-            )
-        }
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        self.visit_str(value.as_str())
+                    }
+                    """,
+                    "DateTime" to RuntimeType.dateTime(codegenContext.runtimeConfig),
+                    "Format" to RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("date_time::Format"),
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
 
-    private fun parseCollection(
+    private fun renderDocumentVisitor(
+        shape: DocumentShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        visitorHeader(
+            shape,
+            info,
+            "a document",
+            writable {
+                rustTemplate(
+                    """
+                    fn visit_unit<E>(self) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::Null)
+                    }
+
+                    fn visit_none<E>(self) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::Null)
+                    }
+
+                    fn visit_bool<E>(self, value: bool) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::Bool(value))
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::String(value.to_string()))
+                    }
+
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::String(value))
+                    }
+
+                    fn visit_i64<E>(self, value: i64) -> #{Result}<Self::Value, E> {
+                        if value < 0 {
+                            #{Ok}(#{Document}::Number(#{Number}::NegInt(value)))
+                        } else {
+                            #{Ok}(#{Document}::Number(#{Number}::PosInt(value as u64)))
+                        }
+                    }
+
+                    fn visit_u64<E>(self, value: u64) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::Number(#{Number}::PosInt(value)))
+                    }
+
+                    fn visit_f64<E>(self, value: f64) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{Document}::Number(#{Number}::Float(value)))
+                    }
+
+                    fn visit_some<D>(self, deserializer: D) -> #{Result}<Self::Value, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        #{serde}::de::DeserializeSeed::deserialize(
+                            ${seedName(shape)} {
+                                settings: self.settings,
+                                depth: self.depth,
+                            },
+                            deserializer,
+                        )
+                    }
+
+                    fn visit_seq<A>(self, mut seq: A) -> #{Result}<Self::Value, A::Error>
+                    where
+                        A: #{serde}::de::SeqAccess<'de>,
+                    {
+                        let mut result = #{Vec}::with_capacity(
+                            seq.size_hint().unwrap_or(0).min(10_000)
+                        );
+                        while let #{Some}(value) = seq.next_element_seed(
+                            ${seedName(shape)} {
+                                settings: self.settings,
+                                depth: self.depth,
+                            }
+                        )? {
+                            result.push(value);
+                        }
+                        #{Ok}(#{Document}::Array(result))
+                    }
+
+                    fn visit_map<A>(self, mut map: A) -> #{Result}<Self::Value, A::Error>
+                    where
+                        A: #{serde}::de::MapAccess<'de>,
+                    {
+                        let mut result = #{HashMap}::with_capacity(
+                            map.size_hint().unwrap_or(0).min(10_000)
+                        );
+                        while let #{Some}(key) = map.next_key::<#{String}>()? {
+                            let value = map.next_value_seed(
+                                ${seedName(shape)} {
+                                    settings: self.settings,
+                                    depth: self.depth,
+                                }
+                            )?;
+                            result.insert(key, value);
+                        }
+                        #{Ok}(#{Document}::Object(result))
+                    }
+                    """,
+                    "Document" to RuntimeType.document(codegenContext.runtimeConfig),
+                    "Number" to RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("Number"),
+                    "HashMap" to RuntimeType.HashMap,
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
+
+    private fun renderCollectionVisitor(
         shape: CollectionShape,
         info: ReturnSymbolToParse,
     ): Writable =
-        writable {
-            val memberTarget = model.expectShape(shape.member.target)
-            val memberParser = parser(memberTarget)
-            rustTemplate(
-                """
-                let values = match value {
-                    #{Value}::Seq(values) => values,
-                    _ => return #{Err}("expected a sequence".to_string()),
-                };
-                let mut result = #{Vec}::with_capacity(values.len());
-                for value in values {
-                    #{ParseMember}
-                }
-                #{Finish}
-                """,
-                "Value" to dynamicValue(),
-                "ParseMember" to
-                    writable {
-                        if (shape.hasTrait<SparseTrait>()) {
-                            rustTemplate(
-                                """
-                                if matches!(value, #{Value}::Null) {
-                                    result.push(#{None});
-                                } else {
-                                    result.push(#{Some}(#{MemberParser}(value, settings)?));
-                                }
-                                """,
-                                "Value" to dynamicValue(),
-                                "MemberParser" to memberParser,
-                                *RuntimeType.preludeScope,
-                            )
-                        } else {
-                            rustTemplate("result.push(#{MemberParser}(value, settings)?);", "MemberParser" to memberParser)
+        visitorHeader(
+            shape,
+            info,
+            "a sequence",
+            writable {
+                val memberSeed = seed(model.expectShape(shape.member.target))
+                rustTemplate(
+                    """
+                    fn visit_seq<A>(self, mut seq: A) -> #{Result}<Self::Value, A::Error>
+                    where
+                        A: #{serde}::de::SeqAccess<'de>,
+                    {
+                        let mut result = #{Vec}::with_capacity(
+                            seq.size_hint().unwrap_or(0).min(10_000)
+                        );
+                        while let #{Some}(value) = seq.next_element_seed(#{MemberSeed})? {
+                            result.push(value);
                         }
-                    },
-                "Finish" to finishContainer(shape, info),
-                *RuntimeType.preludeScope,
-            )
-        }
+                        #{Finish}
+                    }
+                    """,
+                    "MemberSeed" to
+                        writable {
+                            if (shape.hasTrait<SparseTrait>()) {
+                                rustTemplate(
+                                    """
+                                    #{OptionalSeed}(#{Seed} {
+                                        settings: self.settings,
+                                        depth: self.depth,
+                                    })
+                                    """,
+                                    "OptionalSeed" to optionalSeed(),
+                                    "Seed" to memberSeed,
+                                )
+                            } else {
+                                rustTemplate(
+                                    """
+                                    #{Seed} {
+                                        settings: self.settings,
+                                        depth: self.depth,
+                                    }
+                                    """,
+                                    "Seed" to memberSeed,
+                                )
+                            }
+                        },
+                    "Finish" to finishContainer(shape, info, "A::Error"),
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
 
-    private fun parseMap(
+    private fun renderMapVisitor(
         shape: MapShape,
         info: ReturnSymbolToParse,
     ): Writable =
-        writable {
-            val keyParser = parser(model.expectShape(shape.key.target))
-            val valueParser = parser(model.expectShape(shape.value.target))
-            rustTemplate(
-                """
-                let entries = match value {
-                    #{Value}::Map(entries) => entries,
-                    _ => return #{Err}("expected a map".to_string()),
-                };
-                let mut result = #{HashMap}::with_capacity(entries.len());
-                for (key, value) in entries {
-                    let key = #{KeyParser}(key, settings)?;
-                    #{ParseValue}
-                    if result.insert(key, value).is_some() {
-                        return #{Err}("duplicate map key".to_string());
-                    }
-                }
-                #{Finish}
-                """,
-                "Value" to dynamicValue(),
-                "HashMap" to RuntimeType.HashMap,
-                "KeyParser" to keyParser,
-                "ParseValue" to
-                    writable {
-                        if (shape.hasTrait<SparseTrait>()) {
-                            rustTemplate(
-                                """
-                                let value = if matches!(value, #{Value}::Null) {
-                                    #{None}
-                                } else {
-                                    #{Some}(#{ValueParser}(value, settings)?)
-                                };
-                                """,
-                                "Value" to dynamicValue(),
-                                "ValueParser" to valueParser,
-                                *RuntimeType.preludeScope,
-                            )
-                        } else {
-                            rustTemplate(
-                                "let value = #{ValueParser}(value, settings)?;",
-                                "ValueParser" to valueParser,
-                            )
+        visitorHeader(
+            shape,
+            info,
+            "a map",
+            writable {
+                val keySeed = seed(model.expectShape(shape.key.target))
+                val valueSeed = seed(model.expectShape(shape.value.target))
+                rustTemplate(
+                    """
+                    fn visit_map<A>(self, mut map: A) -> #{Result}<Self::Value, A::Error>
+                    where
+                        A: #{serde}::de::MapAccess<'de>,
+                    {
+                        let mut result = #{HashMap}::with_capacity(
+                            map.size_hint().unwrap_or(0).min(10_000)
+                        );
+                        while let #{Some}(key) = map.next_key_seed(
+                            #{KeySeed} {
+                                settings: self.settings,
+                                depth: self.depth,
+                            }
+                        )? {
+                            let value = map.next_value_seed(#{ValueSeed})?;
+                            if result.insert(key, value).is_some() {
+                                return #{Err}(<A::Error as #{serde}::de::Error>::custom(
+                                    "duplicate map key"
+                                ));
+                            }
                         }
-                    },
-                "Finish" to finishContainer(shape, info),
-                *RuntimeType.preludeScope,
-            )
-        }
+                        #{Finish}
+                    }
+                    """,
+                    "HashMap" to RuntimeType.HashMap,
+                    "KeySeed" to keySeed,
+                    "ValueSeed" to
+                        writable {
+                            if (shape.hasTrait<SparseTrait>()) {
+                                rustTemplate(
+                                    """
+                                    #{OptionalSeed}(#{Seed} {
+                                        settings: self.settings,
+                                        depth: self.depth,
+                                    })
+                                    """,
+                                    "OptionalSeed" to optionalSeed(),
+                                    "Seed" to valueSeed,
+                                )
+                            } else {
+                                rustTemplate(
+                                    """
+                                    #{Seed} {
+                                        settings: self.settings,
+                                        depth: self.depth,
+                                    }
+                                    """,
+                                    "Seed" to valueSeed,
+                                )
+                            }
+                        },
+                    "Finish" to finishContainer(shape, info, "A::Error"),
+                    *SupportStructures.codegenScope,
+                    *RuntimeType.preludeScope,
+                )
+            },
+        )
 
     private fun finishContainer(
         shape: Shape,
         info: ReturnSymbolToParse,
+        errorType: String,
     ): Writable =
         writable {
             if (info.isUnconstrained) {
@@ -546,9 +943,11 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             } else if (serverContext != null && shape.canReachConstrainedShape(model, symbolProvider)) {
                 rustTemplate(
                     """
-                    <#{Return} as #{TryFrom}<_>>::try_from(result).map_err(|err| err.to_string())
+                    <#{Return} as #{TryFrom}<_>>::try_from(result)
+                        .map_err(<$errorType as #{serde}::de::Error>::custom)
                     """,
                     "Return" to info.symbol,
+                    *SupportStructures.codegenScope,
                     *RuntimeType.preludeScope,
                 )
             } else {
@@ -556,42 +955,119 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             }
         }
 
-    private fun parseStructure(
+    private fun renderStructureVisitor(
         shape: StructureShape,
         info: ReturnSymbolToParse,
     ): Writable =
         writable {
+            renderStructureField(shape)(this)
             val builder = structureBuilderSymbol(shape)
+            visitorHeader(
+                shape,
+                info,
+                "a structure",
+                writable {
+                    rustTemplate(
+                        """
+                        fn visit_seq<A>(self, mut seq: A) -> #{Result}<Self::Value, A::Error>
+                        where
+                            A: #{serde}::de::SeqAccess<'de>,
+                        {
+                            let mut builder = #{Builder}::default();
+                            #{SequenceMembers}
+                            while seq.next_element::<#{serde}::de::IgnoredAny>()?.is_some() {}
+                            #{Finish}
+                        }
+
+                        fn visit_map<A>(self, mut map: A) -> #{Result}<Self::Value, A::Error>
+                        where
+                            A: #{serde}::de::MapAccess<'de>,
+                        {
+                            let mut builder = #{Builder}::default();
+                            let mut seen: #{HashSet}<&'static str> = #{HashSet}::new();
+                            while let #{Some}(field) = map.next_key::<${fieldName(shape)}>()? {
+                                match field {
+                                    #{MapMembers}
+                                    ${fieldName(shape)}::Ignore => {
+                                        map.next_value::<#{serde}::de::IgnoredAny>()?;
+                                    }
+                                }
+                            }
+                            #{Finish}
+                        }
+                        """,
+                        "Builder" to builder,
+                        "HashSet" to RuntimeType.std.resolve("collections::HashSet"),
+                        "SequenceMembers" to
+                            writable {
+                                shape.members().forEach { member ->
+                                    renderStructureSequenceMember(shape, member)
+                                }
+                            },
+                        "MapMembers" to
+                            writable {
+                                shape.members().forEachIndexed { index, member ->
+                                    renderStructureMapMember(shape, member, index)
+                                }
+                            },
+                        "Finish" to finishStructure(shape, info, "A::Error"),
+                        *SupportStructures.codegenScope,
+                        *RuntimeType.preludeScope,
+                    )
+                },
+            )(this)
+        }
+
+    private fun renderStructureField(shape: StructureShape): Writable =
+        writable {
             rustTemplate(
                 """
-                let entries = match value {
-                    #{Value}::Map(entries) => entries,
-                    _ => return #{Err}("expected a structure map".to_string()),
-                };
-                let mut builder = #{Builder}::default();
-                let mut seen: #{HashSet}<&'static str> = #{HashSet}::new();
-                for (key, value) in entries {
-                    let key = match key {
-                        #{Value}::String(key) => key,
-                        _ => return #{Err}("structure field names must be strings".to_string()),
-                    };
-                    match key.as_str() {
-                        #{Members}
-                        _ => {}
+                enum ${fieldName(shape)} {
+                    #{Variants}
+                    Ignore,
+                }
+
+                struct ${fieldVisitorName(shape)};
+
+                ##[allow(clippy::match_single_binding)]
+                impl<'de> #{serde}::de::Visitor<'de> for ${fieldVisitorName(shape)} {
+                    type Value = ${fieldName(shape)};
+
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        formatter.write_str("a structure field name")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        match value {
+                            #{Matches}
+                            _ => #{Ok}(${fieldName(shape)}::Ignore),
+                        }
                     }
                 }
-                #{Finish}
+
+                impl<'de> #{serde}::Deserialize<'de> for ${fieldName(shape)} {
+                    fn deserialize<D>(deserializer: D) -> #{Result}<Self, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_identifier(${fieldVisitorName(shape)})
+                    }
+                }
                 """,
-                "Value" to dynamicValue(),
-                "Builder" to builder,
-                "HashSet" to RuntimeType.std.resolve("collections::HashSet"),
-                "Members" to
+                "Variants" to
                     writable {
-                        shape.members().forEach { member ->
-                            renderStructureMember(shape, member)
+                        shape.members().indices.forEach { rust("Field$it,") }
+                    },
+                "Matches" to
+                    writable {
+                        shape.members().forEachIndexed { index, member ->
+                            rust("${member.memberName.dq()} => Ok(${fieldName(shape)}::Field$index),")
                         }
                     },
-                "Finish" to finishStructure(shape, info),
+                *SupportStructures.codegenScope,
                 *RuntimeType.preludeScope,
             )
         }
@@ -603,34 +1079,149 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             else -> shape.serverBuilderSymbol(symbolProvider, false)
         }
 
-    private fun RustWriter.renderStructureMember(
+    private fun RustWriter.renderStructureSequenceMember(
         container: StructureShape,
         member: MemberShape,
     ) {
         val target = model.expectShape(member.target)
         val targetInfo = parseInfo(target)
-        val fieldName = symbolProvider.toMemberName(member)
-        val wireName = member.memberName
+        val field = symbolProvider.toMemberName(member)
+        val memberSymbol = symbolProvider.toSymbol(member)
+        if (memberSymbol.isOptional()) {
+            rustTemplate(
+                """
+                let parsed = match seq.next_element_seed(
+                    #{OptionalSeed}(#{TargetSeed} {
+                        settings: self.settings,
+                        depth: self.depth,
+                    })
+                )? {
+                    #{Some}(parsed) => parsed,
+                    #{None} => return #{Finish},
+                };
+                if let #{Some}(parsed) = parsed {
+                    #{Prepare}
+                    builder.$field = #{Some}(parsed);
+                }
+                """,
+                "OptionalSeed" to optionalSeed(),
+                "TargetSeed" to seed(target),
+                "Finish" to finishStructure(container, parseInfo(container), "A::Error"),
+                "Prepare" to
+                    prepareMember(
+                        container,
+                        target,
+                        targetInfo,
+                        memberSymbol.isRustBoxed(),
+                        "A::Error",
+                    ),
+                *RuntimeType.preludeScope,
+            )
+            return
+        }
         rustTemplate(
             """
-            ${wireName.dq()} => {
-                if !seen.insert(${wireName.dq()}) {
-                    return #{Err}("duplicate field `$wireName`".to_string());
+            let parsed = match seq.next_element_seed(
+                #{TargetSeed} {
+                    settings: self.settings,
+                    depth: self.depth,
                 }
-                let parsed = #{TargetParser}(value, settings)
-                    .map_err(|err| format!("invalid field `$wireName`: {err}"))?;
-                #{Prepare}
-                builder.$fieldName = #{Some}(parsed);
-            },
+            )? {
+                #{Some}(parsed) => parsed,
+                #{None} => return #{Finish},
+            };
+            #{Prepare}
+            builder.$field = #{Some}(parsed);
             """,
-            "TargetParser" to parser(target),
+            "TargetSeed" to seed(target),
+            "Finish" to finishStructure(container, parseInfo(container), "A::Error"),
             "Prepare" to
                 prepareMember(
                     container,
                     target,
                     targetInfo,
-                    symbolProvider.toSymbol(member).isRustBoxed(),
+                    memberSymbol.isRustBoxed(),
+                    "A::Error",
                 ),
+            *RuntimeType.preludeScope,
+        )
+    }
+
+    private fun RustWriter.renderStructureMapMember(
+        container: StructureShape,
+        member: MemberShape,
+        index: Int,
+    ) {
+        val target = model.expectShape(member.target)
+        val targetInfo = parseInfo(target)
+        val field = symbolProvider.toMemberName(member)
+        val wireName = member.memberName
+        val memberSymbol = symbolProvider.toSymbol(member)
+        rustTemplate(
+            """
+            ${fieldName(container)}::Field$index => {
+                if !seen.insert(${wireName.dq()}) {
+                    return #{Err}(<A::Error as #{serde}::de::Error>::custom(
+                        ${"duplicate field `$wireName`".dq()}
+                    ));
+                }
+                #{Parse}
+            }
+            """,
+            "Parse" to
+                writable {
+                    if (memberSymbol.isOptional()) {
+                        rustTemplate(
+                            """
+                            let parsed = map.next_value_seed(
+                                #{OptionalSeed}(#{TargetSeed} {
+                                    settings: self.settings,
+                                    depth: self.depth,
+                                })
+                            )?;
+                            if let #{Some}(parsed) = parsed {
+                                #{Prepare}
+                                builder.$field = #{Some}(parsed);
+                            }
+                            """,
+                            "OptionalSeed" to optionalSeed(),
+                            "TargetSeed" to seed(target),
+                            "Prepare" to
+                                prepareMember(
+                                    container,
+                                    target,
+                                    targetInfo,
+                                    memberSymbol.isRustBoxed(),
+                                    "A::Error",
+                                ),
+                            *RuntimeType.preludeScope,
+                        )
+                    } else {
+                        rustTemplate(
+                            """
+                            let parsed = map.next_value_seed(
+                                #{TargetSeed} {
+                                    settings: self.settings,
+                                    depth: self.depth,
+                                }
+                            )?;
+                            #{Prepare}
+                            builder.$field = #{Some}(parsed);
+                            """,
+                            "TargetSeed" to seed(target),
+                            "Prepare" to
+                                prepareMember(
+                                    container,
+                                    target,
+                                    targetInfo,
+                                    memberSymbol.isRustBoxed(),
+                                    "A::Error",
+                                ),
+                            *RuntimeType.preludeScope,
+                        )
+                    }
+                },
+            *SupportStructures.codegenScope,
             *RuntimeType.preludeScope,
         )
     }
@@ -640,6 +1231,7 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
         target: Shape,
         targetInfo: ReturnSymbolToParse,
         boxed: Boolean,
+        errorType: String,
     ): Writable =
         writable {
             val serverInput =
@@ -654,7 +1246,7 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
                     !serverContext.settings.codegenConfig.publicConstrainedTypes &&
                     target.isDirectlyConstrained(symbolProvider)
             if (serverContext != null && !serverInput && (requiresConversion(targetInfo, target) || hiddenDirectConstraint)) {
-                convertServerOutputMember(target, targetInfo)(this)
+                convertServerOutputMember(target, targetInfo, errorType)(this)
             }
             when {
                 serverInput && boxed && targetInfo.isUnconstrained ->
@@ -677,6 +1269,7 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
     private fun convertServerOutputMember(
         target: Shape,
         targetInfo: ReturnSymbolToParse,
+        errorType: String,
     ): Writable =
         writable {
             val server = checkNotNull(serverContext)
@@ -700,22 +1293,24 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
                 rustTemplate(
                     """
                     let parsed = <#{Constrained} as #{TryFrom}<#{Parsed}>>::try_from(parsed)
-                        .map_err(|err| err.to_string())?;
+                        .map_err(<$errorType as #{serde}::de::Error>::custom)?;
                     let parsed: #{Final} = parsed.into();
                     """,
                     "Constrained" to constrainedSymbol,
                     "Parsed" to targetInfo.symbol,
                     "Final" to finalSymbol,
+                    *SupportStructures.codegenScope,
                     *RuntimeType.preludeScope,
                 )
             } else {
                 rustTemplate(
                     """
                     let parsed = <#{Final} as #{TryFrom}<#{Parsed}>>::try_from(parsed)
-                        .map_err(|err| err.to_string())?;
+                        .map_err(<$errorType as #{serde}::de::Error>::custom)?;
                     """,
                     "Final" to finalSymbol,
                     "Parsed" to targetInfo.symbol,
+                    *SupportStructures.codegenScope,
                     *RuntimeType.preludeScope,
                 )
             }
@@ -724,6 +1319,7 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
     private fun finishStructure(
         shape: StructureShape,
         info: ReturnSymbolToParse,
+        errorType: String,
     ): Writable =
         writable {
             if (info.isUnconstrained) {
@@ -737,74 +1333,143 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
                     ServerBuilderKindBehavior(codegenContext).hasFallibleBuilder(shape)
                 }
             if (fallible) {
-                rust("builder.build().map_err(|err| err.to_string())")
+                rustTemplate(
+                    """
+                    builder.build().map_err(<$errorType as #{serde}::de::Error>::custom)
+                    """,
+                    *SupportStructures.codegenScope,
+                )
             } else {
                 rustTemplate("#{Ok}(builder.build())", *RuntimeType.preludeScope)
             }
         }
 
-    private fun parseUnion(
+    private fun renderUnionVisitor(
         shape: UnionShape,
         info: ReturnSymbolToParse,
     ): Writable =
         writable {
+            renderUnionField(shape)(this)
+            visitorHeader(
+                shape,
+                info,
+                "an externally tagged union",
+                writable {
+                    rustTemplate(
+                        """
+                        fn visit_enum<A>(self, data: A) -> #{Result}<Self::Value, A::Error>
+                        where
+                            A: #{serde}::de::EnumAccess<'de>,
+                        {
+                            let (variant, access) = data.variant::<${fieldName(shape)}>()?;
+                            match variant {
+                                #{Variants}
+                            }
+                        }
+                        """,
+                        "Variants" to
+                            writable {
+                                shape.members().forEachIndexed { index, member ->
+                                    renderUnionVariant(shape, member, info, index)
+                                }
+                            },
+                        *SupportStructures.codegenScope,
+                        *RuntimeType.preludeScope,
+                    )
+                },
+            )(this)
+        }
+
+    private fun renderUnionField(shape: UnionShape): Writable =
+        writable {
             rustTemplate(
                 """
-                match value {
-                    #{Value}::String(name) => match name.as_str() {
-                        #{UnitVariants}
-                        _ => #{Err}("unknown union variant".to_string()),
-                    },
-                    #{Value}::Map(mut entries) if entries.len() == 1 => {
-                        let (key, value) = entries.pop().expect("length checked");
-                        let key = match key {
-                            #{Value}::String(key) => key,
-                            _ => return #{Err}("union variant names must be strings".to_string()),
-                        };
-                        match key.as_str() {
-                            #{Variants}
-                            _ => #{Err}("unknown union variant".to_string()),
+                enum ${fieldName(shape)} {
+                    #{Variants}
+                }
+
+                struct ${fieldVisitorName(shape)};
+
+                impl<'de> #{serde}::de::Visitor<'de> for ${fieldVisitorName(shape)} {
+                    type Value = ${fieldName(shape)};
+
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        formatter.write_str("a union variant name")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        match value {
+                            #{Matches}
+                            _ => #{Err}(E::unknown_variant(value, &[#{Names}])),
                         }
-                    },
-                    _ => #{Err}("expected an externally tagged union".to_string()),
+                    }
+
+                    fn visit_u64<E>(self, value: u64) -> #{Result}<Self::Value, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        match value {
+                            #{IndexMatches}
+                            _ => #{Err}(E::invalid_value(
+                                #{serde}::de::Unexpected::Unsigned(value),
+                                &self,
+                            )),
+                        }
+                    }
+                }
+
+                impl<'de> #{serde}::Deserialize<'de> for ${fieldName(shape)} {
+                    fn deserialize<D>(deserializer: D) -> #{Result}<Self, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_identifier(${fieldVisitorName(shape)})
+                    }
                 }
                 """,
-                "Value" to dynamicValue(),
-                "UnitVariants" to
-                    writable {
-                        shape.members().filter(MemberShape::isTargetUnit).forEach { member ->
-                            rustTemplate(
-                                "${member.memberName.dq()} => #{Ok}(#{Return}::${symbolProvider.toMemberName(member)}),",
-                                "Return" to info.symbol,
-                                *RuntimeType.preludeScope,
-                            )
-                        }
-                    },
                 "Variants" to
                     writable {
-                        shape.members().forEach { member ->
-                            renderUnionVariant(member, info)
+                        shape.members().indices.forEach { rust("Field$it,") }
+                    },
+                "Matches" to
+                    writable {
+                        shape.members().forEachIndexed { index, member ->
+                            rust("${member.memberName.dq()} => Ok(${fieldName(shape)}::Field$index),")
                         }
                     },
+                "Names" to
+                    writable {
+                        rust(shape.members().joinToString(", ") { it.memberName.dq() })
+                    },
+                "IndexMatches" to
+                    writable {
+                        shape.members().indices.forEach { rust("$it => Ok(${fieldName(shape)}::Field$it),") }
+                    },
+                *SupportStructures.codegenScope,
                 *RuntimeType.preludeScope,
             )
         }
 
     private fun RustWriter.renderUnionVariant(
+        container: UnionShape,
         member: MemberShape,
         unionInfo: ReturnSymbolToParse,
+        index: Int,
     ) {
         val variant = symbolProvider.toMemberName(member)
         if (member.isTargetUnit()) {
             rustTemplate(
                 """
-                ${member.memberName.dq()} => match value {
-                    #{Value}::Null => #{Ok}(#{Return}::$variant),
-                    _ => #{Err}("unit union variants must contain null".to_string()),
-                },
+                ${fieldName(container)}::Field$index => {
+                    #{serde}::de::VariantAccess::unit_variant(access)?;
+                    #{Ok}(#{Return}::$variant)
+                }
                 """,
-                "Value" to dynamicValue(),
                 "Return" to unionInfo.symbol,
+                *SupportStructures.codegenScope,
                 *RuntimeType.preludeScope,
             )
         } else {
@@ -812,22 +1477,29 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
             val targetInfo = parseInfo(target)
             rustTemplate(
                 """
-                ${member.memberName.dq()} => {
-                    let parsed = #{TargetParser}(value, settings)
-                        .map_err(|err| format!("invalid union variant `${member.memberName}`: {err}"))?;
+                ${fieldName(container)}::Field$index => {
+                    let parsed = #{serde}::de::VariantAccess::newtype_variant_seed(
+                        access,
+                        #{TargetSeed} {
+                            settings: self.settings,
+                            depth: self.depth,
+                        },
+                    )?;
                     #{Prepare}
                     #{Ok}(#{Return}::$variant(parsed))
-                },
+                }
                 """,
-                "TargetParser" to parser(target),
+                "TargetSeed" to seed(target),
                 "Prepare" to
                     prepareMember(
-                        model.expectShape(member.container),
+                        container,
                         target,
                         targetInfo,
                         member.hasTrait<RustBoxTrait>(),
+                        "A::Error",
                     ),
                 "Return" to unionInfo.symbol,
+                *SupportStructures.codegenScope,
                 *RuntimeType.preludeScope,
             )
         }
@@ -838,41 +1510,25 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
         info: ReturnSymbolToParse,
     ) {
         val finalSymbol = symbolProvider.toSymbol(shape)
-        val seedName = shape.contextName(codegenContext.serviceShape).toPascalCase() + "Seed"
         rustTemplate(
             """
-            struct $seedName<'a> {
-                settings: &'a #{DeserializationSettings},
-            }
-
-            impl<'de> #{serde}::de::DeserializeSeed<'de> for $seedName<'_> {
-                type Value = #{Final};
-
-                fn deserialize<D>(self, deserializer: D) -> #{Result}<Self::Value, D::Error>
-                where
-                    D: #{serde}::Deserializer<'de>,
-                {
-                    let value = <#{Value} as #{serde}::Deserialize>::deserialize(deserializer)?;
-                    let parsed = ${parseFunctionName(shape)}(value, self.settings)
-                        .map_err(<D::Error as #{serde}::de::Error>::custom)?;
-                    #{Finalize}
-                }
-            }
-
             impl<'de> #{serde}::Deserialize<'de> for #{Final} {
                 fn deserialize<D>(deserializer: D) -> #{Result}<Self, D::Error>
                 where
                     D: #{serde}::Deserializer<'de>,
                 {
                     let settings = #{DeserializationSettings}::current();
-                    #{serde}::de::DeserializeSeed::deserialize(
-                        $seedName { settings: &settings },
+                    let parsed = #{serde}::de::DeserializeSeed::deserialize(
+                        ${seedName(shape)} {
+                            settings: &settings,
+                            depth: 128,
+                        },
                         deserializer,
-                    )
+                    )?;
+                    #{Finalize}
                 }
             }
             """,
-            "Value" to dynamicValue(),
             "Final" to finalSymbol,
             "Finalize" to
                 writable {
@@ -904,108 +1560,52 @@ class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
         info.isUnconstrained &&
             info.symbol.rustType() != symbolProvider.toSymbol(finalShape).rustType()
 
-    private fun dynamicValue(): RuntimeType =
-        RuntimeType.forInlineFun("SerdeDeserializeValue", DeserializerModule) {
+    private fun optionalSeed(): RuntimeType =
+        RuntimeType.forInlineFun("SerdeOptionalSeed", DeserializerModule) {
             rustTemplate(
                 """
-                ##[allow(dead_code)]
-                enum SerdeDeserializeValue {
-                    Null,
-                    Bool(bool),
-                    I64(i64),
-                    U64(u64),
-                    F64(f64),
-                    String(#{String}),
-                    Bytes(#{Vec}<u8>),
-                    Seq(#{Vec}<SerdeDeserializeValue>),
-                    Map(#{Vec}<(SerdeDeserializeValue, SerdeDeserializeValue)>),
-                }
+                struct SerdeOptionalSeed<S>(S);
 
-                struct SerdeDeserializeValueVisitor;
+                struct SerdeOptionalSeedVisitor<S>(#{Option}<S>);
 
-                impl<'de> #{serde}::de::Visitor<'de> for SerdeDeserializeValueVisitor {
-                    type Value = SerdeDeserializeValue;
+                impl<'de, S> #{serde}::de::Visitor<'de> for SerdeOptionalSeedVisitor<S>
+                where
+                    S: #{serde}::de::DeserializeSeed<'de>,
+                {
+                    type Value = #{Option}<S::Value>;
 
                     fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        formatter.write_str("a Serde value")
+                        formatter.write_str("an optional value")
                     }
 
-                    fn visit_unit<E>(self) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::Null) }
-                    fn visit_none<E>(self) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::Null) }
-                    fn visit_bool<E>(self, value: bool) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::Bool(value)) }
-                    fn visit_i8<E>(self, value: i8) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value as i64)) }
-                    fn visit_i16<E>(self, value: i16) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value as i64)) }
-                    fn visit_i32<E>(self, value: i32) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value as i64)) }
-                    fn visit_i64<E>(self, value: i64) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value)) }
-                    fn visit_u8<E>(self, value: u8) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value as u64)) }
-                    fn visit_u16<E>(self, value: u16) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value as u64)) }
-                    fn visit_u32<E>(self, value: u32) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value as u64)) }
-                    fn visit_u64<E>(self, value: u64) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value)) }
-                    fn visit_f32<E>(self, value: f32) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::F64(value as f64)) }
-                    fn visit_f64<E>(self, value: f64) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::F64(value)) }
-
-                    fn visit_str<E>(self, value: &str) -> #{Result}<SerdeDeserializeValue, E>
-                    where
-                        E: #{serde}::de::Error,
-                    {
-                        #{Ok}(SerdeDeserializeValue::String(value.to_string()))
+                    fn visit_none<E>(self) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{None})
                     }
 
-                    fn visit_string<E>(self, value: #{String}) -> #{Result}<SerdeDeserializeValue, E> {
-                        #{Ok}(SerdeDeserializeValue::String(value))
+                    fn visit_unit<E>(self) -> #{Result}<Self::Value, E> {
+                        #{Ok}(#{None})
                     }
 
-                    fn visit_bytes<E>(self, value: &[u8]) -> #{Result}<SerdeDeserializeValue, E> {
-                        #{Ok}(SerdeDeserializeValue::Bytes(value.to_vec()))
-                    }
-
-                    fn visit_byte_buf<E>(self, value: #{Vec}<u8>) -> #{Result}<SerdeDeserializeValue, E> {
-                        #{Ok}(SerdeDeserializeValue::Bytes(value))
-                    }
-
-                    fn visit_some<D>(self, deserializer: D) -> #{Result}<SerdeDeserializeValue, D::Error>
+                    fn visit_some<D>(mut self, deserializer: D) -> #{Result}<Self::Value, D::Error>
                     where
                         D: #{serde}::Deserializer<'de>,
                     {
-                        <SerdeDeserializeValue as #{serde}::Deserialize>::deserialize(deserializer)
-                    }
-
-                    fn visit_newtype_struct<D>(self, deserializer: D) -> #{Result}<SerdeDeserializeValue, D::Error>
-                    where
-                        D: #{serde}::Deserializer<'de>,
-                    {
-                        <SerdeDeserializeValue as #{serde}::Deserialize>::deserialize(deserializer)
-                    }
-
-                    fn visit_seq<A>(self, mut seq: A) -> #{Result}<SerdeDeserializeValue, A::Error>
-                    where
-                        A: #{serde}::de::SeqAccess<'de>,
-                    {
-                        let mut values = #{Vec}::with_capacity(seq.size_hint().unwrap_or(0));
-                        while let #{Some}(value) = seq.next_element()? {
-                            values.push(value);
-                        }
-                        #{Ok}(SerdeDeserializeValue::Seq(values))
-                    }
-
-                    fn visit_map<A>(self, mut map: A) -> #{Result}<SerdeDeserializeValue, A::Error>
-                    where
-                        A: #{serde}::de::MapAccess<'de>,
-                    {
-                        let mut entries = #{Vec}::with_capacity(map.size_hint().unwrap_or(0));
-                        while let #{Some}(entry) = map.next_entry()? {
-                            entries.push(entry);
-                        }
-                        #{Ok}(SerdeDeserializeValue::Map(entries))
+                        let seed = self.0.take().expect("optional seed is visited once");
+                        seed.deserialize(deserializer).map(#{Some})
                     }
                 }
 
-                impl<'de> #{serde}::Deserialize<'de> for SerdeDeserializeValue {
-                    fn deserialize<D>(deserializer: D) -> #{Result}<Self, D::Error>
+                impl<'de, S> #{serde}::de::DeserializeSeed<'de> for SerdeOptionalSeed<S>
+                where
+                    S: #{serde}::de::DeserializeSeed<'de>,
+                {
+                    type Value = #{Option}<S::Value>;
+
+                    fn deserialize<D>(self, deserializer: D) -> #{Result}<Self::Value, D::Error>
                     where
                         D: #{serde}::Deserializer<'de>,
                     {
-                        deserializer.deserialize_any(SerdeDeserializeValueVisitor)
+                        deserializer.deserialize_option(SerdeOptionalSeedVisitor(#{Some}(self.0)))
                     }
                 }
                 """,

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/DeserializeImplGenerator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/DeserializeImplGenerator.kt
@@ -1,0 +1,1020 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.serde
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.knowledge.TopDownIndex
+import software.amazon.smithy.model.shapes.BigDecimalShape
+import software.amazon.smithy.model.shapes.BigIntegerShape
+import software.amazon.smithy.model.shapes.BlobShape
+import software.amazon.smithy.model.shapes.BooleanShape
+import software.amazon.smithy.model.shapes.ByteShape
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.DocumentShape
+import software.amazon.smithy.model.shapes.DoubleShape
+import software.amazon.smithy.model.shapes.EnumShape
+import software.amazon.smithy.model.shapes.FloatShape
+import software.amazon.smithy.model.shapes.IntegerShape
+import software.amazon.smithy.model.shapes.LongShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.NumberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShortShape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.TimestampShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.EnumTrait
+import software.amazon.smithy.model.traits.SparseTrait
+import software.amazon.smithy.model.traits.StreamingTrait
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.contextName
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.isRustBoxed
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.ReturnSymbolToParse
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.shapeFunctionName
+import software.amazon.smithy.rust.codegen.core.smithy.rustType
+import software.amazon.smithy.rust.codegen.core.smithy.traits.RustBoxTrait
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.hasEventStreamMember
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+import software.amazon.smithy.rust.codegen.core.util.isEventStream
+import software.amazon.smithy.rust.codegen.core.util.isTargetUnit
+import software.amazon.smithy.rust.codegen.core.util.toPascalCase
+import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
+import software.amazon.smithy.rust.codegen.server.smithy.canReachConstrainedShape
+import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerBuilderKindBehavior
+import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.returnSymbolToParseFn
+import software.amazon.smithy.rust.codegen.server.smithy.generators.serverBuilderSymbol
+import software.amazon.smithy.rust.codegen.server.smithy.isDirectlyConstrained
+import software.amazon.smithy.rust.codegen.server.smithy.traits.ShapeReachableFromOperationInputTagTrait
+import software.amazon.smithy.rust.codegen.server.smithy.traits.isReachableFromOperationInput
+
+/**
+ * Generates ordinary `Deserialize` implementations for nominal model types.
+ *
+ * Serde formats are first decoded into a private value tree. Shape-specific parsers then convert that tree into
+ * generated model types. This preserves duplicate map entries and lets server input shapes flow through their
+ * unconstrained representations before constraints are enforced at the root.
+ */
+class DeserializeImplGenerator(private val codegenContext: CodegenContext) {
+    private val model = codegenContext.model
+    private val symbolProvider = codegenContext.symbolProvider
+    private val topIndex = TopDownIndex.of(model)
+    private val serverContext = codegenContext as? ServerCodegenContext
+    private val serverReturnSymbol = serverContext?.let(::returnSymbolToParseFn)
+
+    fun generateRootDeserializerForShape(shape: Shape): Writable =
+        when (shape) {
+            is ServiceShape ->
+                topIndex.getContainedOperations(shape)
+                    .map(::generateRootDeserializerForShape)
+                    .fold(writable { }) { left, right ->
+                        writable {
+                            left(this)
+                            right(this)
+                        }
+                    }
+
+            is OperationShape ->
+                if (shape.isEventStream(model)) {
+                    writable { }
+                } else {
+                    writable {
+                        generateRootDeserializerForShape(model.expectShape(shape.inputShape))(this)
+                        generateRootDeserializerForShape(model.expectShape(shape.outputShape))(this)
+                        shape.errors.forEach {
+                            generateRootDeserializerForShape(model.expectShape(it))(this)
+                        }
+                    }
+                }
+
+            is UnionShape ->
+                if (shape.isEventStream()) {
+                    writable { }
+                } else {
+                    writable { addDependency(parser(shape).toSymbol()) }
+                }
+
+            is StructureShape ->
+                if (shape.hasEventStreamMember(model)) {
+                    writable { }
+                } else {
+                    writable { addDependency(parser(shape).toSymbol()) }
+                }
+
+            is EnumShape -> writable { addDependency(parser(shape).toSymbol()) }
+            is StringShape ->
+                if (shape.hasTrait<EnumTrait>()) {
+                    writable { addDependency(parser(shape).toSymbol()) }
+                } else {
+                    writable { }
+                }
+
+            else -> writable { }
+        }
+
+    private fun parser(shape: Shape): RuntimeType =
+        RuntimeType.forInlineFun(parseFunctionName(shape), DeserializerModule) {
+            renderParser(shape)(this)
+        }
+
+    private fun parseFunctionName(shape: Shape): String =
+        symbolProvider.shapeFunctionName(codegenContext.serviceShape, shape) + "_serde_deserialize"
+
+    private fun parseInfo(shape: Shape): ReturnSymbolToParse {
+        if (shape is BlobShape && shape.hasTrait<StreamingTrait>()) {
+            return ReturnSymbolToParse(RuntimeType.byteStream(codegenContext.runtimeConfig).toSymbol(), false)
+        }
+        if (
+            serverReturnSymbol != null &&
+            shape.isDirectlyConstrained(symbolProvider) &&
+            (shape is StringShape || shape is NumberShape || shape is BlobShape)
+        ) {
+            return serverReturnSymbol.invoke(shape)
+        }
+        return if (serverReturnSymbol != null && shape.hasTrait<ShapeReachableFromOperationInputTagTrait>()) {
+            serverReturnSymbol.invoke(shape)
+        } else {
+            ReturnSymbolToParse(symbolProvider.toSymbol(shape), false)
+        }
+    }
+
+    private fun renderParser(shape: Shape): Writable =
+        writable {
+            val info = parseInfo(shape)
+            rustTemplate(
+                """
+                ##[allow(unused_mut, unused_variables)]
+                ##[allow(clippy::match_single_binding, clippy::single_match)]
+                fn ${parseFunctionName(shape)}(
+                    value: #{Value},
+                    settings: &#{DeserializationSettings},
+                ) -> #{Result}<#{Return}, #{String}> {
+                    let _ = settings;
+                    #{Body}
+                }
+                """,
+                "Value" to dynamicValue(),
+                "Return" to info.symbol,
+                "Body" to parserBody(shape, info),
+                *SupportStructures.codegenScope,
+                *RuntimeType.preludeScope,
+            )
+            if (isNominal(shape)) {
+                renderNominalDeserializeImpl(shape, info)
+            }
+        }
+
+    private fun isNominal(shape: Shape): Boolean =
+        shape is StructureShape ||
+            shape is UnionShape ||
+            shape is EnumShape ||
+            (shape is StringShape && shape.hasTrait<EnumTrait>())
+
+    private fun parserBody(
+        shape: Shape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        when (shape) {
+            is StructureShape -> parseStructure(shape, info)
+            is UnionShape -> parseUnion(shape, info)
+            is EnumShape -> parseEnum(shape, info)
+            is StringShape ->
+                if (shape.hasTrait<EnumTrait>()) {
+                    parseEnum(shape, info)
+                } else {
+                    parseString()
+                }
+
+            is BooleanShape -> parseBoolean()
+            is NumberShape -> parseNumber(shape)
+            is BlobShape -> parseBlob(shape)
+            is TimestampShape -> parseTimestamp()
+            is DocumentShape -> parseDocument(shape)
+            is CollectionShape -> parseCollection(shape, info)
+            is MapShape -> parseMap(shape, info)
+            else -> writable { rust("Err(\"unsupported shape for deserialization\".to_string())") }
+        }
+
+    private fun parseBoolean(): Writable =
+        writable {
+            rustTemplate(
+                """
+                match value {
+                    #{Value}::Bool(value) => #{Ok}(value),
+                    _ => #{Err}("expected a boolean".to_string()),
+                }
+                """,
+                "Value" to dynamicValue(),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseString(): Writable =
+        writable {
+            rustTemplate(
+                """
+                match value {
+                    #{Value}::String(value) => #{Ok}(value),
+                    _ => #{Err}("expected a string".to_string()),
+                }
+                """,
+                "Value" to dynamicValue(),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseEnum(
+        shape: Shape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            rustTemplate(
+                """
+                let text = match value {
+                    #{Value}::String(value) => value,
+                    _ => return #{Err}("expected an enum string".to_string()),
+                };
+                """,
+                "Value" to dynamicValue(),
+                *RuntimeType.preludeScope,
+            )
+            when {
+                codegenContext.target == CodegenTarget.SERVER && info.isUnconstrained ->
+                    rustTemplate("#{Ok}(text)", *RuntimeType.preludeScope)
+
+                codegenContext.target == CodegenTarget.SERVER ->
+                    rustTemplate(
+                        "#{Return}::try_from(text).map_err(|err| err.to_string())",
+                        "Return" to info.symbol,
+                    )
+
+                else ->
+                    rustTemplate(
+                        "#{Ok}(#{Return}::from(text.as_str()))",
+                        "Return" to info.symbol,
+                        *RuntimeType.preludeScope,
+                    )
+            }
+        }
+
+    private fun parseNumber(shape: NumberShape): Writable =
+        when (shape) {
+            is FloatShape -> parseFloat("f32")
+            is DoubleShape -> parseFloat("f64")
+            is BigIntegerShape -> parseBigNumber(RuntimeType.bigInteger(codegenContext.runtimeConfig))
+            is BigDecimalShape -> parseBigNumber(RuntimeType.bigDecimal(codegenContext.runtimeConfig))
+            is ByteShape -> parseInteger("i8")
+            is ShortShape -> parseInteger("i16")
+            is IntegerShape -> parseInteger("i32")
+            is LongShape -> parseInteger("i64")
+            else -> writable { rust("Err(\"unsupported number shape\".to_string())") }
+        }
+
+    private fun parseInteger(rustType: String): Writable =
+        writable {
+            rustTemplate(
+                """
+                match value {
+                    #{Value}::I64(value) => <$rustType as #{TryFrom}<i64>>::try_from(value)
+                        .map_err(|_| "integer is out of range".to_string()),
+                    #{Value}::U64(value) => <$rustType as #{TryFrom}<u64>>::try_from(value)
+                        .map_err(|_| "integer is out of range".to_string()),
+                    _ => #{Err}("expected an integer".to_string()),
+                }
+                """,
+                "Value" to dynamicValue(),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseFloat(rustType: String): Writable =
+        writable {
+            val parsedF64 = if (rustType == "f64") "value" else "value as $rustType"
+            rustTemplate(
+                """
+                match value {
+                    #{Value}::F64(value) => #{Ok}($parsedF64),
+                    #{Value}::I64(value) => #{Ok}(value as $rustType),
+                    #{Value}::U64(value) => #{Ok}(value as $rustType),
+                    #{Value}::String(value) if settings.allow_non_finite_float_strings => match value.as_str() {
+                        "NaN" => #{Ok}($rustType::NAN),
+                        "Infinity" => #{Ok}($rustType::INFINITY),
+                        "-Infinity" => #{Ok}($rustType::NEG_INFINITY),
+                        _ => #{Err}("expected a floating-point number".to_string()),
+                    },
+                    _ => #{Err}("expected a floating-point number".to_string()),
+                }
+                """,
+                "Value" to dynamicValue(),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseBigNumber(type: RuntimeType): Writable =
+        writable {
+            rustTemplate(
+                """
+                let text = match value {
+                    #{Value}::String(value) => value,
+                    #{Value}::I64(value) => value.to_string(),
+                    #{Value}::U64(value) => value.to_string(),
+                    #{Value}::F64(value) => value.to_string(),
+                    _ => return #{Err}("expected a number".to_string()),
+                };
+                <#{Type} as ::std::str::FromStr>::from_str(&text).map_err(|err| err.to_string())
+                """,
+                "Value" to dynamicValue(),
+                "Type" to type,
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseBlob(shape: BlobShape): Writable =
+        writable {
+            rustTemplate(
+                """
+                let bytes = match value {
+                    #{Value}::Bytes(value) => value,
+                    #{Value}::String(value) => {
+                        if value == "streaming data" {
+                            return #{Err}("the streaming data placeholder cannot be deserialized".to_string());
+                        }
+                        #{base64_decode}(value).map_err(|_| "invalid base64 blob".to_string())?
+                    },
+                    _ => return #{Err}("expected a base64 string or bytes".to_string()),
+                };
+                """,
+                "Value" to dynamicValue(),
+                "base64_decode" to RuntimeType.base64Decode(codegenContext.runtimeConfig),
+                *RuntimeType.preludeScope,
+            )
+            if (shape.hasTrait<StreamingTrait>()) {
+                rustTemplate(
+                    "#{Ok}(#{ByteStream}::from(bytes))",
+                    "ByteStream" to RuntimeType.byteStream(codegenContext.runtimeConfig),
+                    *RuntimeType.preludeScope,
+                )
+            } else {
+                rustTemplate(
+                    "#{Ok}(#{Blob}::new(bytes))",
+                    "Blob" to RuntimeType.blob(codegenContext.runtimeConfig),
+                    *RuntimeType.preludeScope,
+                )
+            }
+        }
+
+    private fun parseTimestamp(): Writable =
+        writable {
+            rustTemplate(
+                """
+                let text = match value {
+                    #{Value}::String(value) => value,
+                    _ => return #{Err}("expected a timestamp string".to_string()),
+                };
+                #{DateTime}::from_str(&text, #{Format}::DateTime).map_err(|err| err.to_string())
+                """,
+                "Value" to dynamicValue(),
+                "DateTime" to RuntimeType.dateTime(codegenContext.runtimeConfig),
+                "Format" to RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("date_time::Format"),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseDocument(shape: DocumentShape): Writable =
+        writable {
+            val parseName = parseFunctionName(shape)
+            rustTemplate(
+                """
+                let document = match value {
+                    #{Value}::Null => #{Document}::Null,
+                    #{Value}::Bool(value) => #{Document}::Bool(value),
+                    #{Value}::String(value) => #{Document}::String(value),
+                    #{Value}::I64(value) if value < 0 => #{Document}::Number(#{Number}::NegInt(value)),
+                    #{Value}::I64(value) => #{Document}::Number(#{Number}::PosInt(value as u64)),
+                    #{Value}::U64(value) => #{Document}::Number(#{Number}::PosInt(value)),
+                    #{Value}::F64(value) => #{Document}::Number(#{Number}::Float(value)),
+                    #{Value}::Seq(values) => {
+                        let mut result = #{Vec}::with_capacity(values.len());
+                        for value in values {
+                            result.push($parseName(value, settings)?);
+                        }
+                        #{Document}::Array(result)
+                    },
+                    #{Value}::Map(entries) => {
+                        let mut result = #{HashMap}::with_capacity(entries.len());
+                        for (key, value) in entries {
+                            let key = match key {
+                                #{Value}::String(key) => key,
+                                _ => return #{Err}("document object keys must be strings".to_string()),
+                            };
+                            result.insert(key, $parseName(value, settings)?);
+                        }
+                        #{Document}::Object(result)
+                    },
+                    #{Value}::Bytes(_) => return #{Err}("documents cannot contain raw bytes".to_string()),
+                };
+                #{Ok}(document)
+                """,
+                "Value" to dynamicValue(),
+                "Document" to RuntimeType.document(codegenContext.runtimeConfig),
+                "Number" to RuntimeType.smithyTypes(codegenContext.runtimeConfig).resolve("Number"),
+                "HashMap" to RuntimeType.HashMap,
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseCollection(
+        shape: CollectionShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            val memberTarget = model.expectShape(shape.member.target)
+            val memberParser = parser(memberTarget)
+            rustTemplate(
+                """
+                let values = match value {
+                    #{Value}::Seq(values) => values,
+                    _ => return #{Err}("expected a sequence".to_string()),
+                };
+                let mut result = #{Vec}::with_capacity(values.len());
+                for value in values {
+                    #{ParseMember}
+                }
+                #{Finish}
+                """,
+                "Value" to dynamicValue(),
+                "ParseMember" to
+                    writable {
+                        if (shape.hasTrait<SparseTrait>()) {
+                            rustTemplate(
+                                """
+                                if matches!(value, #{Value}::Null) {
+                                    result.push(#{None});
+                                } else {
+                                    result.push(#{Some}(#{MemberParser}(value, settings)?));
+                                }
+                                """,
+                                "Value" to dynamicValue(),
+                                "MemberParser" to memberParser,
+                                *RuntimeType.preludeScope,
+                            )
+                        } else {
+                            rustTemplate("result.push(#{MemberParser}(value, settings)?);", "MemberParser" to memberParser)
+                        }
+                    },
+                "Finish" to finishContainer(shape, info),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun parseMap(
+        shape: MapShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            val keyParser = parser(model.expectShape(shape.key.target))
+            val valueParser = parser(model.expectShape(shape.value.target))
+            rustTemplate(
+                """
+                let entries = match value {
+                    #{Value}::Map(entries) => entries,
+                    _ => return #{Err}("expected a map".to_string()),
+                };
+                let mut result = #{HashMap}::with_capacity(entries.len());
+                for (key, value) in entries {
+                    let key = #{KeyParser}(key, settings)?;
+                    #{ParseValue}
+                    if result.insert(key, value).is_some() {
+                        return #{Err}("duplicate map key".to_string());
+                    }
+                }
+                #{Finish}
+                """,
+                "Value" to dynamicValue(),
+                "HashMap" to RuntimeType.HashMap,
+                "KeyParser" to keyParser,
+                "ParseValue" to
+                    writable {
+                        if (shape.hasTrait<SparseTrait>()) {
+                            rustTemplate(
+                                """
+                                let value = if matches!(value, #{Value}::Null) {
+                                    #{None}
+                                } else {
+                                    #{Some}(#{ValueParser}(value, settings)?)
+                                };
+                                """,
+                                "Value" to dynamicValue(),
+                                "ValueParser" to valueParser,
+                                *RuntimeType.preludeScope,
+                            )
+                        } else {
+                            rustTemplate(
+                                "let value = #{ValueParser}(value, settings)?;",
+                                "ValueParser" to valueParser,
+                            )
+                        }
+                    },
+                "Finish" to finishContainer(shape, info),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun finishContainer(
+        shape: Shape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            if (info.isUnconstrained) {
+                rustTemplate("#{Ok}(#{Return}(result))", "Return" to info.symbol, *RuntimeType.preludeScope)
+            } else if (serverContext != null && shape.canReachConstrainedShape(model, symbolProvider)) {
+                rustTemplate(
+                    """
+                    <#{Return} as #{TryFrom}<_>>::try_from(result).map_err(|err| err.to_string())
+                    """,
+                    "Return" to info.symbol,
+                    *RuntimeType.preludeScope,
+                )
+            } else {
+                rustTemplate("#{Ok}(result)", *RuntimeType.preludeScope)
+            }
+        }
+
+    private fun parseStructure(
+        shape: StructureShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            val builder = structureBuilderSymbol(shape)
+            rustTemplate(
+                """
+                let entries = match value {
+                    #{Value}::Map(entries) => entries,
+                    _ => return #{Err}("expected a structure map".to_string()),
+                };
+                let mut builder = #{Builder}::default();
+                let mut seen: #{HashSet}<&'static str> = #{HashSet}::new();
+                for (key, value) in entries {
+                    let key = match key {
+                        #{Value}::String(key) => key,
+                        _ => return #{Err}("structure field names must be strings".to_string()),
+                    };
+                    match key.as_str() {
+                        #{Members}
+                        _ => {}
+                    }
+                }
+                #{Finish}
+                """,
+                "Value" to dynamicValue(),
+                "Builder" to builder,
+                "HashSet" to RuntimeType.std.resolve("collections::HashSet"),
+                "Members" to
+                    writable {
+                        shape.members().forEach { member ->
+                            renderStructureMember(shape, member)
+                        }
+                    },
+                "Finish" to finishStructure(shape, info),
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun structureBuilderSymbol(shape: StructureShape): Symbol =
+        when {
+            serverContext == null -> symbolProvider.symbolForBuilder(shape)
+            shape.isReachableFromOperationInput() -> shape.serverBuilderSymbol(serverContext)
+            else -> shape.serverBuilderSymbol(symbolProvider, false)
+        }
+
+    private fun RustWriter.renderStructureMember(
+        container: StructureShape,
+        member: MemberShape,
+    ) {
+        val target = model.expectShape(member.target)
+        val targetInfo = parseInfo(target)
+        val fieldName = symbolProvider.toMemberName(member)
+        val wireName = member.memberName
+        rustTemplate(
+            """
+            ${wireName.dq()} => {
+                if !seen.insert(${wireName.dq()}) {
+                    return #{Err}("duplicate field `$wireName`".to_string());
+                }
+                let parsed = #{TargetParser}(value, settings)
+                    .map_err(|err| format!("invalid field `$wireName`: {err}"))?;
+                #{Prepare}
+                builder.$fieldName = #{Some}(parsed);
+            },
+            """,
+            "TargetParser" to parser(target),
+            "Prepare" to
+                prepareMember(
+                    container,
+                    target,
+                    targetInfo,
+                    symbolProvider.toSymbol(member).isRustBoxed(),
+                ),
+            *RuntimeType.preludeScope,
+        )
+    }
+
+    private fun prepareMember(
+        container: Shape,
+        target: Shape,
+        targetInfo: ReturnSymbolToParse,
+        boxed: Boolean,
+    ): Writable =
+        writable {
+            val serverInput =
+                serverContext != null &&
+                    when (container) {
+                        is StructureShape -> container.isReachableFromOperationInput()
+                        is UnionShape -> container.isReachableFromOperationInput()
+                        else -> false
+                    }
+            val hiddenDirectConstraint =
+                serverContext != null &&
+                    !serverContext.settings.codegenConfig.publicConstrainedTypes &&
+                    target.isDirectlyConstrained(symbolProvider)
+            if (serverContext != null && !serverInput && (requiresConversion(targetInfo, target) || hiddenDirectConstraint)) {
+                convertServerOutputMember(target, targetInfo)(this)
+            }
+            when {
+                serverInput && boxed && targetInfo.isUnconstrained ->
+                    rustTemplate(
+                        "let parsed = #{Box}::new(parsed.into());",
+                        *RuntimeType.preludeScope,
+                    )
+
+                boxed ->
+                    rustTemplate(
+                        "let parsed = #{Box}::new(parsed);",
+                        *RuntimeType.preludeScope,
+                    )
+
+                serverInput && targetInfo.isUnconstrained ->
+                    rust("let parsed = parsed.into();")
+            }
+        }
+
+    private fun convertServerOutputMember(
+        target: Shape,
+        targetInfo: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            val server = checkNotNull(serverContext)
+            val finalSymbol = symbolProvider.toSymbol(target)
+            val usesIntermediateConstrainedType =
+                target !is StructureShape &&
+                    target !is UnionShape &&
+                    target !is EnumShape &&
+                    !(target is StringShape && target.hasTrait<EnumTrait>()) &&
+                    (
+                        !server.settings.codegenConfig.publicConstrainedTypes ||
+                            !target.isDirectlyConstrained(symbolProvider)
+                    )
+            if (usesIntermediateConstrainedType) {
+                val constrainedSymbol =
+                    if (target.isDirectlyConstrained(symbolProvider)) {
+                        server.constrainedShapeSymbolProvider.toSymbol(target)
+                    } else {
+                        server.pubCrateConstrainedShapeSymbolProvider.toSymbol(target)
+                    }
+                rustTemplate(
+                    """
+                    let parsed = <#{Constrained} as #{TryFrom}<#{Parsed}>>::try_from(parsed)
+                        .map_err(|err| err.to_string())?;
+                    let parsed: #{Final} = parsed.into();
+                    """,
+                    "Constrained" to constrainedSymbol,
+                    "Parsed" to targetInfo.symbol,
+                    "Final" to finalSymbol,
+                    *RuntimeType.preludeScope,
+                )
+            } else {
+                rustTemplate(
+                    """
+                    let parsed = <#{Final} as #{TryFrom}<#{Parsed}>>::try_from(parsed)
+                        .map_err(|err| err.to_string())?;
+                    """,
+                    "Final" to finalSymbol,
+                    "Parsed" to targetInfo.symbol,
+                    *RuntimeType.preludeScope,
+                )
+            }
+        }
+
+    private fun finishStructure(
+        shape: StructureShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            if (info.isUnconstrained) {
+                rustTemplate("#{Ok}(builder)", *RuntimeType.preludeScope)
+                return@writable
+            }
+            val fallible =
+                if (serverContext == null) {
+                    BuilderGenerator.hasFallibleBuilder(shape, symbolProvider)
+                } else {
+                    ServerBuilderKindBehavior(codegenContext).hasFallibleBuilder(shape)
+                }
+            if (fallible) {
+                rust("builder.build().map_err(|err| err.to_string())")
+            } else {
+                rustTemplate("#{Ok}(builder.build())", *RuntimeType.preludeScope)
+            }
+        }
+
+    private fun parseUnion(
+        shape: UnionShape,
+        info: ReturnSymbolToParse,
+    ): Writable =
+        writable {
+            rustTemplate(
+                """
+                match value {
+                    #{Value}::String(name) => match name.as_str() {
+                        #{UnitVariants}
+                        _ => #{Err}("unknown union variant".to_string()),
+                    },
+                    #{Value}::Map(mut entries) if entries.len() == 1 => {
+                        let (key, value) = entries.pop().expect("length checked");
+                        let key = match key {
+                            #{Value}::String(key) => key,
+                            _ => return #{Err}("union variant names must be strings".to_string()),
+                        };
+                        match key.as_str() {
+                            #{Variants}
+                            _ => #{Err}("unknown union variant".to_string()),
+                        }
+                    },
+                    _ => #{Err}("expected an externally tagged union".to_string()),
+                }
+                """,
+                "Value" to dynamicValue(),
+                "UnitVariants" to
+                    writable {
+                        shape.members().filter(MemberShape::isTargetUnit).forEach { member ->
+                            rustTemplate(
+                                "${member.memberName.dq()} => #{Ok}(#{Return}::${symbolProvider.toMemberName(member)}),",
+                                "Return" to info.symbol,
+                                *RuntimeType.preludeScope,
+                            )
+                        }
+                    },
+                "Variants" to
+                    writable {
+                        shape.members().forEach { member ->
+                            renderUnionVariant(member, info)
+                        }
+                    },
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    private fun RustWriter.renderUnionVariant(
+        member: MemberShape,
+        unionInfo: ReturnSymbolToParse,
+    ) {
+        val variant = symbolProvider.toMemberName(member)
+        if (member.isTargetUnit()) {
+            rustTemplate(
+                """
+                ${member.memberName.dq()} => match value {
+                    #{Value}::Null => #{Ok}(#{Return}::$variant),
+                    _ => #{Err}("unit union variants must contain null".to_string()),
+                },
+                """,
+                "Value" to dynamicValue(),
+                "Return" to unionInfo.symbol,
+                *RuntimeType.preludeScope,
+            )
+        } else {
+            val target = model.expectShape(member.target)
+            val targetInfo = parseInfo(target)
+            rustTemplate(
+                """
+                ${member.memberName.dq()} => {
+                    let parsed = #{TargetParser}(value, settings)
+                        .map_err(|err| format!("invalid union variant `${member.memberName}`: {err}"))?;
+                    #{Prepare}
+                    #{Ok}(#{Return}::$variant(parsed))
+                },
+                """,
+                "TargetParser" to parser(target),
+                "Prepare" to
+                    prepareMember(
+                        model.expectShape(member.container),
+                        target,
+                        targetInfo,
+                        member.hasTrait<RustBoxTrait>(),
+                    ),
+                "Return" to unionInfo.symbol,
+                *RuntimeType.preludeScope,
+            )
+        }
+    }
+
+    private fun RustWriter.renderNominalDeserializeImpl(
+        shape: Shape,
+        info: ReturnSymbolToParse,
+    ) {
+        val finalSymbol = symbolProvider.toSymbol(shape)
+        val seedName = shape.contextName(codegenContext.serviceShape).toPascalCase() + "Seed"
+        rustTemplate(
+            """
+            struct $seedName<'a> {
+                settings: &'a #{DeserializationSettings},
+            }
+
+            impl<'de> #{serde}::de::DeserializeSeed<'de> for $seedName<'_> {
+                type Value = #{Final};
+
+                fn deserialize<D>(self, deserializer: D) -> #{Result}<Self::Value, D::Error>
+                where
+                    D: #{serde}::Deserializer<'de>,
+                {
+                    let value = <#{Value} as #{serde}::Deserialize>::deserialize(deserializer)?;
+                    let parsed = ${parseFunctionName(shape)}(value, self.settings)
+                        .map_err(<D::Error as #{serde}::de::Error>::custom)?;
+                    #{Finalize}
+                }
+            }
+
+            impl<'de> #{serde}::Deserialize<'de> for #{Final} {
+                fn deserialize<D>(deserializer: D) -> #{Result}<Self, D::Error>
+                where
+                    D: #{serde}::Deserializer<'de>,
+                {
+                    let settings = #{DeserializationSettings}::current();
+                    #{serde}::de::DeserializeSeed::deserialize(
+                        $seedName { settings: &settings },
+                        deserializer,
+                    )
+                }
+            }
+            """,
+            "Value" to dynamicValue(),
+            "Final" to finalSymbol,
+            "Finalize" to
+                writable {
+                    if (requiresConversion(info, shape)) {
+                        rustTemplate(
+                            """
+                            let parsed = <#{Final} as #{TryFrom}<#{Parsed}>>::try_from(parsed)
+                                .map_err(<D::Error as #{serde}::de::Error>::custom)?;
+                            #{Ok}(parsed)
+                            """,
+                            "Final" to finalSymbol,
+                            "Parsed" to info.symbol,
+                            *SupportStructures.codegenScope,
+                            *RuntimeType.preludeScope,
+                        )
+                    } else {
+                        rustTemplate("#{Ok}(parsed)", *RuntimeType.preludeScope)
+                    }
+                },
+            *SupportStructures.codegenScope,
+            *RuntimeType.preludeScope,
+        )
+    }
+
+    private fun requiresConversion(
+        info: ReturnSymbolToParse,
+        finalShape: Shape,
+    ): Boolean =
+        info.isUnconstrained &&
+            info.symbol.rustType() != symbolProvider.toSymbol(finalShape).rustType()
+
+    private fun dynamicValue(): RuntimeType =
+        RuntimeType.forInlineFun("SerdeDeserializeValue", DeserializerModule) {
+            rustTemplate(
+                """
+                ##[allow(dead_code)]
+                enum SerdeDeserializeValue {
+                    Null,
+                    Bool(bool),
+                    I64(i64),
+                    U64(u64),
+                    F64(f64),
+                    String(#{String}),
+                    Bytes(#{Vec}<u8>),
+                    Seq(#{Vec}<SerdeDeserializeValue>),
+                    Map(#{Vec}<(SerdeDeserializeValue, SerdeDeserializeValue)>),
+                }
+
+                struct SerdeDeserializeValueVisitor;
+
+                impl<'de> #{serde}::de::Visitor<'de> for SerdeDeserializeValueVisitor {
+                    type Value = SerdeDeserializeValue;
+
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        formatter.write_str("a Serde value")
+                    }
+
+                    fn visit_unit<E>(self) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::Null) }
+                    fn visit_none<E>(self) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::Null) }
+                    fn visit_bool<E>(self, value: bool) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::Bool(value)) }
+                    fn visit_i8<E>(self, value: i8) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value as i64)) }
+                    fn visit_i16<E>(self, value: i16) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value as i64)) }
+                    fn visit_i32<E>(self, value: i32) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value as i64)) }
+                    fn visit_i64<E>(self, value: i64) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::I64(value)) }
+                    fn visit_u8<E>(self, value: u8) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value as u64)) }
+                    fn visit_u16<E>(self, value: u16) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value as u64)) }
+                    fn visit_u32<E>(self, value: u32) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value as u64)) }
+                    fn visit_u64<E>(self, value: u64) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::U64(value)) }
+                    fn visit_f32<E>(self, value: f32) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::F64(value as f64)) }
+                    fn visit_f64<E>(self, value: f64) -> #{Result}<SerdeDeserializeValue, E> { #{Ok}(SerdeDeserializeValue::F64(value)) }
+
+                    fn visit_str<E>(self, value: &str) -> #{Result}<SerdeDeserializeValue, E>
+                    where
+                        E: #{serde}::de::Error,
+                    {
+                        #{Ok}(SerdeDeserializeValue::String(value.to_string()))
+                    }
+
+                    fn visit_string<E>(self, value: #{String}) -> #{Result}<SerdeDeserializeValue, E> {
+                        #{Ok}(SerdeDeserializeValue::String(value))
+                    }
+
+                    fn visit_bytes<E>(self, value: &[u8]) -> #{Result}<SerdeDeserializeValue, E> {
+                        #{Ok}(SerdeDeserializeValue::Bytes(value.to_vec()))
+                    }
+
+                    fn visit_byte_buf<E>(self, value: #{Vec}<u8>) -> #{Result}<SerdeDeserializeValue, E> {
+                        #{Ok}(SerdeDeserializeValue::Bytes(value))
+                    }
+
+                    fn visit_some<D>(self, deserializer: D) -> #{Result}<SerdeDeserializeValue, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        <SerdeDeserializeValue as #{serde}::Deserialize>::deserialize(deserializer)
+                    }
+
+                    fn visit_newtype_struct<D>(self, deserializer: D) -> #{Result}<SerdeDeserializeValue, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        <SerdeDeserializeValue as #{serde}::Deserialize>::deserialize(deserializer)
+                    }
+
+                    fn visit_seq<A>(self, mut seq: A) -> #{Result}<SerdeDeserializeValue, A::Error>
+                    where
+                        A: #{serde}::de::SeqAccess<'de>,
+                    {
+                        let mut values = #{Vec}::with_capacity(seq.size_hint().unwrap_or(0));
+                        while let #{Some}(value) = seq.next_element()? {
+                            values.push(value);
+                        }
+                        #{Ok}(SerdeDeserializeValue::Seq(values))
+                    }
+
+                    fn visit_map<A>(self, mut map: A) -> #{Result}<SerdeDeserializeValue, A::Error>
+                    where
+                        A: #{serde}::de::MapAccess<'de>,
+                    {
+                        let mut entries = #{Vec}::with_capacity(map.size_hint().unwrap_or(0));
+                        while let #{Some}(entry) = map.next_entry()? {
+                            entries.push(entry);
+                        }
+                        #{Ok}(SerdeDeserializeValue::Map(entries))
+                    }
+                }
+
+                impl<'de> #{serde}::Deserialize<'de> for SerdeDeserializeValue {
+                    fn deserialize<D>(deserializer: D) -> #{Result}<Self, D::Error>
+                    where
+                        D: #{serde}::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(SerdeDeserializeValueVisitor)
+                    }
+                }
+                """,
+                *SupportStructures.codegenScope,
+                *RuntimeType.preludeScope,
+            )
+        }
+
+    companion object {
+        private val DeserializerModule = RustModule.pubCrate("de", parent = SerdeModule)
+    }
+}

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecorator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecorator.kt
@@ -6,7 +6,14 @@
 package software.amazon.smithy.rust.codegen.serde
 
 import software.amazon.smithy.model.neighbor.Walker
+import software.amazon.smithy.model.shapes.EnumShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
@@ -14,6 +21,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.Feature
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
@@ -23,7 +31,7 @@ val SerdeModule =
     RustModule.public(
         "serde",
         additionalAttributes = listOf(Attribute.featureGate(SerdeFeature.name)),
-        documentationOverride = "Implementations of `serde` for model types. NOTE: These implementations are NOT used for wire serialization as part of a Smithy protocol and WILL NOT match the wire format. They are provided for convenience only.",
+        documentationOverride = "Configurable `serde` serialization and deserialization support for model types. These conversions are provided for convenience only. They are not used for Smithy protocol wire serialization or deserialization and are not guaranteed to match any protocol wire format.",
     )
 
 class ClientSerdeDecorator : ClientCodegenDecorator {
@@ -51,16 +59,26 @@ private fun extrasCommon(
     codegenContext: CodegenContext,
     rustCrate: RustCrate,
 ) {
-    val roots = serializationRoots(codegenContext)
-    if (roots.isNotEmpty()) {
+    val serializationRoots = serializationRoots(codegenContext)
+    val deserializationRoots = deserializationRoots(codegenContext)
+    if (serializationRoots.isNotEmpty() || deserializationRoots.isNotEmpty()) {
         rustCrate.mergeFeature(SerdeFeature)
-        val generator = SerializeImplGenerator(codegenContext)
         rustCrate.withModule(SerdeModule) {
-            roots.forEach {
-                generator.generateRootSerializerForShape(it)(this)
+            if (serializationRoots.isNotEmpty()) {
+                val generator = SerializeImplGenerator(codegenContext)
+                serializationRoots.forEach {
+                    generator.generateRootSerializerForShape(it)(this)
+                }
+                addDependency(SupportStructures.serializeRedacted().toSymbol())
+                addDependency(SupportStructures.serializeUnredacted().toSymbol())
             }
-            addDependency(SupportStructures.serializeRedacted().toSymbol())
-            addDependency(SupportStructures.serializeUnredacted().toSymbol())
+            if (deserializationRoots.isNotEmpty()) {
+                val generator = DeserializeImplGenerator(codegenContext)
+                deserializationRoots.forEach {
+                    generator.generateRootDeserializerForShape(it)(this)
+                }
+                addDependency(SupportStructures.serdeDependency().toSymbol())
+            }
         }
     }
 }
@@ -69,7 +87,27 @@ private fun extrasCommon(
  * All entry points for serialization in the service closure.
  */
 fun serializationRoots(ctx: CodegenContext): List<Shape> {
-    val serviceShape = ctx.serviceShape
-    val walker = Walker(ctx.model)
-    return walker.walkShapes(serviceShape).filter { it.hasTrait<SerdeTrait>() }
+    return serdeRoots(ctx) { it.serialize }
 }
+
+/**
+ * All nominal entry points for deserialization in the service closure.
+ */
+fun deserializationRoots(ctx: CodegenContext): List<Shape> =
+    serdeRoots(ctx) { it.deserialize }
+        .filter {
+            it is StructureShape ||
+                it is UnionShape ||
+                it is EnumShape ||
+                (it is StringShape && it.hasTrait<EnumTrait>()) ||
+                it is OperationShape ||
+                it is ServiceShape
+        }
+
+private fun serdeRoots(
+    ctx: CodegenContext,
+    directionEnabled: (SerdeTrait) -> Boolean,
+): List<Shape> =
+    Walker(ctx.model)
+        .walkShapes(ctx.serviceShape)
+        .filter { shape -> shape.getTrait<SerdeTrait>()?.let(directionEnabled) == true }

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
@@ -91,6 +91,9 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
             return writable {
                 serializerFn(model.expectShape(shape.inputShape), null)(this)
                 serializerFn(model.expectShape(shape.outputShape), null)(this)
+                shape.errors.forEach {
+                    serializerFn(model.expectShape(it), null)(this)
+                }
             }
         }
         val name = codegenContext.symbolProvider.shapeFunctionName(codegenContext.serviceShape, shape) + "_serde"

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SupportStructures.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SupportStructures.kt
@@ -27,11 +27,14 @@ object SupportStructures {
             "SerializeConfigured" to serializeConfigured(),
             "ConfigurableSerdeRef" to configurableSerdeRef(),
             "SerializationSettings" to serializationSettings(),
+            "DeserializationSettings" to deserializationSettings(),
             "Sensitive" to sensitive(),
             "serde" to serde,
             "serialize_redacted" to serializeRedacted(),
             "serialize_unredacted" to serializeUnredacted(),
         )
+
+    fun serdeDependency(): RuntimeType = serde
 
     fun serializeRedacted(): RuntimeType =
         RuntimeType.forInlineFun("serialize_redacted", supportModule) {
@@ -241,6 +244,64 @@ object SupportStructures {
                     pub const fn leak_sensitive_fields() -> Self { Self { redact_sensitive_fields: false, out_of_range_floats_as_strings: false } }
                 }
                 """,
+            )
+        }
+
+    private fun deserializationSettings() =
+        RuntimeType.forInlineFun("DeserializationSettings", supportModule) {
+            rustTemplate(
+                """
+                /// Settings for use when deserializing structures.
+                ##[non_exhaustive]
+                ##[derive(Clone, Debug, Default)]
+                pub struct DeserializationSettings {
+                    /// Accept `NaN`, `Infinity`, and `-Infinity` strings as floating-point values.
+                    pub allow_non_finite_float_strings: bool,
+                }
+
+                #{thread_local}! {
+                    static DESERIALIZATION_SETTINGS: #{RefCell}<#{Vec}<DeserializationSettings>> =
+                        const { #{RefCell}::new(#{Vec}::new()) };
+                }
+
+                struct DeserializationSettingsScopeGuard;
+
+                impl #{Drop} for DeserializationSettingsScopeGuard {
+                    fn drop(&mut self) {
+                        DESERIALIZATION_SETTINGS.with(|settings| {
+                            let _ = settings.borrow_mut().pop();
+                        });
+                    }
+                }
+
+                impl DeserializationSettings {
+                    /// Run `f` with these settings active for generated `Deserialize` implementations.
+                    ///
+                    /// Scopes may be nested. The previous settings are restored even if `f` panics.
+                    /// Outside a scope, generated implementations use `DeserializationSettings::default()`.
+                    ///
+                    /// This scope is synchronous. If `f` returns a future, these settings will not remain
+                    /// active while that future is polled.
+                    pub fn scope<R>(&self, f: impl #{FnOnce}() -> R) -> R {
+                        DESERIALIZATION_SETTINGS.with(|settings| {
+                            settings.borrow_mut().push(self.clone());
+                        });
+                        let _guard = DeserializationSettingsScopeGuard;
+                        f()
+                    }
+
+                    /// Return an owned snapshot of the settings active on this thread.
+                    pub(crate) fn current() -> Self {
+                        DESERIALIZATION_SETTINGS.with(|settings| {
+                            let settings = settings.borrow();
+                            settings.last().cloned().unwrap_or_default()
+                        })
+                    }
+                }
+                """,
+                "thread_local" to RuntimeType.std.resolve("thread_local"),
+                "RefCell" to RuntimeType.std.resolve("cell::RefCell"),
+                *RuntimeType.preludeScope,
             )
         }
 }

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/Traits.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/Traits.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.rust.codegen.serde
 
-import software.amazon.smithy.build.SmithyBuildException
 import software.amazon.smithy.model.SourceLocation
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ShapeId
@@ -14,8 +13,8 @@ import software.amazon.smithy.model.traits.Trait
 import software.amazon.smithy.rust.codegen.core.util.orNull
 
 class SerdeTrait constructor(
-    private val serialize: Boolean,
-    private val deserialize: Boolean,
+    val serialize: Boolean,
+    val deserialize: Boolean,
     private val tag: String?,
     private val content: String?,
     sourceLocation: SourceLocation,
@@ -42,9 +41,6 @@ class SerdeTrait constructor(
                     val deserialize = getBooleanMemberOrDefault("deserialize", false)
                     val tag = getStringMember("tag").orNull()?.value
                     val content = getStringMember("content").orNull()?.value
-                    if (deserialize) {
-                        throw SmithyBuildException("deserialize is not currently supported.")
-                    }
                     val result =
                         SerdeTrait(
                             serialize,

--- a/codegen-serde/src/main/resources/META-INF/smithy/serde.smithy
+++ b/codegen-serde/src/main/resources/META-INF/smithy/serde.smithy
@@ -5,8 +5,10 @@ namespace smithy.rust
 @documentation(
     "Indicates a shape should support Rust's [serde](https://serde.rs/) library.
   When a shape is marked with this trait, the generator in this package will auto-generate
-  implementations of the `serde::ser::Serialize` trait. Support for `Deserialize` is currently
-   unsupported. When applied to a service, all shapes in the service closure will implement these traits."
+  configurable serialization and deserialization support. This support is provided for convenience
+  only. It is not used for Smithy protocol wire serialization or deserialization, and its
+  representations are not guaranteed to match any protocol wire format. When applied to a service,
+  all supported shapes in the service closure will support the enabled directions."
 )
 @trait(selector: ":is(structure, union, enum, string, map, service, operation)")
 @internal
@@ -14,6 +16,6 @@ structure serde {
     @documentation("Generate support for serde::ser::Serialize")
     serialize: Boolean = true
 
-    @documentation("Generate support for serde::ser::Deserialize. This is not currently supported.")
+    @documentation("Generate support for serde deserialization.")
     deserialize: Boolean = false
 }

--- a/codegen-serde/src/main/resources/META-INF/smithy/serde.smithy
+++ b/codegen-serde/src/main/resources/META-INF/smithy/serde.smithy
@@ -10,7 +10,7 @@ namespace smithy.rust
   representations are not guaranteed to match any protocol wire format. When applied to a service,
   all supported shapes in the service closure will support the enabled directions."
 )
-@trait(selector: ":is(structure, union, enum, string, map, service, operation)")
+@trait(selector: ":is(structure, union, enum, string, service, operation)")
 @internal
 structure serde {
     @documentation("Generate support for serde::ser::Serialize")

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
@@ -421,6 +421,11 @@ class SerdeDecoratorTest {
                         assert_eq!(value.float, Some(1.5));
                         assert_eq!(value.double, Some(2.5));
                         assert_eq!(value.defaulted, 7);
+
+                        let value: Payload = #{serde_json}::from_str(
+                            r##"{"message":null}"##
+                        ).expect("null optional field should deserialize");
+                        assert_eq!(value.message, None);
                         """,
                         *codegenScope,
                     )
@@ -533,6 +538,136 @@ class SerdeDecoratorTest {
                             )
                         }).expect("failed to deserialize customer-owned envelope");
                         assert_eq!(envelope.payload.float, Some(f32::INFINITY));
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `all-required structure round trips through bincode`() {
+        val model =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            service BincodeService {
+                operations: [Put]
+            }
+
+            operation Put {
+                input: PutInput
+            }
+
+            structure PutInput {
+                record: BincodeRecord
+            }
+
+            @serde(serialize: true, deserialize: true)
+            structure BincodeRecord {
+                @required
+                nested: Nested
+                @required
+                text: String
+                @required
+                count: Integer
+                @required
+                ratio: Float
+                @required
+                labels: Labels
+                @required
+                counts: Counts
+                @required
+                kind: Kind
+                @required
+                choice: Choice
+            }
+
+            structure Nested {
+                @required
+                label: String
+                @required
+                number: Integer
+            }
+
+            list Labels {
+                member: String
+            }
+
+            map Counts {
+                key: String
+                value: Integer
+            }
+
+            enum Kind {
+                A
+                B
+            }
+
+            union Choice {
+                text: String
+                empty: Unit
+            }
+            """.asSmithyModel(smithyVersion = "2")
+
+        clientIntegrationTest(
+            model,
+            params =
+                IntegrationTestParams(
+                    cargoCommand = "cargo test --all-features",
+                    service = "com.example#BincodeService",
+                ),
+        ) { ctx, crate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(ctx.moduleUseName()),
+                    "bincode" to CargoDependency("bincode", CratesIo("1")).toDevDependency().toType(),
+                )
+
+            crate.integrationTest("test_bincode_deserialization") {
+                unitTest("all_required_structure_round_trips") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::{SerializationSettings, SerializeConfigured};
+                        use #{crate}::types::{BincodeRecord, Choice, Kind, Nested};
+
+                        fn record(choice: Choice) -> BincodeRecord {
+                            BincodeRecord::builder()
+                                .nested(
+                                    Nested::builder()
+                                        .label("nested")
+                                        .number(7)
+                                        .build()
+                                        .expect("nested structure should build")
+                                )
+                                .text("root")
+                                .count(42)
+                                .ratio(1.5)
+                                .labels("one")
+                                .labels("two")
+                                .counts("first", 1)
+                                .counts("second", 2)
+                                .kind(Kind::A)
+                                .choice(choice)
+                                .build()
+                                .expect("record should build")
+                        }
+
+                        fn round_trip(value: BincodeRecord) {
+                            let settings = SerializationSettings::default();
+                            let encoded = #{bincode}::serialize(&value.serialize_ref(&settings))
+                                .expect("record should serialize");
+                            let decoded: BincodeRecord = #{bincode}::deserialize(&encoded)
+                                .expect("record should deserialize");
+                            assert_eq!(decoded, value);
+                        }
+
+                        round_trip(record(Choice::Text("payload".to_string())));
+                        round_trip(record(Choice::Empty));
                         """,
                         *codegenScope,
                     )

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
@@ -51,7 +51,7 @@ class SerdeDecoratorTest {
             member: Recursive
         }
 
-        @serde
+        @serde(deserialize: true)
         operation Streaming {
             input: StreamingInput
             errors: [ValidationException]
@@ -65,7 +65,7 @@ class SerdeDecoratorTest {
         @streaming
         blob StreamingBlob
 
-        @serde
+        @serde(deserialize: true)
         structure TestInput {
            foo: SensitiveString,
            e: TestEnum,
@@ -263,6 +263,284 @@ class SerdeDecoratorTest {
         }
     }
 
+    @Test
+    fun `serialize and deserialize flags independently control the serde feature`() {
+        val serializeOnlyModel =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            service SerializeOnlyService {
+                operations: [UseSerializeOnly]
+            }
+
+            operation UseSerializeOnly {
+                input: UseSerializeOnlyInput
+            }
+
+            structure UseSerializeOnlyInput {
+                value: SerializeOnly
+            }
+
+            @serde(serialize: true, deserialize: false)
+            structure SerializeOnly {
+                value: String
+            }
+            """.asSmithyModel(smithyVersion = "2")
+
+        clientIntegrationTest(
+            serializeOnlyModel,
+            params =
+                IntegrationTestParams(
+                    cargoCommand = "cargo test --all-features",
+                    service = "com.example#SerializeOnlyService",
+                ),
+        ) { ctx, crate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(ctx.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                )
+
+            crate.integrationTest("test_serialize_only") {
+                unitTest("explicit_serialize_only") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::{SerializationSettings, SerializeConfigured};
+                        use #{crate}::types::SerializeOnly;
+
+                        let value = SerializeOnly::builder().value("hello").build();
+                        let json = #{serde_json}::to_string(
+                            &value.serialize_ref(&SerializationSettings::default())
+                        ).expect("failed to serialize");
+                        assert_eq!(json, r##"{"value":"hello"}"##);
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+
+        val disabledModel =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            service DisabledService {
+                operations: [Disabled]
+            }
+
+            operation Disabled {
+                input: DisabledInput
+            }
+
+            @serde(serialize: false, deserialize: false)
+            structure DisabledInput {}
+            """.asSmithyModel(smithyVersion = "2")
+
+        clientIntegrationTest(
+            disabledModel,
+            params =
+                IntegrationTestParams(
+                    cargoCommand = "cargo test --all-features",
+                    service = "com.example#DisabledService",
+                ),
+        ) { _, crate ->
+            crate.integrationTest("test_disabled_serde") {
+                rust("##![allow(unexpected_cfgs)]")
+                unitTest(
+                    "fails_if_serde_feature_exists",
+                    additionalAttributes = listOf(Attribute(cfg(feature("serde")))),
+                ) {
+                    rust("assert!(false);")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `deserialize supports JSON and scoped settings`() {
+        val model =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            service DeserializationService {
+                operations: [ExerciseDeserialization]
+            }
+
+            operation ExerciseDeserialization {
+                input: ExerciseDeserializationInput
+            }
+
+            structure ExerciseDeserializationInput {
+                payload: Payload
+            }
+
+            @serde(serialize: false, deserialize: true)
+            structure Payload {
+                message: String
+                float: Float
+                double: Double
+                defaulted: Integer = 7
+            }
+            """.asSmithyModel(smithyVersion = "2")
+
+        clientIntegrationTest(
+            model,
+            params =
+                IntegrationTestParams(
+                    cargoCommand = "cargo test --all-features",
+                    service = "com.example#DeserializationService",
+                ),
+        ) { ctx, crate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(ctx.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                    "serde_derive" to
+                        CargoDependency("serde_derive", CratesIo("1")).toDevDependency().toType(),
+                )
+
+            crate.integrationTest("test_deserialization_api") {
+                unitTest("ordinary_json_deserialize") {
+                    rustTemplate(
+                        """
+                        use #{crate}::types::Payload;
+
+                        let value: Payload = #{serde_json}::from_str(
+                            r##"{"message":"hello","float":1.5,"double":2.5}"##
+                        ).expect("failed to deserialize");
+                        assert_eq!(value.message.as_deref(), Some("hello"));
+                        assert_eq!(value.float, Some(1.5));
+                        assert_eq!(value.double, Some(2.5));
+                        assert_eq!(value.defaulted, 7);
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("default_and_configured_non_finite_float_strings") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::DeserializationSettings;
+                        use #{crate}::types::Payload;
+
+                        let json = r##"{"float":"Infinity","double":"NaN"}"##;
+                        assert!(#{serde_json}::from_str::<Payload>(json).is_err());
+
+                        let mut settings = DeserializationSettings::default();
+                        settings.allow_non_finite_float_strings = true;
+                        let value = settings.scope(|| #{serde_json}::from_str::<Payload>(json))
+                            .expect("configured non-finite floats should deserialize");
+                        assert_eq!(value.float, Some(f32::INFINITY));
+                        assert!(value.double.expect("double should be set").is_nan());
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("nested_scopes_restore_previous_settings") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::DeserializationSettings;
+                        use #{crate}::types::Payload;
+
+                        let parses_non_finite = || {
+                            #{serde_json}::from_str::<Payload>(
+                                r##"{"float":"-Infinity"}"##
+                            ).is_ok()
+                        };
+                        let mut enabled = DeserializationSettings::default();
+                        enabled.allow_non_finite_float_strings = true;
+                        let disabled = DeserializationSettings::default();
+
+                        assert!(!parses_non_finite());
+                        enabled.scope(|| {
+                            assert!(parses_non_finite());
+                            disabled.scope(|| assert!(!parses_non_finite()));
+                            assert!(parses_non_finite());
+                        });
+                        assert!(!parses_non_finite());
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("panicking_scope_restores_previous_settings") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::DeserializationSettings;
+                        use #{crate}::types::Payload;
+
+                        let mut enabled = DeserializationSettings::default();
+                        enabled.allow_non_finite_float_strings = true;
+                        let panic = std::panic::catch_unwind(|| {
+                            enabled.scope(|| panic!("expected panic"));
+                        });
+                        assert!(panic.is_err());
+                        assert!(#{serde_json}::from_str::<Payload>(
+                            r##"{"double":"Infinity"}"##
+                        ).is_err());
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("scoped_settings_do_not_cross_threads") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::DeserializationSettings;
+                        use #{crate}::types::Payload;
+
+                        let mut enabled = DeserializationSettings::default();
+                        enabled.allow_non_finite_float_strings = true;
+                        let child_result = enabled.scope(|| {
+                            std::thread::spawn(|| {
+                                #{serde_json}::from_str::<Payload>(
+                                    r##"{"float":"Infinity"}"##
+                                )
+                            }).join().expect("child thread should not panic")
+                        });
+                        assert!(child_result.is_err());
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("customer_owned_derive_envelope_uses_scoped_settings") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::DeserializationSettings;
+                        use #{crate}::types::Payload;
+
+                        ##[derive(#{serde_derive}::Deserialize)]
+                        struct Envelope {
+                            payload: Payload,
+                        }
+
+                        let mut settings = DeserializationSettings::default();
+                        settings.allow_non_finite_float_strings = true;
+                        let envelope = settings.scope(|| {
+                            #{serde_json}::from_str::<Envelope>(
+                                r##"{"payload":{"float":"Infinity"}}"##
+                            )
+                        }).expect("failed to deserialize customer-owned envelope");
+                        assert_eq!(envelope.payload.float, Some(f32::INFINITY));
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
     val onlyConstrained =
         """
         namespace com.example
@@ -311,11 +589,37 @@ class SerdeDecoratorTest {
                 arrayOf(
                     "crate" to RustType.Opaque(ctx.moduleUseName()),
                     "serde_json" to CargoDependency("serde_json", CratesIo("1")).toDevDependency().toType(),
+                    "ciborium" to CargoDependency.Ciborium.toType(),
                     // we need the derive feature
                     "serde" to CargoDependency.Serde.toDevDependency().toType(),
                 )
 
             crate.integrationTest("test_serde") {
+                unitTest("input_deserialized_from_json_and_cbor") {
+                    rustTemplate(
+                        """
+                        use #{crate}::input::SayHelloInput;
+                        use #{crate}::model::{EnumKeyedMap, Nested, Recursive, TestEnum, U};
+                        fn assert_enum_map(map: &EnumKeyedMap) {
+                            assert_eq!(map.inner().get(&TestEnum::A), Some(&TestEnum::B));
+                        }
+                        fn assert_collections(nested: &Nested, recursive: &Recursive) {
+                            assert_eq!(
+                                nested.many_enums(),
+                                Some([TestEnum::A, TestEnum::B].as_slice())
+                            );
+                            let sparse = nested.sparse().expect("sparse list");
+                            assert_eq!(sparse, [None, Some(TestEnum::B)].as_slice());
+                            let children = recursive.inner().expect("recursive children");
+                            assert_eq!(children.len(), 1);
+                            assert!(children[0].inner().is_none());
+                        }
+                        $roundTripDeserializationTest
+                        """,
+                        *codegenScope,
+                    )
+                }
+
                 unitTest("input_serialized") {
                     rustTemplate(
                         """
@@ -369,6 +673,16 @@ class SerdeDecoratorTest {
                         let serialized = #{serde_json}::to_string(&input.serialize_ref(&settings)).expect("failed to serialize");
                         assert_eq!(serialized, ${expectedStreaming.dq()});
 
+                        let deserialized: StreamingInput =
+                            #{serde_json}::from_str(&serialized).expect("failed to deserialize JSON");
+                        assert_eq!(deserialized.data().bytes(), Some(b"123".as_slice()));
+
+                        let mut serialized = Vec::new();
+                        #{ciborium}::ser::into_writer(&input.serialize_ref(&settings), &mut serialized)
+                            .expect("failed to serialize CBOR");
+                        let deserialized: StreamingInput = #{ciborium}::de::from_reader(serialized.as_slice())
+                            .expect("failed to deserialize CBOR");
+                        assert_eq!(deserialized.data().bytes(), Some(b"123".as_slice()));
                         """,
                         *codegenScope,
                     )
@@ -459,6 +773,82 @@ class SerdeDecoratorTest {
 
     private val expectedStreaming = """{"data":"MTIz"}"""
 
+    private val roundTripDeserializationTest =
+        """
+        fn assert_input(input: &SayHelloInput) {
+            assert_eq!(input.foo(), Some("foo-value"));
+            assert_eq!(input.e(), Some(&TestEnum::A));
+            assert_eq!(input.float(), Some(1.25));
+            assert_eq!(input.double(), Some(2.5));
+            assert_eq!(input.blob().expect("blob").as_ref(), b"hello");
+
+            let nested = input.nested().expect("nested structure");
+            assert_eq!(nested.int(), 5);
+            assert_eq!(
+                nested.not_sensitive().expect("timestamp map")["epoch"].secs(),
+                0
+            );
+
+            let sparse_map = nested.map().expect("sparse map");
+            assert!(matches!(sparse_map.get("missing"), Some(None)));
+            assert_eq!(
+                sparse_map["present"].as_ref().expect("present sparse value")["epoch"].secs(),
+                0
+            );
+
+            match input.union().expect("union") {
+                U::Nested(value) => assert_eq!(value.int(), 7),
+                other => panic!("unexpected union variant: {other:?}"),
+            }
+            assert_eq!(
+                input.document()
+                    .expect("document")
+                    .as_object()
+                    .expect("document object")["message"]
+                    .as_string(),
+                Some("hello")
+            );
+            assert_enum_map(input.map().expect("enum-keyed map"));
+
+            let recursive = input.recursive().expect("recursive structure");
+            assert_collections(nested, recursive);
+        }
+
+        let json = r##"{
+            "foo":"foo-value",
+            "e":"A",
+            "nested":{
+                "int":5,
+                "notSensitive":{"epoch":"1970-01-01T00:00:00Z"},
+                "manyEnums":["A","B"],
+                "sparse":[null,"B"],
+                "map":{
+                    "missing":null,
+                    "present":{"epoch":"1970-01-01T00:00:00Z"}
+                }
+            },
+            "union":{"nested":{"int":7}},
+            "document":{"message":"hello"},
+            "blob":"aGVsbG8=",
+            "recursive":{"inner":[{}]},
+            "map":{"A":"B"},
+            "float":1.25,
+            "double":2.5
+        }"##;
+
+        let from_json: SayHelloInput =
+            #{serde_json}::from_str(json).expect("failed to deserialize JSON");
+        assert_input(&from_json);
+
+        let cbor_value: #{serde_json}::Value =
+            #{serde_json}::from_str(json).expect("failed to construct CBOR value");
+        let mut cbor = Vec::new();
+        #{ciborium}::ser::into_writer(&cbor_value, &mut cbor).expect("failed to encode CBOR");
+        let from_cbor: SayHelloInput = #{ciborium}::de::from_reader(cbor.as_slice())
+            .expect("failed to deserialize CBOR");
+        assert_input(&from_cbor);
+        """
+
     @Test
     fun generateSerializersThatWorkClient() {
         val path =
@@ -473,6 +863,35 @@ class SerdeDecoratorTest {
                     )
 
                 crate.integrationTest("test_serde") {
+                    unitTest("input_deserialized_from_json_and_cbor") {
+                        rustTemplate(
+                            """
+                            use #{crate}::operation::say_hello::SayHelloInput;
+                            use #{crate}::types::{Nested, Recursive, TestEnum, U};
+                            fn assert_enum_map(
+                                map: &std::collections::HashMap<TestEnum, TestEnum>
+                            ) {
+                                assert_eq!(map.get(&TestEnum::A), Some(&TestEnum::B));
+                            }
+                            fn assert_collections(nested: &Nested, recursive: &Recursive) {
+                                assert_eq!(
+                                    nested.many_enums(),
+                                    [TestEnum::A, TestEnum::B].as_slice()
+                                );
+                                assert_eq!(
+                                    nested.sparse(),
+                                    [None, Some(TestEnum::B)].as_slice()
+                                );
+                                let children = recursive.inner();
+                                assert_eq!(children.len(), 1);
+                                assert!(children[0].inner().is_empty());
+                            }
+                            $roundTripDeserializationTest
+                            """,
+                            *codegenScope,
+                        )
+                    }
+
                     unitTest("input_serialized") {
                         rustTemplate(
                             """
@@ -525,6 +944,13 @@ class SerdeDecoratorTest {
                             let settings = SerializationSettings::default();
                             let serialized = #{serde_json}::to_string(&input.serialize_ref(&settings)).expect("failed to serialize");
                             assert_eq!(serialized, ${expectedStreaming.dq()});
+
+                            let deserialized: StreamingInput =
+                                #{serde_json}::from_str(&serialized).expect("failed to deserialize JSON");
+                            assert_eq!(deserialized.data().bytes(), Some(b"123".as_slice()));
+                            assert!(#{serde_json}::from_str::<StreamingInput>(
+                                r##"{"data":"streaming data"}"##
+                            ).is_err());
                             """,
                             *codegenScope,
                         )
@@ -567,6 +993,11 @@ class SerdeDecoratorTest {
                             #{ciborium}::ser::into_writer(&input.serialize_ref(&settings), &mut serialized)
                                 .expect("failed to serialize input into CBOR format using `ciborium`");
                             assert_eq!(serialized, b"\xa1ddataC123");
+
+                            let deserialized: StreamingInput =
+                                #{ciborium}::de::from_reader(serialized.as_slice())
+                                    .expect("failed to deserialize CBOR");
+                            assert_eq!(deserialized.data().bytes(), Some(b"123".as_slice()));
                             """,
                             *codegenScope,
                         )

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
@@ -6,7 +6,9 @@
 package software.amazon.smithy.rust.codegen.serde
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.validation.ValidatedResultException
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute.Companion.cfg
@@ -183,6 +185,22 @@ class SerdeDecoratorTest {
         }
         structure NotSerde {}
         """.asSmithyModel(smithyVersion = "2")
+
+    @Test
+    fun `serde trait cannot be applied directly to maps`() {
+        assertThrows<ValidatedResultException> {
+            """
+            namespace com.example
+            use smithy.rust#serde
+
+            @serde(deserialize: true)
+            map Values {
+                key: String
+                value: String
+            }
+            """.asSmithyModel(smithyVersion = "2")
+        }
+    }
 
     @Test
     fun `decorator should traverse resources`() {

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.serde
 
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.smithy.model.Model
@@ -13,17 +14,58 @@ import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
 import java.io.File
 
 class SerdeProtocolTestTest {
+    private val behaviorModel =
+        """
+        namespace com.example
+        use smithy.rust#serde
+        use aws.protocols#awsJson1_0
+        use smithy.framework#ValidationException
+
+        @awsJson1_0
+        @serde(serialize: false, deserialize: true)
+        service BehaviorService {
+            operations: [Check]
+        }
+
+        operation Check {
+            input: CheckInput
+            errors: [ValidationException]
+        }
+
+        structure CheckInput {
+            value: String
+            kind: TestEnum
+            choice: Choice
+        }
+
+        enum TestEnum {
+            A
+            B
+        }
+
+        union Choice {
+            text: String
+            empty: Unit
+        }
+        """.asSmithyModel(smithyVersion = "2")
+
     private fun Model.attachSerdeToService(serviceShapeId: ShapeId): Model {
         val service =
             this.expectShape(serviceShapeId, ServiceShape::class.java).toBuilder().addTrait(
-                SerdeTrait(true, false, null, null, SourceLocation.NONE),
+                SerdeTrait(true, true, null, null, SourceLocation.NONE),
             ).build()
         return ModelTransformer.create().mapShapes(this) { serviceShape ->
             serviceShape.letIf(serviceShape.id == serviceShapeId) {
@@ -52,7 +94,407 @@ class SerdeProtocolTestTest {
                 cargoCommand = "cargo test --all-features",
                 additionalSettings = constrainedShapesSettings,
             ),
-        ) { clientCodegenContext, rustCrate ->
+        ) { _, _ ->
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testDeserializationConstraintValidation(usePublicConstrainedTypes: Boolean) {
+        val service = ShapeId.from("com.example#ConstraintService")
+        val model =
+            """
+            namespace com.example
+            use aws.protocols#awsJson1_0
+            use smithy.framework#ValidationException
+
+            @awsJson1_0
+            service ConstraintService {
+                operations: [Check]
+            }
+
+            operation Check {
+                input: CheckInput
+                output: CheckOutput
+                errors: [ValidationException]
+            }
+
+            structure CheckInput {
+                @required
+                value: BoundedString
+            }
+
+            @length(min: 2, max: 4)
+            string BoundedString
+
+            structure CheckOutput {
+                choice: OutputChoice
+            }
+
+            union OutputChoice {
+                value: OutputBoundedString
+            }
+
+            @length(min: 2, max: 4)
+            string OutputBoundedString
+            """.asSmithyModel(smithyVersion = "2").attachSerdeToService(service)
+        val constrainedShapesSettings =
+            Node.objectNodeBuilder().withMember(
+                "codegen",
+                Node.objectNodeBuilder()
+                    .withMember("publicConstrainedTypes", usePublicConstrainedTypes)
+                    .build(),
+            ).build()
+
+        serverIntegrationTest(
+            model,
+            IntegrationTestParams(
+                service = service.toString(),
+                cargoCommand = "cargo test --all-features",
+                additionalSettings = constrainedShapesSettings,
+            ),
+        ) { codegenContext, rustCrate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(codegenContext.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                )
+
+            rustCrate.integrationTest("constraint_deserialization") {
+                unitTest("constrained_values_are_validated") {
+                    rustTemplate(
+                        """
+                        use #{crate}::input::CheckInput;
+
+                        let valid: Result<CheckInput, _> =
+                            #{serde_json}::from_str(r##"{"value":"okay"}"##);
+                        assert!(valid.is_ok(), "valid constrained value was rejected: {valid:?}");
+
+                        let invalid: Result<CheckInput, _> =
+                            #{serde_json}::from_str(r##"{"value":"x"}"##);
+                        assert!(invalid.is_err(), "invalid constrained value was accepted");
+
+                        let missing: Result<CheckInput, _> = #{serde_json}::from_str("{}");
+                        assert!(missing.is_err(), "missing required value was accepted");
+
+                        use #{crate}::output::CheckOutput;
+                        let valid_output: Result<CheckOutput, _> =
+                            #{serde_json}::from_str(r##"{"choice":{"value":"okay"}}"##);
+                        assert!(
+                            valid_output.is_ok(),
+                            "valid constrained union value was rejected: {valid_output:?}"
+                        );
+
+                        let invalid_output: Result<CheckOutput, _> =
+                            #{serde_json}::from_str(r##"{"choice":{"value":"x"}}"##);
+                        assert!(
+                            invalid_output.is_err(),
+                            "invalid output-only union constraint was accepted"
+                        );
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testClientDeserializationBehavior(useCbor: Boolean) {
+        clientIntegrationTest(
+            behaviorModel,
+            IntegrationTestParams(
+                service = "com.example#BehaviorService",
+                cargoCommand = "cargo test --all-features",
+            ),
+        ) { codegenContext, rustCrate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(codegenContext.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                    "ciborium" to CargoDependency.Ciborium.toDevDependency().toType(),
+                )
+
+            rustCrate.integrationTest("client_deserialization_behavior_$useCbor") {
+                unitTest("structure_enum_and_union_behavior") {
+                    rustTemplate(
+                        """
+                        use #{crate}::operation::check::CheckInput;
+
+                        fn decode(input: &str) -> Result<CheckInput, String> {
+                            if $useCbor {
+                                let value: #{serde_json}::Value =
+                                    #{serde_json}::from_str(input).map_err(|err| err.to_string())?;
+                                let mut bytes = Vec::new();
+                                #{ciborium}::ser::into_writer(&value, &mut bytes)
+                                    .map_err(|err| err.to_string())?;
+                                #{ciborium}::de::from_reader(bytes.as_slice())
+                                    .map_err(|err| err.to_string())
+                            } else {
+                                #{serde_json}::from_str(input).map_err(|err| err.to_string())
+                            }
+                        }
+
+                        let value = decode(
+                            r##"{"value":"hello","kind":"FUTURE","choice":{"text":"world"},"ignored":{"nested":true}}"##
+                        ).expect("unknown fields and client enum variants should be accepted");
+                        assert_eq!(value.value.as_deref(), Some("hello"));
+                        assert_eq!(value.kind.expect("kind should be set").as_str(), "FUTURE");
+
+                        assert!(decode(r##"{"choice":{"future":null}}"##).is_err());
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("duplicate_known_fields_are_rejected") {
+                    rustTemplate(
+                        """
+                        use #{crate}::operation::check::CheckInput;
+
+                        let duplicate = r##"{"value":"first","value":"second"}"##;
+                        let result: Result<CheckInput, _> = #{serde_json}::from_str(duplicate);
+                        assert!(result.is_err());
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testServerDeserializationBehavior(usePublicConstrainedTypes: Boolean) {
+        val settings =
+            Node.objectNodeBuilder().withMember(
+                "codegen",
+                Node.objectNodeBuilder()
+                    .withMember("publicConstrainedTypes", usePublicConstrainedTypes)
+                    .build(),
+            ).build()
+        serverIntegrationTest(
+            behaviorModel,
+            IntegrationTestParams(
+                service = "com.example#BehaviorService",
+                cargoCommand = "cargo test --all-features",
+                additionalSettings = settings,
+            ),
+        ) { codegenContext, rustCrate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(codegenContext.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                )
+
+            rustCrate.integrationTest("server_deserialization_behavior") {
+                unitTest("unknown_fields_are_ignored_but_unknown_variants_are_rejected") {
+                    rustTemplate(
+                        """
+                        use #{crate}::input::CheckInput;
+
+                        let known: Result<CheckInput, _> = #{serde_json}::from_str(
+                            r##"{"kind":"A","choice":{"empty":null},"ignored":true}"##
+                        );
+                        assert!(known.is_ok(), "known variants should deserialize: {known:?}");
+
+                        let unknown_enum: Result<CheckInput, _> =
+                            #{serde_json}::from_str(r##"{"kind":"FUTURE"}"##);
+                        assert!(unknown_enum.is_err());
+
+                        let unknown_union: Result<CheckInput, _> =
+                            #{serde_json}::from_str(r##"{"choice":{"future":null}}"##);
+                        assert!(unknown_union.is_err());
+
+                        let duplicate: Result<CheckInput, _> =
+                            #{serde_json}::from_str(r##"{"value":"first","value":"second"}"##);
+                        assert!(duplicate.is_err());
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDirectlyAnnotatedLegacyEnumDeserialization() {
+        val model =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            service LegacyEnumService {
+                operations: [UseLegacyEnum]
+            }
+
+            operation UseLegacyEnum {
+                input: UseLegacyEnumInput
+            }
+
+            structure UseLegacyEnumInput {
+                value: LegacyEnum
+            }
+
+            @serde(serialize: false, deserialize: true)
+            @enum([
+                { name: "A", value: "A" }
+            ])
+            string LegacyEnum
+            """.asSmithyModel()
+
+        clientIntegrationTest(
+            model,
+            IntegrationTestParams(
+                service = "com.example#LegacyEnumService",
+                cargoCommand = "cargo test --all-features",
+            ),
+        ) { codegenContext, rustCrate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(codegenContext.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                )
+
+            rustCrate.integrationTest("legacy_enum_deserialization") {
+                unitTest("directly_annotated_enum_has_deserialize_impl") {
+                    rustTemplate(
+                        """
+                        use #{crate}::types::LegacyEnum;
+
+                        let known: LegacyEnum = #{serde_json}::from_str(r##""A""##)
+                            .expect("known enum should deserialize");
+                        assert_eq!(known.as_str(), "A");
+
+                        let unknown: LegacyEnum = #{serde_json}::from_str(r##""FUTURE""##)
+                            .expect("client unknown enum should be preserved");
+                        assert_eq!(unknown.as_str(), "FUTURE");
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testLegacySetAndModeledErrorDeserialization() {
+        val model =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            @serde(serialize: false, deserialize: true)
+            service LegacyService {
+                operations: [UseSet]
+            }
+
+            operation UseSet {
+                input: UseSetInput
+                errors: [CustomError]
+            }
+
+            structure UseSetInput {
+                tags: Tags
+            }
+
+            set Tags {
+                member: String
+            }
+
+            @error("client")
+            structure CustomError {
+                message: String
+            }
+            """.asSmithyModel()
+
+        clientIntegrationTest(
+            model,
+            IntegrationTestParams(
+                service = "com.example#LegacyService",
+                cargoCommand = "cargo test --all-features",
+            ),
+        ) { codegenContext, rustCrate ->
+            val codegenScope =
+                arrayOf(
+                    "crate" to RustType.Opaque(codegenContext.moduleUseName()),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                )
+
+            rustCrate.integrationTest("legacy_set_and_error_deserialization") {
+                unitTest("set_uses_generated_container_and_errors_are_in_the_service_closure") {
+                    rustTemplate(
+                        """
+                        use #{crate}::operation::use_set::UseSetInput;
+                        use #{crate}::types::error::CustomError;
+
+                        let input: UseSetInput = #{serde_json}::from_str(
+                            r##"{"tags":["one","two"]}"##
+                        ).expect("set should deserialize");
+                        let tags = input.tags.expect("tags should be set");
+                        assert_eq!(tags.len(), 2);
+                        assert_eq!(tags[0], "one");
+                        assert_eq!(tags[1], "two");
+
+                        let error: CustomError = #{serde_json}::from_str(
+                            r##"{"message":"failed"}"##
+                        ).expect("modeled error should deserialize");
+                        assert_eq!(error.message(), Some("failed"));
+                        """,
+                        *codegenScope,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDirectlyAnnotatedEventStreamEnvelopeIsSkipped() {
+        val model =
+            """
+            namespace com.example
+            use smithy.rust#serde
+            use aws.protocols#awsJson1_0
+            use smithy.framework#ValidationException
+
+            @awsJson1_0
+            service EventService {
+                operations: [Stream]
+            }
+
+            operation Stream {
+                input: StreamInput
+                errors: [ValidationException]
+            }
+
+            @serde(serialize: false, deserialize: true)
+            structure StreamInput {
+                events: Events
+            }
+
+            @streaming
+            @serde(serialize: false, deserialize: true)
+            union Events {
+                message: Message
+            }
+
+            structure Message {
+                value: String
+            }
+            """.asSmithyModel(smithyVersion = "2")
+
+        serverIntegrationTest(
+            model,
+            IntegrationTestParams(
+                service = "com.example#EventService",
+                cargoCommand = "cargo test --all-features",
+            ),
+        ) { _, _ ->
         }
     }
 }

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
@@ -10,23 +10,82 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.SourceLocation
+import software.amazon.smithy.model.knowledge.OperationIndex
+import software.amazon.smithy.model.knowledge.TopDownIndex
+import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.node.StringNode
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.DoubleShape
+import software.amazon.smithy.model.shapes.FloatShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.HttpHeaderTrait
 import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.protocoltests.traits.AppliesTo
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ClientInstantiator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.CratesIo
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.generators.Instantiator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.BrokenTest
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.FailingTest
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolTestGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ServiceShapeId.REST_JSON
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.TestCase
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+import software.amazon.smithy.rust.codegen.core.testutil.testModule
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+import software.amazon.smithy.rust.codegen.core.util.hasStreamingMember
+import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.letIf
+import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
+import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
+import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
+import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerInstantiator
+import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocolTestGenerator
+import software.amazon.smithy.rust.codegen.server.smithy.protocols.ServerRestJsonFactory
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.HttpTestType
 import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverIntegrationTest
 import java.io.File
+import java.util.logging.Logger
 
 class SerdeProtocolTestTest {
+    private val semanticallyLossyRoundTripTests =
+        setOf(
+            // These values contain Some(Document::Null). Serde encodes both that and None as null.
+            "RestJsonServerPopulatesDefaultsWhenMissingInRequestBody",
+            "RestJsonServerPopulatesDefaultsInResponseWhenMissingInParams",
+        )
+
+    private enum class NonFiniteValues {
+        NONE,
+        INFINITY,
+        NAN,
+        ;
+
+        fun combine(other: NonFiniteValues): NonFiniteValues = maxOf(this, other)
+    }
+
     private val behaviorModel =
         """
         namespace com.example
@@ -70,6 +129,399 @@ class SerdeProtocolTestTest {
         return ModelTransformer.create().mapShapes(this) { serviceShape ->
             serviceShape.letIf(serviceShape.id == serviceShapeId) {
                 service
+            }
+        }
+    }
+
+    private fun restJsonProtocolTestModel(): Model {
+        val serviceShapeId = ShapeId.from(REST_JSON)
+        val model =
+            Model.assembler()
+                .discoverModels()
+                .assemble()
+                .result
+                .get()
+                .attachSerdeToService(serviceShapeId)
+        val service = model.expectShape(serviceShapeId, ServiceShape::class.java)
+        val operationIndex = OperationIndex.of(model)
+        val errorShapeIds =
+            TopDownIndex.of(model)
+                .getContainedOperations(service)
+                .flatMap(operationIndex::getErrors)
+                .mapTo(mutableSetOf()) { it.id }
+
+        // Operation serializers cover inputs and outputs. Directly annotate modeled errors so
+        // response test cases can exercise the same public serde entry point.
+        return ModelTransformer.create().mapShapes(model) { shape ->
+            shape.letIf(shape.id in errorShapeIds) {
+                (shape as StructureShape).toBuilder()
+                    .addTrait(SerdeTrait(true, true, null, null, SourceLocation.NONE))
+                    .build()
+            }
+        }
+    }
+
+    private fun noRenderedProtocolTests(base: ProtocolTestGenerator): ProtocolTestGenerator =
+        object : ProtocolTestGenerator() {
+            override val codegenContext: CodegenContext
+                get() = base.codegenContext
+            override val protocolSupport: ProtocolSupport
+                get() = base.protocolSupport
+            override val operationShape: OperationShape
+                get() = base.operationShape
+            override val appliesTo: AppliesTo
+                get() = base.appliesTo
+            override val logger: Logger
+                get() = base.logger
+            override val expectFail: Set<FailingTest>
+                get() = base.expectFail
+            override val brokenTests: Set<BrokenTest>
+                get() = base.brokenTests
+            override val generateOnly: Set<String>
+                get() = base.generateOnly
+            override val disabledTests: Set<String>
+                get() = base.disabledTests
+
+            override fun RustWriter.renderAllTestCases(allTests: List<TestCase>) {}
+        }
+
+    private fun nonFiniteValues(
+        model: Model,
+        shape: Shape,
+        value: Node,
+    ): NonFiniteValues =
+        when (shape) {
+            is MemberShape -> nonFiniteValues(model, model.expectShape(shape.target), value)
+            is FloatShape, is DoubleShape ->
+                when ((value as? StringNode)?.value) {
+                    "NaN" -> NonFiniteValues.NAN
+                    "Infinity", "-Infinity" -> NonFiniteValues.INFINITY
+                    else -> NonFiniteValues.NONE
+                }
+            is StructureShape, is UnionShape -> {
+                val objectValue = value as? ObjectNode ?: return NonFiniteValues.NONE
+                objectValue.members.entries.fold(NonFiniteValues.NONE) { result, (name, memberValue) ->
+                    val member = shape.getMember(name.value).orElse(null)
+                    if (member == null) result else result.combine(nonFiniteValues(model, member, memberValue))
+                }
+            }
+            is CollectionShape -> {
+                val arrayValue = value as? ArrayNode ?: return NonFiniteValues.NONE
+                arrayValue.elements.fold(NonFiniteValues.NONE) { result, memberValue ->
+                    result.combine(nonFiniteValues(model, shape.member, memberValue))
+                }
+            }
+            is MapShape -> {
+                val objectValue = value as? ObjectNode ?: return NonFiniteValues.NONE
+                objectValue.members.values.fold(NonFiniteValues.NONE) { result, memberValue ->
+                    result.combine(nonFiniteValues(model, shape.value, memberValue))
+                }
+            }
+            else -> NonFiniteValues.NONE
+        }
+
+    private fun nonFiniteHeaderValues(
+        model: Model,
+        shape: StructureShape,
+        headers: Map<String, String>,
+    ): NonFiniteValues =
+        shape.members().fold(NonFiniteValues.NONE) { result, member ->
+            val headerName = member.getTrait(HttpHeaderTrait::class.java).orElse(null)?.value
+            val headerValue = headerName?.let(headers::get)
+            if (headerValue == null) {
+                result
+            } else {
+                result.combine(nonFiniteValues(model, member, Node.from(headerValue)))
+            }
+        }
+
+    private fun RustWriter.renderRoundTripSupport() {
+        rustTemplate(
+            """
+            use crate::serde::{
+                DeserializationSettings,
+                SerializationSettings,
+                SerializeConfigured,
+            };
+            use #{rstest}::rstest;
+
+            ##[derive(Clone, Copy, Debug)]
+            enum RoundTripFormat {
+                Json,
+                Cbor,
+            }
+
+            fn assert_round_trip<T>(
+                expected: T,
+                format: RoundTripFormat,
+                out_of_range_floats_as_strings: bool,
+                contains_nan: bool,
+            )
+            where
+                T: SerializeConfigured + #{DeserializeOwned} + #{PartialEq} + #{Debug},
+            {
+                let mut serialization = SerializationSettings::default();
+                serialization.out_of_range_floats_as_strings =
+                    out_of_range_floats_as_strings;
+
+                let encoded = match format {
+                    RoundTripFormat::Json => {
+                        #{serde_json}::to_vec(&expected.serialize_ref(&serialization))
+                            .expect("failed to serialize JSON")
+                    }
+                    RoundTripFormat::Cbor => {
+                        // Direct CBOR serialization is covered separately from this
+                        // deserializer corpus because omitted optional fields currently
+                        // leave definite-length struct maps with an incorrect length.
+                        let value = #{serde_json}::to_value(
+                            &expected.serialize_ref(&serialization),
+                        ).expect("failed to capture the serde representation");
+                        let mut encoded = #{Vec}::new();
+                        #{ciborium}::ser::into_writer(&value, &mut encoded)
+                            .expect("failed to serialize CBOR");
+                        encoded
+                    }
+                };
+
+                let mut deserialization = DeserializationSettings::default();
+                deserialization.allow_non_finite_float_strings =
+                    out_of_range_floats_as_strings;
+                let actual: T = deserialization.scope(|| match format {
+                    RoundTripFormat::Json => {
+                        #{serde_json}::from_slice(&encoded)
+                            .expect("failed to deserialize JSON")
+                    }
+                    RoundTripFormat::Cbor => {
+                        #{ciborium}::de::from_reader(encoded.as_slice())
+                            .expect("failed to deserialize CBOR")
+                    }
+                });
+
+                if contains_nan {
+                    let expected_representation = #{serde_json}::to_value(
+                        &expected.serialize_ref(&serialization),
+                    ).expect("failed to capture expected serde representation");
+                    let actual_representation = #{serde_json}::to_value(
+                        &actual.serialize_ref(&serialization),
+                    ).expect("failed to capture actual serde representation");
+                    assert_eq!(
+                        expected_representation,
+                        actual_representation,
+                        "serde representation changed after {format:?} round trip \
+                         with out_of_range_floats_as_strings={out_of_range_floats_as_strings}",
+                    );
+                } else {
+                    assert_eq!(
+                        expected,
+                        actual,
+                        "semantic value changed after {format:?} round trip \
+                         with out_of_range_floats_as_strings={out_of_range_floats_as_strings}",
+                    );
+                }
+            }
+            """,
+            "rstest" to CargoDependency("rstest", CratesIo("0.23")).toDevDependency().toType(),
+            "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+            "ciborium" to CargoDependency.Ciborium.toDevDependency().toType(),
+            "DeserializeOwned" to CargoDependency.Serde.toDevDependency().toType().resolve("de::DeserializeOwned"),
+            "PartialEq" to RuntimeType.std.resolve("cmp::PartialEq"),
+            "Debug" to RuntimeType.std.resolve("fmt::Debug"),
+            *RuntimeType.preludeScope,
+        )
+    }
+
+    private fun RustWriter.renderRoundTripTest(
+        operationShape: OperationShape,
+        testCase: TestCase,
+        expected: software.amazon.smithy.rust.codegen.core.rustlang.Writable,
+        nonFiniteValues: NonFiniteValues,
+    ) {
+        val kind =
+            when (testCase) {
+                is TestCase.RequestTest -> "request"
+                is TestCase.ResponseTest -> "response"
+                is TestCase.MalformedRequestTest -> error("malformed requests do not contain semantic values")
+            }
+        val testName =
+            listOf("round_trip", operationShape.id.name, testCase.id, kind)
+                .joinToString("_")
+                .toSnakeCase()
+        val containsNan = nonFiniteValues == NonFiniteValues.NAN
+
+        rustTemplate(
+            """
+            ##[rstest]
+            #{DefaultCases:W}
+            ##[case::json_non_finite_strings(RoundTripFormat::Json, true)]
+            ##[case::cbor_non_finite_strings(RoundTripFormat::Cbor, true)]
+            fn $testName(
+                ##[case] format: RoundTripFormat,
+                ##[case] out_of_range_floats_as_strings: bool,
+            ) {
+                let expected = #{Expected:W};
+                assert_round_trip(
+                    expected,
+                    format,
+                    out_of_range_floats_as_strings,
+                    $containsNan,
+                );
+            }
+            """,
+            "DefaultCases" to
+                software.amazon.smithy.rust.codegen.core.rustlang.writable {
+                    if (nonFiniteValues == NonFiniteValues.NONE) {
+                        rustTemplate(
+                            """
+                            ##[case::json_default(RoundTripFormat::Json, false)]
+                            ##[case::cbor_default(RoundTripFormat::Cbor, false)]
+                            """,
+                        )
+                    }
+                },
+            "Expected" to expected,
+        )
+    }
+
+    private fun renderProtocolRoundTrips(
+        codegenContext: CodegenContext,
+        rustCrate: RustCrate,
+        instantiator: Instantiator,
+        protocolTestGenerator: (OperationShape) -> ProtocolTestGenerator,
+    ) {
+        val model = codegenContext.model
+        val operationShapes =
+            TopDownIndex.of(model)
+                .getContainedOperations(codegenContext.serviceShape)
+                .sortedBy { it.id.toString() }
+
+        rustCrate.testModule {
+            renderRoundTripSupport()
+
+            for (operationShape in operationShapes) {
+                val generator = protocolTestGenerator(operationShape)
+                val inputShape = operationShape.inputShape(model)
+
+                for (testCase in generator.requestTestCases().filter { it.protocol == codegenContext.protocol }) {
+                    check(testCase is TestCase.RequestTest)
+                    if (
+                        inputShape.hasStreamingMember(model) ||
+                        testCase.id in semanticallyLossyRoundTripTests
+                    ) {
+                        continue
+                    }
+
+                    val values =
+                        nonFiniteValues(model, inputShape, testCase.testCase.params)
+                            .combine(nonFiniteHeaderValues(model, inputShape, testCase.testCase.headers))
+
+                    renderRoundTripTest(
+                        operationShape,
+                        testCase,
+                        instantiator.generate(
+                            inputShape,
+                            testCase.testCase.params,
+                            testCase.testCase.headers,
+                        ),
+                        values,
+                    )
+                }
+
+                for (testCase in generator.responseTestCases().filter { it.protocol == codegenContext.protocol }) {
+                    check(testCase is TestCase.ResponseTest)
+                    if (
+                        testCase.targetShape.hasStreamingMember(model) ||
+                        testCase.id in semanticallyLossyRoundTripTests
+                    ) {
+                        continue
+                    }
+
+                    val values = nonFiniteValues(model, testCase.targetShape, testCase.testCase.params)
+
+                    renderRoundTripTest(
+                        operationShape,
+                        testCase,
+                        instantiator.generate(testCase.targetShape, testCase.testCase.params),
+                        values,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testClientRestJsonProtocolValuesRoundTripThroughSerde() {
+        val noProtocolTestsDecorator =
+            object : ClientCodegenDecorator {
+                override val name: String = "Suppress HTTP protocol tests for serde round trips"
+                override val order: Byte = 0
+
+                override fun protocolTestGenerator(
+                    codegenContext: ClientCodegenContext,
+                    baseGenerator: ProtocolTestGenerator,
+                ): ProtocolTestGenerator = noRenderedProtocolTests(baseGenerator)
+            }
+        val clientProtocolSupport =
+            ProtocolSupport(
+                requestSerialization = true,
+                requestBodySerialization = true,
+                responseDeserialization = true,
+                errorDeserialization = true,
+                requestDeserialization = false,
+                requestBodyDeserialization = false,
+                responseSerialization = false,
+                errorSerialization = false,
+            )
+
+        clientIntegrationTest(
+            restJsonProtocolTestModel(),
+            IntegrationTestParams(
+                service = REST_JSON,
+                cargoCommand = "cargo test --quiet --all-features round_trip_ -- --test-threads=1",
+            ),
+            additionalDecorators = listOf(noProtocolTestsDecorator),
+        ) { codegenContext, rustCrate ->
+            renderProtocolRoundTrips(
+                codegenContext,
+                rustCrate,
+                ClientInstantiator(codegenContext),
+            ) { operationShape ->
+                ClientProtocolTestGenerator(codegenContext, clientProtocolSupport, operationShape)
+            }
+        }
+    }
+
+    @Test
+    fun testServerRestJsonProtocolValuesRoundTripThroughSerde() {
+        val noProtocolTestsDecorator =
+            object : ServerCodegenDecorator {
+                override val name: String = "Suppress HTTP protocol tests for serde round trips"
+                override val order: Byte = 0
+
+                override fun protocolTestGenerator(
+                    codegenContext: ServerCodegenContext,
+                    baseGenerator: ProtocolTestGenerator,
+                ): ProtocolTestGenerator = noRenderedProtocolTests(baseGenerator)
+            }
+
+        serverIntegrationTest(
+            restJsonProtocolTestModel(),
+            IntegrationTestParams(
+                service = REST_JSON,
+                cargoCommand = "cargo test --quiet --all-features round_trip_ -- --test-threads=1",
+            ),
+            additionalDecorators = listOf(noProtocolTestsDecorator),
+            testCoverage = HttpTestType.Default,
+        ) { codegenContext, rustCrate ->
+            renderProtocolRoundTrips(
+                codegenContext,
+                rustCrate,
+                ServerInstantiator(codegenContext),
+            ) { operationShape ->
+                ServerProtocolTestGenerator(
+                    codegenContext,
+                    ServerRestJsonFactory().support(),
+                    operationShape,
+                )
             }
         }
     }

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.SourceLocation
-import software.amazon.smithy.model.knowledge.OperationIndex
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.Node
@@ -135,30 +134,12 @@ class SerdeProtocolTestTest {
 
     private fun restJsonProtocolTestModel(): Model {
         val serviceShapeId = ShapeId.from(REST_JSON)
-        val model =
-            Model.assembler()
-                .discoverModels()
-                .assemble()
-                .result
-                .get()
-                .attachSerdeToService(serviceShapeId)
-        val service = model.expectShape(serviceShapeId, ServiceShape::class.java)
-        val operationIndex = OperationIndex.of(model)
-        val errorShapeIds =
-            TopDownIndex.of(model)
-                .getContainedOperations(service)
-                .flatMap(operationIndex::getErrors)
-                .mapTo(mutableSetOf()) { it.id }
-
-        // Operation serializers cover inputs and outputs. Directly annotate modeled errors so
-        // response test cases can exercise the same public serde entry point.
-        return ModelTransformer.create().mapShapes(model) { shape ->
-            shape.letIf(shape.id in errorShapeIds) {
-                (shape as StructureShape).toBuilder()
-                    .addTrait(SerdeTrait(true, true, null, null, SourceLocation.NONE))
-                    .build()
-            }
-        }
+        return Model.assembler()
+            .discoverModels()
+            .assemble()
+            .result
+            .get()
+            .attachSerdeToService(serviceShapeId)
     }
 
     private fun noRenderedProtocolTests(base: ProtocolTestGenerator): ProtocolTestGenerator =
@@ -833,7 +814,7 @@ class SerdeProtocolTestTest {
     }
 
     @Test
-    fun testLegacySetAndModeledErrorDeserialization() {
+    fun testLegacySetAndModeledErrorSerde() {
         val model =
             """
             namespace com.example
@@ -841,7 +822,7 @@ class SerdeProtocolTestTest {
             use aws.protocols#awsJson1_0
 
             @awsJson1_0
-            @serde(serialize: false, deserialize: true)
+            @serde(serialize: true, deserialize: true)
             service LegacyService {
                 operations: [UseSet]
             }
@@ -878,11 +859,12 @@ class SerdeProtocolTestTest {
                     "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
                 )
 
-            rustCrate.integrationTest("legacy_set_and_error_deserialization") {
+            rustCrate.integrationTest("legacy_set_and_error_serde") {
                 unitTest("set_uses_generated_container_and_errors_are_in_the_service_closure") {
                     rustTemplate(
                         """
                         use #{crate}::operation::use_set::UseSetInput;
+                        use #{crate}::serde::{SerializationSettings, SerializeConfigured};
                         use #{crate}::types::error::CustomError;
 
                         let input: UseSetInput = #{serde_json}::from_str(
@@ -897,6 +879,11 @@ class SerdeProtocolTestTest {
                             r##"{"message":"failed"}"##
                         ).expect("modeled error should deserialize");
                         assert_eq!(error.message(), Some("failed"));
+
+                        let settings = SerializationSettings::default();
+                        let serialized = #{serde_json}::to_string(&error.serialize_ref(&settings))
+                            .expect("modeled error should serialize");
+                        assert_eq!(serialized, r##"{"message":"failed"}"##);
                         """,
                         *codegenScope,
                     )


### PR DESCRIPTION
## Motivation and Context
`codegen-serde` currently generates configurable serialization only. Generated model types should also support ordinary `serde::Deserialize`, including configurable representations such as non-finite float strings.

## Description
- Add independent `serialize` and `deserialize` controls to the `smithy.rust#serde` trait.
- Generate ordinary `Deserialize` implementations for structures, unions, enums, and reachable model shapes.
- Deserialize through typed visitors and `DeserializeSeed`s that drive generated builders directly, without an intermediate value tree.
- Snapshot scoped, thread-local deserialization settings once per nominal root and propagate them through nested seeds.
- Preserve client/server enum behavior, constraints, defaults, duplicate detection, unknown-field handling, sparse aggregates, recursion, documents, timestamps, blobs, and buffered streaming blobs.
- Bound recursive deserialization depth and untrusted container preallocation.
- Skip event streams.

JSON and self-describing CBOR are the required formats. Non-self-describing formats remain best effort; an all-required generated model is covered by a bincode round trip. Optional and sparse binary serialization semantics can be addressed separately.

## Usage

Enable deserialization independently from serialization on a shape:

```smithy
$version: "2"

namespace com.example

use aws.protocols#awsJson1_0
use smithy.rust#serde

@awsJson1_0
service ExampleService {
    operations: [Put]
}

operation Put {
    input: PutInput
}

structure PutInput {
    payload: Payload
}

@serde(serialize: false, deserialize: true)
structure Payload {
    message: String
    float: Float
    defaulted: Integer = 7
}
```

The generated model type implements ordinary `serde::Deserialize`:

```rust
use example_client::types::Payload;

let payload: Payload = serde_json::from_str(
    r#"{"message":"hello","float":1.5}"#,
)?;

assert_eq!(payload.message.as_deref(), Some("hello"));
assert_eq!(payload.float, Some(1.5));
assert_eq!(payload.defaulted, 7);
```

Configuration is scoped around the normal Serde entry point, so it also works when a generated type is nested inside a customer-owned `#[derive(Deserialize)]` type:

```rust
use example_client::serde::DeserializationSettings;
use example_client::types::Payload;

let mut settings = DeserializationSettings::default();
settings.allow_non_finite_float_strings = true;

let payload = settings.scope(|| {
    serde_json::from_str::<Payload>(
        r#"{"float":"Infinity"}"#,
    )
})?;

assert_eq!(payload.float, Some(f32::INFINITY));
```

The trait can instead be applied to a service or operation to enable the selected directions for supported shapes in its closure:

```smithy
@serde(serialize: true, deserialize: true)
service ExampleService {
    operations: [Put]
}
```

## Generated Code

For the `Payload` shape above, codegen emits an ordinary `Deserialize` implementation. It snapshots the active settings once and starts a typed seed with a bounded recursion depth:

```rust
impl<'de> serde::Deserialize<'de> for crate::types::Payload {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: serde::Deserializer<'de>,
    {
        let settings = DeserializationSettings::current();
        serde::de::DeserializeSeed::deserialize(
            PayloadSerdeDeserializeSeed {
                settings: &settings,
                depth: 128,
            },
            deserializer,
        )
    }
}

struct PayloadSerdeDeserializeSeed<'a> {
    settings: &'a DeserializationSettings,
    depth: usize,
}

impl<'de> serde::de::DeserializeSeed<'de> for PayloadSerdeDeserializeSeed<'_> {
    type Value = crate::types::Payload;

    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
    where
        D: serde::Deserializer<'de>,
    {
        let depth = self.depth.checked_sub(1).ok_or_else(|| {
            <D::Error as serde::de::Error>::custom(
                "maximum deserialization depth exceeded",
            )
        })?;
        deserializer.deserialize_struct(
            "Payload",
            &["message", "float", "defaulted"],
            PayloadSerdeDeserializeSeedVisitor {
                settings: self.settings,
                depth,
            },
        )
    }
}
```

The structure visitor drives the generated builder directly as fields arrive. The real output contains one typed seed arm per field; abridged:

```rust
fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
where
    A: serde::de::MapAccess<'de>,
{
    let mut builder = crate::types::builders::PayloadBuilder::default();
    let mut seen = std::collections::HashSet::new();

    while let Some(field) =
        map.next_key::<PayloadSerdeDeserializeSeedField>()?
    {
        match field {
            PayloadSerdeDeserializeSeedField::Field0 => {
                if !seen.insert("message") {
                    return Err(serde::de::Error::custom(
                        "duplicate field `message`",
                    ));
                }
                let parsed = map.next_value_seed(SerdeOptionalSeed(
                    StringSerdeDeserializeSeed {
                        settings: self.settings,
                        depth: self.depth,
                    },
                ))?;
                if let Some(parsed) = parsed {
                    builder.message = Some(parsed);
                }
            }
            // `float` and `defaulted` use their corresponding typed seeds.
            PayloadSerdeDeserializeSeedField::Ignore => {
                map.next_value::<serde::de::IgnoredAny>()?;
            }
        }
    }

    builder.build().map_err(serde::de::Error::custom)
}
```

Codegen also exposes the configuration type used by these implementations:

```rust
#[non_exhaustive]
#[derive(Clone, Debug, Default)]
pub struct DeserializationSettings {
    /// Accept `NaN`, `Infinity`, and `-Infinity` strings as floating-point values.
    pub allow_non_finite_float_strings: bool,
}

impl DeserializationSettings {
    pub fn scope<R>(&self, f: impl FnOnce() -> R) -> R {
        DESERIALIZATION_SETTINGS.with(|settings| {
            settings.borrow_mut().push(self.clone());
        });
        let _guard = DeserializationSettingsScopeGuard;
        f()
    }
}
```

## Checklist
- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
