### PR TITLE
Declare tokio dev-dependency for AWS decorators that use `#[tokio::test]`

### DIFF
--- a/.changelog/4805.md
+++ b/.changelog/4805.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+- aws-sdk-rust
+authors:
+- ysaito1001
+references:
+- smithy-rs#4814
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix `cargo test` failing to build for generated clients that use certain inlineables. The `http_request_checksum`, `http_response_checksum`, `dsql_auth_token`, `rds_auth_token`, and `endpoint_discovery` inlineables each ship a `#[cfg(test)]` module that uses `#[tokio::test]`, but none of them declared tokio as a dev-dependency. Tokio was instead arriving incidentally, either from protocol test code generation or from the integration-test dependencies added for services that have a directory under `aws/sdk/integration-tests/`.

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -52,6 +52,7 @@ internal fun RuntimeConfig.awsInlineableHttpRequestChecksum() =
             CargoDependency.smithyTypes(this),
             AwsCargoDependency.awsSigv4(this),
             CargoDependency.TempFile.toDevDependency(),
+            CargoDependency.Tokio.toDevDependency(),
         ),
     )
 

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
@@ -45,6 +45,7 @@ private fun RuntimeConfig.awsInlineableHttpResponseChecksum() =
             CargoDependency.smithyHttp(this),
             CargoDependency.smithyRuntimeApiClient(this),
             CargoDependency.smithyTypes(this),
+            CargoDependency.Tokio.toDevDependency(),
         ),
     )
 

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/dsql/DsqlDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/dsql/DsqlDecorator.kt
@@ -36,6 +36,7 @@ class DsqlDecorator : ClientCodegenDecorator {
                         AwsCargoDependency.awsSigv4(rc),
                         CargoDependency.smithyRuntimeApiClient(rc),
                         CargoDependency.smithyAsync(rc).toDevDependency().withFeature("test-util"),
+                        CargoDependency.Tokio.toDevDependency(),
                         CargoDependency.Url,
                     ),
                 ),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/rds/RdsDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/rds/RdsDecorator.kt
@@ -36,6 +36,7 @@ class RdsDecorator : ClientCodegenDecorator {
                         AwsCargoDependency.awsSigv4(rc),
                         CargoDependency.smithyRuntimeApiClient(rc),
                         CargoDependency.smithyAsync(rc).toDevDependency().withFeature("test-util"),
+                        CargoDependency.Tokio.toDevDependency(),
                         CargoDependency.Url,
                     ),
                 ),

--- a/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
+++ b/aws/codegen-aws-sdk/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
@@ -55,6 +55,7 @@ class TimestreamDecorator : ClientCodegenDecorator {
                 "endpoint_discovery",
                 Visibility.PUBLIC,
                 CargoDependency.Tokio.copy(scope = DependencyScope.Compile, features = setOf("sync")),
+                CargoDependency.Tokio.toDevDependency(),
                 CargoDependency.smithyAsync(codegenContext.runtimeConfig).toDevDependency().withFeature("test-util"),
             )
         rustCrate.withModule(ClientRustModule.client) {

--- a/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/InlineableTestDependenciesTest.kt
+++ b/aws/codegen-aws-sdk/src/test/kotlin/software/amazon/smithy/rustsdk/InlineableTestDependenciesTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.core.rustlang.Feature
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+import software.amazon.smithy.rustsdk.customize.dsql.DsqlDecorator
+import software.amazon.smithy.rustsdk.customize.rds.RdsDecorator
+
+/**
+ * These inlineables have `#[cfg(test)]` modules using `#[tokio::test]`, so they need to declare tokio
+ * as a dev-dependency. Otherwise tokio only shows up by luck: from protocol test codegen, or from
+ * `IntegrationTestDependencies` when the service has a dir in `aws/sdk/integration-tests/`.
+ *
+ * The models below have neither, so without the dev-dependency `cargo test` fails to build while
+ * `cargo build` succeeds.
+ *
+ * `endpoint_discovery` has the same gap, but generating it needs a `DescribeEndpoints` operation, so
+ * it's verified against the real `aws-sdk-timestreamwrite` crate instead.
+ */
+internal class InlineableTestDependenciesTest {
+    companion object {
+        private fun model(operations: String = "") =
+            """
+            namespace test
+
+            use aws.api#service
+            use aws.auth#sigv4
+            use aws.protocols#httpChecksum
+            use aws.protocols#restJson1
+            use smithy.rules#endpointRuleSet
+
+            @service(sdkId: "dontcare")
+            @restJson1
+            @sigv4(name: "dontcare")
+            @auth([sigv4])
+            @endpointRuleSet({
+                "version": "1.0",
+                "rules": [{ "type": "endpoint", "conditions": [], "endpoint": { "url": "https://example.com" } }],
+                "parameters": {
+                    "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+                }
+            })
+            service TestService {
+                version: "2023-01-01",
+                operations: [SomeOperation]
+            }
+
+            @http(uri: "/SomeOperation", method: "POST")
+            @optionalAuth
+            $operations
+            operation SomeOperation {
+                input: SomeInput,
+                output: SomeOutput
+            }
+
+            @input
+            structure SomeInput {
+                @httpHeader("x-amz-request-algorithm")
+                checksumAlgorithm: ChecksumAlgorithm
+
+                @httpHeader("x-amz-response-validation-mode")
+                validationMode: ValidationMode
+
+                @httpHeader("x-amz-checksum-crc32")
+                ChecksumCRC32: String
+
+                @httpPayload
+                @required
+                body: Blob
+            }
+
+            @output
+            structure SomeOutput {}
+
+            enum ChecksumAlgorithm {
+                CRC32
+            }
+
+            enum ValidationMode {
+                ENABLED
+            }
+            """.asSmithyModel(smithyVersion = "2")
+
+        /** A model whose only operation opts into both request and response checksums. */
+        private val checksumModel =
+            model(
+                """
+                @httpChecksum(
+                    requestChecksumRequired: true,
+                    requestAlgorithmMember: "checksumAlgorithm",
+                    requestValidationModeMember: "validationMode",
+                    responseAlgorithms: ["CRC32"]
+                )
+                """,
+            )
+
+        private val plainModel = model()
+    }
+
+    /**
+     * `http_request_checksum` refers to `crate::presigning::PresigningMarker`, which these models
+     * don't wire up. Naming the type in a comment is enough to pull the inlineable in, and it needs
+     * the `http-1x` feature alongside it.
+     */
+    private fun withPresigning(): (Any, RustCrate) -> Unit =
+        { _, rustCrate ->
+            rustCrate.mergeFeature(Feature("http-1x", default = false, listOf("aws-smithy-runtime-api/http-1x")))
+            rustCrate.integrationTest("presigning_marker") {
+                rustTemplate(
+                    "//#{PresigningMarker};",
+                    "PresigningMarker" to AwsRuntimeType.presigning().resolve("PresigningMarker"),
+                )
+            }
+        }
+
+    private fun assertCargoTestBuilds(
+        model: Model,
+        decorators: List<ClientCodegenDecorator> = listOf(),
+        needsPresigning: Boolean = false,
+    ) {
+        awsSdkIntegrationTest(model, additionalDecorators = decorators) { ctx, rustCrate ->
+            if (needsPresigning) {
+                withPresigning()(ctx, rustCrate)
+            }
+        }
+    }
+
+    @Test
+    fun httpRequestAndResponseChecksumInlineables() {
+        assertCargoTestBuilds(checksumModel, needsPresigning = true)
+    }
+
+    @Test
+    fun dsqlAuthTokenInlineable() {
+        assertCargoTestBuilds(plainModel, decorators = listOf(DsqlDecorator()))
+    }
+
+    @Test
+    fun rdsAuthTokenInlineable() {
+        assertCargoTestBuilds(plainModel, decorators = listOf(RdsDecorator()))
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Learned that a customer ran into a build issue where a client with `aws.protocols#httpChecksum` failed to build tests:
```
  error[E0433]: cannot find module or crate `tokio`
  391 |     #[tokio::test]
```
The `http_request_checksum` inlineable uses `#[tokio::test]`, but its `InlineDependency` didn't declare `tokio`. Inlineables are copied verbatim into generated crates and get only the dependencies their declaration lists, but this usually wasn't a problem until the customer reported it because tokio happened to arrive from two accidental sources:
- ProtocolTestGenerator, when the model carries `@httpRequestTests`/`@httpResponseTests`
- IntegrationTestDependencies, which adds tokio only when the service has a directory under `aws/sdk/integration-tests/`

## Description
The PR declares tokio as a dev-dependency on the five `aws-inlineable` modules whose test code needs it: `http_request_checksum`, `http_response_checksum`, `dsql_auth_token`, `rds_auth_token`, and `endpoint_discovery` in order to address the reported issue and potential ones for now.

Created an [enhancement](https://github.com/smithy-lang/smithy-rs/issues/4815): detecting these gaps automatically in general.

## Testing
- New `InlineableTestDependenciesTest` generates crates from models with no protocol tests and no integration-tests directory, then runs cargo test. Verified in both directions — passed with the fixes and failed as expected without them.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
