### PR TITLE
Make `XmlBindingTraitSerializerGenerator` extensible

### DIFF
--- a/.changelog/xml-serializer-extension-seam.md
+++ b/.changelog/xml-serializer-extension-seam.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+- client
+- server
+authors:
+- DarkIsDude
+references:
+- smithy-rs#4771
+breaking: false
+new_feature: false
+bug_fix: false
+---
+`XmlBindingTraitSerializerGenerator` is now `open`, and the members it walks shapes with are `protected` instead of `private`, so a protocol defined outside `codegen-core` can subclass it rather than re-implement XML serialization. Visibility only: no behavior or generated-code change.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -55,16 +55,16 @@ import software.amazon.smithy.rust.codegen.core.util.isTargetUnit
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 
-class XmlBindingTraitSerializerGenerator(
+open class XmlBindingTraitSerializerGenerator(
     codegenContext: CodegenContext,
-    private val httpBindingResolver: HttpBindingResolver,
+    protected val httpBindingResolver: HttpBindingResolver,
 ) : StructuredDataSerializerGenerator {
-    private val symbolProvider = codegenContext.symbolProvider
-    private val runtimeConfig = codegenContext.runtimeConfig
-    private val model = codegenContext.model
-    private val codegenTarget = codegenContext.target
-    private val protocolFunctions = ProtocolFunctions(codegenContext)
-    private val codegenScope =
+    protected val symbolProvider = codegenContext.symbolProvider
+    protected val runtimeConfig = codegenContext.runtimeConfig
+    protected val model = codegenContext.model
+    protected val codegenTarget = codegenContext.target
+    protected val protocolFunctions = ProtocolFunctions(codegenContext)
+    protected val codegenScope =
         arrayOf(
             "XmlWriter" to
                 RuntimeType.smithyXml(runtimeConfig).resolve("encode::XmlWriter"),
@@ -75,9 +75,9 @@ class XmlBindingTraitSerializerGenerator(
             *RuntimeType.preludeScope,
         )
 
-    private val xmlIndex = XmlNameIndex.of(model)
-    private val rootNamespace = codegenContext.serviceShape.getTrait<XmlNamespaceTrait>()
-    private val util = SerializerUtil(model, symbolProvider)
+    protected val xmlIndex = XmlNameIndex.of(model)
+    protected val rootNamespace = codegenContext.serviceShape.getTrait<XmlNamespaceTrait>()
+    protected val util = SerializerUtil(model, symbolProvider)
 
     sealed class Ctx {
         abstract val input: String
@@ -101,10 +101,10 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    private fun Ctx.Element.scopedTo(member: MemberShape) =
+    protected fun Ctx.Element.scopedTo(member: MemberShape) =
         this.copy(input = "$input.${symbolProvider.toMemberName(member)}")
 
-    private fun Ctx.Scope.scopedTo(member: MemberShape) =
+    protected fun Ctx.Scope.scopedTo(member: MemberShape) =
         this.copy(input = "$input.${symbolProvider.toMemberName(member)}")
 
     override fun operationInputSerializer(operationShape: OperationShape): RuntimeType? {
@@ -295,13 +295,13 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    private fun XmlNamespaceTrait?.apply(): String {
+    protected fun XmlNamespaceTrait?.apply(): String {
         this ?: return ""
         val prefix = prefix.map { prefix -> "Some(${prefix.dq()})" }.orElse("None")
         return ".write_ns(${uri.dq()}, $prefix)"
     }
 
-    private fun RustWriter.structureInner(
+    protected open fun RustWriter.structureInner(
         members: XmlMemberIndex,
         ctx: Ctx.Element,
     ) {
@@ -325,7 +325,7 @@ class XmlBindingTraitSerializerGenerator(
         rust("scope.finish();")
     }
 
-    private fun RustWriter.serializeRawMember(
+    protected open fun RustWriter.serializeRawMember(
         member: MemberShape,
         input: String,
     ) {
@@ -374,7 +374,7 @@ class XmlBindingTraitSerializerGenerator(
     }
 
     @Suppress("NAME_SHADOWING")
-    private fun RustWriter.serializeMember(
+    protected open fun RustWriter.serializeMember(
         memberShape: MemberShape,
         ctx: Ctx.Scope,
         rootNameOverride: String? = null,
@@ -454,7 +454,7 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    private fun RustWriter.serializeStructure(
+    protected open fun RustWriter.serializeStructure(
         structureShape: StructureShape,
         members: XmlMemberIndex,
         ctx: Ctx.Element,
@@ -480,7 +480,7 @@ class XmlBindingTraitSerializerGenerator(
         rust("#T(${ctx.input}, ${ctx.elementWriter})?", structureSerializer)
     }
 
-    private fun RustWriter.serializeUnion(
+    protected open fun RustWriter.serializeUnion(
         unionShape: UnionShape,
         ctx: Ctx.Element,
     ) {
@@ -536,7 +536,7 @@ class XmlBindingTraitSerializerGenerator(
         rust("#T(${ctx.input}, ${ctx.elementWriter})?", structureSerializer)
     }
 
-    private fun RustWriter.serializeList(
+    protected open fun RustWriter.serializeList(
         listShape: CollectionShape,
         ctx: Ctx.Scope,
     ) {
@@ -546,7 +546,7 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    private fun RustWriter.serializeFlatList(
+    protected open fun RustWriter.serializeFlatList(
         member: MemberShape,
         listShape: CollectionShape,
         ctx: Ctx.Scope,
@@ -561,7 +561,7 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    private fun RustWriter.serializeMap(
+    protected open fun RustWriter.serializeMap(
         mapShape: MapShape,
         entryName: String,
         ctx: Ctx.Scope,
@@ -588,7 +588,7 @@ class XmlBindingTraitSerializerGenerator(
      * [inner] is passed a new `ctx` object to use for code generation which handles the potentially
      * new name of the input.
      */
-    private fun <T : Ctx> RustWriter.handleOptional(
+    protected open fun <T : Ctx> RustWriter.handleOptional(
         member: MemberShape,
         ctx: T,
         inner: RustWriter.(T) -> Unit,
@@ -624,17 +624,17 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    private fun OperationShape.requestBodyMembers(): XmlMemberIndex =
+    protected fun OperationShape.requestBodyMembers(): XmlMemberIndex =
         XmlMemberIndex.fromMembers(
             httpBindingResolver.requestMembers(this, HttpLocation.DOCUMENT),
         )
 
-    private fun OperationShape.responseBodyMembers(): XmlMemberIndex =
+    protected fun OperationShape.responseBodyMembers(): XmlMemberIndex =
         XmlMemberIndex.fromMembers(
             httpBindingResolver.responseMembers(this, HttpLocation.DOCUMENT),
         )
 
-    private fun Shape.xmlNamespace(root: Boolean): XmlNamespaceTrait? {
+    protected fun Shape.xmlNamespace(root: Boolean): XmlNamespaceTrait? {
         return this.getTrait<XmlNamespaceTrait>().letIf(root) { it ?: rootNamespace }
     }
 }


### PR DESCRIPTION
## Motivation and Context

This came up in #4771, while building a server-side `awsQuery` protocol out of tree — a
`ServerCodegenDecorator` with no fork of smithy-rs.

`awsQuery` response bodies are restXml bodies inside two extra framing layers
(`<XActionResponse><XActionResult>…`), so `XmlBindingTraitSerializerGenerator` is very nearly
what such a server needs. But it is `class` rather than `open class`, and every member-walking
function (`structureInner`, `serializeMember`, `serializeStructure`, `serializeList`,
`serializeMap`, `serializeUnion`, …) is `private`, so there is no seam to subclass through and
nothing is reachable from another package.

Lacking one, we re-implemented roughly 300 lines of XML serialization that already exist here —
and re-implemented them worse: the copy handles structures, lists and scalars, and throws
`CodegenException` on maps, unions and member-level `@xmlNamespace`, all of which this class
already gets right. A seam deletes most of that and brings maps, unions, flattened collections
and namespaces along with it.

Nothing here is specific to `awsQuery`: it is useful to any protocol defined outside
`codegen-core`, whether or not server `awsQuery` is ever in scope for smithy-rs.

## Description

Visibility only:

- `class` → `open class`
- the constructor's `httpBindingResolver` and the private fields (`model`, `symbolProvider`,
  `runtimeConfig`, `codegenTarget`, `protocolFunctions`, `codegenScope`, `xmlIndex`,
  `rootNamespace`, `util`) → `protected`
- the shape-walking `RustWriter` extensions → `protected open`
- the small helpers (`scopedTo`, `xmlNamespace`, `apply`, `requestBodyMembers`,
  `responseBodyMembers`) → `protected`

No signature, no behaviour and no generated code changes. The public overrides
(`operationOutputSerializer`, `serverErrorSerializer`, …) are already implicitly `open` in
Kotlin, so a subclass can wrap them to inject its own root element and then delegate to the
inherited `structureInner`/`serializeMember` for everything below it.

## Testing

`./gradlew :codegen-core:compileKotlin ktlint`. The change is a
visibility widening with no call-site changes, so the existing
`XmlBindingTraitSerializerGeneratorTest` and the restXml protocol tests cover the behaviour that
must not move.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.*
