### PR TITLE
Add presigning support for S3 ListObjectVersions

### DIFF
--- a/.changelog/list-object-versions-presigning.md
+++ b/.changelog/list-object-versions-presigning.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["aws-sdk-rust"]
+authors: ["alastair-phantom"]
+references: ["aws-sdk-rust#488"]
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add presigned request support for the S3 `ListObjectVersions` operation.

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -79,6 +79,7 @@ internal val PRESIGNABLE_OPERATIONS by lazy {
         // TODO(https://github.com/awslabs/aws-sdk-rust/issues/488) Technically, all S3 operations support presigning
         ShapeId.from("com.amazonaws.s3#HeadObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#GetObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
+        ShapeId.from("com.amazonaws.s3#ListObjectVersions") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#PutObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#UploadPart") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#DeleteObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -13,6 +13,7 @@ use http_1x::Uri;
 use s3::config::{Credentials, Region};
 use s3::operation::get_object::builders::GetObjectFluentBuilder;
 use s3::operation::head_object::builders::HeadObjectFluentBuilder;
+use s3::operation::list_object_versions::builders::ListObjectVersionsFluentBuilder;
 use s3::operation::put_object::builders::PutObjectFluentBuilder;
 use s3::operation::upload_part::builders::UploadPartFluentBuilder;
 use s3::presigning::{PresignedRequest, PresigningConfig};
@@ -43,6 +44,7 @@ rig_operation!(GetObjectFluentBuilder);
 rig_operation!(PutObjectFluentBuilder);
 rig_operation!(UploadPartFluentBuilder);
 rig_operation!(HeadObjectFluentBuilder);
+rig_operation!(ListObjectVersionsFluentBuilder);
 
 /// Generates a `PresignedRequest` from the given input.
 /// Assumes that that input has a `presigned` method on it.


### PR DESCRIPTION
## Motivation and Context

S3 supports presigning for the ListObjectVersions operation, but the Rust SDK doesnt generate a presign function. This marks `ListObjectVersions` as presignable so that the necessary sdk code is generated. Partially addressing https://github.com/awslabs/aws-sdk-rust/issues/488.

## Description

- Mark S3 `ListObjectVersions` as presignable with an unsigned payload.

## Testing

- Ran all applicable pre-commit hooks on the changed files.
- Rust formatting, Ktlint, Kotlin block quote validation, and SDK lints passed.

## Checklist

- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._