### PR TITLE
Add a setting to serialize unset fields

### DIFF
--- a/.changelog/4819.md
+++ b/.changelog/4819.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client", "server"]
+authors: ["rcoh"]
+references: ["smithy-rs#4819"]
+breaking: false
+new_feature: true
+bug_fix: false
+---
+Add `SerializationSettings::serialize_unset_fields` to preserve structure lengths and field positions by serializing absent optional members as `None`.

--- a/codegen-serde/README.md
+++ b/codegen-serde/README.md
@@ -84,6 +84,9 @@ let json = serde_json::to_string(&serializable)?;
 - `out_of_range_floats_as_strings`: writes `NaN`, `Infinity`, and
   `-Infinity` as strings instead of relying on the format's non-finite float
   behavior.
+- `serialize_unset_fields`: writes absent optional structure members as
+  `None`/`null` instead of omitting them. Enable this for formats that require
+  exact structure lengths or fixed field positions.
 
 The generated module also exports `serialize_redacted` and
 `serialize_unredacted` for embedding generated types in application-owned
@@ -145,12 +148,11 @@ protocol bindings, timestamp formats, headers, payload placement, or error
 envelopes.
 
 Unset optional structure members are currently omitted during serialization.
-The generated serializer still reports the modeled member count to serde.
-Formats that rely on an exact, up-front structure length may therefore reject
-or misread structures with unset optional members. JSON is not affected;
-length-sensitive formats such as CBOR should only be used when the selected
-serializer can handle this representation or all serialized members are
-present.
+This is compatible with self-describing formats such as JSON, but formats that
+rely on an exact, up-front structure length or fixed field positions may reject
+or misread the result. Set `SerializationSettings::serialize_unset_fields` to
+`true` to serialize those members as `None`/`null` and preserve the full
+modeled structure.
 
 Non-self-describing formats also require the serializer and deserializer to
 agree on the same shape and field order. Test the exact model and format

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SerializeImplGenerator.kt
@@ -408,7 +408,17 @@ class SerializeImplGenerator(private val codegenContext: CodegenContext) {
                                 )
                             }
                         if (codegenContext.symbolProvider.toSymbol(member).isOptional()) {
-                            rust("if let Some($field) = &inner.$fieldName { #T }", fieldSerialization)
+                            rustTemplate(
+                                """
+                                if let #{Some}($field) = &inner.$fieldName {
+                                    #{FieldSerialization}
+                                } else if self.settings.serialize_unset_fields {
+                                    s.serialize_field($serializedName, &#{None}::<()>)?;
+                                }
+                                """,
+                                "FieldSerialization" to fieldSerialization,
+                                *RuntimeType.preludeScope,
+                            )
                         } else {
                             rust("let $field = &inner.$fieldName; #T", fieldSerialization)
                         }

--- a/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SupportStructures.kt
+++ b/codegen-serde/src/main/kotlin/software/amazon/smithy/rust/codegen/serde/SupportStructures.kt
@@ -231,6 +231,11 @@ object SupportStructures {
                     /// For protocols like JSON, this avoids the loss-of-information that occurs when these out-of-range values
                     /// are serialized as null.
                     pub out_of_range_floats_as_strings: bool,
+
+                    /// Serialize unset optional structure members as `None` instead of omitting them.
+                    ///
+                    /// Enable this for formats that require an exact structure length or fixed field positions.
+                    pub serialize_unset_fields: bool,
                 }
 
                 impl SerializationSettings {
@@ -238,10 +243,22 @@ object SupportStructures {
                     ///
                     /// Note: This may alter the type of the serialized output and make it impossible to deserialize as
                     /// numerical fields will be replaced with strings.
-                    pub const fn redact_sensitive_fields() -> Self { Self { redact_sensitive_fields: true, out_of_range_floats_as_strings: true } }
+                    pub const fn redact_sensitive_fields() -> Self {
+                        Self {
+                            redact_sensitive_fields: true,
+                            out_of_range_floats_as_strings: true,
+                            serialize_unset_fields: false,
+                        }
+                    }
 
                     /// Preserve the contents of sensitive fields during serializing
-                    pub const fn leak_sensitive_fields() -> Self { Self { redact_sensitive_fields: false, out_of_range_floats_as_strings: false } }
+                    pub const fn leak_sensitive_fields() -> Self {
+                        Self {
+                            redact_sensitive_fields: false,
+                            out_of_range_floats_as_strings: false,
+                            serialize_unset_fields: false,
+                        }
+                    }
                 }
                 """,
             )

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeDecoratorTest.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.CratesIo
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
@@ -565,7 +566,7 @@ class SerdeDecoratorTest {
     }
 
     @Test
-    fun `all-required structure round trips through bincode`() {
+    fun `structures round trip through bincode`() {
         val model =
             """
             namespace com.example
@@ -583,6 +584,7 @@ class SerdeDecoratorTest {
 
             structure PutInput {
                 record: BincodeRecord
+                optionalRecord: OptionalRecord
             }
 
             @serde(serialize: true, deserialize: true)
@@ -603,6 +605,12 @@ class SerdeDecoratorTest {
                 kind: Kind
                 @required
                 choice: Choice
+            }
+
+            @serde(serialize: true, deserialize: true)
+            structure OptionalRecord {
+                text: String
+                count: Integer
             }
 
             structure Nested {
@@ -644,6 +652,9 @@ class SerdeDecoratorTest {
                 arrayOf(
                     "crate" to RustType.Opaque(ctx.moduleUseName()),
                     "bincode" to CargoDependency("bincode", CratesIo("1")).toDevDependency().toType(),
+                    "ciborium" to CargoDependency.Ciborium.toType(),
+                    "serde_json" to CargoDependency.SerdeJson.toDevDependency().toType(),
+                    *RuntimeType.preludeScope,
                 )
 
             crate.integrationTest("test_bincode_deserialization") {
@@ -686,6 +697,47 @@ class SerdeDecoratorTest {
 
                         round_trip(record(Choice::Text("payload".to_string())));
                         round_trip(record(Choice::Empty));
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                unitTest("unset_fields_round_trip_when_configured") {
+                    rustTemplate(
+                        """
+                        use #{crate}::serde::{SerializationSettings, SerializeConfigured};
+                        use #{crate}::types::OptionalRecord;
+
+                        let value = OptionalRecord::builder().build();
+
+                        let default_settings = SerializationSettings::default();
+                        let json = #{serde_json}::to_string(
+                            &value.serialize_ref(&default_settings)
+                        ).expect("record should serialize with default settings");
+                        assert_eq!(json, "{}");
+
+                        let mut settings = SerializationSettings::default();
+                        settings.serialize_unset_fields = true;
+                        let json = #{serde_json}::to_string(
+                            &value.serialize_ref(&settings)
+                        ).expect("record should serialize unset fields");
+                        assert_eq!(json, r##"{"text":null,"count":null}"##);
+
+                        let encoded = #{bincode}::serialize(&value.serialize_ref(&settings))
+                            .expect("record should serialize to bincode");
+                        let decoded: OptionalRecord = #{bincode}::deserialize(&encoded)
+                            .expect("record should deserialize from bincode");
+                        assert_eq!(decoded, value);
+
+                        let mut encoded = #{Vec}::new();
+                        #{ciborium}::ser::into_writer(
+                            &value.serialize_ref(&settings),
+                            &mut encoded,
+                        ).expect("record should serialize to CBOR");
+                        let decoded: OptionalRecord =
+                            #{ciborium}::de::from_reader(encoded.as_slice())
+                                .expect("record should deserialize from CBOR");
+                        assert_eq!(decoded, value);
                         """,
                         *codegenScope,
                     )

--- a/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
+++ b/codegen-serde/src/test/kotlin/software/amazon/smithy/rust/codegen/serde/SerdeProtocolTestTest.kt
@@ -244,6 +244,7 @@ class SerdeProtocolTestTest {
                 let mut serialization = SerializationSettings::default();
                 serialization.out_of_range_floats_as_strings =
                     out_of_range_floats_as_strings;
+                serialization.serialize_unset_fields = true;
 
                 let encoded = match format {
                     RoundTripFormat::Json => {
@@ -251,15 +252,11 @@ class SerdeProtocolTestTest {
                             .expect("failed to serialize JSON")
                     }
                     RoundTripFormat::Cbor => {
-                        // Direct CBOR serialization is covered separately from this
-                        // deserializer corpus because omitted optional fields currently
-                        // leave definite-length struct maps with an incorrect length.
-                        let value = #{serde_json}::to_value(
-                            &expected.serialize_ref(&serialization),
-                        ).expect("failed to capture the serde representation");
                         let mut encoded = #{Vec}::new();
-                        #{ciborium}::ser::into_writer(&value, &mut encoded)
-                            .expect("failed to serialize CBOR");
+                        #{ciborium}::ser::into_writer(
+                            &expected.serialize_ref(&serialization),
+                            &mut encoded,
+                        ).expect("failed to serialize CBOR");
                         encoded
                     }
                 };


### PR DESCRIPTION
Adds `SerializationSettings::serialize_unset_fields`, preserving the existing omission behavior by default while allowing callers to emit absent optional members as serde `None`/`null`.

```rust
let mut settings = SerializationSettings::default();
settings.serialize_unset_fields = true;
let serializable = value.serialize_ref(&settings);
```

This keeps declared structure lengths and field positions consistent for CBOR and non-self-describing formats. The protocol-value corpus now uses direct CBOR serialization instead of converting through `serde_json::Value`.

This PR is stacked on #4816.