### PR TITLE
Make `check-semver-hazards` optional in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,7 +663,6 @@ jobs:
     - generate
     - generate-full
     - test-codegen
-    - check-semver-hazards
     - test-sdk
     - test-sdk-full
     - test-rust-windows


### PR DESCRIPTION
## Motivation and Context
The semver hazards check swaps in this branch's runtime crates for the ones used by the latest released SDKs in `aws-sdk-rust` and runs their integration tests. Occasionally we deliberately break those tests to improve previously accepted behavior. When that happens the check fails in CI and merging PRs to `main` requires an admin override until the next `aws-sdk-rust` release picks up the smithy-rs commit.

This PR makes the semver hazards check optional, so PRs can be merged to `main` without a permission override.

## Description
Removed `check-semver-hazards` from the `needs` list of the `require-all` job ("Matrix Success"). The job still runs and reports its own check; it just no longer blocks merging.

## Testing
- CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
