### PR TITLE
Support required strings in telemetry input capture

### DIFF
--- a/.changelog/4822.md
+++ b/.changelog/4822.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+- client
+authors:
+- lauzadis
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix telemetry input capture code generation for required string members when `nullabilityCheckMode` is set to `SERVER`.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/TelemetryInputCaptureInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/TelemetryInputCaptureInterceptorGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
+import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 
@@ -155,16 +156,26 @@ class TelemetryInputCaptureInterceptorGenerator(
                 val memberName = symbolProvider.toMemberName(member)
                 // The Smithy member name is what the customer names in their list.
                 val smithyName = member.memberName
-                rustTemplate(
-                    """
-                    if requested.should_capture(${smithyName.dq()}) {
-                        if let #{Some}(value) = input.$memberName.as_deref() {
-                            captured.insert(${smithyName.dq()}, value);
+                if (symbolProvider.toSymbol(member).isOptional()) {
+                    rustTemplate(
+                        """
+                        if requested.should_capture(${smithyName.dq()}) {
+                            if let #{Some}(value) = input.$memberName.as_deref() {
+                                captured.insert(${smithyName.dq()}, value);
+                            }
                         }
-                    }
-                    """,
-                    *preludeScope,
-                )
+                        """,
+                        *preludeScope,
+                    )
+                } else {
+                    rustTemplate(
+                        """
+                        if requested.should_capture(${smithyName.dq()}) {
+                            captured.insert(${smithyName.dq()}, input.$memberName.as_str());
+                        }
+                        """,
+                    )
+                }
             }
         }
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/TelemetryInputCaptureDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/TelemetryInputCaptureDecoratorTest.kt
@@ -6,12 +6,14 @@
 package software.amazon.smithy.rust.codegen.client.smithy.customizations
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
 
@@ -224,6 +226,26 @@ class TelemetryInputCaptureDecoratorTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `required string capture compiles with server nullability`() {
+        clientIntegrationTest(
+            model,
+            params =
+                IntegrationTestParams(
+                    cargoCommand = "cargo check --features behavior-version-latest",
+                    additionalSettings =
+                        ObjectNode.builder()
+                            .withMember(
+                                "codegen",
+                                ObjectNode.builder()
+                                    .withMember("nullabilityCheckMode", "SERVER")
+                                    .build(),
+                            )
+                            .build(),
+                ),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context

Telemetry input capture, introduced in #4751, assumes all string input members were optional. With `nullabilityCheckMode` configured to `SERVER`, required strings are generated as `String`, causing invalid Rust code that called `as_deref()` on them.

Internal failing build for reference: 7997300744

## Description

Use the generated symbol’s optionality when rendering telemetry capture code:

  - Optional strings continue using `as_deref()`
  - Required strings are captured using `as_str()`

Added a regression test using `SERVER` nullability.

  ## Testing

  - `./gradlew :codegen-client:test --tests 'software.amazon.smithy.rust.codegen.client.smithy.customizations.TelemetryInputCaptureDecoratorTest'`
  - `./gradlew ktlint`
  
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._