### PR TITLE
Replace `urlencoding` with `percent-encoding`

### DIFF
--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -13,7 +13,7 @@ aws-smithy-runtime-api = { path = "../aws-smithy-runtime-api", features = ["clie
 aws-smithy-schema = { path = "../aws-smithy-schema" }
 aws-smithy-types = { path = "../aws-smithy-types", features = ["http-body-1-x"] }
 aws-smithy-xml = { path = "../aws-smithy-xml" }
-urlencoding = "2.1"
+percent-encoding = "2"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/rust-runtime/aws-smithy-query/src/codec/serializer.rs
+++ b/rust-runtime/aws-smithy-query/src/codec/serializer.rs
@@ -7,8 +7,40 @@ use aws_smithy_schema::codec::FinishSerializer;
 use aws_smithy_schema::serde::{SerdeError, SerializableStruct, ShapeSerializer};
 use aws_smithy_schema::Schema;
 use aws_smithy_types::{BigDecimal, BigInteger, DateTime, Document};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use std::fmt::Write;
-use urlencoding::encode;
+
+/// Everything except "A-Z a-z 0-9 - . _ ~"
+pub(crate) const PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
 
 /// A collection path segment, kept `Copy` so it can be formatted directly into
 /// the output/prefix without an intermediate `String` allocation.
@@ -69,8 +101,8 @@ impl QueryShapeSerializer {
         let _ = write!(
             output,
             "Action={}&Version={}",
-            encode(action),
-            encode(version)
+            utf8_percent_encode(action, PERCENT_ENCODE_SET),
+            utf8_percent_encode(version, PERCENT_ENCODE_SET)
         );
         Self {
             output,
@@ -220,7 +252,8 @@ impl QueryShapeSerializer {
             }
         }
         self.output.push('=');
-        self.output.push_str(&encode(value));
+        self.output
+            .push_str(&utf8_percent_encode(value, PERCENT_ENCODE_SET).to_string());
         Ok(())
     }
 }

--- a/rust-runtime/aws-smithy-query/src/lib.rs
+++ b/rust-runtime/aws-smithy-query/src/lib.rs
@@ -19,12 +19,13 @@
 pub mod codec;
 pub mod protocol;
 
+use crate::codec::serializer::PERCENT_ENCODE_SET;
 use aws_smithy_types::date_time::{DateTimeFormatError, Format};
 use aws_smithy_types::primitive::Encoder;
 use aws_smithy_types::{DateTime, Number};
+use percent_encoding::utf8_percent_encode;
 use std::borrow::Cow;
 use std::fmt::Write;
-use urlencoding::encode;
 
 pub struct QueryWriter<'a> {
     output: &'a mut String,
@@ -33,9 +34,9 @@ pub struct QueryWriter<'a> {
 impl<'a> QueryWriter<'a> {
     pub fn new(output: &'a mut String, action: &str, version: &str) -> Self {
         output.push_str("Action=");
-        output.push_str(&encode(action));
+        output.push_str(&utf8_percent_encode(action, PERCENT_ENCODE_SET).to_string());
         output.push_str("&Version=");
-        output.push_str(&encode(version));
+        output.push_str(&utf8_percent_encode(version, PERCENT_ENCODE_SET).to_string());
         QueryWriter { output }
     }
 
@@ -85,7 +86,7 @@ impl<'a> QueryMapWriter<'a> {
             entry,
             self.next_index,
             self.key_name,
-            encode(key)
+            utf8_percent_encode(key, PERCENT_ENCODE_SET)
         )
         // The `Write` implementation for `String` is infallible,
         // see https://doc.rust-lang.org/src/alloc/string.rs.html#2815
@@ -187,7 +188,8 @@ impl<'a> QueryValueWriter<'a> {
     /// Writes a string `value`.
     pub fn string(mut self, value: &str) {
         self.write_param_name();
-        self.output.push_str(&encode(value));
+        self.output
+            .push_str(&utf8_percent_encode(value, PERCENT_ENCODE_SET).to_string());
     }
 
     /// Writes a number `value`.


### PR DESCRIPTION
Dependency `urlencoding` appears to be no longer supported, and most of the ecosystem uses ` percent-encoding`.