### PR TITLE
test(client): cover EventStreamSender re-export

### DIFF
--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGeneratorTest.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy.generators
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.testutil.EventStreamTestModels
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 
@@ -60,6 +61,20 @@ class ClientRuntimeTypesReExportGeneratorTest {
 
                         use crate::error::BoxError;
                     }
+                    """,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `it should reexport EventStreamSender for event stream clients`() {
+        clientIntegrationTest(EventStreamTestModels.TEST_CASES.first().model) { _, crate ->
+            crate.unitTest {
+                rust(
+                    """
+                    ##[allow(unused_imports)]
+                    use crate::primitives::event_stream::EventStreamSender;
                     """,
                 )
             }


### PR DESCRIPTION
## Motivation and Context

Closes #4817.

Generated event-stream clients should expose `EventStreamSender` through
`crate::primitives::event_stream`, so users do not need a direct
`aws-smithy-http` dependency.

The production export was added in #4574, but its unit test invokes the shared
re-export writer directly. It does not verify that client codegen wires that
writer into the generated `primitives::event_stream` module.

## Description

Add a client integration test that generates an event-stream client and compiles
an import of:

```rust
use crate::primitives::event_stream::EventStreamSender;
```

This covers the public generated-client API and fails if either the shared export
or its client customization wiring regresses.

No changelog entry is included because this is a test-only change; generated
behavior is unchanged.

## Testing

- Verified the new test fails with `E0432` when the production export is
  temporarily removed.
- `./gradlew :codegen-client:test --tests '*ClientRuntimeTypesReExportGeneratorTest.it should reexport EventStreamSender for event stream clients' --console=plain`
- `./gradlew :codegen-client:test --tests '*ClientRuntimeTypesReExportGeneratorTest*' --console=plain`
- `./gradlew :codegen-core:test --tests '*SmithyTypesPubUseExtraTest*' --console=plain`
- `./gradlew ktlint --console=plain`
- `./gradlew :codegen-client:test --console=plain`
