### PR TITLE
aws-smithy-http-client: connection pool h2 implementation

### DIFF
--- a/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
+++ b/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
@@ -615,11 +615,15 @@ produces run on the same runtime.
 Connection establishment and installed connection lifetime are separate
 ownership phases. The establishment authority exists before DNS and owns the
 connector future and any bounded-origin permit. After DNS, socket connection,
-proxy negotiation, TLS, and ALPN produce a negotiated transport, the pool
-creates `ConnectionState` in `PendingOpen`. The Hyper protocol handshake and
-cell installation move it to `Open`. Lifecycle observation treats failed DNS,
-transport, and TLS attempts independently from installed-connection events;
-failed attempts have no synthetic `ConnectionState`.
+proxy negotiation, TLS, and ALPN produce connected I/O with a selected HTTP
+protocol, the pool creates `ConnectionState` in `PendingOpen`. At that point
+transport establishment and protocol selection are complete, but Hyper has not
+produced the request handle required for dispatch. Successful Hyper protocol
+setup moves the state to `Open` and attaches the bounded-origin permit before
+cell installation makes the connection discoverable. Lifecycle observation
+treats failed DNS, transport, and TLS attempts independently from
+installed-connection events; failed attempts have no synthetic
+`ConnectionState`.
 
 An **explicit partition** names its owner runtime through `DriverSpawner`. The
 **anonymous partition** captures the current Tokio runtime on first use. A

--- a/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
+++ b/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
@@ -2417,18 +2417,22 @@ aws-smithy-http-client/src/client/
     cell.rs            — OriginCell and cell-level acquisition coordination
     cell/
       h1.rs            — HTTP/1 records, sender ownership, and reuse reservation
+      h2.rs            — HTTP/2 flights, generations, routes, gates, and request leases
       waiters.rs       — local acquisition queue and delivery reservation
     admission.rs       — bounded-origin capacity and unlocked action driving
     admission/
       demand.rs        — versioned demand order and delivery fences
       reuse.rs         — H1 availability order and cross-cell reuse operations
       delivery.rs      — capacity/H1 crossing guards and acknowledgements
+      publication.rs   — HTTP/2 advertisements, peer publication, and fences
     establish.rs       — transport construction below protocol establishment
     establish/
-      h1.rs            — HTTP/1 connect, handshake, installation, and driver
+      h1.rs            — HTTP/1 handshake, installation, and driver
+      h2.rs            — post-ALPN flight convergence, handshake, and driver
     dispatch.rs        — protocol-neutral request routing
     dispatch/
-      h1.rs            — HTTP/1 acquisition, dispatch, retry, and response ownership
+      h1.rs            — HTTP/1 dispatch, reacquisition, and response ownership
+      h2.rs            — HTTP/2 dispatch and two-ended request completion
     maintenance.rs     — idle-deadline scheduling and partition task lifetime
     connection.rs      — records, leases, logical close, physical completion
     events.rs          — listener and lifecycle event types
@@ -2466,9 +2470,10 @@ The evidence levels have distinct jobs:
   identifies its operation alphabet and bound; ordinary transition tests are not described as exhaustive.
 * Focused **Loom kernels** compile the production synchronization-bearing code against Loom and exercise
   concurrent cell publication, permit and H1 delivery, H1 selection and return, borrowed-H1 materialization,
-  reuse cancellation, logical close, and maintenance publication or shutdown. They model these
-  ownership boundaries rather than sockets or the complete network client. HTTP/2 generation publication and
-  request-lease kernels are added with those mechanisms.
+  reuse cancellation, logical close, maintenance publication or shutdown, HTTP/2 activation against close,
+  two-ended request completion, route installation against requesting-cell cancellation, and peer publication
+  against connection-cell close. They model these ownership boundaries rather than sockets or the complete
+  network client.
 * **Controlled-runtime tests** use injected time, sleep, connectors, and executors to force cancellation at
   ownership-distinct cancellation boundaries, submitted-future drop, idle deadlines, independent-runtime
   request movement, explicit placement checks, and connector or handshake failure.

--- a/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
+++ b/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
@@ -612,6 +612,15 @@ on another, every readiness event would cross runtimes, and the socket's reactor
 the driver that holds it. So establishment — connector, transport, TLS, ALPN, handshake — and the driver it
 produces run on the same runtime.
 
+Connection establishment and installed connection lifetime are separate
+ownership phases. The establishment authority exists before DNS and owns the
+connector future and any bounded-origin permit. After DNS, socket connection,
+proxy negotiation, TLS, and ALPN produce a negotiated transport, the pool
+creates `ConnectionState` in `PendingOpen`. The Hyper protocol handshake and
+cell installation move it to `Open`. Lifecycle observation treats failed DNS,
+transport, and TLS attempts independently from installed-connection events;
+failed attempts have no synthetic `ConnectionState`.
+
 An **explicit partition** names its owner runtime through `DriverSpawner`. The
 **anonymous partition** captures the current Tokio runtime on first use. A
 request may be polled on another runtime, so every new connection submits the
@@ -682,15 +691,24 @@ not share machinery with the connector's Tower readiness. The two are related on
 
 #### HTTP/1 attempts and HTTP/2 flights
 
+One HTTP/2 connection carries many concurrent request streams. The pool calls
+one installed incarnation of that connection a *generation*. Replacements
+receive new generation identities so delayed routes, GOAWAY handling, close
+work, and request completion cannot affect a newer connection. An
+`H2Activation` is a reservation for a prospective stream on one exact
+generation; it becomes an accepted request lease only after Hyper accepts the
+request.
+
 The pool supports HTTP/1.1 and HTTP/2 and lets connector ALPN select the protocol. Each request has one of
 three requirements. `H1Required` covers accepted request forms that require HTTP/1 wire semantics, including
 HTTP/1.0, ordinary `CONNECT`, and Upgrade. `H1Compatible` may use either protocol. `H2Required` cannot dispatch
 on HTTP/1. Request protocol is not part of the origin key.
 
 The default rustls connector offers only `http/1.1` for `H1Required` and offers `h2, http/1.1` otherwise.
-The s2n connector has a fixed HTTP ALPN offer, and custom connectors remain responsible for their own protocol
-configuration. Those connectors may therefore negotiate H2 for `H1Required`; the pool rejects that result as
-a protocol mismatch before Hyper establishment. `H2Required` does not make an H2-only offer. If the server
+The s2n connector has a fixed HTTP ALPN offer. Connectors injected through the unstable test utility own
+their protocol configuration and do not receive the pool's offer. Those paths may therefore negotiate H2
+for `H1Required`; the pool rejects that result as a protocol mismatch before Hyper establishment.
+`H2Required` does not make an H2-only offer. If the server
 selects HTTP/1, the pool retains the useful H1 connection for compatible demand and returns an
 unsupported-version error with that connection's metadata to the launching request.
 
@@ -953,6 +971,10 @@ pub enum ConnectionReuseScope {
 interface, with all unbound partitions in one group. `Pool` permits reuse across every partition. Scope
 controls only dispatch eligibility: it does not constrain reclaim, which closes a connection and transfers
 capacity rather than moving I/O authority.
+
+An **eligibility group** is the exact set of partitions whose reuse policies
+allow them to share a connection. Each partition belongs to one such group for
+an origin, derived from the configured scope above.
 
 Dispatching through a connection that already exists consumes no capacity; that connection already holds one
 of the admitted permits. So an eligible reusable connection serves the waiter whether or not a permit is
@@ -1397,10 +1419,14 @@ closing it. Logical close returns its capacity to origin admission, which can th
 H1-required head. A generation with request work is not reclaimed. Its transition to idle publishes a new
 advertisement and makes reclaim eligible.
 
-Admission attempts this reclaim only when the transport factory guarantees that an H1-required establishment
-uses HTTP/1. The default rustls and cleartext connectors provide that guarantee. The fixed-ALPN s2n connector
-and custom connectors do not, so H1-required demand remains queued behind their healthy H2 capacity until an
-ordinary close releases a permit.
+Admission attempts this reclaim only when the transport factory guarantees that
+an H1-required establishment uses HTTP/1. Without that guarantee, admission
+could close a healthy H2 connection, negotiate H2 again, reject the result, and
+repeat without satisfying the waiting request. The default rustls and cleartext
+connectors provide the guarantee. The fixed-ALPN s2n connector and connectors
+injected through the unstable test utility do not, so H1-required demand
+remains queued behind their healthy H2 capacity until an ordinary close
+releases a permit.
 
 For bounded origins, a generation publishes only its zero-to-one and one-to-zero request-work transitions.
 Intermediate multiplexed request counts remain cell-local. Unbounded origins have no admission publication.
@@ -2207,7 +2233,11 @@ while already accepted streams finish. A draining connection has logically close
 still has physically live root I/O, and is counted by `h1_draining` or `h2_draining`. An H2 record may be both
 while its accepted streams and transport finish.
 
-**Generation** — an HTTP/2 connection's dispatch epoch, a first-class object with a lifecycle.
+**Generation** — one uniquely identified incarnation of an installed HTTP/2
+connection. It owns the authoritative request handle, accepting or draining
+state, request counts, and connection capacity. A replacement connection has a
+new generation identity so delayed work for the previous incarnation is
+rejected.
 
 **Demand generation** — one cell queue head's `DemandId`. A **snapshot version** orders complete publications
 for that generation. Readers retain the newest publication and reject work for a retired generation.
@@ -2469,12 +2499,18 @@ use the default `h2, http/1.1` offer. An HTTP/2-marked request does not force an
 protocol-policy API requires a concrete Smithy caller and a definition of how that policy composes when
 multiple clients share one pool.
 
-The default rustls connector applies the per-attempt offer. The s2n connector's fixed HTTP ALPN list cannot be
-narrowed by the pool, and a custom connector owns its own ALPN configuration. The pool validates the
-negotiated result but does not replace either connector's TLS implementation. Making the s2n offer
-configurable is an upstream connector follow-up. Because neither path can guarantee HTTP/1 for an H1-required
-attempt, bounded admission does not reclaim a healthy idle H2 generation solely to serve that demand. The
-request remains queued until ordinary close releases capacity.
+The default rustls connector applies the per-attempt offer. The s2n connector's
+fixed HTTP ALPN list cannot be narrowed by the pool. A connector injected
+through the unstable test utility also owns its own protocol configuration and
+does not receive the pool's offer. The pool validates the negotiated result but
+does not replace either connector's TLS implementation. Making the s2n offer
+configurable is an upstream connector follow-up.
+
+Because those paths cannot force HTTP/1, bounded admission does not reclaim a
+healthy idle H2 generation solely to serve H1-required demand. Closing that
+generation could negotiate H2 again and discard useful capacity without
+satisfying the request. The request remains queued until ordinary close
+releases capacity.
 
 An unset `idle_timeout` uses a 90-second default. Passing `None` to the fluent setter disables idle
 timeout. The mutable setter preserves all three configuration states: outer `None` restores the default,

--- a/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
+++ b/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md
@@ -504,12 +504,14 @@ authority.
 Connect and read timeouts remain operation policy rather than connection identity. The facade uses the
 operation's `AsyncSleep` from `RuntimeComponents` when present, then the same default-sleep fallback as the
 existing client. A configured timeout requires the resulting sleep implementation; its absence never disables
-the timeout. The read timeout wraps `PoolConnector::call` through response headers. A connect timeout wraps
-only the transport-connector operation through TLS and ALPN for an establishment attempt owned by that
-request; the Hyper protocol handshake remains under the read timeout. A request joining an existing HTTP/2
-flight owns no connector operation, so its connect timeout does not apply to that shared flight; its read
-timeout or caller cancellation can remove that participant. If it later becomes an establishment driver, its
-own connect timeout applies to that attempt.
+the timeout. The read timeout bounds `PoolConnector::call` through response headers, including time spent
+waiting for acquisition or a shared HTTP/2 flight. A connect timeout wraps only the transport connector through
+TLS and ALPN. Once the connected transport moves to the connection-partition owner task, neither request
+timeout supervises or cancels that task's Hyper handshake; the pool has no separate handshake timeout.
+A request joining an existing HTTP/2 flight owns no connector operation, so its connect timeout does not apply
+to that flight. Its read timeout or caller cancellation removes that participant while the owner task
+continues. A fully cancelled successful flight may therefore install an idle generation that remains until
+ordinary close or idle expiration.
 
 Idle maintenance is pool policy, not operation policy. Its `TimeSource` and `AsyncSleep` are fixed by the pool
 builder and shared by the partition maintenance tasks; they do not depend on which operation first asks for a
@@ -680,9 +682,17 @@ not share machinery with the connector's Tower readiness. The two are related on
 
 #### HTTP/1 attempts and HTTP/2 flights
 
-The pool supports HTTP/1.1 and HTTP/2 and lets connector ALPN select the protocol. Request version controls
-dispatch compatibility, not connector negotiation: an HTTP/2-marked request cannot dispatch on H1, an
-HTTP/1.1-marked request may dispatch on H2, and request version is not part of the origin key.
+The pool supports HTTP/1.1 and HTTP/2 and lets connector ALPN select the protocol. Each request has one of
+three requirements. `H1Required` covers accepted request forms that require HTTP/1 wire semantics, including
+HTTP/1.0, ordinary `CONNECT`, and Upgrade. `H1Compatible` may use either protocol. `H2Required` cannot dispatch
+on HTTP/1. Request protocol is not part of the origin key.
+
+The default rustls connector offers only `http/1.1` for `H1Required` and offers `h2, http/1.1` otherwise.
+The s2n connector has a fixed HTTP ALPN offer, and custom connectors remain responsible for their own protocol
+configuration. Those connectors may therefore negotiate H2 for `H1Required`; the pool rejects that result as
+a protocol mismatch before Hyper establishment. `H2Required` does not make an H2-only offer. If the server
+selects HTTP/1, the pool retains the useful H1 connection for compatible demand and returns an
+unsupported-version error with that connection's metadata to the launching request.
 
 The two protocols establish differently because they reuse differently. An HTTP/1 connection carries one
 request at a time, so a cell that needs more concurrency needs more connections: each establishment is an
@@ -695,8 +705,9 @@ waits for it rather than starting its own, and the resulting generation is publi
 ##### Post-ALPN convergence
 
 The initial API imposes no pool-wide HTTP/1-only or HTTP/2-only policy. Connector ALPN resolves a transport's
-protocol only after connect, so concurrent misses may each own a transport until then. Attempts remain
-independent when they negotiate H1 and converge on the cell's one flight only when they negotiate H2.
+protocol only after connect, so concurrent misses may each own a transport until then. Compatible attempts
+remain independent when they negotiate H1 and converge on the cell's one flight only when they negotiate H2.
+An H1-required attempt that nevertheless negotiates H2 terminates with a protocol-mismatch error.
 
 The logical owner carried through this decision is an *establishment authority*: the transport and, on a
 bounded origin, its capacity lease. The authority has exactly one owner even though the request waiting for
@@ -715,28 +726,32 @@ automatic attempt owns transport + optional capacity lease + launching waiter
   |           `-- error -> close transport; return lease; fail launching waiter
   |
   `-- ALPN = H2
-        `-- atomically inspect this cell's accepting generation and H2 flight
-              +-- accepting generation -> register waiter against generation
-              |                           close losing transport; return its lease
-              +-- flight exists --------> register waiter as follower
-              |                           close losing transport; return its lease
-              `-- neither exists -------> install flight as driver
-                                          flight takes transport + lease
-                                            |
-                                            +-- H2 handshake succeeds
-                                            |     -> install record; record takes lease
-                                            |     -> publish generation; serve participants
-                                            `-- error
-                                                  -> close transport; return lease
-                                                  -> fail participants
+        +-- H1 required -> close transport; return lease; fail launching waiter
+        |
+        `-- H2 compatible
+              `-- atomically inspect this cell's accepting generation and H2 flight
+                    +-- accepting generation -> register waiter against generation
+                    |                           close losing transport; return its lease
+                    +-- flight exists --------> register waiter as participant
+                    |                           close losing transport; return its lease
+                    `-- neither exists -------> register flight; owner task drives it
+                                                owner task retains transport + lease
+                                                  |
+                                                  +-- H2 handshake succeeds
+                                                  |     -> install record; record takes lease
+                                                  |     -> publish generation; serve participants
+                                                  `-- error
+                                                        -> close transport; return lease
+                                                        -> fail participants
 ```
 
 The inspection and either registration or flight installation are one transition under the cell's
 coordination. This is the linearization point: many automatic attempts may reach H2 ALPN, but at most one
 becomes the flight. A losing authority has not started a Hyper driver, so its guard closes the negotiated
 transport and returns its capacity lease; its launching waiter remains represented exactly once, as a
-generation user or flight follower. The winning flight installs the connection record before publishing the
-generation, so no waiter can observe a generation without a driver and capacity owner behind it. Activation
+generation user or flight participant. The owner task completes the handshake, transfers capacity to the
+connection record, and installs the generation before submitting the driver. A request activated during that
+submission interval is retained by Hyper's dispatch channel until the driver is polled. Activation
 revalidates the generation identity and accepting state; if either changed after registration, the waiter
 returns to acquisition rather than dispatching through stale state.
 
@@ -750,15 +765,15 @@ negotiates HTTP/1, the H1 connection remains useful and is handed to compatible 
 The launching request receives the same unsupported-version classification and connection metadata as the
 existing client; it neither dispatches on H1 nor loops establishing until ALPN happens to choose H2.
 
-A flight owns a generation identity, a set of participant waiter identities, and optionally a pool-completion
-interest transferred from a started attempt whose launching waiter was served or cancelled. Cancelling one
-participant removes only that participant. The flight continues while another participant, compatible demand,
-or pool-completion interest remains. The completion interest ends when the attempt installs, converges with
-existing state, or fails; it prevents the no-participant rule from cancelling a started acquisition loser. If
-none of those interests remains, dropping the establishment authority closes the transport and returns the
-lease. A dropped flight task performs the same guarded cleanup and reconciles every still-live participant back
-to acquisition, so no waiter remains attached to a missing flight. Completion from an old generation identity
-is stale and cannot clear or publish over a successor.
+A flight record owns its identity and participant waiter identities. The
+connection-partition owner task separately owns the transport and optional
+capacity lease while it drives the handshake. Cancelling a participant removes
+only that waiter; it does not cancel the owner task. If every participant
+cancels, the task may still install an idle generation, which retains bounded
+capacity until ordinary close or idle expiration. Task drop closes the
+transport, returns capacity, and fails every participant still retained by the
+exact flight. Completion from an old flight identity is stale and cannot clear
+or publish over a successor.
 
 The ownership transfer is therefore fixed at each boundary:
 
@@ -766,7 +781,7 @@ The ownership transfer is therefore fixed at each boundary:
 | ------------------- | ------------------------- | ------------------------------------------- | ---------------------------------- |
 | independent attempt | establishment authority   | its optional capacity lease                 | cell waiter entry                  |
 | H1 installed        | H1 connection record      | record's capacity lease                     | checked-out H1 guard or cell queue |
-| H2 flight driver    | flight authority          | flight's capacity lease                     | flight participant entry           |
+| H2 flight driver    | connection owner task     | owner task until record installation        | flight participant entry           |
 | H2 joiner           | existing flight or record | existing owner; own capacity lease returned | participant or activation          |
 | H2 published        | H2 connection record      | record's capacity lease                     | H2 request lease after activation  |
 | failure or drop     | cleanup guard             | guard until admission return                | terminal result or re-acquisition  |
@@ -798,8 +813,10 @@ covers.
 * **Losing-attempt cleanup** [safety] — an automatic H2 attempt that joins existing state closes its
   unhandshaken transport and returns its capacity lease while retaining its launching waiter exactly once.
 * **Compatibility-preserving H1 result** [safety] — an H1 result is retained for compatible demand; an
-  H2-required launching waiter receives the existing unsupported-version result and never dispatches on H1 or
-  loops establishment for a different ALPN outcome.
+  H2-required launching waiter receives the existing unsupported-version result with connection metadata and
+  never dispatches on H1 or loops establishment for a different ALPN outcome.
+* **Required-H1 negotiation** [safety] — an H1-required request never dispatches on H2. A connector that
+  accepts per-attempt ALPN offers receives an HTTP/1-only offer for that request.
 * **Flight cancellation** [safety] — participant cancellation removes only that participant; terminal flight
   drop closes its transport, returns its lease, and leaves no live waiter attached to the retired flight
   identity.
@@ -824,15 +841,15 @@ The waiting requests queue behind the ticket in arrival order. An arriving permi
 head, which stops waiting; the next becomes the head. The ticket is how returning connections and other
 cells find a cell with unmet demand; the queue is how that cell chooses whom to serve first.
 
-The ticket carries one thing beyond its presence: whether the head request can use an HTTP/1 connection. A
-peer with a reusable HTTP/1 connection to lend needs to know its offer will be taken before it acts, and a
-head that requires HTTP/2 cannot use an HTTP/1 handle. This is the minimum the signal must distinguish;
-finer matching is a dispatch-time question, not a demand-signal one.
+The ticket carries one thing beyond its presence: the head request's protocol requirement. Admission must know
+whether an HTTP/1 return, an HTTP/2 publication, or either can satisfy the head before it reserves a resource.
+This is the minimum the signal must distinguish; finer matching remains a dispatch-time question.
 
 The logical snapshot published to admission is:
 
 ```rust
 enum ProtocolRequirement {
+    H1Required,
     H1Compatible,
     H2Required,
 }
@@ -1317,18 +1334,39 @@ Publication also installs a local fairness gate:
 
 ```rust
 enum GenerationGate {
-    Prioritizing { cutoff: WaiterSequence },
-    Open,
+    Closed,
+    Prioritizing {
+        generation: H2GenerationId,
+        cutoff: WaiterId,
+        activating: Option<WaiterId>,
+    },
+    Open { generation: H2GenerationId },
 }
 ```
 
-The cutoff is the newest compatible waiter already committed when publication becomes visible. While the gate
-is `Prioritizing`, those waiters are offered generation activation oldest first in bounded turns, and a newer
-arrival cannot activate through the generation ahead of them. Cancellation removes its waiter from the owed
-set. When no waiter at or before the cutoff remains, the gate opens and later arrivals use the ordinary local
-path. Generation invalidation removes the gate and sends any unserved committed waiter back through
-acquisition. The gate orders activation opportunities; each successful activation still creates its own H2
-request lease.
+`Closed` names no usable generation. The cutoff is the newest compatible
+waiter committed when a generation becomes visible. While the gate is
+`Prioritizing`, those waiters receive activation oldest first, and
+`activating` retains the one priority turn crossing to Hyper acceptance or
+cancellation. When no waiter at or before the cutoff remains, the gate becomes
+`Open`. Open generations issue concurrent prospective activations; Hyper owns
+stream credit and flow control. Generation invalidation closes the gate and
+returns unserved transferred waiters to acquisition. Each successful
+activation creates its own H2 request lease.
+
+A requesting cell retains peer-route crossing state separately:
+
+```rust
+struct PeerH2Route {
+    route: H2Route,
+    gate: GenerationGate,
+    crossing: Option<WaiterId>,
+}
+```
+
+Queued peer-route activations cross the connection-cell lock one at a time so a failed exact-generation
+reservation can restore the requesting cell's oldest turn. Once the route gate is open, direct arrivals
+reserve independent prospective leases concurrently; `crossing` does not serialize them.
 
 The peer-cell index holds one group-scoped advertisement for each accepting H2 generation. Record and
 generation installation precede advertisement; transition out of accepting removes it. Either a new
@@ -1351,6 +1389,22 @@ named head's activation opportunity are committed, not after every local waiter 
 waiters proceed through the generation gate in bounded turns and no longer advertise a connection need while
 that generation remains usable. Later group tickets are handled by subsequent bounded publication turns, so
 one-to-many visibility does not turn one host action into work proportional to partition count.
+
+An H1-required head cannot use an advertised HTTP/2 generation. If bounded origin capacity is exhausted,
+admission may instead reserve the oldest advertised idle generation for reclaim. The connection cell
+revalidates the exact generation, accepting residence, and zero prospective or accepted request counts before
+closing it. Logical close returns its capacity to origin admission, which can then grant establishment to the
+H1-required head. A generation with request work is not reclaimed. Its transition to idle publishes a new
+advertisement and makes reclaim eligible.
+
+Admission attempts this reclaim only when the transport factory guarantees that an H1-required establishment
+uses HTTP/1. The default rustls and cleartext connectors provide that guarantee. The fixed-ALPN s2n connector
+and custom connectors do not, so H1-required demand remains queued behind their healthy H2 capacity until an
+ordinary close releases a permit.
+
+For bounded origins, a generation publishes only its zero-to-one and one-to-zero request-work transitions.
+Intermediate multiplexed request counts remain cell-local. Unbounded origins have no admission publication.
+
 Dropping a pending publication guard submits its `on_drop` acknowledgement so the fence retries or closes;
 there is no single-owner payload to refunnel. Committing publication stores the requesting-cell
 acknowledgement, which is submitted before the guard disarms.
@@ -1372,6 +1426,10 @@ checks specified in [Appendix B](#appendix-b-validation).
   its owning partition.
 * **Reclaim scope independence** [safety] — reclaim moves a permit without dispatching across a partition
   boundary, so it is not constrained by the reuse scope.
+* **Protocol-compatible reclaim** [safety] — admission reclaims idle H2 capacity for H1-required demand only
+  when the transport factory guarantees an HTTP/1 establishment result.
+* **H2 work publication** [safety, optimization] — bounded cells publish when a generation crosses between
+  zero and nonzero request work; intermediate stream counts require no admission update.
 * **Single delivery** [safety] — one delivery identity owns at most one permit or provisional H1, commits it
   to at most one requesting waiter, and retains its scheduling fence until requesting-cell acknowledgement.
 * **Refunnelling** [safety] — rejection, supersession, cancellation, task drop, or panic returns every
@@ -1528,7 +1586,18 @@ disarms any unaccepted H2 body endpoint, retires or invalidates the stale select
 same request through acquisition again. An unsent failure from a fresh connection is terminal and still
 retires a sender Hyper reported unable to accept the request; its inert body endpoint and selected guard cannot
 survive the error. The pool does not clone a request or replay one Hyper accepted.
-The existing caller timeout and cancellation remain able to terminate repeated stale selections.
+
+`AcquisitionResult::Reacquire` is the internal transition for a waiter whose selected generation became stale
+before Hyper observed the request. It carries no request copy and is not an SDK retry attempt: the original
+request remains owned by the pool future and re-enters acquisition. A request returned unsent by Hyper uses the
+same loop only under the reused-connection rule above. Negotiated-protocol mismatch and a fresh Hyper error
+without the original envelope are terminal.
+
+After dispatch receives an H2 activation, the request may select at most two replacement H2 generations.
+A third pre-acceptance rejection returns its retained connection error. This bound is independent of caller
+timeout and cancellation and prevents repeated GOAWAY or close races from creating an unbounded establishment
+loop.
+
 With Hyper 1.11, the returned-request path after `try_send_request` is reachable for H1; H2 dispatch errors
 after call do not carry the original request and are terminal. An H2 readiness failure observed before call is
 different: the request is still locally owned and may return to acquisition without being replayed.
@@ -2022,7 +2091,7 @@ H1-draining until its wrapped root I/O drops. `physically_live` starts when the 
 is wrapped for
 lifecycle tracking and ends only at root-I/O drop, so it includes handshaking, admitted, draining, and
 upgraded transports and may exceed the configured limit. `waiting_requests` counts requests registered in
-acquisition that do not yet own a dispatch authority, including flight followers.
+acquisition that do not yet own a dispatch authority, including flight participants.
 
 `OriginStats::admitted` derives the saturating sum of `establishing`, `h1_idle`, `h1_active`, and
 `h2_accepting` from the captured partition rows; it is not another shared counter or admission authority.
@@ -2111,13 +2180,22 @@ capacity.
 **Retry authority** — proof that the same request may be dispatched again. Only Hyper returning the original
 request unsent from a reused connection creates this authority; request clonability does not.
 
+**Reacquire** — returning a still pool-owned request to acquisition after its selected protocol state becomes
+stale before dispatch. It is an internal state transition, not an SDK retry or authority to clone an accepted
+request.
+
 **Publish** and **deliver** — publication makes state visible to many unnamed readers; delivery hands one
 value to one waiting party. `DemandResidence` tracks a ticket's residence and acknowledgement fence;
 `DeliveryGuardState` owns a one-to-one payload while it crosses locks.
 
 **Attempt** and **flight** — an HTTP/1 establishment is an attempt, independent of other attempts; an
 HTTP/2 establishment is a flight. Automatic attempts remain independent before ALPN, then atomically join or
-install at most one post-ALPN H2 flight per cell.
+install at most one post-ALPN H2 flight per cell. The flight record owns participant identities; the
+connection-partition owner task owns handshake completion.
+
+**Advertisement** and **route** — an advertisement is admission's report that one connection cell has an
+accepting H2 generation. Publication installs a route in a requesting cell. The route names that exact
+connection cell and generation but owns no sender, socket, driver, or capacity.
 
 **Logical close** — a connection stops accepting new work and releases its permit. **Physical close** —
 the socket is gone. Physical close follows logical close by an unbounded interval, so live sockets can
@@ -2385,10 +2463,18 @@ set, it bounds one scheme-host-port origin across all partitions and interface g
 and HTTPS and distinct non-default ports are bounded separately. The limit counts every establishing, idle, and
 active connection rather than only idle connections.
 
-The initial builder exposes no pool-wide HTTP/1-only or HTTP/2-only policy. The connector determines the
-negotiated protocol, while request version controls dispatch compatibility after negotiation and does not
-configure connector ALPN. A future protocol-policy API requires a concrete Smithy caller and a definition of
-how that policy composes when multiple clients share one pool.
+The initial builder exposes no pool-wide HTTP/1-only or HTTP/2-only policy. Accepted request forms that require
+HTTP/1 wire semantics narrow the per-attempt offer to `http/1.1` when the connector supports it; other requests
+use the default `h2, http/1.1` offer. An HTTP/2-marked request does not force an H2-only offer. A future
+protocol-policy API requires a concrete Smithy caller and a definition of how that policy composes when
+multiple clients share one pool.
+
+The default rustls connector applies the per-attempt offer. The s2n connector's fixed HTTP ALPN list cannot be
+narrowed by the pool, and a custom connector owns its own ALPN configuration. The pool validates the
+negotiated result but does not replace either connector's TLS implementation. Making the s2n offer
+configurable is an upstream connector follow-up. Because neither path can guarantee HTTP/1 for an H1-required
+attempt, bounded admission does not reclaim a healthy idle H2 generation solely to serve that demand. The
+request remains queued until ordinary close releases capacity.
 
 An unset `idle_timeout` uses a 90-second default. Passing `None` to the fluent setter disables idle
 timeout. The mutable setter preserves all three configuration states: outer `None` restores the default,
@@ -2422,6 +2508,7 @@ aws-smithy-http-client/src/client/
     admission.rs       — bounded-origin capacity and unlocked action driving
     admission/
       demand.rs        — versioned demand order and delivery fences
+      order.rs         — checked intrusive order shared by admission indexes
       reuse.rs         — H1 availability order and cross-cell reuse operations
       delivery.rs      — capacity/H1 crossing guards and acknowledgements
       publication.rs   — HTTP/2 advertisements, peer publication, and fences
@@ -2471,14 +2558,15 @@ The evidence levels have distinct jobs:
 * Focused **Loom kernels** compile the production synchronization-bearing code against Loom and exercise
   concurrent cell publication, permit and H1 delivery, H1 selection and return, borrowed-H1 materialization,
   reuse cancellation, logical close, maintenance publication or shutdown, HTTP/2 activation against close,
-  two-ended request completion, route installation against requesting-cell cancellation, and peer publication
-  against connection-cell close. They model these ownership boundaries rather than sockets or the complete
-  network client.
+  two-ended request completion against generation close, route installation against requesting-cell
+  cancellation, and peer publication against connection-cell close. They model these ownership boundaries
+  rather than sockets or the complete network client.
 * **Controlled-runtime tests** use injected time, sleep, connectors, and executors to force cancellation at
   ownership-distinct cancellation boundaries, submitted-future drop, idle deadlines, independent-runtime
   request movement, explicit placement checks, and connector or handshake failure.
 * The **wire harness** verifies HTTP/1.1 and HTTP/2 behavior against scripted peers, including reuse,
-  multiplexing, ALPN, GOAWAY, stream reset, incomplete bodies, upgrades, poisoning, and transport close.
+  multiplexing, request-specific ALPN, GOAWAY before and after first-stream acceptance, stream reset,
+  incomplete bodies, upgrades, poisoning, and transport close.
 * **Differential tests** run the same implementation-neutral behavior contracts against the current
   Hyper-util-backed client and this pool. Any difference in request behavior, metadata, timeout scope, or error
   classification requires an explicit design decision rather than a rewritten oracle.

--- a/rust-runtime/aws-smithy-http-client/src/client/pool.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool.rs
@@ -24,16 +24,21 @@
 //! establishment task
 //!     |-- DNS, socket, proxy, TLS, and ALPN
 //!     `-- negotiated transport
-//!             |-- Hyper protocol handshake
-//!             `-- pool installation
-//!                     `-- open connection -> draining -> closed
+//!             `-- PendingOpen
+//!                     |-- Hyper protocol setup
+//!                     `-- Open
+//!                             `-- pool installation
+//!                                     `-- discoverable -> draining -> closed
 //! ```
 //!
 //! The establishment task and its permit represent work that may fail before a
 //! physical connection exists. `ConnectionState` begins only after the
-//! connector returns a negotiated transport. Establishment and connection
-//! events can therefore be observed independently without representing failed
-//! attempts as installed connections.
+//! connector returns connected I/O and selects HTTP/1 or HTTP/2. For TLS, that
+//! boundary follows TLS and ALPN. Hyper protocol setup moves the state from
+//! `PendingOpen` to `Open`; cell installation then makes the connection
+//! discoverable. Establishment and connection events can therefore be observed
+//! independently without representing failed attempts as installed
+//! connections.
 //!
 //! # State ownership
 //!

--- a/rust-runtime/aws-smithy-http-client/src/client/pool.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool.rs
@@ -72,6 +72,39 @@
 //! a complete reusable message boundary. Failure retires the connection, and
 //! an upgrade closes the pool record before exposing upgraded root I/O.
 //!
+//! # HTTP/2 request lifecycle
+//!
+//! An HTTP/2 connection keeps its authoritative sender and capacity in the
+//! connection-owning cell. A requesting cell may retain only a route naming
+//! that cell and one exact accepting generation. Each use revalidates the
+//! route at the owning cell before cloning a transient sender.
+//!
+//! ```text
+//! Client(partition, request)
+//! `-- OriginCell(partition, origin)
+//!     |-- local accepting generation ----------------> H2Activation
+//!     `-- acquisition queue
+//!         |-- local flight result --------------------> H2Activation
+//!         |-- eligible peer generation route --------> H2Activation
+//!         `-- capacity permit -> connect + ALPN
+//!             |-- HTTP/2 -> join or drive one flight -> H2Activation
+//!             `-- HTTP/1 -> H1Selection or incompatible-version error
+//!
+//! H2Activation -- Hyper accepts request --> accepted request lease
+//! accepted request lease
+//!     |-- request body ends or drops -----> send endpoint complete
+//!     `-- response body ends or drops ----> receive endpoint complete
+//! both endpoints complete ----------------> release generation request count
+//! ```
+//!
+//! An activation is prospective: dropping it before Hyper accepts the request
+//! returns its generation-gate turn and request count. Acceptance creates two
+//! independent endpoints because an upload and response can finish in either
+//! order. Logical close stops new activations and releases bounded capacity;
+//! accepted requests retain the draining generation until both endpoints end.
+//! Peer publication moves only route identity. The socket, protocol driver,
+//! sender, and capacity remain with the connection-owning partition.
+//!
 //! `ConnectionState` separates logical close, accepted-request accounting, and
 //! root-I/O ownership. Logical close rejects new dispatch and releases bounded
 //! capacity. `DispatchGuard` follows an accepted request, while

--- a/rust-runtime/aws-smithy-http-client/src/client/pool.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool.rs
@@ -14,6 +14,26 @@
 //! maintenance. [`ConnectionReuseScope`] controls whether another partition may
 //! dispatch through those connections. Reuse transfers protocol dispatch
 //! authority; it never moves the socket, driver, or capacity accounting.
+//! Partitions in the same eligibility group are exactly those whose configured
+//! reuse scope permits them to share a connection.
+//!
+//! Connection establishment and installed connection lifetime are separate
+//! ownership phases:
+//!
+//! ```text
+//! establishment task
+//!     |-- DNS, socket, proxy, TLS, and ALPN
+//!     `-- negotiated transport
+//!             |-- Hyper protocol handshake
+//!             `-- pool installation
+//!                     `-- open connection -> draining -> closed
+//! ```
+//!
+//! The establishment task and its permit represent work that may fail before a
+//! physical connection exists. `ConnectionState` begins only after the
+//! connector returns a negotiated transport. Establishment and connection
+//! events can therefore be observed independently without representing failed
+//! attempts as installed connections.
 //!
 //! # State ownership
 //!
@@ -79,10 +99,15 @@
 //!
 //! # HTTP/2 request lifecycle
 //!
-//! An HTTP/2 connection keeps its authoritative sender and capacity in the
-//! connection-owning cell. A requesting cell may retain only a route naming
-//! that cell and one exact accepting generation. Each use revalidates the
-//! route at the owning cell before cloning a transient sender.
+//! One HTTP/2 connection carries many concurrent request streams. The pool
+//! calls one installed incarnation of that connection a generation. A
+//! replacement connection receives a new generation identity so delayed
+//! close, route, and completion work cannot affect it.
+//!
+//! The connection-owning cell retains the generation's authoritative Hyper
+//! request handle and capacity. A requesting cell may retain only a route that
+//! names the owning cell and one exact accepting generation. Each use
+//! revalidates that route before cloning a transient request handle.
 //!
 //! ```text
 //! Client(partition, request)
@@ -102,13 +127,17 @@
 //! both endpoints complete ----------------> release generation request count
 //! ```
 //!
-//! An activation is prospective: dropping it before Hyper accepts the request
-//! returns its generation-gate turn and request count. Acceptance creates two
-//! independent endpoints because an upload and response can finish in either
-//! order. Logical close stops new activations and releases bounded capacity;
-//! accepted requests retain the draining generation until both endpoints end.
+//! `H2Activation` reserves pool accounting for a prospective stream on one
+//! exact generation. It is not yet an HTTP/2 stream. Dropping it before Hyper
+//! accepts the request returns its generation-gate turn and request count.
+//! Acceptance creates two independent endpoints because an upload and response
+//! can finish in either order. Logical close stops new activations and releases
+//! bounded capacity; accepted streams retain the draining generation until
+//! both endpoints end. Hyper remains responsible for stream identifiers,
+//! stream credit, and flow control.
+//!
 //! Peer publication moves only route identity. The socket, protocol driver,
-//! sender, and capacity remain with the connection-owning partition.
+//! request handle, and capacity remain with the connection-owning partition.
 //!
 //! `ConnectionState` separates logical close, accepted-request accounting, and
 //! root-I/O ownership. Logical close rejects new dispatch and releases bounded

--- a/rust-runtime/aws-smithy-http-client/src/client/pool.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool.rs
@@ -35,9 +35,14 @@
 //!
 //! One `OriginCell` lock owns local acquisition order and protocol residence.
 //! For a bounded origin, `OriginAdmission` separately owns the origin-wide
-//! connection limit and cross-cell scheduling. Delivery values carry their own
-//! payload and cancellation fallback between those lock domains; cell and
-//! admission locks are never held together.
+//! connection limit and cross-cell scheduling. An H2 request-lease lock owns
+//! its two endpoint bits. `ConnectionState` owns logical connection lifetime,
+//! and partition maintenance owns its scheduler state.
+//!
+//! No two pool locks are held together. Delivery and publication guards carry
+//! payload or identity between cell and admission scopes. H2 lease completion
+//! detaches its dispatch guard before entering connection or cell state.
+//! Maintenance detaches cells and wakers before expiration or wake callbacks.
 //!
 //! # HTTP/1 request lifecycle
 //!

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
@@ -14,20 +14,24 @@
 //!
 //! 1. A cell publishes a complete [`DemandSnapshot`] after releasing its lock.
 //! 2. [`DemandSchedule`] replaces that partition snapshot and links active
-//!    demand in origin-wide FIFO order.
-//! 3. Admission takes one unit of capacity or reserves a peer HTTP/1 sender for
-//!    the oldest demand that can make progress.
-//! 4. [`DeliveryGuard`] carries the demand fence and payload out of admission.
-//!    It completes fallible connection-cell work before locking the requesting
-//!    cell. If peer-sender revalidation fails, no requesting waiter has been
-//!    reserved.
-//! 5. The requesting cell reserves its waiter, then `commit` transfers the
-//!    materialized payload into the waiter result.
-//! 6. `DeliveryAck` closes the fence. Rejection and drop return owned values
-//!    before admission makes the demand schedulable again.
+//!    demand in the origin order and its eligibility-group order.
+//! 3. Capacity delivery and HTTP/1 reuse select from the origin head. HTTP/2
+//!    publication pairs a group head with an advertised peer generation.
+//! 4. A [`DeliveryGuard`] materializes its one capacity or HTTP/1 payload before
+//!    reserving the requesting waiter. Payload materialization failure therefore leaves the waiter in its existing
+//!    residence.
+//! 5. An [`H2PublicationGuard`] crosses the same lock domains with identities
+//!    only. It revalidates the connection-owning generation, then installs a
+//!    route and activation opportunity in the requesting cell.
+//! 6. The requesting cell becomes authoritative before either guard submits its
+//!    admission acknowledgement. Rejection and drop execute the same terminal
+//!    acknowledgement paths.
 //!
-//! Values crossing either lock boundary own their fallback, so cancellation
-//! cannot lose capacity or an HTTP/1 sender.
+//! Capacity and HTTP/1 crossings own the payload they must return on failure.
+//! HTTP/2 publication moves no payload: the connection-owning cell retains its
+//! sender, driver, socket, and capacity. No cell lock is held with the
+//! admission lock, and connection-owning and requesting cell locks are never
+//! held together.
 
 use super::cell::OriginCell;
 use super::origin::OriginKey;
@@ -40,11 +44,14 @@ use std::num::NonZeroUsize;
 mod delivery;
 mod demand;
 mod order;
+mod publication;
 pub(in crate::client::pool) mod reuse;
 
 use self::demand::{DemandSchedule, PreparedCapacityDelivery};
 use self::order::{IntrusiveLinks, IntrusiveOrder};
+use self::publication::{H2Publication, H2PublicationGuard, PreparedH2Publication};
 pub(in crate::client::pool) use delivery::DeliveryGuard;
+pub(in crate::client::pool) use publication::H2AdvertisementSnapshot;
 
 /// Protocol capability required by the head waiter in a cell.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -52,7 +59,6 @@ pub(crate) enum ProtocolRequirement {
     /// The waiter may dispatch over HTTP/1 or HTTP/2.
     H1Compatible,
     /// The waiter requires HTTP/2.
-    #[allow(dead_code, reason = "reserved for HTTP/2-only acquisition")]
     H2Required,
 }
 
@@ -153,8 +159,14 @@ impl DemandSnapshot {
         }
     }
 
+    /// Returns the demand identity for cross-module transition tests.
+    #[cfg(all(test, smithy_http_client_loom))]
+    pub(in crate::client::pool) fn id_for_test(&self) -> DemandId {
+        self.id
+    }
+
     /// Returns whether this snapshot still requests capacity.
-    fn is_active(&self) -> bool {
+    pub(in crate::client::pool) fn is_active(&self) -> bool {
         matches!(self.state, DemandState::Active { .. })
     }
 
@@ -266,6 +278,12 @@ impl OriginAdmission {
                 pending.permit,
             )));
         }
+        if let Some(publication) = state.prepare_h2_publication() {
+            return Some(AdmissionAction::H2(H2PublicationGuard::new(
+                origin.clone(),
+                publication,
+            )));
+        }
         state
             .h1
             .prepare_reuse(&state.demand_schedule)
@@ -331,6 +349,46 @@ impl OriginAdmission {
         Self::prepare_action(origin, &mut state)
     }
 
+    /// Replaces one connection cell's complete HTTP/2 advertisement.
+    pub(in crate::client::pool) fn update_h2_advertisement(
+        origin: &Arc<Self>,
+        connection_partition: PartitionId,
+        group: EligibilityGroup,
+        snapshot: H2AdvertisementSnapshot,
+    ) {
+        let action = {
+            let mut state = origin.state.lock();
+            let AdmissionState {
+                h2,
+                demand_schedule,
+                ..
+            } = &mut *state;
+            h2.update(connection_partition, group, snapshot, demand_schedule);
+            Self::prepare_action(origin, &mut state)
+        };
+        Self::drive(action);
+    }
+
+    /// Applies one H2 publication acknowledgement and prepares its successor.
+    fn finish_h2_publication(
+        origin: &Arc<Self>,
+        prepared: &PreparedH2Publication,
+        stale_generation: Option<super::cell::h2::H2GenerationId>,
+        result: DeliveryAckResult,
+    ) -> Option<AdmissionAction> {
+        let mut state = origin.state.lock();
+        if let Some(generation) = stale_generation {
+            let AdmissionState {
+                h2,
+                demand_schedule,
+                ..
+            } = &mut *state;
+            h2.remove_if_exact(&prepared.connection_partition, generation, demand_schedule);
+        }
+        state.finish_delivery(prepared.delivery, &prepared.requesting_partition, result);
+        Self::prepare_action(origin, &mut state)
+    }
+
     #[cfg(test)]
     pub(super) fn publish_action_without_driving(
         origin: &Arc<Self>,
@@ -352,6 +410,9 @@ impl OriginAdmission {
             Some(AdmissionAction::Delivery(delivery)) => Some(delivery),
             Some(AdmissionAction::H1(_)) => {
                 panic!("capacity-only test unexpectedly prepared an HTTP/1 action")
+            }
+            Some(AdmissionAction::H2(_)) => {
+                panic!("capacity-only test unexpectedly prepared an HTTP/2 action")
             }
             None => None,
         }
@@ -404,6 +465,8 @@ pub(super) enum AdmissionAction {
     Delivery(DeliveryGuard),
     /// HTTP/1 availability, reservation, or borrowed-sender work.
     H1(reuse::H1ReuseAction),
+    /// HTTP/2 generation visibility crossing to one requesting cell.
+    H2(H2PublicationGuard),
 }
 
 impl AdmissionAction {
@@ -412,6 +475,7 @@ impl AdmissionAction {
         match self {
             Self::Delivery(delivery) => delivery.deliver_once(),
             Self::H1(action) => action.drive_once(),
+            Self::H2(publication) => publication.publish_once(),
         }
     }
 
@@ -497,6 +561,8 @@ struct AdmissionState {
     demand_schedule: DemandSchedule,
     /// HTTP/1 availability reports and cross-cell reuse operations.
     h1: reuse::H1Reuse,
+    /// HTTP/2 advertisements and eligibility-group publication turns.
+    h2: H2Publication,
     /// Next never-reused delivery identity.
     next_delivery: u64,
     /// Configured connection bound used to check capacity conservation.
@@ -513,6 +579,7 @@ impl AdmissionState {
             next_permit_id: 0,
             demand_schedule: DemandSchedule::default(),
             h1: reuse::H1Reuse::default(),
+            h2: H2Publication::default(),
             next_delivery: 0,
             limit,
         }
@@ -550,9 +617,21 @@ impl AdmissionState {
 
     /// Applies one complete cell publication to cross-cell scheduling.
     fn publish_demand(&mut self, requesting_partition: PartitionId, snapshot: DemandSnapshot) {
+        let old_group = self.demand_schedule.group_for(&requesting_partition);
         self.demand_schedule.publish(requesting_partition, snapshot);
         self.h1
             .reconcile_requesting_cell(&requesting_partition, &self.demand_schedule);
+        if let Some(old_group) = old_group {
+            self.h2.reconcile_group(&old_group, &self.demand_schedule);
+        }
+        self.reconcile_h2_demand(&requesting_partition);
+    }
+
+    /// Recomputes publication readiness for one cell's latest demand group.
+    fn reconcile_h2_demand(&mut self, requesting_partition: &PartitionId) {
+        if let Some(group) = self.demand_schedule.group_for(requesting_partition) {
+            self.h2.reconcile_group(&group, &self.demand_schedule);
+        }
     }
 
     /// Pairs the oldest deliverable demand with one available permit.
@@ -565,10 +644,11 @@ impl AdmissionState {
         let delivery = self.take_delivery_id();
         let scheduled = self
             .demand_schedule
-            .reserve_head(delivery)
+            .reserve_origin_head(delivery)
             .expect("queued demand head disappeared");
         self.h1
             .reconcile_requesting_cell(&scheduled.requesting_partition, &self.demand_schedule);
+        self.reconcile_h2_demand(&scheduled.requesting_partition);
         Some(PreparedCapacityDelivery {
             permit,
             delivery,
@@ -596,8 +676,22 @@ impl AdmissionState {
         requesting_partition: &PartitionId,
         result: DeliveryAckResult,
     ) {
+        let old_group = self.demand_schedule.group_for(requesting_partition);
         self.demand_schedule
             .finish_delivery(delivery, requesting_partition, result);
+        if let Some(old_group) = old_group {
+            self.h2.reconcile_group(&old_group, &self.demand_schedule);
+        }
+        self.reconcile_h2_demand(requesting_partition);
+    }
+
+    /// Reserves one eligibility-group head for identity-only H2 publication.
+    fn prepare_h2_publication(&mut self) -> Option<PreparedH2Publication> {
+        if !self.h2.has_ready_group() {
+            return None;
+        }
+        let delivery = self.take_delivery_id();
+        self.h2.prepare(&mut self.demand_schedule, delivery)
     }
 
     /// Allocates a delivery-fence identity that is never reused by this origin.

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
@@ -49,17 +49,33 @@ pub(in crate::client::pool) mod reuse;
 
 use self::demand::{DemandSchedule, PreparedCapacityDelivery};
 use self::order::{IntrusiveLinks, IntrusiveOrder};
-use self::publication::{H2Publication, H2PublicationGuard, PreparedH2Publication};
+use self::publication::{
+    H2Publication, H2PublicationGuard, H2ReclaimAction, PreparedH2Publication, PreparedH2Reclaim,
+};
 pub(in crate::client::pool) use delivery::DeliveryGuard;
 pub(in crate::client::pool) use publication::H2AdvertisementSnapshot;
 
 /// Protocol capability required by the head waiter in a cell.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ProtocolRequirement {
+    /// The waiter requires HTTP/1 wire semantics.
+    H1Required,
     /// The waiter may dispatch over HTTP/1 or HTTP/2.
     H1Compatible,
     /// The waiter requires HTTP/2.
     H2Required,
+}
+
+impl ProtocolRequirement {
+    /// Returns whether an HTTP/1 sender can satisfy this requirement.
+    pub(crate) fn accepts_h1(self) -> bool {
+        self != Self::H2Required
+    }
+
+    /// Returns whether an HTTP/2 activation can satisfy this requirement.
+    pub(crate) fn accepts_h2(self) -> bool {
+        self != Self::H1Required
+    }
 }
 
 /// Identity of one cell-local demand generation.
@@ -150,6 +166,14 @@ impl DemandSnapshot {
         }
     }
 
+    /// Returns whether this active demand can use an HTTP/2 generation.
+    pub(crate) fn accepts_h2(&self) -> bool {
+        matches!(
+            self.state,
+            DemandState::Active { head, .. } if head.accepts_h2()
+        )
+    }
+
     /// Retires a demand generation at the supplied publication version.
     pub(crate) fn inactive(id: DemandId, version: SnapshotVersion) -> Self {
         Self {
@@ -160,7 +184,7 @@ impl DemandSnapshot {
     }
 
     /// Returns the demand identity for cross-module transition tests.
-    #[cfg(all(test, smithy_http_client_loom))]
+    #[cfg(test)]
     pub(in crate::client::pool) fn id_for_test(&self) -> DemandId {
         self.id
     }
@@ -204,25 +228,37 @@ pub(super) struct DeliveryId(u64);
 pub(crate) struct OriginAdmission {
     /// Canonical origin shared by every partition represented in `state`.
     origin: OriginKey,
+    /// Whether establishment can guarantee HTTP/1 before reclaim spends H2 capacity.
+    guarantees_http1: bool,
     /// Capacity, demand, and delivery-fence state for this origin.
     state: Mutex<AdmissionState>,
 }
 
 impl OriginAdmission {
     /// Creates admission for at most `limit` logically open connections.
-    pub(crate) fn new(origin: OriginKey, limit: NonZeroUsize) -> Arc<Self> {
+    pub(crate) fn new(origin: OriginKey, limit: NonZeroUsize, guarantees_http1: bool) -> Arc<Self> {
         Arc::new(Self {
             origin,
+            guarantees_http1,
             state: Mutex::new(AdmissionState::new(limit)),
         })
     }
 
     #[cfg(test)]
     pub(super) fn for_test(limit: NonZeroUsize) -> Arc<Self> {
+        Self::for_test_with_http1_guarantee(limit, true)
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test_with_http1_guarantee(
+        limit: NonZeroUsize,
+        guarantees_http1: bool,
+    ) -> Arc<Self> {
         Self::new(
             OriginKey::from_parts(http_1x::uri::Scheme::HTTPS, "example.com", None)
                 .expect("test origin is valid"),
             limit,
+            guarantees_http1,
         )
     }
 
@@ -284,10 +320,21 @@ impl OriginAdmission {
                 publication,
             )));
         }
+        if let Some(reuse) = state.h1.prepare_reuse(&state.demand_schedule) {
+            return Some(AdmissionAction::H1(reuse::H1ReuseAction::install(
+                origin.clone(),
+                reuse,
+            )));
+        }
+        if !origin.guarantees_http1 {
+            return None;
+        }
         state
-            .h1
-            .prepare_reuse(&state.demand_schedule)
-            .map(|reuse| AdmissionAction::H1(reuse::H1ReuseAction::install(origin.clone(), reuse)))
+            .h2
+            .prepare_reclaim(&state.demand_schedule)
+            .map(|reclaim| {
+                AdmissionAction::H2Reclaim(H2ReclaimAction::new(origin.clone(), reclaim))
+            })
     }
 
     /// Upgrades a registered requesting cell without holding the admission lock.
@@ -389,6 +436,21 @@ impl OriginAdmission {
         Self::prepare_action(origin, &mut state)
     }
 
+    /// Completes one exact idle-H2 reclaim crossing.
+    fn finish_h2_reclaim(
+        origin: &Arc<Self>,
+        prepared: &PreparedH2Reclaim,
+        snapshot: Option<H2AdvertisementSnapshot>,
+    ) -> Option<AdmissionAction> {
+        let mut state = origin.state.lock();
+        let AdmissionState {
+            h2,
+            demand_schedule,
+            ..
+        } = &mut *state;
+        h2.finish_reclaim(prepared, snapshot, demand_schedule);
+        Self::prepare_action(origin, &mut state)
+    }
     #[cfg(test)]
     pub(super) fn publish_action_without_driving(
         origin: &Arc<Self>,
@@ -413,6 +475,9 @@ impl OriginAdmission {
             }
             Some(AdmissionAction::H2(_)) => {
                 panic!("capacity-only test unexpectedly prepared an HTTP/2 action")
+            }
+            Some(AdmissionAction::H2Reclaim(_)) => {
+                panic!("capacity-only test unexpectedly prepared an HTTP/2 reclaim action")
             }
             None => None,
         }
@@ -467,6 +532,8 @@ pub(super) enum AdmissionAction {
     H1(reuse::H1ReuseAction),
     /// HTTP/2 generation visibility crossing to one requesting cell.
     H2(H2PublicationGuard),
+    /// Exact idle HTTP/2 generation crossing to its connection cell.
+    H2Reclaim(H2ReclaimAction),
 }
 
 impl AdmissionAction {
@@ -476,6 +543,7 @@ impl AdmissionAction {
             Self::Delivery(delivery) => delivery.deliver_once(),
             Self::H1(action) => action.drive_once(),
             Self::H2(publication) => publication.publish_once(),
+            Self::H2Reclaim(reclaim) => reclaim.drive_once(),
         }
     }
 
@@ -619,16 +687,20 @@ impl AdmissionState {
     fn publish_demand(&mut self, requesting_partition: PartitionId, snapshot: DemandSnapshot) {
         let old_group = self.demand_schedule.group_for(&requesting_partition);
         self.demand_schedule.publish(requesting_partition, snapshot);
+        self.reconcile_demand_indexes(&requesting_partition, old_group);
+    }
+
+    /// Repairs every protocol index affected by one demand transition.
+    fn reconcile_demand_indexes(
+        &mut self,
+        requesting_partition: &PartitionId,
+        old_group: Option<EligibilityGroup>,
+    ) {
         self.h1
-            .reconcile_requesting_cell(&requesting_partition, &self.demand_schedule);
+            .reconcile_requesting_cell(requesting_partition, &self.demand_schedule);
         if let Some(old_group) = old_group {
             self.h2.reconcile_group(&old_group, &self.demand_schedule);
         }
-        self.reconcile_h2_demand(&requesting_partition);
-    }
-
-    /// Recomputes publication readiness for one cell's latest demand group.
-    fn reconcile_h2_demand(&mut self, requesting_partition: &PartitionId) {
         if let Some(group) = self.demand_schedule.group_for(requesting_partition) {
             self.h2.reconcile_group(&group, &self.demand_schedule);
         }
@@ -642,13 +714,15 @@ impl AdmissionState {
 
         let permit = self.take_permit()?;
         let delivery = self.take_delivery_id();
+        let old_group = self
+            .demand_schedule
+            .queued_head()
+            .and_then(|head| self.demand_schedule.group_for(&head.requesting_partition));
         let scheduled = self
             .demand_schedule
             .reserve_origin_head(delivery)
             .expect("queued demand head disappeared");
-        self.h1
-            .reconcile_requesting_cell(&scheduled.requesting_partition, &self.demand_schedule);
-        self.reconcile_h2_demand(&scheduled.requesting_partition);
+        self.reconcile_demand_indexes(&scheduled.requesting_partition, old_group);
         Some(PreparedCapacityDelivery {
             permit,
             delivery,
@@ -679,10 +753,7 @@ impl AdmissionState {
         let old_group = self.demand_schedule.group_for(requesting_partition);
         self.demand_schedule
             .finish_delivery(delivery, requesting_partition, result);
-        if let Some(old_group) = old_group {
-            self.h2.reconcile_group(&old_group, &self.demand_schedule);
-        }
-        self.reconcile_h2_demand(requesting_partition);
+        self.reconcile_demand_indexes(requesting_partition, old_group);
     }
 
     /// Reserves one eligibility-group head for identity-only H2 publication.

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission.rs
@@ -10,7 +10,7 @@
 //! sole authority for available capacity, origin-wide demand order, and reuse
 //! operations. Cell locks are never held with the admission lock.
 //!
-//! A bounded acquisition crosses the layer in this order:
+//! A bounded acquisition moves through the layer in this order:
 //!
 //! 1. A cell publishes a complete [`DemandSnapshot`] after releasing its lock.
 //! 2. [`DemandSchedule`] replaces that partition snapshot and links active
@@ -18,20 +18,20 @@
 //! 3. Capacity delivery and HTTP/1 reuse select from the origin head. HTTP/2
 //!    publication pairs a group head with an advertised peer generation.
 //! 4. A [`DeliveryGuard`] materializes its one capacity or HTTP/1 payload before
-//!    reserving the requesting waiter. Payload materialization failure therefore leaves the waiter in its existing
-//!    residence.
-//! 5. An [`H2PublicationGuard`] crosses the same lock domains with identities
-//!    only. It revalidates the connection-owning generation, then installs a
-//!    route and activation opportunity in the requesting cell.
+//!    reserving the requesting waiter. Payload materialization failure
+//!    therefore leaves the waiter in its existing residence.
+//! 5. An [`H2PublicationGuard`] carries identities through the same unlocked
+//!    handoff. It revalidates the connection-owning generation, then installs
+//!    a route and activation opportunity in the requesting cell.
 //! 6. The requesting cell becomes authoritative before either guard submits its
 //!    admission acknowledgement. Rejection and drop execute the same terminal
 //!    acknowledgement paths.
 //!
-//! Capacity and HTTP/1 crossings own the payload they must return on failure.
+//! Capacity and HTTP/1 handoffs own the payload they must return on failure.
 //! HTTP/2 publication moves no payload: the connection-owning cell retains its
-//! sender, driver, socket, and capacity. No cell lock is held with the
-//! admission lock, and connection-owning and requesting cell locks are never
-//! held together.
+//! request handle, driver, socket, and capacity. No cell lock is held with
+//! the admission lock, and connection-owning and requesting cell locks are
+//! never held together.
 
 use super::cell::OriginCell;
 use super::origin::OriginKey;
@@ -228,37 +228,41 @@ pub(super) struct DeliveryId(u64);
 pub(crate) struct OriginAdmission {
     /// Canonical origin shared by every partition represented in `state`.
     origin: OriginKey,
-    /// Whether establishment can guarantee HTTP/1 before reclaim spends H2 capacity.
-    guarantees_http1: bool,
+    /// Whether admission may close idle H2 capacity for H1-required demand.
+    allow_h2_reclaim_for_h1: bool,
     /// Capacity, demand, and delivery-fence state for this origin.
     state: Mutex<AdmissionState>,
 }
 
 impl OriginAdmission {
     /// Creates admission for at most `limit` logically open connections.
-    pub(crate) fn new(origin: OriginKey, limit: NonZeroUsize, guarantees_http1: bool) -> Arc<Self> {
+    pub(crate) fn new(
+        origin: OriginKey,
+        limit: NonZeroUsize,
+        allow_h2_reclaim_for_h1: bool,
+    ) -> Arc<Self> {
         Arc::new(Self {
             origin,
-            guarantees_http1,
+            allow_h2_reclaim_for_h1,
             state: Mutex::new(AdmissionState::new(limit)),
         })
     }
 
     #[cfg(test)]
     pub(super) fn for_test(limit: NonZeroUsize) -> Arc<Self> {
-        Self::for_test_with_http1_guarantee(limit, true)
+        Self::for_test_with_h2_reclaim(limit, true)
     }
 
     #[cfg(test)]
-    pub(super) fn for_test_with_http1_guarantee(
+    pub(super) fn for_test_with_h2_reclaim(
         limit: NonZeroUsize,
-        guarantees_http1: bool,
+        allow_h2_reclaim_for_h1: bool,
     ) -> Arc<Self> {
         Self::new(
             OriginKey::from_parts(http_1x::uri::Scheme::HTTPS, "example.com", None)
                 .expect("test origin is valid"),
             limit,
-            guarantees_http1,
+            allow_h2_reclaim_for_h1,
         )
     }
 
@@ -297,7 +301,13 @@ impl OriginAdmission {
         Self::drive(action);
     }
 
-    /// Extracts the next bounded-origin action while admission is locked.
+    /// Selects at most one action while admission is locked.
+    ///
+    /// Cancellation cleanup runs first, followed by available capacity,
+    /// compatible HTTP/2 publication, HTTP/1 reuse, and idle-H2 reclaim. The
+    /// returned action owns everything needed to run after releasing the
+    /// admission lock. Its completion prepares the next action, forming an
+    /// iterative pump without nesting admission and cell locks.
     fn prepare_action(origin: &Arc<Self>, state: &mut AdmissionState) -> Option<AdmissionAction> {
         if let Some(cancellation) = state.h1.prepare_cancellation() {
             return Some(AdmissionAction::H1(reuse::H1ReuseAction::cancel(
@@ -326,7 +336,7 @@ impl OriginAdmission {
                 reuse,
             )));
         }
-        if !origin.guarantees_http1 {
+        if !origin.allow_h2_reclaim_for_h1 {
             return None;
         }
         state
@@ -524,20 +534,20 @@ impl OriginAdmission {
     }
 }
 
-/// One unlocked step prepared while holding the bounded-origin lock.
+/// One detached step prepared while holding the bounded-origin lock.
 pub(super) enum AdmissionAction {
-    /// One capacity or borrowed-H1 payload crossing to a requesting cell.
+    /// One capacity or borrowed-H1 payload handed to a requesting cell.
     Delivery(DeliveryGuard),
     /// HTTP/1 availability, reservation, or borrowed-sender work.
     H1(reuse::H1ReuseAction),
-    /// HTTP/2 generation visibility crossing to one requesting cell.
+    /// HTTP/2 generation visibility handed to one requesting cell.
     H2(H2PublicationGuard),
-    /// Exact idle HTTP/2 generation crossing to its connection cell.
+    /// Exact idle HTTP/2 generation reserved at its connection cell.
     H2Reclaim(H2ReclaimAction),
 }
 
 impl AdmissionAction {
-    /// Executes one lock-domain crossing and returns the next prepared step.
+    /// Executes one detached action and returns the next prepared step.
     fn drive_once(self) -> Option<Self> {
         match self {
             Self::Delivery(delivery) => delivery.deliver_once(),
@@ -690,7 +700,12 @@ impl AdmissionState {
         self.reconcile_demand_indexes(&requesting_partition, old_group);
     }
 
-    /// Repairs every protocol index affected by one demand transition.
+    /// Refreshes protocol indexes derived from the canonical demand schedule.
+    ///
+    /// HTTP/1 indexes depend on the requesting partition's origin position.
+    /// HTTP/2 publication depends on both the previous and current eligibility
+    /// groups, so a group change must repair each view. The derived indexes do
+    /// not own demand or ordering.
     fn reconcile_demand_indexes(
         &mut self,
         requesting_partition: &PartitionId,

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/delivery.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/delivery.rs
@@ -410,6 +410,11 @@ enum DeliveryKind {
 }
 
 impl DeliveryAck {
+    /// Keeps a successor local while an H2 generation or route can serve it.
+    pub(in crate::client::pool) fn suppress_successor(&mut self) {
+        self.successor = None;
+    }
+
     /// Acknowledges that requesting cell state accepted the acquisition event.
     pub(in crate::client::pool) fn accept(mut self) -> Option<AdmissionAction> {
         let kind = self

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/delivery.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/delivery.rs
@@ -410,7 +410,12 @@ enum DeliveryKind {
 }
 
 impl DeliveryAck {
-    /// Keeps an H2-compatible successor local while a visible H2 can serve it.
+    /// Avoids republishing a successor already covered by visible HTTP/2 state.
+    ///
+    /// Capacity or HTTP/1 delivery may reveal another waiter after the
+    /// requesting cell already gained a local generation or peer route. That
+    /// visible HTTP/2 state can serve an H2-compatible successor directly. If
+    /// it later closes, its close path publishes the cell's current demand.
     pub(in crate::client::pool) fn suppress_h2_successor(&mut self) {
         if self
             .successor

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/delivery.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/delivery.rs
@@ -410,9 +410,15 @@ enum DeliveryKind {
 }
 
 impl DeliveryAck {
-    /// Keeps a successor local while an H2 generation or route can serve it.
-    pub(in crate::client::pool) fn suppress_successor(&mut self) {
-        self.successor = None;
+    /// Keeps an H2-compatible successor local while a visible H2 can serve it.
+    pub(in crate::client::pool) fn suppress_h2_successor(&mut self) {
+        if self
+            .successor
+            .as_ref()
+            .is_some_and(DemandSnapshot::accepts_h2)
+        {
+            self.successor = None;
+        }
     }
 
     /// Acknowledges that requesting cell state accepted the acquisition event.

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/demand.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/demand.rs
@@ -116,6 +116,8 @@ enum DemandResidence {
     Delivering {
         /// Demand generation fenced at one scheduling head.
         demand: DemandId,
+        /// Snapshot version current when admission created the fence.
+        version: super::SnapshotVersion,
         /// Delivery allowed to complete this fence.
         delivery: DeliveryId,
         /// Scheduling view whose head owns this crossing.
@@ -499,6 +501,7 @@ impl DemandSchedule {
                 debug_assert!(record.latest.is_active());
                 record.residence = DemandResidence::Delivering {
                     demand,
+                    version: record.latest.version,
                     delivery,
                     view,
                     links,
@@ -565,11 +568,13 @@ impl DemandSchedule {
         let delivered_demand = match &record.residence {
             DemandResidence::Delivering {
                 demand,
+                version,
                 delivery: current,
                 ..
-            } if *current == delivery => *demand,
+            } if *current == delivery => (*demand, *version),
             _ => return,
         };
+        let (delivered_demand, delivered_version) = delivered_demand;
 
         match result {
             DeliveryAckResult::RetrySameResidence => {
@@ -585,6 +590,7 @@ impl DemandSchedule {
                     let residence = std::mem::replace(&mut record.residence, DemandResidence::Idle);
                     let DemandResidence::Delivering {
                         demand,
+                        version: _,
                         delivery: current,
                         view: _,
                         links,
@@ -628,20 +634,16 @@ impl DemandSchedule {
                         .get_mut(requesting_partition)
                         .expect("delivery demand record disappeared")
                         .latest = successor.expect("validated successor disappeared");
-                } else if self
-                    .records
-                    .get(requesting_partition)
-                    .expect("delivery demand record disappeared")
-                    .latest
-                    .id
-                    == delivered_demand
-                {
+                } else {
+                    let retirement =
+                        DemandSnapshot::inactive(delivered_demand, delivered_version.next());
                     let record = self
                         .records
                         .get_mut(requesting_partition)
                         .expect("delivery demand record disappeared");
-                    record.latest =
-                        DemandSnapshot::inactive(delivered_demand, record.latest.version.next());
+                    if retirement.is_newer_than(&record.latest) {
+                        record.latest = retirement;
+                    }
                 }
 
                 if self
@@ -693,7 +695,12 @@ impl DemandSchedule {
     /// Checks residence, link, length, group, and fence relationships.
     fn assert_consistent(&self) {
         #[cfg(any(debug_assertions, test))]
-        self.assert_consistent_debug();
+        {
+            if std::thread::panicking() {
+                return;
+            }
+            self.assert_consistent_debug();
+        }
     }
 
     #[cfg(any(debug_assertions, test))]
@@ -703,6 +710,23 @@ impl DemandSchedule {
             .values()
             .filter(|record| record.residence.links(DemandOrderView::Origin).is_some())
             .count();
+        let origin_deliveries = self
+            .records
+            .values()
+            .filter(|record| {
+                matches!(
+                    record.residence,
+                    DemandResidence::Delivering {
+                        view: DeliveryView::Origin,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert!(
+            origin_deliveries <= 1,
+            "more than one origin delivery fence was active"
+        );
         self.origin_order.assert_consistent(
             ordered_records,
             self.records.len(),
@@ -773,6 +797,24 @@ impl DemandSchedule {
         );
 
         for (group, order) in &self.group_orders {
+            let group_deliveries = self
+                .records
+                .values()
+                .filter(|record| {
+                    record.group.as_ref() == Some(group)
+                        && matches!(
+                            record.residence,
+                            DemandResidence::Delivering {
+                                view: DeliveryView::Group,
+                                ..
+                            }
+                        )
+                })
+                .count();
+            assert!(
+                group_deliveries <= 1,
+                "more than one group delivery fence was active"
+            );
             let expected = self
                 .records
                 .values()
@@ -944,6 +986,97 @@ mod tests {
         );
         assert_eq!(0, schedule.len());
         assert!(schedule.queued_group_head(&group).is_none());
+    }
+
+    #[test]
+    fn accepted_fence_does_not_retire_a_newer_active_publication() {
+        let group = EligibilityGroup::Pool;
+        let partition = partition(1);
+        let demand = DemandId::from_u64(1);
+        let initial = super::super::SnapshotVersion::INITIAL;
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(
+            partition,
+            DemandSnapshot::active(
+                demand,
+                initial,
+                ProtocolRequirement::H2Required,
+                group.clone(),
+            ),
+        );
+        let delivery = DeliveryId(12);
+        schedule
+            .reserve_group_head(&group, &partition, demand, delivery)
+            .expect("group head should reserve");
+        let republished = DemandSnapshot::active(
+            demand,
+            initial.next().next(),
+            ProtocolRequirement::H2Required,
+            group.clone(),
+        );
+        schedule.publish(partition, republished.clone());
+
+        schedule.finish_delivery(
+            delivery,
+            &partition,
+            DeliveryAckResult::Accepted { successor: None },
+        );
+
+        assert_eq!(Some(&republished), schedule.latest_for_test(&partition));
+        assert_eq!(
+            Some(partition),
+            schedule.queued_head().map(|head| head.requesting_partition)
+        );
+        assert_eq!(
+            Some(partition),
+            schedule
+                .queued_group_head(&group)
+                .map(|head| head.requesting_partition)
+        );
+    }
+
+    #[test]
+    fn group_reservation_rejects_a_stale_demand_identity() {
+        let group = EligibilityGroup::Pool;
+        let partition = partition(1);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(partition, active(1, group.clone()));
+        schedule.publish(partition, active(2, group.clone()));
+
+        assert!(schedule
+            .reserve_group_head(&group, &partition, DemandId::from_u64(1), DeliveryId(13),)
+            .is_none());
+        assert_eq!(
+            Some(DemandId::from_u64(2)),
+            schedule
+                .queued_group_head(&group)
+                .map(|queued| queued.demand)
+        );
+    }
+
+    #[test]
+    fn stale_acknowledgement_does_not_close_a_newer_delivery_fence() {
+        let group = EligibilityGroup::Pool;
+        let partition = partition(1);
+        let demand = DemandId::from_u64(1);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(partition, active(1, group.clone()));
+        schedule
+            .reserve_group_head(&group, &partition, demand, DeliveryId(14))
+            .expect("group head should reserve");
+
+        schedule.finish_delivery(
+            DeliveryId(15),
+            &partition,
+            DeliveryAckResult::Accepted { successor: None },
+        );
+
+        assert!(schedule.delivery_is_current(DeliveryId(14), &partition, demand));
+        assert!(!schedule.delivery_is_current(DeliveryId(15), &partition, demand));
+        assert_eq!(
+            Some(&active(1, group)),
+            schedule.latest_for_test(&partition)
+        );
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/demand.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/demand.rs
@@ -5,9 +5,10 @@
 
 //! Versioned cross-cell demand scheduling for one bounded origin.
 //!
-//! Each retained cell publishes a complete demand snapshot. Active snapshots
-//! occupy one origin-wide FIFO, and a delivery remains at the head as a fence
-//! until its requesting cell acknowledges ownership or rejection.
+//! Each retained cell publishes a complete demand snapshot. An active snapshot
+//! occupies one origin-wide FIFO and one FIFO for its eligibility group.
+//! Deliveries retain both positions until the requesting cell acknowledges
+//! ownership or rejection.
 
 use super::{
     DeliveryAckResult, DeliveryId, DemandId, DemandSnapshot, DemandState, IntrusiveLinks,
@@ -16,15 +17,16 @@ use super::{
 use crate::client::pool::partition::{EligibilityGroup, PartitionId};
 use std::collections::HashMap;
 
-/// Cross-cell demand records and their origin-wide scheduling order.
+/// Cross-cell demand records and their scheduling orders.
 ///
 /// At every completed transition:
 ///
 /// - `records` owns the newest snapshot for every retained cell.
-/// - `IntrusiveOrder::Active` contains exactly the `Queued` and `Delivering`
-///   records.
-/// - Queue links live inside those ordered residence variants.
-/// - A `Delivering` record remains at the head as a scheduling fence.
+/// - the origin order and the record's eligibility-group order contain exactly
+///   the `Queued` and `Delivering` records;
+/// - links for both views live inside those ordered residence variants;
+/// - an origin delivery fences the origin head; and
+/// - an HTTP/2 publication fences its eligibility-group head.
 ///
 /// Admission coordinates capacity extraction with this schedule while holding
 /// the same origin lock.
@@ -32,8 +34,10 @@ use std::collections::HashMap;
 pub(super) struct DemandSchedule {
     /// Latest demand and scheduling residence for each retained cell.
     records: HashMap<PartitionId, DemandRecord>,
-    /// Origin-wide order, including an outstanding delivery fence.
-    order: IntrusiveOrder<PartitionId>,
+    /// Origin-wide order used by capacity and HTTP/1 reuse.
+    origin_order: IntrusiveOrder<PartitionId>,
+    /// All-protocol demand order for each connection-reuse group.
+    group_orders: HashMap<EligibilityGroup, IntrusiveOrder<PartitionId>>,
 }
 
 /// Complete origin-order head used to choose one HTTP/1 reuse action.
@@ -54,8 +58,37 @@ pub(super) struct QueuedDemand {
 struct DemandRecord {
     /// Newest complete publication observed for the cell.
     pub(super) latest: DemandSnapshot,
+    /// Stable group retained while an inactive replacement crosses a fence.
+    group: Option<EligibilityGroup>,
     /// Scheduling residence, including links while ordered.
     residence: DemandResidence,
+}
+
+/// Links retained by one demand in both scheduling views.
+#[derive(Clone, Debug)]
+struct DemandLinks {
+    /// Position in origin-wide capacity and HTTP/1 order.
+    origin: IntrusiveLinks<PartitionId>,
+    /// Position in the demand's all-protocol eligibility-group order.
+    group: IntrusiveLinks<PartitionId>,
+}
+
+/// Order whose head is fenced by one delivery crossing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeliveryView {
+    /// Capacity or HTTP/1 delivery selected from origin order.
+    Origin,
+    /// HTTP/2 publication selected from eligibility-group order.
+    Group,
+}
+
+/// Selects one of a demand residence's intrusive link sets.
+#[derive(Clone, Copy)]
+enum DemandOrderView {
+    /// Origin-wide capacity and HTTP/1 order.
+    Origin,
+    /// Eligibility-group all-protocol order.
+    Group,
 }
 
 /// Admission residence for one partition's latest demand.
@@ -76,44 +109,61 @@ enum DemandResidence {
     Queued {
         /// Demand generation represented by this residence.
         demand: DemandId,
-        /// Origin-wide scheduling links and arrival sequence.
-        links: IntrusiveLinks<PartitionId>,
+        /// Origin-wide and eligibility-group scheduling links.
+        links: DemandLinks,
     },
-    /// One delivery guard owns capacity for this demand.
+    /// One delivery or publication guard fences this demand.
     Delivering {
-        /// Demand generation fenced at the order head.
+        /// Demand generation fenced at one scheduling head.
         demand: DemandId,
         /// Delivery allowed to complete this fence.
         delivery: DeliveryId,
-        /// Origin-wide scheduling links retained until acknowledgement.
-        links: IntrusiveLinks<PartitionId>,
+        /// Scheduling view whose head owns this crossing.
+        #[cfg_attr(
+            not(debug_assertions),
+            allow(
+                dead_code,
+                reason = "the scheduling view is retained for debug invariant checks"
+            )
+        )]
+        view: DeliveryView,
+        /// Both scheduling positions retained until acknowledgement.
+        links: DemandLinks,
     },
 }
 
 impl DemandResidence {
-    #[cfg(debug_assertions)]
-    /// Borrows order links while this record is queued or delivering.
-    fn links(&self) -> Option<&IntrusiveLinks<PartitionId>> {
-        match self {
-            Self::Idle => None,
-            Self::Queued { links, .. } | Self::Delivering { links, .. } => Some(links),
+    #[cfg(any(debug_assertions, test))]
+    /// Borrows one view's links while this record is ordered.
+    fn links(&self, view: DemandOrderView) -> Option<&IntrusiveLinks<PartitionId>> {
+        let links = match self {
+            Self::Idle => return None,
+            Self::Queued { links, .. } | Self::Delivering { links, .. } => links,
+        };
+        match view {
+            DemandOrderView::Origin => Some(&links.origin),
+            DemandOrderView::Group => Some(&links.group),
         }
     }
 
-    /// Mutably borrows links from a record known to be ordered.
+    /// Mutably borrows one view's links from an ordered record.
     ///
     /// # Panics
     ///
     /// Panics when called for an idle record.
-    fn links_mut(&mut self) -> &mut IntrusiveLinks<PartitionId> {
-        match self {
-            Self::Idle => panic!("idle demand has no order links"),
+    fn links_mut(&mut self, view: DemandOrderView) -> &mut IntrusiveLinks<PartitionId> {
+        let links = match self {
+            Self::Idle => panic!("idle demand has no scheduling links"),
             Self::Queued { links, .. } | Self::Delivering { links, .. } => links,
+        };
+        match view {
+            DemandOrderView::Origin => &mut links.origin,
+            DemandOrderView::Group => &mut links.group,
         }
     }
 
-    /// Detaches links while moving a record out of origin-wide order.
-    fn into_links(self) -> Option<IntrusiveLinks<PartitionId>> {
+    /// Detaches both link sets while moving a record out of scheduling.
+    fn into_links(self) -> Option<DemandLinks> {
         match self {
             Self::Idle => None,
             Self::Queued { links, .. } | Self::Delivering { links, .. } => Some(links),
@@ -154,6 +204,7 @@ impl DemandSchedule {
                 requesting_partition,
                 DemandRecord {
                     latest: snapshot.clone(),
+                    group: None,
                     residence: DemandResidence::Idle,
                 },
             );
@@ -172,6 +223,15 @@ impl DemandSchedule {
             self.remove_from_order(&requesting_partition);
         }
 
+        if let DemandState::Active {
+            eligibility_group, ..
+        } = &snapshot.state
+        {
+            self.records
+                .get_mut(&requesting_partition)
+                .expect("published demand record disappeared")
+                .group = Some(eligibility_group.clone());
+        }
         self.records
             .get_mut(&requesting_partition)
             .expect("published demand record disappeared")
@@ -187,15 +247,31 @@ impl DemandSchedule {
         self.assert_consistent();
     }
 
-    /// Appends an idle active demand to the origin-wide order.
+    /// Appends an idle active demand to both scheduling orders.
     fn enqueue(&mut self, requesting_partition: PartitionId) {
-        let links = self.order.push_back(requesting_partition);
-        if let Some(previous) = links.previous {
+        let group = self
+            .group_for(&requesting_partition)
+            .expect("enqueued demand was inactive");
+        let origin = self.origin_order.push_back(requesting_partition);
+        let group_links = self
+            .group_orders
+            .entry(group)
+            .or_default()
+            .push_back(requesting_partition);
+        if let Some(previous) = origin.previous {
             self.records
                 .get_mut(&previous)
-                .expect("order tail disappeared")
+                .expect("origin demand tail disappeared")
                 .residence
-                .links_mut()
+                .links_mut(DemandOrderView::Origin)
+                .next = Some(requesting_partition);
+        }
+        if let Some(previous) = group_links.previous {
+            self.records
+                .get_mut(&previous)
+                .expect("group demand tail disappeared")
+                .residence
+                .links_mut(DemandOrderView::Group)
                 .next = Some(requesting_partition);
         }
 
@@ -205,11 +281,20 @@ impl DemandSchedule {
             .expect("queued demand record disappeared");
         debug_assert!(matches!(record.residence, DemandResidence::Idle));
         let demand = record.latest.id;
-        record.residence = DemandResidence::Queued { demand, links };
+        record.residence = DemandResidence::Queued {
+            demand,
+            links: DemandLinks {
+                origin,
+                group: group_links,
+            },
+        };
     }
 
-    /// Removes an ordered demand and leaves its retained record idle.
+    /// Removes an ordered demand from both views and leaves its record idle.
     fn remove_from_order(&mut self, requesting_partition: &PartitionId) {
+        let group = self
+            .group_for(requesting_partition)
+            .expect("removed demand had no eligibility group");
         let residence = {
             let record = self
                 .records
@@ -219,31 +304,56 @@ impl DemandSchedule {
         };
         let links = residence
             .into_links()
-            .expect("removed demand had no order links");
+            .expect("removed demand had no scheduling links");
 
-        if let Some(previous) = links.previous {
+        if let Some(previous) = links.origin.previous {
             self.records
                 .get_mut(&previous)
-                .expect("previous demand disappeared")
+                .expect("previous origin demand disappeared")
                 .residence
-                .links_mut()
-                .next = links.next;
+                .links_mut(DemandOrderView::Origin)
+                .next = links.origin.next;
         }
-        if let Some(next) = links.next {
+        if let Some(next) = links.origin.next {
             self.records
                 .get_mut(&next)
-                .expect("next demand disappeared")
+                .expect("next origin demand disappeared")
                 .residence
-                .links_mut()
-                .previous = links.previous;
+                .links_mut(DemandOrderView::Origin)
+                .previous = links.origin.previous;
         }
+        self.origin_order
+            .remove(*requesting_partition, links.origin);
 
-        self.order.remove(*requesting_partition, links);
+        if let Some(previous) = links.group.previous {
+            self.records
+                .get_mut(&previous)
+                .expect("previous group demand disappeared")
+                .residence
+                .links_mut(DemandOrderView::Group)
+                .next = links.group.next;
+        }
+        if let Some(next) = links.group.next {
+            self.records
+                .get_mut(&next)
+                .expect("next group demand disappeared")
+                .residence
+                .links_mut(DemandOrderView::Group)
+                .previous = links.group.previous;
+        }
+        let order = self
+            .group_orders
+            .get_mut(&group)
+            .expect("ordered demand lost its eligibility-group order");
+        order.remove(*requesting_partition, links.group);
+        if order.len() == 0 {
+            self.group_orders.remove(&group);
+        }
     }
 
     /// Returns whether the head can begin a new one-to-one delivery.
     pub(super) fn head_is_queued(&self) -> bool {
-        let Some(head) = self.order.head() else {
+        let Some(head) = self.origin_order.head() else {
             return false;
         };
         matches!(
@@ -258,7 +368,7 @@ impl DemandSchedule {
 
     /// Returns the complete origin-order head when it may begin reuse.
     pub(super) fn queued_head(&self) -> Option<QueuedDemand> {
-        let head = self.order.head()?;
+        let head = self.origin_order.head()?;
         let record = self.records.get(&head).expect("order head disappeared");
         let DemandResidence::Queued { demand, .. } = &record.residence else {
             return None;
@@ -276,6 +386,39 @@ impl DemandSchedule {
             requirement: *requirement,
             eligibility_group: eligibility_group.clone(),
         })
+    }
+
+    /// Returns one eligibility-group head when it may receive H2 visibility.
+    pub(super) fn queued_group_head(&self, group: &EligibilityGroup) -> Option<QueuedDemand> {
+        let head = self.group_orders.get(group)?.head()?;
+        let record = self
+            .records
+            .get(&head)
+            .expect("group demand head disappeared");
+        let DemandResidence::Queued { demand, .. } = &record.residence else {
+            return None;
+        };
+        let DemandState::Active {
+            head: requirement,
+            eligibility_group,
+        } = &record.latest.state
+        else {
+            unreachable!("queued group demand became inactive");
+        };
+        debug_assert_eq!(eligibility_group, group);
+        Some(QueuedDemand {
+            requesting_partition: head,
+            demand: *demand,
+            requirement: *requirement,
+            eligibility_group: eligibility_group.clone(),
+        })
+    }
+
+    /// Returns the latest eligibility group retained for one cell.
+    pub(super) fn group_for(&self, requesting_partition: &PartitionId) -> Option<EligibilityGroup> {
+        self.records
+            .get(requesting_partition)
+            .and_then(|record| record.group.clone())
     }
 
     /// Returns whether `requesting_partition` still has this demand queued for a new action.
@@ -309,17 +452,42 @@ impl DemandSchedule {
         if !self.is_current_queued(requesting_partition, demand) {
             return None;
         }
-        let head = self.order.head()?;
+        let head = self.origin_order.head()?;
         if head != *requesting_partition {
             return None;
         }
-        self.reserve_head(delivery)
+        self.reserve_origin_head(delivery)
     }
 
-    /// Changes the queued head into a delivery fence at the same order position.
-    pub(super) fn reserve_head(&mut self, delivery: DeliveryId) -> Option<ScheduledDemand> {
-        let head = self.order.head()?;
-        let requesting_partition = head;
+    /// Fences one eligibility-group head for an H2 publication.
+    pub(super) fn reserve_group_head(
+        &mut self,
+        group: &EligibilityGroup,
+        requesting_partition: &PartitionId,
+        demand: DemandId,
+        delivery: DeliveryId,
+    ) -> Option<ScheduledDemand> {
+        if !self.is_current_queued(requesting_partition, demand)
+            || self.group_orders.get(group)?.head() != Some(*requesting_partition)
+        {
+            return None;
+        }
+        self.reserve(*requesting_partition, delivery, DeliveryView::Group)
+    }
+
+    /// Changes the origin head into a delivery fence at the same positions.
+    pub(super) fn reserve_origin_head(&mut self, delivery: DeliveryId) -> Option<ScheduledDemand> {
+        let head = self.origin_order.head()?;
+        self.reserve(head, delivery, DeliveryView::Origin)
+    }
+
+    /// Changes one queued demand into a delivery fence.
+    fn reserve(
+        &mut self,
+        requesting_partition: PartitionId,
+        delivery: DeliveryId,
+        view: DeliveryView,
+    ) -> Option<ScheduledDemand> {
         let record = self
             .records
             .get_mut(&requesting_partition)
@@ -332,6 +500,7 @@ impl DemandSchedule {
                 record.residence = DemandResidence::Delivering {
                     demand,
                     delivery,
+                    view,
                     links,
                 };
                 self.assert_consistent();
@@ -417,6 +586,7 @@ impl DemandSchedule {
                     let DemandResidence::Delivering {
                         demand,
                         delivery: current,
+                        view: _,
                         links,
                     } = residence
                     else {
@@ -501,7 +671,7 @@ impl DemandSchedule {
 
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
-        self.order.len()
+        self.origin_order.len()
     }
 
     #[cfg(test)]
@@ -520,32 +690,32 @@ impl DemandSchedule {
             .count()
     }
 
-    /// Checks record residence, FIFO links, length, and head-fence relationships.
+    /// Checks residence, link, length, group, and fence relationships.
     fn assert_consistent(&self) {
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, test))]
         self.assert_consistent_debug();
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, test))]
     fn assert_consistent_debug(&self) {
         let ordered_records = self
             .records
             .values()
-            .filter(|record| record.residence.links().is_some())
+            .filter(|record| record.residence.links(DemandOrderView::Origin).is_some())
             .count();
-        let head = self.order.head();
-        let mut delivering = 0;
-        self.order.assert_consistent(
+        self.origin_order.assert_consistent(
             ordered_records,
             self.records.len(),
-            "demand order",
+            "origin demand order",
             |requesting_partition| {
                 let record = self
                     .records
                     .get(&requesting_partition)
-                    .expect("ordered demand disappeared");
+                    .expect("origin-ordered demand disappeared");
                 match &record.residence {
-                    DemandResidence::Idle => unreachable!("ordered demand became idle"),
+                    DemandResidence::Idle => {
+                        unreachable!("origin-ordered demand became idle")
+                    }
                     DemandResidence::Queued { demand, .. } => {
                         assert!(record.latest.is_active(), "queued demand became inactive");
                         assert_eq!(
@@ -553,13 +723,14 @@ impl DemandSchedule {
                             "queued residence did not match its latest demand"
                         );
                     }
-                    DemandResidence::Delivering { demand, .. } => {
-                        delivering += 1;
-                        assert_eq!(
-                            Some(requesting_partition),
-                            head,
-                            "delivery fence moved away from the order head"
-                        );
+                    DemandResidence::Delivering { demand, view, .. } => {
+                        if *view == DeliveryView::Origin {
+                            assert_eq!(
+                                Some(requesting_partition),
+                                self.origin_order.head(),
+                                "origin delivery fence moved away from its head"
+                            );
+                        }
                         assert!(
                             record.latest.id >= *demand,
                             "delivery fence named a future demand"
@@ -568,10 +739,221 @@ impl DemandSchedule {
                 }
                 *record
                     .residence
-                    .links()
-                    .expect("ordered demand lost its links")
+                    .links(DemandOrderView::Origin)
+                    .expect("origin-ordered demand lost its links")
             },
         );
-        assert!(delivering <= 1, "more than one delivery fence was active");
+
+        let group_ordered_records = self
+            .records
+            .values()
+            .filter(|record| record.residence.links(DemandOrderView::Group).is_some())
+            .count();
+        for record in self
+            .records
+            .values()
+            .filter(|record| record.residence.links(DemandOrderView::Group).is_some())
+        {
+            let group = record
+                .group
+                .as_ref()
+                .expect("group-ordered demand lost its eligibility group");
+            assert!(
+                self.group_orders.contains_key(group),
+                "ordered demand lost its eligibility-group order"
+            );
+        }
+        assert_eq!(
+            group_ordered_records,
+            self.group_orders
+                .values()
+                .map(IntrusiveOrder::len)
+                .sum::<usize>(),
+            "eligibility-group orders did not contain every ordered demand"
+        );
+
+        for (group, order) in &self.group_orders {
+            let expected = self
+                .records
+                .values()
+                .filter(|record| {
+                    record.residence.links(DemandOrderView::Group).is_some()
+                        && record.group.as_ref() == Some(group)
+                })
+                .count();
+            order.assert_consistent(
+                expected,
+                self.records.len(),
+                "eligibility-group demand order",
+                |requesting_partition| {
+                    let record = self
+                        .records
+                        .get(&requesting_partition)
+                        .expect("group-ordered demand disappeared");
+                    assert_eq!(
+                        record.group.as_ref(),
+                        Some(group),
+                        "demand occupied the wrong eligibility-group order"
+                    );
+                    if matches!(
+                        record.residence,
+                        DemandResidence::Delivering {
+                            view: DeliveryView::Group,
+                            ..
+                        }
+                    ) {
+                        assert_eq!(
+                            Some(requesting_partition),
+                            order.head(),
+                            "group publication fence moved away from its head"
+                        );
+                    }
+                    *record
+                        .residence
+                        .links(DemandOrderView::Group)
+                        .expect("group-ordered demand lost its links")
+                },
+            );
+        }
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+
+    fn partition(index: usize) -> PartitionId {
+        PartitionId::from_index(index)
+    }
+
+    fn active(id: u64, group: EligibilityGroup) -> DemandSnapshot {
+        DemandSnapshot::active(
+            DemandId::from_u64(id),
+            super::super::SnapshotVersion::INITIAL,
+            ProtocolRequirement::H1Compatible,
+            group,
+        )
+    }
+
+    #[test]
+    fn origin_and_group_orders_repair_independently() {
+        let pool = EligibilityGroup::Pool;
+        let isolated = EligibilityGroup::Partition(partition(2));
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(partition(1), active(1, pool.clone()));
+        schedule.publish(partition(2), active(2, isolated.clone()));
+        schedule.publish(partition(3), active(3, pool.clone()));
+
+        assert_eq!(
+            Some(partition(1)),
+            schedule.queued_head().map(|head| head.requesting_partition)
+        );
+        assert_eq!(
+            Some(partition(1)),
+            schedule
+                .queued_group_head(&pool)
+                .map(|head| head.requesting_partition)
+        );
+        assert_eq!(
+            Some(partition(2)),
+            schedule
+                .queued_group_head(&isolated)
+                .map(|head| head.requesting_partition)
+        );
+
+        let delivery = DeliveryId(7);
+        schedule
+            .reserve_group_head(&pool, &partition(1), DemandId::from_u64(1), delivery)
+            .expect("pool group head should reserve");
+        assert!(schedule.queued_group_head(&pool).is_none());
+        assert_eq!(
+            Some(partition(2)),
+            schedule
+                .queued_group_head(&isolated)
+                .map(|head| head.requesting_partition)
+        );
+        assert!(schedule.queued_head().is_none());
+
+        schedule.finish_delivery(
+            delivery,
+            &partition(1),
+            DeliveryAckResult::Accepted { successor: None },
+        );
+        assert_eq!(
+            Some(partition(2)),
+            schedule.queued_head().map(|head| head.requesting_partition)
+        );
+        assert_eq!(
+            Some(partition(3)),
+            schedule
+                .queued_group_head(&pool)
+                .map(|head| head.requesting_partition)
+        );
+    }
+
+    #[test]
+    fn retry_preserves_both_order_positions() {
+        let group = EligibilityGroup::Pool;
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(partition(1), active(1, group.clone()));
+        schedule.publish(partition(2), active(2, group.clone()));
+
+        let delivery = DeliveryId(9);
+        schedule
+            .reserve_group_head(&group, &partition(1), DemandId::from_u64(1), delivery)
+            .expect("group head should reserve");
+        schedule.finish_delivery(
+            delivery,
+            &partition(1),
+            DeliveryAckResult::RetrySameResidence,
+        );
+
+        assert_eq!(
+            Some(partition(1)),
+            schedule.queued_head().map(|head| head.requesting_partition)
+        );
+        assert_eq!(
+            Some(partition(1)),
+            schedule
+                .queued_group_head(&group)
+                .map(|head| head.requesting_partition)
+        );
+    }
+
+    #[test]
+    fn inactive_snapshot_during_group_fence_retires_without_losing_group() {
+        let group = EligibilityGroup::Pool;
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(partition(1), active(1, group.clone()));
+        let delivery = DeliveryId(11);
+        schedule
+            .reserve_group_head(&group, &partition(1), DemandId::from_u64(1), delivery)
+            .expect("group head should reserve");
+        schedule.publish(
+            partition(1),
+            DemandSnapshot::inactive(
+                DemandId::from_u64(1),
+                super::super::SnapshotVersion::INITIAL.next(),
+            ),
+        );
+
+        schedule.finish_delivery(
+            delivery,
+            &partition(1),
+            DeliveryAckResult::RetrySameResidence,
+        );
+        assert_eq!(0, schedule.len());
+        assert!(schedule.queued_group_head(&group).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "ordered demand lost its eligibility-group order")]
+    fn consistency_check_rejects_an_orphaned_group_link() {
+        let group = EligibilityGroup::Pool;
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(partition(1), active(1, group.clone()));
+
+        schedule.group_orders.remove(&group);
+        schedule.assert_consistent();
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/demand.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/demand.rs
@@ -5,10 +5,22 @@
 
 //! Versioned cross-cell demand scheduling for one bounded origin.
 //!
-//! Each retained cell publishes a complete demand snapshot. An active snapshot
-//! occupies one origin-wide FIFO and one FIFO for its eligibility group.
-//! Deliveries retain both positions until the requesting cell acknowledges
-//! ownership or rejection.
+//! Each cell publishes at most one active demand: its acquisition queue's
+//! current head. That demand may be satisfied either by origin-wide connection
+//! capacity or by an existing HTTP/2 connection in its eligibility group.
+//! These resources require different orderings.
+//!
+//! For example, the origin order may contain `A(group X), B(group Y)` while
+//! only group Y has a reusable HTTP/2 connection. A remains first for the next
+//! available connection permit, while the group-Y connection can serve B
+//! without consuming that permit or delaying A. The group order finds B
+//! directly instead of scanning every partition.
+//!
+//! The same demand occupies both orders because capacity and HTTP/2 publication
+//! can race to satisfy it. Reserving either position retains a fence in both
+//! orders until the requesting cell accepts or rejects the handoff. The other
+//! resource therefore cannot serve the same demand while the first handoff is
+//! running outside the admission lock.
 
 use super::{
     DeliveryAckResult, DeliveryId, DemandId, DemandSnapshot, DemandState, IntrusiveLinks,
@@ -34,9 +46,9 @@ use std::collections::HashMap;
 pub(super) struct DemandSchedule {
     /// Latest demand and scheduling residence for each retained cell.
     records: HashMap<PartitionId, DemandRecord>,
-    /// Origin-wide order used by capacity and HTTP/1 reuse.
+    /// Origin-wide order used by one-to-one capacity and HTTP/1 reuse.
     origin_order: IntrusiveOrder<PartitionId>,
-    /// All-protocol demand order for each connection-reuse group.
+    /// Reusable-HTTP/2 demand order for each connection-reuse group.
     group_orders: HashMap<EligibilityGroup, IntrusiveOrder<PartitionId>>,
 }
 

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/publication.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/publication.rs
@@ -16,11 +16,20 @@
 //! connection generation validation -> requesting-cell route visibility
 //! requesting-cell visibility -> admission acknowledgement
 //! stale connection or requesting cell -> retry or retire fenced demand
+//! idle generation + H1-required demand -> exact-generation reclaim
 //! ```
+//!
+//! An accepting generation with no prospective or accepted requests also
+//! enters an origin-wide reclaim order. H1-required demand may reserve one
+//! exact idle generation, revalidate it under the connection-cell lock, and
+//! close it to return bounded capacity. Busy generations never enter that
+//! order.
 //!
 //! The connection-owning and requesting cell locks never nest.
 //! [`H2PublicationGuard`] owns the admission fence between those scopes and
-//! submits a terminal acknowledgement on drop.
+//! submits a terminal acknowledgement on drop. [`H2ReclaimAction`] owns an
+//! idle-generation reservation and repairs admission's view if the crossing is
+//! rejected or dropped.
 
 use super::{
     AdmissionAction, DeliveryAckResult, DeliveryId, DemandId, DemandSchedule, IntrusiveLinks,
@@ -31,12 +40,17 @@ use crate::client::pool::cell::OriginCell;
 use crate::client::pool::partition::{EligibilityGroup, PartitionId};
 use crate::sync::Arc;
 use std::collections::{BTreeSet, HashMap};
+use std::ops::Bound::{Excluded, Unbounded};
 
 /// Complete connection-cell advertisement at one monotonic revision.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(in crate::client::pool) struct H2AdvertisementSnapshot {
+    /// Connection-cell revision used to reject stale reports.
     revision: u64,
+    /// Exact accepting generation, or `None` after withdrawal.
     generation: Option<H2GenerationId>,
+    /// Whether the accepting generation has no prospective or accepted requests.
+    idle: bool,
 }
 
 impl H2AdvertisementSnapshot {
@@ -45,6 +59,16 @@ impl H2AdvertisementSnapshot {
         Self {
             revision,
             generation: Some(generation),
+            idle: false,
+        }
+    }
+
+    /// Reports one accepting generation with no request work.
+    pub(in crate::client::pool) fn idle(revision: u64, generation: H2GenerationId) -> Self {
+        Self {
+            revision,
+            generation: Some(generation),
+            idle: true,
         }
     }
 
@@ -53,6 +77,7 @@ impl H2AdvertisementSnapshot {
         Self {
             revision,
             generation: None,
+            idle: false,
         }
     }
 }
@@ -63,33 +88,56 @@ impl H2AdvertisementSnapshot {
 ///
 /// - each connection cell has at most one retained advertisement record;
 /// - each advertised connection cell is linked once in its eligibility-group order;
+/// - each idle advertised generation is linked once in the origin reclaim
+///   order unless it owns the active reclaim reservation;
 /// - each linked identity names the newest reported generation;
-/// - `ready_groups` contains exactly the groups with queued demand and an
-///   advertised peer connection; and
-/// - neither advertisements nor prepared publications own connection
-///   capacity or a protocol sender.
+/// - `ready_groups` contains exactly the groups with H2-compatible queued
+///   demand and an advertised peer connection;
+/// - at most one reclaim reservation crosses to a connection cell; and
+/// - advertisements, prepared publications, and reclaim reservations own no
+///   connection capacity or protocol sender.
 #[derive(Debug, Default)]
 pub(super) struct H2Publication {
+    /// Latest report retained for each connection cell.
     advertisements: HashMap<PartitionId, AdvertisementRecord>,
+    /// Advertised connection cells ordered within each reuse group.
     group_orders: HashMap<EligibilityGroup, IntrusiveOrder<PartitionId>>,
+    /// Idle accepting generations ordered across the origin for reclaim.
+    idle_order: IntrusiveOrder<PartitionId>,
+    /// Groups that have both compatible demand and a peer advertisement.
     ready_groups: BTreeSet<EligibilityGroup>,
+    /// Group selected by the previous publication turn.
+    last_ready_group: Option<EligibilityGroup>,
+    /// Exact idle generation currently crossing to its connection cell.
+    reclaiming: Option<PreparedH2Reclaim>,
 }
 
 /// Admission's latest complete report for one connection cell.
 #[derive(Debug)]
 struct AdvertisementRecord {
+    /// Reuse group in which this connection may be published.
     group: EligibilityGroup,
+    /// Newest connection-cell report retained by admission.
     revision: u64,
+    /// Exact accepting generation named by the report.
     generation: Option<H2GenerationId>,
+    /// Intrusive-order residence for an available generation.
     residence: AdvertisementResidence,
+    /// Whether the accepting generation has no request work.
+    idle: bool,
+    /// Links in the origin-wide idle-generation order.
+    idle_links: Option<IntrusiveLinks<PartitionId>>,
 }
 
 /// Whether one connection cell occupies its advertisement order.
 #[derive(Debug, Default)]
 enum AdvertisementResidence {
+    /// This connection cell has no generation available to peers.
     #[default]
     Unavailable,
+    /// The cell is linked in its eligibility-group advertisement order.
     Advertised {
+        /// Intrusive links owned by this residence.
         links: IntrusiveLinks<PartitionId>,
     },
 }
@@ -113,20 +161,46 @@ impl AdvertisementResidence {
 /// Identity selected before connection and requesting cell validation.
 #[derive(Clone, Debug)]
 pub(super) struct PreparedH2Publication {
+    /// Admission fence identity.
     pub(super) delivery: DeliveryId,
+    /// Cell whose demand is fenced.
     pub(super) requesting_partition: PartitionId,
+    /// Exact demand generation selected for publication.
     pub(super) demand: DemandId,
+    /// Cell that owns the advertised connection.
     pub(super) connection_partition: PartitionId,
+    /// Exact accepting generation selected from the advertisement.
     pub(super) generation: H2GenerationId,
+    /// Reuse group shared by demand and advertisement.
+    pub(super) group: EligibilityGroup,
+}
+
+/// Exact idle generation selected to release bounded origin capacity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct PreparedH2Reclaim {
+    /// Cell whose H1-required demand caused reclaim.
+    pub(super) requesting_partition: PartitionId,
+    /// Exact demand generation that caused reclaim.
+    pub(super) demand: DemandId,
+    /// Cell that owns the idle H2 generation.
+    pub(super) connection_partition: PartitionId,
+    /// Exact accepting generation observed idle by admission.
+    pub(super) generation: H2GenerationId,
+    /// Reuse group retained for advertisement repair.
     pub(super) group: EligibilityGroup,
 }
 
 /// Candidate selected from stored demand and advertisement heads.
 struct PublicationCandidate {
+    /// Requesting cell selected from the group demand head.
     requesting_partition: PartitionId,
+    /// Demand generation at that head.
     demand: DemandId,
+    /// Peer connection cell selected from the advertisement head.
     connection_partition: PartitionId,
+    /// Advertised generation in that connection cell.
     generation: H2GenerationId,
+    /// Eligibility group whose turn was selected.
     group: EligibilityGroup,
 }
 
@@ -165,13 +239,17 @@ impl H2Publication {
                 revision: snapshot.revision,
                 generation: snapshot.generation,
                 residence: AdvertisementResidence::Unavailable,
+                idle: snapshot.idle,
+                idle_links: None,
             });
         record.group = group.clone();
         record.revision = snapshot.revision;
         record.generation = snapshot.generation;
+        record.idle = snapshot.idle;
         if record.generation.is_some() {
             self.enqueue(connection_partition);
         }
+        self.enqueue_idle_if_available(connection_partition);
 
         if let Some(old_group) = old_group {
             self.reconcile_group(&old_group, demand);
@@ -195,10 +273,12 @@ impl H2Publication {
         }
         let group = record.group.clone();
         self.unlink(connection_partition);
-        self.advertisements
+        let record = self
+            .advertisements
             .get_mut(connection_partition)
-            .expect("validated H2 advertisement disappeared")
-            .generation = None;
+            .expect("validated H2 advertisement disappeared");
+        record.generation = None;
+        record.idle = false;
         self.reconcile_group(&group, demand);
         self.assert_consistent(demand);
     }
@@ -208,6 +288,9 @@ impl H2Publication {
         let ready = demand
             .queued_group_head(group)
             .and_then(|queued| {
+                if !queued.requirement.accepts_h2() {
+                    return None;
+                }
                 self.first_peer(group, &queued.requesting_partition)
                     .map(|_| queued)
             })
@@ -221,11 +304,20 @@ impl H2Publication {
 
     /// Selects one group head and one peer advertisement without scanning cells.
     fn candidate(&mut self, demand: &DemandSchedule) -> Option<PublicationCandidate> {
-        let group = self.ready_groups.first()?.clone();
+        let group = self
+            .last_ready_group
+            .as_ref()
+            .and_then(|last| self.ready_groups.range((Excluded(last), Unbounded)).next())
+            .or_else(|| self.ready_groups.first())?
+            .clone();
         let Some(queued) = demand.queued_group_head(&group) else {
             self.ready_groups.remove(&group);
             return None;
         };
+        if !queued.requirement.accepts_h2() {
+            self.ready_groups.remove(&group);
+            return None;
+        }
         let Some(connection_partition) = self.first_peer(&group, &queued.requesting_partition)
         else {
             self.ready_groups.remove(&group);
@@ -260,6 +352,7 @@ impl H2Publication {
             candidate.demand,
             delivery,
         )?;
+        self.last_ready_group = Some(candidate.group.clone());
         self.reconcile_group(&candidate.group, demand);
         self.assert_consistent(demand);
         Some(PreparedH2Publication {
@@ -270,6 +363,67 @@ impl H2Publication {
             generation: candidate.generation,
             group: candidate.group,
         })
+    }
+
+    /// Reserves the oldest idle H2 generation for H1-required origin demand.
+    pub(super) fn prepare_reclaim(&mut self, demand: &DemandSchedule) -> Option<PreparedH2Reclaim> {
+        if self.reclaiming.is_some() {
+            return None;
+        }
+        let queued = demand.queued_head()?;
+        if queued.requirement.accepts_h2() {
+            return None;
+        }
+        let connection_partition = self.idle_order.head()?;
+        let record = self
+            .advertisements
+            .get(&connection_partition)
+            .expect("idle HTTP/2 advertisement disappeared");
+        let prepared = PreparedH2Reclaim {
+            requesting_partition: queued.requesting_partition,
+            demand: queued.demand,
+            connection_partition,
+            generation: record
+                .generation
+                .expect("idle HTTP/2 advertisement had no generation"),
+            group: record.group.clone(),
+        };
+        self.reclaiming = Some(prepared.clone());
+        self.unlink_idle(&connection_partition);
+        self.assert_consistent(demand);
+        Some(prepared)
+    }
+
+    /// Completes one reclaim crossing and repairs the exact advertisement.
+    pub(super) fn finish_reclaim(
+        &mut self,
+        prepared: &PreparedH2Reclaim,
+        snapshot: Option<H2AdvertisementSnapshot>,
+        demand: &DemandSchedule,
+    ) {
+        assert_eq!(
+            self.reclaiming.as_ref(),
+            Some(prepared),
+            "HTTP/2 reclaim completion did not match its reservation"
+        );
+        self.reclaiming = None;
+        match snapshot {
+            Some(snapshot) => {
+                self.update(
+                    prepared.connection_partition,
+                    prepared.group.clone(),
+                    snapshot,
+                    demand,
+                );
+            }
+            None => {
+                self.unlink(&prepared.connection_partition);
+                self.advertisements.remove(&prepared.connection_partition);
+                self.reconcile_group(&prepared.group, demand);
+            }
+        }
+        self.enqueue_idle_if_available(prepared.connection_partition);
+        self.assert_consistent(demand);
     }
 
     /// Appends one accepting connection cell to its group order.
@@ -299,8 +453,66 @@ impl H2Publication {
             .residence = AdvertisementResidence::Advertised { links };
     }
 
+    /// Appends one unreserved idle generation to origin reclaim order.
+    fn enqueue_idle_if_available(&mut self, connection_partition: PartitionId) {
+        let reserved = self
+            .reclaiming
+            .as_ref()
+            .is_some_and(|reclaim| reclaim.connection_partition == connection_partition);
+        let Some(record) = self.advertisements.get(&connection_partition) else {
+            return;
+        };
+        if record.generation.is_none() || !record.idle || reserved || record.idle_links.is_some() {
+            return;
+        }
+        let links = self.idle_order.push_back(connection_partition);
+        if let Some(previous) = links.previous {
+            self.advertisements
+                .get_mut(&previous)
+                .expect("previous idle HTTP/2 advertisement disappeared")
+                .idle_links
+                .as_mut()
+                .expect("previous idle HTTP/2 advertisement lost its links")
+                .next = Some(connection_partition);
+        }
+        self.advertisements
+            .get_mut(&connection_partition)
+            .expect("enqueued idle HTTP/2 advertisement disappeared")
+            .idle_links = Some(links);
+    }
+
+    /// Removes one generation from origin reclaim order.
+    fn unlink_idle(&mut self, connection_partition: &PartitionId) {
+        let Some(record) = self.advertisements.get_mut(connection_partition) else {
+            return;
+        };
+        let Some(links) = record.idle_links.take() else {
+            return;
+        };
+        if let Some(previous) = links.previous {
+            self.advertisements
+                .get_mut(&previous)
+                .expect("previous idle HTTP/2 advertisement disappeared")
+                .idle_links
+                .as_mut()
+                .expect("previous idle HTTP/2 advertisement lost its links")
+                .next = links.next;
+        }
+        if let Some(next) = links.next {
+            self.advertisements
+                .get_mut(&next)
+                .expect("next idle HTTP/2 advertisement disappeared")
+                .idle_links
+                .as_mut()
+                .expect("next idle HTTP/2 advertisement lost its links")
+                .previous = links.previous;
+        }
+        self.idle_order.remove(*connection_partition, links);
+    }
+
     /// Removes one connection cell and repairs its group order.
     fn unlink(&mut self, connection_partition: &PartitionId) {
+        self.unlink_idle(connection_partition);
         let Some(record) = self.advertisements.get_mut(connection_partition) else {
             return;
         };
@@ -359,6 +571,9 @@ impl H2Publication {
 
         #[cfg(any(debug_assertions, test))]
         {
+            if std::thread::panicking() {
+                return;
+            }
             for (partition, record) in &self.advertisements {
                 assert_eq!(
                     record.generation.is_some(),
@@ -371,6 +586,19 @@ impl H2Publication {
                         "H2 advertisement lost its group order"
                     );
                 }
+                let reserved = self
+                    .reclaiming
+                    .as_ref()
+                    .is_some_and(|reclaim| reclaim.connection_partition == *partition);
+                assert_eq!(
+                    record.generation.is_some() && record.idle && !reserved,
+                    record.idle_links.is_some(),
+                    "H2 reclaim residence did not match idle availability"
+                );
+                debug_assert_ne!(
+                    record.idle_links.as_ref().and_then(|links| links.next),
+                    Some(*partition)
+                );
                 debug_assert_ne!(
                     record.residence.links().and_then(|links| links.next),
                     Some(*partition)
@@ -399,13 +627,33 @@ impl H2Publication {
                 );
             }
 
+            let expected_idle = self
+                .advertisements
+                .values()
+                .filter(|record| record.idle_links.is_some())
+                .count();
+            self.idle_order.assert_consistent(
+                expected_idle,
+                self.advertisements.len(),
+                "idle HTTP/2 reclaim order",
+                |partition| {
+                    self.advertisements
+                        .get(&partition)
+                        .expect("ordered idle HTTP/2 advertisement disappeared")
+                        .idle_links
+                        .expect("ordered idle HTTP/2 advertisement lost its links")
+                },
+            );
+
             let expected_ready = self
                 .group_orders
                 .keys()
                 .filter(|group| {
                     demand.queued_group_head(group).is_some_and(|queued| {
-                        self.first_peer(group, &queued.requesting_partition)
-                            .is_some()
+                        queued.requirement.accepts_h2()
+                            && self
+                                .first_peer(group, &queued.requesting_partition)
+                                .is_some()
                     })
                 })
                 .cloned()
@@ -420,8 +668,11 @@ impl H2Publication {
 
 /// Identity-only publication crossing with a terminal admission fallback.
 pub(in crate::client::pool) struct H2PublicationGuard {
+    /// Admission owner of the fenced demand and advertisement.
     origin: Arc<OriginAdmission>,
+    /// Identities revalidated across the unlocked cell transitions.
     prepared: PreparedH2Publication,
+    /// Terminal acknowledgement submitted if the crossing unwinds.
     on_drop: Option<DeliveryAckResult>,
 }
 
@@ -434,8 +685,13 @@ impl H2PublicationGuard {
         }
     }
 
-    /// Validates the connection cell, installs requesting-cell visibility, and acknowledges it.
-    pub(super) fn publish_once(mut self) -> Option<AdmissionAction> {
+    /// Crosses connection and requesting cells, then acknowledges the fence.
+    ///
+    /// A missing connection cell or stale generation withdraws that exact
+    /// advertisement and retries the same demand residence. A missing
+    /// requesting cell retires the demand. Requesting-cell rejection retries
+    /// only when the original demand and route installation are still useful.
+    pub(super) fn publish_once(self) -> Option<AdmissionAction> {
         let generation = self.prepared.generation;
         let Some(connection_cell) = self.origin.cell(&self.prepared.connection_partition) else {
             return self.finish(DeliveryAckResult::RetrySameResidence, Some(generation));
@@ -457,9 +713,6 @@ impl H2PublicationGuard {
             return self.finish(DeliveryAckResult::RetrySameResidence, None);
         }
 
-        // Visibility and the requesting cell's suppressed demand are authoritative
-        // before a drop may acknowledge acceptance.
-        self.on_drop = Some(DeliveryAckResult::Accepted { successor: None });
         let next = self.finish(DeliveryAckResult::Accepted { successor: None }, None);
         OriginCell::service_h2_waiters(&requesting_cell);
         OriginCell::service_peer_h2_waiters(&requesting_cell);
@@ -471,12 +724,14 @@ impl H2PublicationGuard {
         result: DeliveryAckResult,
         stale_generation: Option<H2GenerationId>,
     ) -> Option<AdmissionAction> {
-        self.on_drop = None;
         let outcome = match &result {
             DeliveryAckResult::Accepted { .. } => "accepted",
             DeliveryAckResult::RetrySameResidence => "retry",
             DeliveryAckResult::Rejected { .. } => "rejected",
         };
+        // The unlocked cell crossing is complete. Admission owns the fence
+        // again, so unwinding must not replay a failed acknowledgement.
+        self.on_drop = None;
         let next = OriginAdmission::finish_h2_publication(
             &self.origin,
             &self.prepared,
@@ -514,6 +769,80 @@ impl Drop for H2PublicationGuard {
     }
 }
 
+/// Exact idle-generation crossing with an admission repair fallback.
+pub(in crate::client::pool) struct H2ReclaimAction {
+    /// Admission authority that owns the reclaim reservation.
+    origin: Arc<OriginAdmission>,
+    /// Prepared reclaim still owned by this fallback.
+    prepared: Option<PreparedH2Reclaim>,
+}
+
+impl H2ReclaimAction {
+    /// Creates one unlocked exact-generation reclaim crossing.
+    pub(super) fn new(origin: Arc<OriginAdmission>, prepared: PreparedH2Reclaim) -> Self {
+        Self {
+            origin,
+            prepared: Some(prepared),
+        }
+    }
+
+    /// Attempts idle reclaim and returns the next bounded-origin action.
+    pub(super) fn drive_once(mut self) -> Option<AdmissionAction> {
+        let prepared = self
+            .prepared
+            .as_ref()
+            .expect("HTTP/2 reclaim action consumed more than once")
+            .clone();
+        let (snapshot, reclaimed) = match self.origin.cell(&prepared.connection_partition) {
+            Some(cell) => {
+                let (snapshot, connection_id) =
+                    OriginCell::reclaim_idle_h2(&cell, prepared.generation);
+                (Some(snapshot), connection_id)
+            }
+            None => (None, None),
+        };
+        self.prepared = None;
+        let next = OriginAdmission::finish_h2_reclaim(&self.origin, &prepared, snapshot);
+        tracing::trace!(
+            connection_id = ?reclaimed,
+            request_partition = ?prepared.requesting_partition,
+            connection_partition = ?prepared.connection_partition,
+            origin_scheme = %self.origin.origin().scheme(),
+            origin_host = self.origin.origin().host(),
+            origin_port = ?self.origin.origin().port(),
+            h2_generation = ?prepared.generation,
+            demand = ?prepared.demand,
+            outcome = if reclaimed.is_some() { "reclaimed" } else { "rejected" },
+            "HTTP/2 idle reclaim completed"
+        );
+        next
+    }
+}
+
+impl Drop for H2ReclaimAction {
+    fn drop(&mut self) {
+        let Some(prepared) = self.prepared.take() else {
+            return;
+        };
+        let snapshot = self
+            .origin
+            .cell(&prepared.connection_partition)
+            .map(|cell| cell.report_h2_advertisement());
+        let next = OriginAdmission::finish_h2_reclaim(&self.origin, &prepared, snapshot);
+        tracing::trace!(
+            request_partition = ?prepared.requesting_partition,
+            connection_partition = ?prepared.connection_partition,
+            origin_scheme = %self.origin.origin().scheme(),
+            origin_host = self.origin.origin().host(),
+            origin_port = ?self.origin.origin().port(),
+            h2_generation = ?prepared.generation,
+            demand = ?prepared.demand,
+            outcome = "guard_drop",
+            "HTTP/2 idle reclaim completed"
+        );
+        OriginAdmission::drive(next);
+    }
+}
 #[cfg(all(test, not(smithy_http_client_loom)))]
 mod tests {
     use super::*;
@@ -532,6 +861,15 @@ mod tests {
             DemandId::from_u64(id),
             SnapshotVersion::INITIAL,
             ProtocolRequirement::H2Required,
+            group,
+        )
+    }
+
+    fn h1_demand(id: u64, group: EligibilityGroup) -> DemandSnapshot {
+        DemandSnapshot::active(
+            DemandId::from_u64(id),
+            SnapshotVersion::INITIAL,
+            ProtocolRequirement::H1Required,
             group,
         )
     }
@@ -595,7 +933,7 @@ mod tests {
     }
 
     #[test]
-    fn publication_uses_a_peer_connection_from_the_same_group() {
+    fn publication_skips_the_requesting_cell_and_selects_a_peer_in_its_group() {
         let pool = EligibilityGroup::Pool;
         let isolated = EligibilityGroup::Partition(partition(3));
         let requesting_partition = partition(1);
@@ -661,6 +999,74 @@ mod tests {
     }
 
     #[test]
+    fn h1_required_demand_is_not_publication_ready() {
+        let group = EligibilityGroup::Pool;
+        let requesting_partition = partition(1);
+        let connection_partition = partition(2);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(
+            requesting_partition,
+            DemandSnapshot::active(
+                DemandId::from_u64(1),
+                SnapshotVersion::INITIAL,
+                ProtocolRequirement::H1Required,
+                group.clone(),
+            ),
+        );
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group,
+            H2AdvertisementSnapshot::accepting(1, generation(1)),
+            &schedule,
+        );
+
+        assert!(!publication.has_ready_group());
+        assert!(publication.prepare(&mut schedule, DeliveryId(1)).is_none());
+    }
+
+    #[test]
+    fn publication_turns_rotate_across_ready_groups() {
+        let first_group = EligibilityGroup::Partition(partition(10));
+        let second_group = EligibilityGroup::Partition(partition(20));
+        let first_request = partition(1);
+        let first_connection = partition(2);
+        let second_request = partition(3);
+        let second_connection = partition(4);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(first_request, demand(1, first_group.clone()));
+        schedule.publish(second_request, demand(2, second_group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            first_connection,
+            first_group.clone(),
+            H2AdvertisementSnapshot::accepting(1, generation(1)),
+            &schedule,
+        );
+        publication.update(
+            second_connection,
+            second_group.clone(),
+            H2AdvertisementSnapshot::accepting(1, generation(2)),
+            &schedule,
+        );
+
+        let first = publication
+            .prepare(&mut schedule, DeliveryId(1))
+            .expect("first ready group was not selected");
+        schedule.finish_delivery(
+            first.delivery,
+            &first.requesting_partition,
+            DeliveryAckResult::RetrySameResidence,
+        );
+        publication.reconcile_group(&first.group, &schedule);
+
+        let second = publication
+            .prepare(&mut schedule, DeliveryId(2))
+            .expect("second ready group was not selected");
+        assert_ne!(first.group, second.group);
+    }
+
+    #[test]
     #[should_panic(
         expected = "HTTP/2 publication-ready groups did not match demand and advertisements"
     )]
@@ -681,5 +1087,86 @@ mod tests {
         publication.ready_groups.clear();
 
         publication.assert_consistent(&schedule);
+    }
+
+    #[test]
+    fn only_idle_h2_is_selected_for_h1_required_reclaim() {
+        let group = EligibilityGroup::Pool;
+        let requesting_partition = partition(1);
+        let connection_partition = partition(2);
+        let current = generation(10);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, h1_demand(1, group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group.clone(),
+            H2AdvertisementSnapshot::accepting(1, current),
+            &schedule,
+        );
+
+        assert!(
+            publication.prepare_reclaim(&schedule).is_none(),
+            "busy HTTP/2 generation entered reclaim order"
+        );
+
+        publication.update(
+            connection_partition,
+            group,
+            H2AdvertisementSnapshot::idle(2, current),
+            &schedule,
+        );
+        let prepared = publication
+            .prepare_reclaim(&schedule)
+            .expect("idle HTTP/2 generation was not selected");
+        assert_eq!(requesting_partition, prepared.requesting_partition);
+        assert_eq!(connection_partition, prepared.connection_partition);
+        assert_eq!(current, prepared.generation);
+        assert!(publication.idle_order.head().is_none());
+
+        publication.finish_reclaim(
+            &prepared,
+            Some(H2AdvertisementSnapshot::idle(2, current)),
+            &schedule,
+        );
+        assert_eq!(Some(connection_partition), publication.idle_order.head());
+    }
+
+    #[test]
+    fn reclaim_completion_cannot_restore_a_replaced_generation() {
+        let group = EligibilityGroup::Pool;
+        let requesting_partition = partition(1);
+        let connection_partition = partition(2);
+        let old = generation(10);
+        let replacement = generation(11);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, h1_demand(1, group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group.clone(),
+            H2AdvertisementSnapshot::idle(1, old),
+            &schedule,
+        );
+        let prepared = publication
+            .prepare_reclaim(&schedule)
+            .expect("idle HTTP/2 generation was not selected");
+
+        publication.update(
+            connection_partition,
+            group,
+            H2AdvertisementSnapshot::idle(2, replacement),
+            &schedule,
+        );
+        publication.finish_reclaim(
+            &prepared,
+            Some(H2AdvertisementSnapshot::idle(1, old)),
+            &schedule,
+        );
+
+        let next = publication
+            .prepare_reclaim(&schedule)
+            .expect("replacement generation was not restored to reclaim order");
+        assert_eq!(replacement, next.generation);
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/publication.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/publication.rs
@@ -1,0 +1,685 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Cross-cell HTTP/2 generation publication for bounded origins.
+//!
+//! A connection cell advertises only its exact accepting generation. Admission
+//! pairs that identity with the oldest demand in the same eligibility group.
+//! The requesting cell stores an identity-only route; the connection-owning
+//! cell retains its sender, driver, socket, and capacity lease.
+//!
+//! ```text
+//! connection-cell report -> advertisement indexed by eligibility group
+//! group demand + peer advertisement -> publication fence
+//! connection generation validation -> requesting-cell route visibility
+//! requesting-cell visibility -> admission acknowledgement
+//! stale connection or requesting cell -> retry or retire fenced demand
+//! ```
+//!
+//! The connection-owning and requesting cell locks never nest.
+//! [`H2PublicationGuard`] owns the admission fence between those scopes and
+//! submits a terminal acknowledgement on drop.
+
+use super::{
+    AdmissionAction, DeliveryAckResult, DeliveryId, DemandId, DemandSchedule, IntrusiveLinks,
+    IntrusiveOrder, OriginAdmission,
+};
+use crate::client::pool::cell::h2::{H2GenerationId, H2Route};
+use crate::client::pool::cell::OriginCell;
+use crate::client::pool::partition::{EligibilityGroup, PartitionId};
+use crate::sync::Arc;
+use std::collections::{BTreeSet, HashMap};
+
+/// Complete connection-cell advertisement at one monotonic revision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::client::pool) struct H2AdvertisementSnapshot {
+    revision: u64,
+    generation: Option<H2GenerationId>,
+}
+
+impl H2AdvertisementSnapshot {
+    /// Reports one accepting generation.
+    pub(in crate::client::pool) fn accepting(revision: u64, generation: H2GenerationId) -> Self {
+        Self {
+            revision,
+            generation: Some(generation),
+        }
+    }
+
+    /// Reports that the connection cell has no accepting generation.
+    pub(in crate::client::pool) fn unavailable(revision: u64) -> Self {
+        Self {
+            revision,
+            generation: None,
+        }
+    }
+}
+
+/// Admission-owned H2 advertisements and publication-ready groups.
+///
+/// At every completed transition:
+///
+/// - each connection cell has at most one retained advertisement record;
+/// - each advertised connection cell is linked once in its eligibility-group order;
+/// - each linked identity names the newest reported generation;
+/// - `ready_groups` contains exactly the groups with queued demand and an
+///   advertised peer connection; and
+/// - neither advertisements nor prepared publications own connection
+///   capacity or a protocol sender.
+#[derive(Debug, Default)]
+pub(super) struct H2Publication {
+    advertisements: HashMap<PartitionId, AdvertisementRecord>,
+    group_orders: HashMap<EligibilityGroup, IntrusiveOrder<PartitionId>>,
+    ready_groups: BTreeSet<EligibilityGroup>,
+}
+
+/// Admission's latest complete report for one connection cell.
+#[derive(Debug)]
+struct AdvertisementRecord {
+    group: EligibilityGroup,
+    revision: u64,
+    generation: Option<H2GenerationId>,
+    residence: AdvertisementResidence,
+}
+
+/// Whether one connection cell occupies its advertisement order.
+#[derive(Debug, Default)]
+enum AdvertisementResidence {
+    #[default]
+    Unavailable,
+    Advertised {
+        links: IntrusiveLinks<PartitionId>,
+    },
+}
+
+impl AdvertisementResidence {
+    fn links(&self) -> Option<&IntrusiveLinks<PartitionId>> {
+        match self {
+            Self::Unavailable => None,
+            Self::Advertised { links } => Some(links),
+        }
+    }
+
+    fn links_mut(&mut self) -> &mut IntrusiveLinks<PartitionId> {
+        match self {
+            Self::Unavailable => panic!("unavailable H2 connection had advertisement links"),
+            Self::Advertised { links } => links,
+        }
+    }
+}
+
+/// Identity selected before connection and requesting cell validation.
+#[derive(Clone, Debug)]
+pub(super) struct PreparedH2Publication {
+    pub(super) delivery: DeliveryId,
+    pub(super) requesting_partition: PartitionId,
+    pub(super) demand: DemandId,
+    pub(super) connection_partition: PartitionId,
+    pub(super) generation: H2GenerationId,
+    pub(super) group: EligibilityGroup,
+}
+
+/// Candidate selected from stored demand and advertisement heads.
+struct PublicationCandidate {
+    requesting_partition: PartitionId,
+    demand: DemandId,
+    connection_partition: PartitionId,
+    generation: H2GenerationId,
+    group: EligibilityGroup,
+}
+
+impl H2Publication {
+    /// Returns whether some eligibility group may start a publication turn.
+    pub(super) fn has_ready_group(&self) -> bool {
+        !self.ready_groups.is_empty()
+    }
+
+    /// Replaces one connection cell's advertisement and repairs its index.
+    pub(super) fn update(
+        &mut self,
+        connection_partition: PartitionId,
+        group: EligibilityGroup,
+        snapshot: H2AdvertisementSnapshot,
+        demand: &DemandSchedule,
+    ) {
+        if self
+            .advertisements
+            .get(&connection_partition)
+            .is_some_and(|record| record.revision >= snapshot.revision)
+        {
+            return;
+        }
+
+        let old_group = self
+            .advertisements
+            .get(&connection_partition)
+            .map(|record| record.group.clone());
+        self.unlink(&connection_partition);
+        let record = self
+            .advertisements
+            .entry(connection_partition)
+            .or_insert_with(|| AdvertisementRecord {
+                group: group.clone(),
+                revision: snapshot.revision,
+                generation: snapshot.generation,
+                residence: AdvertisementResidence::Unavailable,
+            });
+        record.group = group.clone();
+        record.revision = snapshot.revision;
+        record.generation = snapshot.generation;
+        if record.generation.is_some() {
+            self.enqueue(connection_partition);
+        }
+
+        if let Some(old_group) = old_group {
+            self.reconcile_group(&old_group, demand);
+        }
+        self.reconcile_group(&group, demand);
+        self.assert_consistent(demand);
+    }
+
+    /// Removes one stale generation observed during connection-cell validation.
+    pub(super) fn remove_if_exact(
+        &mut self,
+        connection_partition: &PartitionId,
+        generation: H2GenerationId,
+        demand: &DemandSchedule,
+    ) {
+        let Some(record) = self.advertisements.get(connection_partition) else {
+            return;
+        };
+        if record.generation != Some(generation) {
+            return;
+        }
+        let group = record.group.clone();
+        self.unlink(connection_partition);
+        self.advertisements
+            .get_mut(connection_partition)
+            .expect("validated H2 advertisement disappeared")
+            .generation = None;
+        self.reconcile_group(&group, demand);
+        self.assert_consistent(demand);
+    }
+
+    /// Recomputes whether one group can start a publication.
+    pub(super) fn reconcile_group(&mut self, group: &EligibilityGroup, demand: &DemandSchedule) {
+        let ready = demand
+            .queued_group_head(group)
+            .and_then(|queued| {
+                self.first_peer(group, &queued.requesting_partition)
+                    .map(|_| queued)
+            })
+            .is_some();
+        if ready {
+            self.ready_groups.insert(group.clone());
+        } else {
+            self.ready_groups.remove(group);
+        }
+    }
+
+    /// Selects one group head and one peer advertisement without scanning cells.
+    fn candidate(&mut self, demand: &DemandSchedule) -> Option<PublicationCandidate> {
+        let group = self.ready_groups.first()?.clone();
+        let Some(queued) = demand.queued_group_head(&group) else {
+            self.ready_groups.remove(&group);
+            return None;
+        };
+        let Some(connection_partition) = self.first_peer(&group, &queued.requesting_partition)
+        else {
+            self.ready_groups.remove(&group);
+            return None;
+        };
+        let record = self
+            .advertisements
+            .get(&connection_partition)
+            .expect("selected H2 advertisement disappeared");
+        let generation = record
+            .generation
+            .expect("selected H2 advertisement had no generation");
+        Some(PublicationCandidate {
+            requesting_partition: queued.requesting_partition,
+            demand: queued.demand,
+            connection_partition,
+            generation,
+            group,
+        })
+    }
+
+    /// Reserves one group demand and creates its unlocked publication identity.
+    pub(super) fn prepare(
+        &mut self,
+        demand: &mut DemandSchedule,
+        delivery: DeliveryId,
+    ) -> Option<PreparedH2Publication> {
+        let candidate = self.candidate(demand)?;
+        demand.reserve_group_head(
+            &candidate.group,
+            &candidate.requesting_partition,
+            candidate.demand,
+            delivery,
+        )?;
+        self.reconcile_group(&candidate.group, demand);
+        self.assert_consistent(demand);
+        Some(PreparedH2Publication {
+            delivery,
+            requesting_partition: candidate.requesting_partition,
+            demand: candidate.demand,
+            connection_partition: candidate.connection_partition,
+            generation: candidate.generation,
+            group: candidate.group,
+        })
+    }
+
+    /// Appends one accepting connection cell to its group order.
+    fn enqueue(&mut self, connection_partition: PartitionId) {
+        let group = self
+            .advertisements
+            .get(&connection_partition)
+            .expect("enqueued H2 connection disappeared")
+            .group
+            .clone();
+        let links = self
+            .group_orders
+            .entry(group)
+            .or_default()
+            .push_back(connection_partition);
+        if let Some(previous) = links.previous {
+            self.advertisements
+                .get_mut(&previous)
+                .expect("previous H2 advertisement disappeared")
+                .residence
+                .links_mut()
+                .next = Some(connection_partition);
+        }
+        self.advertisements
+            .get_mut(&connection_partition)
+            .expect("enqueued H2 connection disappeared")
+            .residence = AdvertisementResidence::Advertised { links };
+    }
+
+    /// Removes one connection cell and repairs its group order.
+    fn unlink(&mut self, connection_partition: &PartitionId) {
+        let Some(record) = self.advertisements.get_mut(connection_partition) else {
+            return;
+        };
+        let residence = std::mem::take(&mut record.residence);
+        let AdvertisementResidence::Advertised { links } = residence else {
+            return;
+        };
+        let group = record.group.clone();
+        if let Some(previous) = links.previous {
+            self.advertisements
+                .get_mut(&previous)
+                .expect("previous H2 advertisement disappeared")
+                .residence
+                .links_mut()
+                .next = links.next;
+        }
+        if let Some(next) = links.next {
+            self.advertisements
+                .get_mut(&next)
+                .expect("next H2 advertisement disappeared")
+                .residence
+                .links_mut()
+                .previous = links.previous;
+        }
+        let order = self
+            .group_orders
+            .get_mut(&group)
+            .expect("advertised H2 connection lost its group order");
+        order.remove(*connection_partition, links);
+        if order.len() == 0 {
+            self.group_orders.remove(&group);
+        }
+    }
+
+    /// Returns the group head, or its successor when the requesting cell owns it.
+    fn first_peer(
+        &self,
+        group: &EligibilityGroup,
+        requesting_partition: &PartitionId,
+    ) -> Option<PartitionId> {
+        let head = self.group_orders.get(group)?.head()?;
+        if head != *requesting_partition {
+            return Some(head);
+        }
+        self.advertisements
+            .get(&head)
+            .expect("H2 advertisement head disappeared")
+            .residence
+            .links()
+            .and_then(|links| links.next)
+    }
+
+    fn assert_consistent(&self, demand: &DemandSchedule) {
+        #[cfg(not(any(debug_assertions, test)))]
+        let _ = demand;
+
+        #[cfg(any(debug_assertions, test))]
+        {
+            for (partition, record) in &self.advertisements {
+                assert_eq!(
+                    record.generation.is_some(),
+                    record.residence.links().is_some(),
+                    "H2 advertisement residence did not match connection availability"
+                );
+                if record.residence.links().is_some() {
+                    assert!(
+                        self.group_orders.contains_key(&record.group),
+                        "H2 advertisement lost its group order"
+                    );
+                }
+                debug_assert_ne!(
+                    record.residence.links().and_then(|links| links.next),
+                    Some(*partition)
+                );
+            }
+
+            for (group, order) in &self.group_orders {
+                let expected = self
+                    .advertisements
+                    .values()
+                    .filter(|record| record.group == *group && record.residence.links().is_some())
+                    .count();
+                order.assert_consistent(
+                    expected,
+                    self.advertisements.len(),
+                    "HTTP/2 advertisement order",
+                    |partition| {
+                        *self
+                            .advertisements
+                            .get(&partition)
+                            .expect("ordered H2 advertisement disappeared")
+                            .residence
+                            .links()
+                            .expect("ordered H2 advertisement lost its links")
+                    },
+                );
+            }
+
+            let expected_ready = self
+                .group_orders
+                .keys()
+                .filter(|group| {
+                    demand.queued_group_head(group).is_some_and(|queued| {
+                        self.first_peer(group, &queued.requesting_partition)
+                            .is_some()
+                    })
+                })
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                expected_ready, self.ready_groups,
+                "HTTP/2 publication-ready groups did not match demand and advertisements"
+            );
+        }
+    }
+}
+
+/// Identity-only publication crossing with a terminal admission fallback.
+pub(in crate::client::pool) struct H2PublicationGuard {
+    origin: Arc<OriginAdmission>,
+    prepared: PreparedH2Publication,
+    on_drop: Option<DeliveryAckResult>,
+}
+
+impl H2PublicationGuard {
+    pub(super) fn new(origin: Arc<OriginAdmission>, prepared: PreparedH2Publication) -> Self {
+        Self {
+            origin,
+            prepared,
+            on_drop: Some(DeliveryAckResult::RetrySameResidence),
+        }
+    }
+
+    /// Validates the connection cell, installs requesting-cell visibility, and acknowledges it.
+    pub(super) fn publish_once(mut self) -> Option<AdmissionAction> {
+        let generation = self.prepared.generation;
+        let Some(connection_cell) = self.origin.cell(&self.prepared.connection_partition) else {
+            return self.finish(DeliveryAckResult::RetrySameResidence, Some(generation));
+        };
+        if !OriginCell::h2_generation_is_accepting(&connection_cell, self.prepared.generation) {
+            return self.finish(DeliveryAckResult::RetrySameResidence, Some(generation));
+        }
+
+        let Some(requesting_cell) = self.origin.cell(&self.prepared.requesting_partition) else {
+            return self.finish(DeliveryAckResult::Rejected { successor: None }, None);
+        };
+        let route = H2Route::new(&connection_cell, self.prepared.generation);
+        if !OriginCell::install_h2_route(
+            &requesting_cell,
+            route,
+            &self.prepared.group,
+            self.prepared.demand,
+        ) {
+            return self.finish(DeliveryAckResult::RetrySameResidence, None);
+        }
+
+        // Visibility and the requesting cell's suppressed demand are authoritative
+        // before a drop may acknowledge acceptance.
+        self.on_drop = Some(DeliveryAckResult::Accepted { successor: None });
+        let next = self.finish(DeliveryAckResult::Accepted { successor: None }, None);
+        OriginCell::service_h2_waiters(&requesting_cell);
+        OriginCell::service_peer_h2_waiters(&requesting_cell);
+        next
+    }
+
+    fn finish(
+        mut self,
+        result: DeliveryAckResult,
+        stale_generation: Option<H2GenerationId>,
+    ) -> Option<AdmissionAction> {
+        self.on_drop = None;
+        let outcome = match &result {
+            DeliveryAckResult::Accepted { .. } => "accepted",
+            DeliveryAckResult::RetrySameResidence => "retry",
+            DeliveryAckResult::Rejected { .. } => "rejected",
+        };
+        let next = OriginAdmission::finish_h2_publication(
+            &self.origin,
+            &self.prepared,
+            stale_generation,
+            result,
+        );
+        self.trace(outcome);
+        next
+    }
+
+    fn trace(&self, outcome: &str) {
+        tracing::trace!(
+            request_partition = ?self.prepared.requesting_partition,
+            connection_partition = ?self.prepared.connection_partition,
+            origin_scheme = %self.origin.origin().scheme(),
+            origin_host = self.origin.origin().host(),
+            origin_port = ?self.origin.origin().port(),
+            h2_generation = ?self.prepared.generation,
+            demand = ?self.prepared.demand,
+            outcome,
+            "HTTP/2 peer publication completed"
+        );
+    }
+}
+
+impl Drop for H2PublicationGuard {
+    fn drop(&mut self) {
+        let Some(result) = self.on_drop.take() else {
+            return;
+        };
+        let next =
+            OriginAdmission::finish_h2_publication(&self.origin, &self.prepared, None, result);
+        self.trace("guard_drop");
+        OriginAdmission::drive(next);
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use crate::client::pool::admission::{DemandSnapshot, ProtocolRequirement, SnapshotVersion};
+
+    fn partition(index: usize) -> PartitionId {
+        PartitionId::from_index(index)
+    }
+
+    fn generation(value: u64) -> H2GenerationId {
+        H2GenerationId::for_test(value)
+    }
+
+    fn demand(id: u64, group: EligibilityGroup) -> DemandSnapshot {
+        DemandSnapshot::active(
+            DemandId::from_u64(id),
+            SnapshotVersion::INITIAL,
+            ProtocolRequirement::H2Required,
+            group,
+        )
+    }
+
+    #[test]
+    fn exact_generation_replacement_rejects_stale_removal() {
+        let group = EligibilityGroup::Pool;
+        let connection_partition = partition(1);
+        let requesting_partition = partition(2);
+        let first = generation(10);
+        let second = generation(11);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, demand(1, group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group.clone(),
+            H2AdvertisementSnapshot::accepting(1, first),
+            &schedule,
+        );
+        publication.update(
+            connection_partition,
+            group.clone(),
+            H2AdvertisementSnapshot::accepting(2, second),
+            &schedule,
+        );
+
+        publication.remove_if_exact(&connection_partition, first, &schedule);
+        let prepared = publication
+            .prepare(&mut schedule, DeliveryId(1))
+            .expect("newer advertisement should remain publishable");
+        assert_eq!(second, prepared.generation);
+        assert_eq!(connection_partition, prepared.connection_partition);
+        assert_eq!(requesting_partition, prepared.requesting_partition);
+    }
+
+    #[test]
+    fn current_generation_removal_repairs_the_connection_index() {
+        let group = EligibilityGroup::Pool;
+        let connection_partition = partition(1);
+        let requesting_partition = partition(2);
+        let current = generation(10);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, demand(1, group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group,
+            H2AdvertisementSnapshot::accepting(1, current),
+            &schedule,
+        );
+
+        publication.remove_if_exact(&connection_partition, current, &schedule);
+
+        assert!(!publication.has_ready_group());
+        assert!(publication.group_orders.is_empty());
+        assert!(matches!(
+            publication.advertisements[&connection_partition].residence,
+            AdvertisementResidence::Unavailable
+        ));
+    }
+
+    #[test]
+    fn publication_uses_a_peer_connection_from_the_same_group() {
+        let pool = EligibilityGroup::Pool;
+        let isolated = EligibilityGroup::Partition(partition(3));
+        let requesting_partition = partition(1);
+        let peer = partition(2);
+        let other_group = partition(3);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, demand(1, pool.clone()));
+        schedule.publish(other_group, demand(2, isolated.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            requesting_partition,
+            pool.clone(),
+            H2AdvertisementSnapshot::accepting(1, generation(1)),
+            &schedule,
+        );
+        publication.update(
+            peer,
+            pool,
+            H2AdvertisementSnapshot::accepting(1, generation(2)),
+            &schedule,
+        );
+        publication.update(
+            other_group,
+            isolated,
+            H2AdvertisementSnapshot::accepting(1, generation(3)),
+            &schedule,
+        );
+
+        let prepared = publication
+            .prepare(&mut schedule, DeliveryId(1))
+            .expect("pool demand should find its peer connection");
+        assert_eq!(requesting_partition, prepared.requesting_partition);
+        assert_eq!(peer, prepared.connection_partition);
+        assert_eq!(generation(2), prepared.generation);
+    }
+
+    #[test]
+    fn older_advertisement_cannot_replace_the_current_generation() {
+        let group = EligibilityGroup::Pool;
+        let connection_partition = partition(1);
+        let requesting_partition = partition(2);
+        let current = generation(2);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, demand(1, group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group.clone(),
+            H2AdvertisementSnapshot::accepting(2, current),
+            &schedule,
+        );
+        publication.update(
+            connection_partition,
+            group,
+            H2AdvertisementSnapshot::accepting(1, generation(1)),
+            &schedule,
+        );
+
+        let prepared = publication
+            .prepare(&mut schedule, DeliveryId(1))
+            .expect("current advertisement should remain publishable");
+        assert_eq!(current, prepared.generation);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "HTTP/2 publication-ready groups did not match demand and advertisements"
+    )]
+    fn consistency_check_rejects_a_missing_ready_group() {
+        let group = EligibilityGroup::Pool;
+        let connection_partition = partition(1);
+        let requesting_partition = partition(2);
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(requesting_partition, demand(1, group.clone()));
+        let mut publication = H2Publication::default();
+        publication.update(
+            connection_partition,
+            group,
+            H2AdvertisementSnapshot::accepting(1, generation(1)),
+            &schedule,
+        );
+
+        publication.ready_groups.clear();
+
+        publication.assert_consistent(&schedule);
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/reuse.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/reuse.rs
@@ -39,7 +39,7 @@
 
 use super::{
     AdmissionAction, DeliveryAckResult, DeliveryGuard, DeliveryId, DemandId, DemandSchedule,
-    IntrusiveLinks, IntrusiveOrder, OriginAdmission, ProtocolRequirement,
+    IntrusiveLinks, IntrusiveOrder, OriginAdmission,
 };
 use crate::client::pool::cell::h1::{H1Selection, ProvisionalH1};
 use crate::client::pool::cell::OriginCell;
@@ -366,9 +366,9 @@ impl H1Reuse {
     /// Selects another cell's connection for the oldest origin-wide demand.
     ///
     /// An eligible cell lends its sender. Otherwise, a connection is reclaimed
-    /// so its capacity can satisfy the same demand. A cell is never selected for
-    /// its own demand; local idle and returning senders are handled under the
-    /// cell lock.
+    /// so its capacity can satisfy the same demand. HTTP/1-compatible demand
+    /// does not select its own cell because local senders are handled under the
+    /// cell lock. HTTP/2-only demand may reclaim same-cell idle HTTP/1 capacity.
     pub(super) fn prepare_reuse(
         &mut self,
         schedule: &DemandSchedule,
@@ -381,24 +381,20 @@ impl H1Reuse {
             return None;
         }
 
-        let (connection_partition, mode) =
-            if requesting_partition.requirement == ProtocolRequirement::H1Compatible {
-                match self.take_group_peer(
-                    &requesting_partition.eligibility_group,
-                    &requesting_partition.requesting_partition,
-                ) {
-                    Some(connection_partition) => (connection_partition, ReuseMode::Borrow),
-                    None => (
-                        self.take_origin_peer(&requesting_partition.requesting_partition)?,
-                        ReuseMode::Reclaim,
-                    ),
-                }
-            } else {
-                (
+        let (connection_partition, mode) = if requesting_partition.requirement.accepts_h1() {
+            match self.take_group_peer(
+                &requesting_partition.eligibility_group,
+                &requesting_partition.requesting_partition,
+            ) {
+                Some(connection_partition) => (connection_partition, ReuseMode::Borrow),
+                None => (
                     self.take_origin_peer(&requesting_partition.requesting_partition)?,
                     ReuseMode::Reclaim,
-                )
-            };
+                ),
+            }
+        } else {
+            (self.take_origin_head()?, ReuseMode::Reclaim)
+        };
 
         let id = self.take_reuse_id();
         let availability_record = self
@@ -567,6 +563,13 @@ impl H1Reuse {
         Some(connection_partition)
     }
 
+    /// Removes and returns the oldest origin-wide connection, including local.
+    fn take_origin_head(&mut self) -> Option<PartitionId> {
+        let connection_partition = self.origin_order.head()?;
+        self.unlink_cell(&connection_partition);
+        Some(connection_partition)
+    }
+
     /// Returns the head, or its successor when the head is the requesting cell itself.
     fn first_peer(
         &self,
@@ -697,7 +700,12 @@ impl H1Reuse {
     /// Checks reuse-operation indexes and both availability orders after every mutation.
     fn assert_consistent(&self) {
         #[cfg(debug_assertions)]
-        self.assert_consistent_debug();
+        {
+            if std::thread::panicking() {
+                return;
+            }
+            self.assert_consistent_debug();
+        }
     }
 
     #[cfg(debug_assertions)]
@@ -1222,6 +1230,9 @@ impl OriginAdmission {
             match record.mode {
                 ReuseMode::Borrow => {
                     let delivery = state.take_delivery_id();
+                    let old_group = state
+                        .demand_schedule
+                        .group_for(&record.requesting_partition);
                     let Some(scheduled) = state.demand_schedule.reserve_reuse_demand(
                         &record.requesting_partition,
                         record.demand,
@@ -1231,7 +1242,7 @@ impl OriginAdmission {
                         drop(candidate);
                         return None;
                     };
-                    state.reconcile_h2_demand(&scheduled.requesting_partition);
+                    state.reconcile_demand_indexes(&scheduled.requesting_partition, old_group);
                     Some(AdmissionAction::Delivery(DeliveryGuard::borrowed_h1(
                         origin.clone(),
                         delivery,
@@ -1300,7 +1311,7 @@ impl OriginAdmission {
 #[cfg(all(test, not(smithy_http_client_loom)))]
 mod tests {
     use super::*;
-    use crate::client::pool::admission::{DemandSnapshot, SnapshotVersion};
+    use crate::client::pool::admission::{DemandSnapshot, ProtocolRequirement, SnapshotVersion};
     use crate::client::pool::partition::PartitionId;
 
     fn cell(index: usize) -> PartitionId {
@@ -1373,6 +1384,38 @@ mod tests {
                 .get(&group)
                 .expect("connection cell group disappeared")
                 .len()
+        );
+    }
+
+    #[test]
+    fn h2_required_demand_reclaims_local_h1_capacity() {
+        let requesting_partition = cell(1);
+        let group = EligibilityGroup::Pool;
+        let mut schedule = DemandSchedule::default();
+        schedule.publish(
+            requesting_partition,
+            DemandSnapshot::active(
+                DemandId::from_u64(1),
+                SnapshotVersion::INITIAL,
+                ProtocolRequirement::H2Required,
+                group.clone(),
+            ),
+        );
+        let mut coordination = H1Reuse::default();
+        coordination.update_availability(
+            requesting_partition,
+            group,
+            availability_snapshot(1, true, false),
+        );
+
+        let prepared = coordination
+            .prepare_reuse(&schedule)
+            .expect("local HTTP/1 capacity was not selected for reclaim");
+
+        assert_eq!(requesting_partition, prepared.connection_partition);
+        assert_eq!(
+            ReuseMode::Reclaim,
+            coordination.operations[&prepared.id].mode
         );
     }
 

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/admission/reuse.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/admission/reuse.rs
@@ -1231,6 +1231,7 @@ impl OriginAdmission {
                         drop(candidate);
                         return None;
                     };
+                    state.reconcile_h2_demand(&scheduled.requesting_partition);
                     Some(AdmissionAction::Delivery(DeliveryGuard::borrowed_h1(
                         origin.clone(),
                         delivery,

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/builder.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/builder.rs
@@ -420,12 +420,12 @@ impl<Tls> Builder<Tls> {
             time_source: time_source.clone(),
             sleep: sleep_impl.clone(),
         };
-        let guarantees_http1 = transport.guarantees_http1();
+        let allow_h2_reclaim_for_h1 = transport.guarantees_http1();
         let registry = PartitionRegistry::new(
             self.partitions,
             self.reuse_scope,
             max_connections_per_host,
-            guarantees_http1,
+            allow_h2_reclaim_for_h1,
             maintenance,
         )
         .map_err(BuildError::from)?;

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/builder.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/builder.rs
@@ -9,8 +9,9 @@ use super::establish::{self, TransportFactory};
 use super::maintenance::MaintenanceConfig;
 use super::registry::{PartitionRegistry, PartitionRegistryError};
 use super::{ConnectionPool, ConnectionReuseScope, Partition, PoolConfig, PoolInner};
-use crate::client::TlsUnset;
+use crate::client::{TlsProviderSelected, TlsUnset};
 use crate::sync::Arc;
+use crate::tls::{self, TlsContext};
 use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep, SharedAsyncSleep};
 use aws_smithy_async::time::{SharedTimeSource, TimeSource};
 #[cfg(any(
@@ -241,6 +242,92 @@ impl<Tls> Builder<Tls> {
 }
 
 impl Builder<TlsUnset> {
+    /// Selects the TLS provider used by HTTPS pool connections.
+    pub fn tls_provider(self, provider: tls::Provider) -> Builder<TlsProviderSelected> {
+        Builder {
+            idle_timeout: self.idle_timeout,
+            time_source: self.time_source,
+            sleep_impl: self.sleep_impl,
+            tcp_nodelay: self.tcp_nodelay,
+            tcp_keepalive: self.tcp_keepalive,
+            max_connections_per_host: self.max_connections_per_host,
+            reuse_scope: self.reuse_scope,
+            partitions: self.partitions,
+            tls: TlsProviderSelected {
+                provider,
+                context: TlsContext::default(),
+            },
+        }
+    }
+}
+
+crate::cfg::cfg_tls! {
+    impl Builder<TlsProviderSelected> {
+        /// Sets provider-specific TLS configuration for HTTPS connections.
+        pub fn tls_context(mut self, context: TlsContext) -> Self {
+            self.tls.context = context;
+            self
+        }
+
+        /// Mutably sets provider-specific TLS configuration.
+        pub fn set_tls_context(&mut self, context: TlsContext) -> &mut Self {
+            self.tls.context = context;
+            self
+        }
+
+        /// Builds a pool whose connector performs TLS and ALPN negotiation.
+        pub fn build_https(self) -> Result<ConnectionPool, BuildError> {
+            validate_default_connector_interfaces(self.partitions.as_deref())?;
+            let provider = self.tls.provider.clone();
+            let context = self.tls.context.clone();
+            match provider {
+                #[cfg(feature = "__rustls")]
+                tls::Provider::Rustls(crypto_mode) => {
+                    let tcp_nodelay = self.tcp_nodelay;
+                    let tcp_keepalive = self.tcp_keepalive.clone().resolve(None);
+                    let transport = establish::cached_transport_factory_for_interface(
+                        move |interface| {
+                            let mut connector =
+                                HttpConnector::new_with_resolver(GaiResolver::new());
+                            connector.set_nodelay(tcp_nodelay);
+                            connector.set_keepalive(tcp_keepalive);
+                            set_default_connector_interface(&mut connector, interface);
+                            tls::rustls_provider::build_connector::wrap_connector(
+                                connector,
+                                crypto_mode.clone(),
+                                &context,
+                                crate::proxy::ProxyConfig::disabled(),
+                            )
+                        },
+                    );
+                    self.build_with_transport(transport)
+                }
+                #[cfg(feature = "s2n-tls")]
+                tls::Provider::S2nTls => {
+                    let tcp_nodelay = self.tcp_nodelay;
+                    let tcp_keepalive = self.tcp_keepalive.clone().resolve(None);
+                    let transport = establish::cached_transport_factory_for_interface(
+                        move |interface| {
+                            let mut connector =
+                                HttpConnector::new_with_resolver(GaiResolver::new());
+                            connector.set_nodelay(tcp_nodelay);
+                            connector.set_keepalive(tcp_keepalive);
+                            set_default_connector_interface(&mut connector, interface);
+                            tls::s2n_tls_provider::build_connector::wrap_connector(
+                                connector,
+                                &context,
+                                crate::proxy::ProxyConfig::disabled(),
+                            )
+                        },
+                    );
+                    self.build_with_transport(transport)
+                }
+            }
+        }
+    }
+}
+
+impl Builder<TlsUnset> {
     /// Builds a pool for cleartext HTTP connections.
     #[doc(hidden)]
     pub fn build_http(self) -> Result<ConnectionPool, BuildError> {
@@ -297,7 +384,9 @@ impl Builder<TlsUnset> {
     {
         self.build_with_transport(establish::transport_factory(connector))
     }
+}
 
+impl<Tls> Builder<Tls> {
     /// Validates pool policy and installs the type-erased transport factory.
     fn build_with_transport(
         self,

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/builder.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/builder.rs
@@ -276,6 +276,9 @@ crate::cfg::cfg_tls! {
         }
 
         /// Builds a pool whose connector performs TLS and ALPN negotiation.
+        ///
+        /// This builder currently creates direct connections. Proxy routing
+        /// remains available through the existing `Connector` API.
         pub fn build_https(self) -> Result<ConnectionPool, BuildError> {
             validate_default_connector_interfaces(self.partitions.as_deref())?;
             let provider = self.tls.provider.clone();
@@ -286,19 +289,21 @@ crate::cfg::cfg_tls! {
                     let tcp_nodelay = self.tcp_nodelay;
                     let tcp_keepalive = self.tcp_keepalive.clone().resolve(None);
                     let transport = establish::cached_transport_factory_for_interface(
-                        move |interface| {
+                        move |interface, alpn_protocols| {
                             let mut connector =
                                 HttpConnector::new_with_resolver(GaiResolver::new());
                             connector.set_nodelay(tcp_nodelay);
                             connector.set_keepalive(tcp_keepalive);
                             set_default_connector_interface(&mut connector, interface);
-                            tls::rustls_provider::build_connector::wrap_connector(
+                            tls::rustls_provider::build_connector::wrap_connector_with_alpn(
                                 connector,
                                 crypto_mode.clone(),
                                 &context,
                                 crate::proxy::ProxyConfig::disabled(),
+                                alpn_protocols,
                             )
                         },
+                        true,
                     );
                     self.build_with_transport(transport)
                 }
@@ -307,7 +312,7 @@ crate::cfg::cfg_tls! {
                     let tcp_nodelay = self.tcp_nodelay;
                     let tcp_keepalive = self.tcp_keepalive.clone().resolve(None);
                     let transport = establish::cached_transport_factory_for_interface(
-                        move |interface| {
+                        move |interface, _alpn_protocols| {
                             let mut connector =
                                 HttpConnector::new_with_resolver(GaiResolver::new());
                             connector.set_nodelay(tcp_nodelay);
@@ -319,6 +324,7 @@ crate::cfg::cfg_tls! {
                                 crate::proxy::ProxyConfig::disabled(),
                             )
                         },
+                        false,
                     );
                     self.build_with_transport(transport)
                 }
@@ -414,10 +420,12 @@ impl<Tls> Builder<Tls> {
             time_source: time_source.clone(),
             sleep: sleep_impl.clone(),
         };
+        let guarantees_http1 = transport.guarantees_http1();
         let registry = PartitionRegistry::new(
             self.partitions,
             self.reuse_scope,
             max_connections_per_host,
+            guarantees_http1,
             maintenance,
         )
         .map_err(BuildError::from)?;

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
@@ -31,28 +31,28 @@ mod waiters;
 use self::h1::H1CloseHandle;
 #[cfg(all(test, not(smithy_http_client_loom)))]
 use self::h1::H1DriverGuard;
-use self::h1::{H1Records, H1ReuseReservation, H1Selection, H1Sender, OwnedH1, ProvisionalH1};
+#[cfg(test)]
+use self::h1::H1Sender;
+use self::h1::{H1Records, H1ReuseReservation, H1Selection, OwnedH1};
 #[cfg(test)]
 use self::waiters::CellSnapshot;
 pub(in crate::client::pool) use self::waiters::WaiterId;
 use self::waiters::{AcquisitionQueue, DeliveryReservation, ResultInstallError};
-use super::admission::reuse::{
-    H1Availability, H1AvailabilitySnapshot, PreparedReuseInstall, ReuseCandidate, ReuseId,
-    ReuseInstallResult,
-};
-#[cfg(test)]
-use super::admission::DemandSnapshot;
+use super::admission::reuse::{H1Availability, H1AvailabilitySnapshot, ReuseId};
 use super::admission::{
-    AdmissionAction, CapacityLease, DeliveryGuard, H2AdvertisementSnapshot, OriginAdmission,
-    ProtocolRequirement,
+    AdmissionAction, CapacityLease, DeliveryGuard, DemandSnapshot, H2AdvertisementSnapshot,
+    OriginAdmission, ProtocolRequirement,
 };
+use super::connection::CloseReason;
 #[cfg(test)]
 use super::connection::ConnectionInfo;
-use super::connection::{CloseReason, ConnectionState};
+#[cfg(test)]
+use super::connection::ConnectionState;
 use super::maintenance::PartitionMaintenance;
 use super::origin::OriginKey;
 use super::partition::{EligibilityGroup, PartitionId};
 use crate::sync::{Arc, Mutex};
+#[cfg(test)]
 use aws_smithy_runtime_api::client::connection::ConnectionId;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use std::task::{Context, Poll};
@@ -114,8 +114,8 @@ struct CellState {
     published_h1_availability: Option<H1Availability>,
     /// Revision used to reject availability reports that cross out of order.
     h1_availability_revision: u64,
-    /// Last accepting H2 generation reported to origin admission.
-    published_h2_generation: Option<h2::H2GenerationId>,
+    /// Last complete H2 advertisement reported to origin admission.
+    published_h2_advertisement: Option<(h2::H2GenerationId, bool)>,
     /// Revision used to reject H2 advertisements that cross out of order.
     h2_advertisement_revision: u64,
 }
@@ -123,9 +123,15 @@ struct CellState {
 impl CellState {
     /// Checks the coupled waiter, sender, and reuse-reservation state machines.
     fn assert_consistent(&self) {
+        #[cfg(any(debug_assertions, test))]
+        if std::thread::panicking() {
+            return;
+        }
         self.waiters.assert_consistent();
         self.h1.assert_consistent();
         self.h2.assert_consistent();
+        #[cfg(any(debug_assertions, test))]
+        self.h2.assert_pending_waiters(&self.waiters);
         self.reuse
             .assert_consistent(self.h1.supports_installed_reuse());
     }
@@ -171,21 +177,51 @@ impl CellState {
 
     /// Returns an H2 advertisement only when admission's view must change.
     fn take_h2_advertisement_update(&mut self) -> Option<H2AdvertisementSnapshot> {
-        let current = self.h2.publishable_generation();
-        if self.published_h2_generation == current {
+        let current = self.h2_advertisement();
+        if self.published_h2_advertisement == current {
             return None;
         }
+        Some(self.record_h2_advertisement(current))
+    }
+
+    /// Returns the current versioned H2 advertisement for a reclaim transition.
+    fn report_h2_advertisement(&mut self) -> H2AdvertisementSnapshot {
+        let current = self.h2_advertisement();
+        if self.published_h2_advertisement == current {
+            return Self::h2_advertisement_snapshot(self.h2_advertisement_revision, current);
+        }
+        self.record_h2_advertisement(current)
+    }
+
+    /// Returns the exact publishable generation and its idle state.
+    fn h2_advertisement(&self) -> Option<(h2::H2GenerationId, bool)> {
+        self.h2
+            .publishable_generation()
+            .map(|generation| (generation, self.h2.is_idle(generation)))
+    }
+
+    /// Advances the revision and records changed H2 availability.
+    fn record_h2_advertisement(
+        &mut self,
+        advertisement: Option<(h2::H2GenerationId, bool)>,
+    ) -> H2AdvertisementSnapshot {
         self.h2_advertisement_revision = self
             .h2_advertisement_revision
             .checked_add(1)
             .expect("HTTP/2 advertisement revision exhausted");
-        self.published_h2_generation = current;
-        Some(match current {
-            Some(generation) => {
-                H2AdvertisementSnapshot::accepting(self.h2_advertisement_revision, generation)
-            }
-            None => H2AdvertisementSnapshot::unavailable(self.h2_advertisement_revision),
-        })
+        self.published_h2_advertisement = advertisement;
+        Self::h2_advertisement_snapshot(self.h2_advertisement_revision, advertisement)
+    }
+
+    fn h2_advertisement_snapshot(
+        revision: u64,
+        advertisement: Option<(h2::H2GenerationId, bool)>,
+    ) -> H2AdvertisementSnapshot {
+        match advertisement {
+            Some((generation, true)) => H2AdvertisementSnapshot::idle(revision, generation),
+            Some((generation, false)) => H2AdvertisementSnapshot::accepting(revision, generation),
+            None => H2AdvertisementSnapshot::unavailable(revision),
+        }
     }
 
     /// Atomically decides whether a peer may reserve this cell's connection.
@@ -255,6 +291,18 @@ impl CellState {
         self.assert_consistent();
         self.report_h1_availability()
     }
+
+    /// Removes active HTTP/2-compatible demand already served by visible H2 state.
+    fn publishable_demand_updates(
+        &self,
+        updates: [Option<DemandSnapshot>; 2],
+    ) -> [Option<DemandSnapshot>; 2] {
+        let h2_visible = self.h2.has_visible_h2();
+        updates.map(|snapshot| {
+            snapshot
+                .filter(|snapshot| !h2_visible || !snapshot.is_active() || !snapshot.accepts_h2())
+        })
+    }
 }
 
 /// Cell-local result of attempting to install one peer reuse reservation.
@@ -276,6 +324,8 @@ pub(super) enum AcquisitionResult {
     H2(h2::H2Activation),
     /// Establishment failed before producing a dispatchable connection.
     Failed(ConnectorError),
+    /// An HTTP/2 generation closed before serving a transferred attempt.
+    Reacquire,
 }
 
 /// One event observed while driving an acquisition attempt.
@@ -358,393 +408,6 @@ impl OriginCell {
     #[cfg(test)]
     pub(crate) fn admission(&self) -> Option<&Arc<OriginAdmission>> {
         self.admission.as_ref()
-    }
-
-    /// Installs a fresh H1 record selected by its launching request.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this cell already contains the connection identity.
-    pub(super) fn install_selected_h1(
-        cell: &Arc<Self>,
-        connection: Arc<ConnectionState>,
-        sender: H1Sender,
-    ) -> H1Selection {
-        let (installed, availability) = {
-            let mut state = cell.state.lock();
-            let installed = state.h1.install_selected(connection, sender);
-            state.assert_consistent();
-            (installed, state.take_h1_availability_update())
-        };
-        cell.publish_h1_availability(availability);
-        match installed {
-            Ok(owner) => H1Selection::new(cell, owner),
-            Err(owner) => {
-                owner
-                    .connection()
-                    .logical_close(CloseReason::ProtocolClosed);
-                drop(owner);
-                panic!("duplicate HTTP/1 connection identity installed in one cell");
-            }
-        }
-    }
-
-    /// Installs an H1 record whose launching acquisition already completed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this cell already contains the connection identity.
-    #[cfg(test)]
-    pub(super) fn install_idle_h1(
-        cell: &Arc<Self>,
-        connection: Arc<ConnectionState>,
-        sender: H1Sender,
-    ) {
-        let deadline = cell.idle_deadline();
-        let (installed, availability) = {
-            let mut state = cell.state.lock();
-            let installed = state.h1.install_idle(connection, sender, deadline);
-            state.assert_consistent();
-            (installed, state.take_h1_availability_update())
-        };
-        cell.publish_h1_availability(availability);
-        if let Err(owner) = installed {
-            owner
-                .connection()
-                .logical_close(CloseReason::ProtocolClosed);
-            drop(owner);
-            panic!("duplicate HTTP/1 connection identity installed in one cell");
-        }
-        cell.notify_maintenance(deadline);
-    }
-
-    /// Selects the newest reusable H1 sender without origin-wide coordination.
-    pub(super) fn select_h1(cell: &Arc<Self>) -> Option<H1Selection> {
-        let (owner, availability) = {
-            let mut state = cell.state.lock();
-            let owner = state.h1.select_idle();
-            if owner.is_some() {
-                state.reuse.consume_local_turn();
-            }
-            state.assert_consistent();
-            let availability = cell
-                .admission
-                .as_ref()
-                .and_then(|_| state.take_h1_availability_update());
-            (owner, availability)
-        };
-        cell.publish_h1_availability(availability);
-        let owner = owner?;
-        Some(H1Selection::new(cell, owner))
-    }
-
-    /// Reserves this cell's selected connection for one peer reuse operation.
-    pub(in crate::client::pool) fn install_h1_reuse(
-        cell: &Arc<Self>,
-        origin: Arc<OriginAdmission>,
-        prepared: PreparedReuseInstall,
-    ) -> Option<AdmissionAction> {
-        let decision = {
-            let mut state = cell.state.lock();
-            state.install_reuse(prepared.id)
-        };
-
-        let result = match decision {
-            ReuseInstall::Installed => ReuseInstallResult::Installed,
-            ReuseInstall::Candidate(owner) => {
-                let provisional = ProvisionalH1::new(cell, owner);
-                ReuseInstallResult::Candidate(ReuseCandidate::new(
-                    origin.clone(),
-                    prepared.id,
-                    cell.id.partition(),
-                    provisional,
-                ))
-            }
-            ReuseInstall::Rejected(availability) => ReuseInstallResult::Rejected(availability),
-        };
-        OriginAdmission::finish_h1_reuse_install(&origin, prepared.id, cell.id.partition(), result)
-    }
-
-    /// Clears an installed or resolving reservation after request cancellation.
-    pub(in crate::client::pool) fn cancel_h1_reuse(
-        &self,
-        reuse_id: ReuseId,
-    ) -> H1AvailabilitySnapshot {
-        self.state.lock().cancel_reuse(reuse_id)
-    }
-
-    /// Returns a rejected provisional sender through ordinary connection-owning cell handling.
-    pub(in crate::client::pool) fn reject_h1_reuse_candidate(
-        cell: &Arc<Self>,
-        reuse_id: ReuseId,
-        provisional: ProvisionalH1,
-    ) -> H1AvailabilitySnapshot {
-        {
-            let mut state = cell.state.lock();
-            state.reject_reuse_candidate(reuse_id);
-        }
-        drop(provisional);
-        let mut state = cell.state.lock();
-        state.assert_consistent();
-        state.report_h1_availability()
-    }
-
-    /// Revalidates a reuse operation and commits its provisional sender for dispatch.
-    pub(in crate::client::pool) fn commit_h1_reuse(
-        cell: &Arc<Self>,
-        reuse_id: ReuseId,
-        provisional: ProvisionalH1,
-    ) -> Result<H1Selection, ProvisionalH1> {
-        let (connection_cell, owner) = provisional.into_parts();
-        let committed = cell.state.lock().commit_reuse(reuse_id, &owner);
-        if committed {
-            Ok(H1Selection::new(cell, owner))
-        } else {
-            Err(ProvisionalH1::from_parts(connection_cell, owner))
-        }
-    }
-
-    /// Closes a selected sender and records fairness only if close wins.
-    pub(in crate::client::pool) fn reclaim_h1_reuse(
-        cell: &Arc<Self>,
-        reuse_id: ReuseId,
-        provisional: ProvisionalH1,
-    ) -> Result<(H1AvailabilitySnapshot, bool), ProvisionalH1> {
-        let (connection_cell, owner) = provisional.into_parts();
-        if !cell.state.lock().reuse.names(reuse_id) {
-            return Err(ProvisionalH1::from_parts(connection_cell, owner));
-        }
-
-        let close_won = Self::retire_h1_owner(cell, owner, CloseReason::Reclaimed);
-        let availability = {
-            let mut state = cell.state.lock();
-            let availability = state.finish_reuse(reuse_id, close_won);
-            state.assert_consistent();
-            availability
-        };
-        Ok((availability, close_won))
-    }
-
-    /// Completes local reuse state after a requesting cell accepts the sender.
-    pub(in crate::client::pool) fn complete_h1_reuse(
-        &self,
-        reuse_id: ReuseId,
-        transferred: bool,
-    ) -> H1AvailabilitySnapshot {
-        self.state.lock().finish_reuse(reuse_id, transferred)
-    }
-
-    /// Publishes this cell's HTTP/1 availability when the origin is bounded.
-    fn publish_h1_availability(&self, availability: Option<H1AvailabilitySnapshot>) {
-        if let (Some(admission), Some(availability)) = (&self.admission, availability) {
-            OriginAdmission::update_h1_availability(
-                admission,
-                self.id.partition(),
-                self.eligibility_group.clone(),
-                availability,
-            );
-        }
-    }
-
-    /// Returns a reusable sender to the oldest compatible waiter or idle set.
-    ///
-    /// Demand publication, task wakeup, and any rejected-result fallback all
-    /// run after the cell lock is released. `owner` remains outside the locked
-    /// scope so sender or connection drop cannot run while the cell guard is
-    /// live.
-    fn return_h1_owner(cell: &Arc<Self>, owner: OwnedH1) {
-        let connection_id = owner.id();
-        let mut owner = Some(owner);
-        let mut installation = None;
-        let mut intercepted = None;
-        let mut rejected_reuse = None;
-        let idle_deadline = cell.idle_deadline();
-        let should_retire = {
-            let mut state = cell.state.lock();
-            let returnable = state
-                .h1
-                .accepts_return(owner.as_ref().expect("HTTP/1 owner disappeared"));
-            if !returnable {
-                if let Some(reuse_id) = state.reuse.intercept_return() {
-                    let snapshot = state.finish_reuse(reuse_id, false);
-                    rejected_reuse = Some((reuse_id, snapshot));
-                } else {
-                    state.assert_consistent();
-                }
-                true
-            } else if let Some(reuse_id) = state.reuse.intercept_return() {
-                if state
-                    .h1
-                    .reserve_for_reuse(owner.as_ref().expect("HTTP/1 owner disappeared"))
-                {
-                    state.assert_consistent();
-                    intercepted = Some((
-                        reuse_id,
-                        ProvisionalH1::new(cell, owner.take().expect("HTTP/1 owner disappeared")),
-                    ));
-                    false
-                } else {
-                    let snapshot = state.finish_reuse(reuse_id, false);
-                    rejected_reuse = Some((reuse_id, snapshot));
-                    true
-                }
-            } else if state.waiters.can_accept_h1()
-                && state
-                    .h1
-                    .commit_return_to_waiter(owner.as_ref().expect("HTTP/1 owner disappeared"))
-            {
-                state.reuse.consume_local_turn();
-                state.assert_consistent();
-                let mut returned = owner.take().expect("HTTP/1 owner disappeared");
-                returned.mark_reused();
-                installation = Some(state.waiters.install_returned_h1(
-                    || AcquisitionResult::H1(H1Selection::new(cell, returned)),
-                    &cell.eligibility_group,
-                ));
-                false
-            } else {
-                let returned = state.h1.return_idle(
-                    owner.take().expect("HTTP/1 owner disappeared"),
-                    idle_deadline,
-                );
-                match returned {
-                    Ok(()) => {
-                        state.assert_consistent();
-                        false
-                    }
-                    Err(returned) => {
-                        owner = Some(returned);
-                        true
-                    }
-                }
-            }
-        };
-
-        if should_retire {
-            if tracing::level_enabled!(tracing::Level::TRACE) {
-                trace_h1_return(cell, connection_id, H1ReturnTrace::Rejected);
-            }
-            if let Some((reuse_id, snapshot)) = rejected_reuse {
-                let admission = cell
-                    .admission
-                    .as_ref()
-                    .expect("an HTTP/1 reuse operation requires bounded admission");
-                OriginAdmission::reject_returned_h1_reuse(
-                    admission,
-                    reuse_id,
-                    cell.id.partition(),
-                    snapshot,
-                );
-            }
-            Self::retire_h1_owner(
-                cell,
-                owner.take().expect("retired HTTP/1 owner disappeared"),
-                CloseReason::ProtocolClosed,
-            );
-            return;
-        }
-
-        if let Some((reuse_id, provisional)) = intercepted {
-            if tracing::level_enabled!(tracing::Level::TRACE) {
-                trace_h1_return(cell, connection_id, H1ReturnTrace::ReuseIntercepted);
-            }
-            let admission = cell
-                .admission
-                .as_ref()
-                .expect("an HTTP/1 reuse operation requires bounded admission");
-            let candidate = ReuseCandidate::new(
-                admission.clone(),
-                reuse_id,
-                cell.id.partition(),
-                provisional,
-            );
-            let action = OriginAdmission::resolve_h1_reuse(admission, reuse_id, candidate);
-            OriginAdmission::drive(action);
-            return;
-        }
-
-        let Some(installation) = installation else {
-            if tracing::level_enabled!(tracing::Level::TRACE) {
-                trace_h1_return(cell, connection_id, H1ReturnTrace::Idle);
-            }
-            cell.notify_maintenance(idle_deadline);
-            if cell.admission.is_some() {
-                let availability = cell.state.lock().take_h1_availability_update();
-                cell.publish_h1_availability(availability);
-            }
-            return;
-        };
-        if tracing::level_enabled!(tracing::Level::TRACE) {
-            trace_h1_return(cell, connection_id, H1ReturnTrace::LocalDemand);
-        }
-        if let Some(admission) = &cell.admission {
-            let suppress_active = cell.state.lock().h2.has_visible_h2();
-            for snapshot in installation
-                .demand_updates
-                .into_iter()
-                .flatten()
-                .filter(|snapshot| !suppress_active || !snapshot.is_active())
-            {
-                OriginAdmission::publish_demand(admission, cell.id.partition(), snapshot);
-            }
-        }
-        drop(installation.returned_event);
-        if let Some(waker) = installation.waker {
-            waker.wake();
-        }
-        if cell.admission.is_some() {
-            let availability = cell.state.lock().take_h1_availability_update();
-            cell.publish_h1_availability(availability);
-        }
-    }
-
-    /// Retires an externally owned H1 sender and removes its connection-owning cell record.
-    ///
-    /// Returns whether this path won the connection's logical-close race.
-    fn retire_h1_owner(cell: &Arc<Self>, owner: OwnedH1, reason: CloseReason) -> bool {
-        let should_close = {
-            let mut state = cell.state.lock();
-            let should_close = state.h1.close_owned(&owner);
-            state.assert_consistent();
-            should_close
-        };
-
-        let id = owner.id();
-        let won = should_close && owner.connection().logical_close(reason);
-        drop(owner);
-
-        let mut state = cell.state.lock();
-        state.h1.finish_close(id);
-        state.assert_consistent();
-        let availability = state.take_h1_availability_update();
-        drop(state);
-        cell.publish_h1_availability(availability);
-        won
-    }
-
-    /// Begins close for an installed H1 generation named without its sender.
-    ///
-    /// Returns whether this signal won the connection's logical-close race.
-    fn close_h1(cell: &Arc<Self>, id: ConnectionId, reason: CloseReason) -> bool {
-        let Some((close, availability)) = ({
-            let mut state = cell.state.lock();
-            let close = state.h1.begin_close(id);
-            state.assert_consistent();
-            close.map(|close| (close, state.take_h1_availability_update()))
-        }) else {
-            return false;
-        };
-
-        cell.publish_h1_availability(availability);
-        let remove_record = close.sender.is_some();
-        let won = close.connection.logical_close(reason);
-        drop(close.sender);
-        if remove_record {
-            let mut state = cell.state.lock();
-            state.h1.finish_close(id);
-            state.assert_consistent();
-        }
-        won
     }
 
     /// Closes H1 records and H2 generations whose idle deadline elapsed.
@@ -844,7 +507,7 @@ impl OriginCell {
             (installation, state.h2.has_visible_h2())
         };
         if suppress_successor {
-            acknowledgement.suppress_successor();
+            acknowledgement.suppress_h2_successor();
         }
 
         let accepted = installation.accepted;
@@ -873,21 +536,9 @@ impl OriginCell {
     }
 
     /// Returns the number of retained acquisition waiters for boundary tests.
-    #[cfg(all(test, feature = "rt-tokio"))]
+    #[cfg(test)]
     pub(super) fn retained_waiters_for_test(&self) -> usize {
         self.state.lock().waiters.snapshot().retained
-    }
-
-    /// Returns H1 record counts for focused ownership tests.
-    #[cfg(test)]
-    fn h1_counts(&self) -> (usize, usize) {
-        self.state.lock().h1.counts()
-    }
-
-    /// Returns the sole installed HTTP/1 connection for focused dispatch tests.
-    #[cfg(all(test, feature = "rt-tokio"))]
-    pub(super) fn only_h1_connection_for_test(&self) -> Arc<ConnectionState> {
-        self.state.lock().h1.only_connection_for_test()
     }
 
     /// Registers one acquisition waiter in cell-local arrival order.
@@ -903,7 +554,11 @@ impl OriginCell {
                 &cell.eligibility_group,
                 cell.admission.is_some(),
             );
-            (waiter, snapshot, state.h2.has_visible_h2())
+            (
+                waiter,
+                snapshot,
+                state.h2.has_visible_h2() && requirement.accepts_h2(),
+            )
         };
 
         if let (Some(admission), Some(snapshot), false) = (&cell.admission, snapshot, h2_visible) {
@@ -925,11 +580,12 @@ impl OriginCell {
             let mut state = cell.state.lock();
             state.h2.cancel_flight_participant(waiter);
             state.h2.cancel_peer_activation(waiter);
+            state.h2.cancel_pending_waiter(waiter);
             state
                 .waiters
                 .cancel_waiter(waiter, &cell.eligibility_group)
-                .map(|cancelled| {
-                    let local_install = if state.waiters.can_accept_h1() {
+                .map(|mut cancelled| {
+                    let mut local_install = if state.waiters.can_accept_h1() {
                         state.h1.select_idle().map(|owner| {
                             state.reuse.consume_local_turn();
                             state.waiters.install_returned_h1(
@@ -940,6 +596,16 @@ impl OriginCell {
                     } else {
                         None
                     };
+                    cancelled.demand_updates =
+                        state.publishable_demand_updates(cancelled.demand_updates);
+                    if let Some(install) = &mut local_install {
+                        if let Some(waiter) = install.waiter {
+                            state.h2.cancel_pending_waiter(waiter);
+                        }
+                        install.demand_updates = state.publishable_demand_updates(std::mem::take(
+                            &mut install.demand_updates,
+                        ));
+                    }
                     (cancelled, local_install)
                 })
         };
@@ -948,7 +614,6 @@ impl OriginCell {
         };
 
         if let Some(admission) = &cell.admission {
-            let suppress_active = cell.state.lock().h2.has_visible_h2();
             for snapshot in cancelled
                 .demand_updates
                 .into_iter()
@@ -959,7 +624,6 @@ impl OriginCell {
                         .flat_map(|install| install.demand_updates.iter().cloned()),
                 )
                 .flatten()
-                .filter(|snapshot| !suppress_active || !snapshot.is_active())
             {
                 OriginAdmission::publish_demand(admission, cell.id.partition(), snapshot);
             }
@@ -983,6 +647,7 @@ impl OriginCell {
             state.take_h1_availability_update()
         };
         cell.publish_h1_availability(availability);
+        Self::service_h2_waiters(cell);
         Self::service_peer_h2_waiters(cell);
         true
     }
@@ -1022,6 +687,13 @@ impl OriginCell {
         let installation = {
             let mut state = self.state.lock();
             let installation = state.waiters.install_establishment_result(waiter, result);
+            let served_with_h1 = served_with_h1
+                && !installation.returned_events.iter().any(|event| {
+                    matches!(
+                        event,
+                        Some(AcquisitionEvent::Complete(AcquisitionResult::H1(_)))
+                    )
+                });
             if installation.accepted {
                 if served_with_h1 {
                     state.reuse.consume_local_turn();
@@ -1077,6 +749,9 @@ impl OriginCell {
             AcquisitionEvent::Complete(AcquisitionResult::Failed(_)) => {
                 panic!("HTTP/1 ownership test received establishment failure")
             }
+            AcquisitionEvent::Complete(AcquisitionResult::Reacquire) => {
+                panic!("HTTP/1 ownership test received an internal reacquisition")
+            }
             AcquisitionEvent::Establish(_) => {
                 panic!("HTTP/1 ownership test received establishment capacity")
             }
@@ -1114,60 +789,6 @@ impl OriginCell {
     #[cfg(test)]
     fn snapshot(&self) -> CellSnapshot {
         self.state.lock().waiters.snapshot()
-    }
-}
-
-/// Terminal outcome for one reusable HTTP/1 sender return.
-enum H1ReturnTrace {
-    /// The owning cell no longer accepts the sender.
-    Rejected,
-    /// Origin admission reserved the sender for peer demand.
-    ReuseIntercepted,
-    /// No compatible demand exists, so the sender became idle.
-    Idle,
-    /// A waiter in the owning cell accepted the sender.
-    LocalDemand,
-}
-
-/// Emits a committed HTTP/1 return outcome outside the cell lock.
-// Keep field formatting out of a return transition that can synchronously
-// enter admission and sender fallbacks.
-#[inline(never)]
-fn trace_h1_return(cell: &OriginCell, connection_id: ConnectionId, outcome: H1ReturnTrace) {
-    match outcome {
-        H1ReturnTrace::Rejected => tracing::trace!(
-            connection_id = %connection_id,
-            connection_partition = ?cell.id.partition(),
-            origin_scheme = %cell.id.origin().scheme(),
-            origin_host = cell.id.origin().host(),
-            origin_port = ?cell.id.origin().port(),
-            "HTTP/1 return was rejected by its connection-owning cell"
-        ),
-        H1ReturnTrace::ReuseIntercepted => tracing::trace!(
-            connection_id = %connection_id,
-            connection_partition = ?cell.id.partition(),
-            origin_scheme = %cell.id.origin().scheme(),
-            origin_host = cell.id.origin().host(),
-            origin_port = ?cell.id.origin().port(),
-            "HTTP/1 return was intercepted by a cross-cell reuse operation"
-        ),
-        H1ReturnTrace::Idle => tracing::trace!(
-            connection_id = %connection_id,
-            connection_partition = ?cell.id.partition(),
-            origin_scheme = %cell.id.origin().scheme(),
-            origin_host = cell.id.origin().host(),
-            origin_port = ?cell.id.origin().port(),
-            "HTTP/1 connection returned to idle storage"
-        ),
-        H1ReturnTrace::LocalDemand => tracing::trace!(
-            connection_id = %connection_id,
-            request_partition = ?cell.id.partition(),
-            connection_partition = ?cell.id.partition(),
-            origin_scheme = %cell.id.origin().scheme(),
-            origin_host = cell.id.origin().host(),
-            origin_port = ?cell.id.origin().port(),
-            "HTTP/1 return satisfied local demand"
-        ),
     }
 }
 
@@ -1852,7 +1473,7 @@ mod tests {
     }
 
     #[test]
-    fn cancelling_h2_head_serves_compatible_successor_locally() {
+    fn cancelling_h2_head_refunnels_reclaimed_capacity_to_successor() {
         let (admission, cell) = bounded_cell();
         let lease = OriginAdmission::lease_for_test(&admission);
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
@@ -1860,15 +1481,20 @@ mod tests {
         let h2_head = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
         let h1_successor = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
-        assert!(cell.take_ready_event(h2_head).is_none());
+        let AcquisitionEvent::Establish(permit) = cell
+            .take_ready_event(h2_head)
+            .expect("HTTP/2 demand did not receive reclaimed local capacity")
+        else {
+            panic!("HTTP/2 demand received a protocol handle instead of capacity");
+        };
         assert!(OriginCell::cancel_waiter(&cell, h2_head));
+        drop(permit);
 
-        let selected = cell
-            .take_ready_h1(h1_successor)
-            .expect("local idle H1 did not serve the compatible successor");
-        assert_eq!(11, selected.test_sender_id());
+        let successor = OriginCell::take_ready_lease(&cell, h1_successor)
+            .expect("reclaimed capacity did not reach the compatible successor");
+        assert_eq!((0, 0), cell.h1_counts());
         assert!(cell.state.lock().reuse.is_available());
-        drop(selected);
+        drop(successor);
     }
 
     #[test]
@@ -2304,6 +1930,9 @@ mod tests {
             AcquisitionEvent::Complete(AcquisitionResult::H1(_)) => {
                 panic!("HTTP/2 waiter received an HTTP/1 sender")
             }
+            AcquisitionEvent::Complete(AcquisitionResult::Reacquire) => {
+                panic!("HTTP/2 waiter was returned for reacquisition")
+            }
             AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
                 panic!("HTTP/2 waiter received an establishment failure: {error}")
             }
@@ -2418,6 +2047,119 @@ mod tests {
             &connection_cell,
             generation,
             CloseReason::PoolDropped,
+        ));
+    }
+
+    #[test]
+    fn stale_publication_retries_against_a_replacement_generation() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (first, _first_connection, _first_physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let (waiter, demand) =
+            requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+        let action = OriginAdmission::publish_action_without_driving(
+            &admission,
+            requesting_cell.id().partition(),
+            demand,
+        )
+        .expect("peer demand did not prepare publication");
+
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            first,
+            CloseReason::ProtocolClosed
+        ));
+        let (second, _second_connection, _second_physical) =
+            install_bounded_h2(&admission, &connection_cell, 2);
+        OriginAdmission::drive(Some(action));
+
+        let activation = take_ready_h2(&requesting_cell, waiter);
+        assert_eq!(second, activation.generation());
+        drop(activation);
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            second,
+            CloseReason::PoolDropped
+        ));
+    }
+
+    #[test]
+    fn stale_peer_route_republishes_demand_to_a_replacement_generation() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (first, _first_connection, _first_physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let (waiter, demand) =
+            requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+        assert!(OriginCell::install_h2_route(
+            &requesting_cell,
+            h2::H2Route::new(&connection_cell, first),
+            &EligibilityGroup::Pool,
+            demand.id_for_test(),
+        ));
+
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            first,
+            CloseReason::ProtocolClosed
+        ));
+        let (second, _second_connection, _second_physical) =
+            install_bounded_h2(&admission, &connection_cell, 2);
+        OriginCell::service_peer_h2_waiters(&requesting_cell);
+        let activation = take_ready_h2(&requesting_cell, waiter);
+        assert_eq!(second, activation.generation());
+        drop(activation);
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            second,
+            CloseReason::PoolDropped
+        ));
+    }
+
+    #[test]
+    fn direct_selection_removes_a_stale_peer_route() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (generation, _connection, _physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let waiter = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H2Required);
+        drop(take_ready_h2(&requesting_cell, waiter));
+
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::ProtocolClosed,
+        ));
+        assert!(OriginCell::select_h2(&requesting_cell).is_none());
+        assert!(
+            !requesting_cell.state.lock().h2.has_visible_h2(),
+            "direct selection retained a stale peer route"
+        );
+    }
+
+    #[test]
+    fn open_peer_route_allows_concurrent_prospective_activations() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (generation, _connection, _physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let waiter = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H2Required);
+        drop(take_ready_h2(&requesting_cell, waiter));
+
+        let first = OriginCell::select_h2(&requesting_cell)
+            .expect("first direct peer activation was not selected");
+        let second = OriginCell::select_h2(&requesting_cell)
+            .expect("open peer route serialized the second activation");
+        assert_eq!(generation, first.generation());
+        assert_eq!(generation, second.generation());
+        assert_eq!(Some((2, 0)), connection_cell.h2_request_counts(generation));
+        drop(first);
+        drop(second);
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::PoolDropped
         ));
     }
 
@@ -2852,6 +2594,9 @@ mod loom_tests {
                 AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
                     panic!("unexpected establishment failure: {error}")
                 }
+                AcquisitionEvent::Complete(AcquisitionResult::Reacquire) => {
+                    panic!("HTTP/1 reuse model requested reacquisition")
+                }
                 AcquisitionEvent::Complete(AcquisitionResult::H2(_)) => {
                     panic!("HTTP/1 reuse model received an HTTP/2 activation")
                 }
@@ -2978,7 +2723,53 @@ mod loom_tests {
     }
 
     #[test]
-    fn h2_publication_races_connection_cell_close_without_stranding_demand() {
+    fn h2_publication_acknowledgement_races_generation_close_and_route_service() {
+        let mut model = loom::model::Builder::new();
+        model.preemption_bound = Some(3);
+        model.check(|| {
+            let (admission, connection_cell, requesting_cell) =
+                bounded_peer_cells(EligibilityGroup::Pool, EligibilityGroup::Pool);
+            let lease = OriginAdmission::lease_for_test(&admission);
+            let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
+            let generation = OriginCell::install_h2_for_test(&connection_cell, connection, 1, None);
+            let (waiter, demand) =
+                requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+            let action = OriginAdmission::publish_action_without_driving(
+                &admission,
+                requesting_cell.id().partition(),
+                demand,
+            )
+            .expect("peer demand did not prepare publication");
+
+            let publishing = loom::thread::spawn(move || {
+                OriginAdmission::drive(Some(action));
+            });
+            let closing_cell = connection_cell.clone();
+            let closing = loom::thread::spawn(move || {
+                OriginCell::close_h2(&closing_cell, generation, CloseReason::Poisoned)
+            });
+            let servicing_cell = requesting_cell.clone();
+            let servicing = loom::thread::spawn(move || {
+                OriginCell::service_peer_h2_waiters(&servicing_cell);
+            });
+
+            publishing.join().unwrap();
+            assert!(closing.join().unwrap());
+            servicing.join().unwrap();
+
+            assert!(
+                OriginCell::cancel_waiter(&requesting_cell, waiter),
+                "publication acknowledgement lost the live demand"
+            );
+            assert_eq!(0, requesting_cell.snapshot().retained);
+            assert_eq!(0, admission.ordered_demand_count_for_test());
+            assert_eq!(1, admission.available_capacity_for_test());
+            admission.clear_modeled_cells_for_test();
+        });
+    }
+
+    #[test]
+    fn h2_publication_close_race_preserves_capacity_ownership() {
         let mut model = loom::model::Builder::new();
         model.preemption_bound = Some(2);
         model.check(|| {

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell.rs
@@ -13,14 +13,18 @@
 //! [`AcquisitionQueue`] owns every live acquisition attempt, including the
 //! bounded FIFO, delivery crossings, establishment launch, cancellation, and
 //! terminal results. Its module documents the complete transition model.
-//! [`CellState`] couples that model to HTTP/1 sender residence so a local
-//! return either satisfies one acquisition or becomes idle, never both.
+//! [`CellState`] couples that model to HTTP/1 sender residence, HTTP/2
+//! flight and generation residence, generation gates, and the cross-cell reuse
+//! reservation. A local HTTP/1 return either satisfies one acquisition or
+//! becomes idle, never both. An HTTP/2 activation becomes visible only with a
+//! prospective generation lease and one recorded gate opportunity.
 //!
 //! Permits, senders, admission updates, and task wakes are detached from
 //! mutable state before their fallback or callback runs. This keeps drop and
 //! wake paths outside the cell lock.
 
 pub(super) mod h1;
+pub(super) mod h2;
 mod waiters;
 
 #[cfg(test)]
@@ -39,7 +43,8 @@ use super::admission::reuse::{
 #[cfg(test)]
 use super::admission::DemandSnapshot;
 use super::admission::{
-    AdmissionAction, CapacityLease, DeliveryGuard, OriginAdmission, ProtocolRequirement,
+    AdmissionAction, CapacityLease, DeliveryGuard, H2AdvertisementSnapshot, OriginAdmission,
+    ProtocolRequirement,
 };
 #[cfg(test)]
 use super::connection::ConnectionInfo;
@@ -92,20 +97,27 @@ pub(crate) struct OriginCell {
 
 /// Mutable state protected by one partition-origin cell lock.
 ///
-/// Waiter outcomes and HTTP/1 residence share this lock so a returning sender
-/// either becomes visible to one waiter or enters idle storage, never both.
+/// Waiter outcomes and protocol residence share this lock. HTTP/1 returns,
+/// HTTP/2 activation gates, flight participants, and cancellation therefore
+/// commit against one acquisition order.
 #[derive(Debug, Default)]
 struct CellState {
     /// Cell-local acquisition order and delivered results.
     waiters: AcquisitionQueue,
     /// Cell-owned HTTP/1 records and reusable sender order.
     h1: H1Records,
+    /// Cell-owned HTTP/2 flight and installed generations.
+    h2: h2::H2Records,
     /// One cross-cell reuse reservation and its local fairness debt.
     reuse: H1ReuseReservation,
     /// Last HTTP/1 availability published to bounded-origin admission.
     published_h1_availability: Option<H1Availability>,
     /// Revision used to reject availability reports that cross out of order.
     h1_availability_revision: u64,
+    /// Last accepting H2 generation reported to origin admission.
+    published_h2_generation: Option<h2::H2GenerationId>,
+    /// Revision used to reject H2 advertisements that cross out of order.
+    h2_advertisement_revision: u64,
 }
 
 impl CellState {
@@ -113,6 +125,7 @@ impl CellState {
     fn assert_consistent(&self) {
         self.waiters.assert_consistent();
         self.h1.assert_consistent();
+        self.h2.assert_consistent();
         self.reuse
             .assert_consistent(self.h1.supports_installed_reuse());
     }
@@ -154,6 +167,25 @@ impl CellState {
             .expect("HTTP/1 availability revision exhausted");
         self.published_h1_availability = Some(availability);
         H1AvailabilitySnapshot::new(self.h1_availability_revision, availability)
+    }
+
+    /// Returns an H2 advertisement only when admission's view must change.
+    fn take_h2_advertisement_update(&mut self) -> Option<H2AdvertisementSnapshot> {
+        let current = self.h2.publishable_generation();
+        if self.published_h2_generation == current {
+            return None;
+        }
+        self.h2_advertisement_revision = self
+            .h2_advertisement_revision
+            .checked_add(1)
+            .expect("HTTP/2 advertisement revision exhausted");
+        self.published_h2_generation = current;
+        Some(match current {
+            Some(generation) => {
+                H2AdvertisementSnapshot::accepting(self.h2_advertisement_revision, generation)
+            }
+            None => H2AdvertisementSnapshot::unavailable(self.h2_advertisement_revision),
+        })
     }
 
     /// Atomically decides whether a peer may reserve this cell's connection.
@@ -240,6 +272,8 @@ enum ReuseInstall {
 pub(super) enum AcquisitionResult {
     /// An exclusive HTTP/1 sender selected from an installed cell-owned record.
     H1(H1Selection),
+    /// A prospective request lease against one HTTP/2 generation.
+    H2(h2::H2Activation),
     /// Establishment failed before producing a dispatchable connection.
     Failed(ConnectorError),
 }
@@ -299,7 +333,7 @@ impl OriginCell {
     }
 
     /// Returns the next idle deadline from immutable pool policy.
-    fn idle_deadline(&self) -> Option<SystemTime> {
+    pub(in crate::client::pool) fn idle_deadline(&self) -> Option<SystemTime> {
         self.maintenance
             .as_ref()
             .and_then(|maintenance| maintenance.idle_deadline())
@@ -644,7 +678,13 @@ impl OriginCell {
             trace_h1_return(cell, connection_id, H1ReturnTrace::LocalDemand);
         }
         if let Some(admission) = &cell.admission {
-            for snapshot in installation.demand_updates.into_iter().flatten() {
+            let suppress_active = cell.state.lock().h2.has_visible_h2();
+            for snapshot in installation
+                .demand_updates
+                .into_iter()
+                .flatten()
+                .filter(|snapshot| !suppress_active || !snapshot.is_active())
+            {
                 OriginAdmission::publish_demand(admission, cell.id.partition(), snapshot);
             }
         }
@@ -707,10 +747,13 @@ impl OriginCell {
         won
     }
 
-    /// Closes idle records whose maintenance deadline has elapsed.
+    /// Closes H1 records and H2 generations whose idle deadline elapsed.
     pub(super) fn expire_idle(cell: &Arc<Self>, now: SystemTime) {
-        let expired = cell.state.lock().h1.expired_idle(now);
-        for id in expired {
+        let (expired_h1, expired_h2) = {
+            let state = cell.state.lock();
+            (state.h1.expired_idle(now), state.h2.expired(now))
+        };
+        for id in expired_h1 {
             if Self::close_h1(cell, id, CloseReason::IdleTimeout) {
                 tracing::trace!(
                     connection_id = %id,
@@ -722,18 +765,43 @@ impl OriginCell {
                 );
             }
         }
+        if let Some(generation) = expired_h2 {
+            if Self::close_h2(cell, generation, CloseReason::IdleTimeout) {
+                tracing::trace!(
+                    connection_partition = ?cell.id.partition(),
+                    origin_scheme = %cell.id.origin().scheme(),
+                    origin_host = cell.id.origin().host(),
+                    origin_port = ?cell.id.origin().port(),
+                    h2_generation = ?generation,
+                    "HTTP/2 idle generation expired"
+                );
+            }
+        }
     }
 
-    /// Returns this cell's nearest reusable H1 deadline.
+    /// Returns this cell's nearest reusable connection deadline.
     pub(super) fn nearest_idle_deadline(&self) -> Option<SystemTime> {
-        self.state.lock().h1.nearest_idle_deadline()
+        let state = self.state.lock();
+        [
+            state.h1.nearest_idle_deadline(),
+            state.h2.nearest_idle_deadline(),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
     }
 
-    /// Logically closes every retained H1 record for pool shutdown.
-    pub(super) fn close_all_h1(cell: &Arc<Self>, reason: CloseReason) {
-        let ids = cell.state.lock().h1.connection_ids();
-        for id in ids {
+    /// Logically closes every retained connection for pool shutdown.
+    pub(super) fn close_all(cell: &Arc<Self>, reason: CloseReason) {
+        let (h1, h2) = {
+            let state = cell.state.lock();
+            (state.h1.connection_ids(), state.h2.generation_ids())
+        };
+        for id in h1 {
             Self::close_h1(cell, id, reason);
+        }
+        for generation in h2 {
+            Self::close_h2(cell, generation, reason);
         }
     }
 
@@ -762,18 +830,22 @@ impl OriginCell {
             return delivery.reject(None);
         };
 
-        let (event, acknowledgement) = delivery.commit(successor);
-        let installation = {
+        let (event, mut acknowledgement) = delivery.commit(successor);
+        let (installation, suppress_successor) = {
             let mut state = cell.state.lock();
-            match event {
+            let installation = match event {
                 AcquisitionEvent::Establish(permit) => {
                     state.waiters.install_capacity(waiter, permit)
                 }
                 AcquisitionEvent::Complete(result) => {
                     state.waiters.install_borrowed_h1(waiter, result)
                 }
-            }
+            };
+            (installation, state.h2.has_visible_h2())
         };
+        if suppress_successor {
+            acknowledgement.suppress_successor();
+        }
 
         let accepted = installation.accepted;
         let error = installation.error;
@@ -823,19 +895,22 @@ impl OriginCell {
     /// The waiter and its demand snapshot are committed under the cell lock.
     /// A bounded cell publishes the snapshot to origin admission only after
     /// that lock is released. An unbounded cell retains only local order.
-    pub(super) fn register_waiter(&self, requirement: ProtocolRequirement) -> WaiterId {
-        let (waiter, snapshot) = {
-            let mut state = self.state.lock();
-            state.waiters.register_waiter(
+    pub(super) fn register_waiter(cell: &Arc<Self>, requirement: ProtocolRequirement) -> WaiterId {
+        let (waiter, snapshot, h2_visible) = {
+            let mut state = cell.state.lock();
+            let (waiter, snapshot) = state.waiters.register_waiter(
                 requirement,
-                &self.eligibility_group,
-                self.admission.is_some(),
-            )
+                &cell.eligibility_group,
+                cell.admission.is_some(),
+            );
+            (waiter, snapshot, state.h2.has_visible_h2())
         };
 
-        if let (Some(admission), Some(snapshot)) = (&self.admission, snapshot) {
-            OriginAdmission::publish_demand(admission, self.id.partition(), snapshot);
+        if let (Some(admission), Some(snapshot), false) = (&cell.admission, snapshot, h2_visible) {
+            OriginAdmission::publish_demand(admission, cell.id.partition(), snapshot);
         }
+        Self::service_h2_waiters(cell);
+        Self::service_peer_h2_waiters(cell);
         waiter
     }
 
@@ -848,6 +923,8 @@ impl OriginCell {
     pub(super) fn cancel_waiter(cell: &Arc<Self>, waiter: WaiterId) -> bool {
         let transition = {
             let mut state = cell.state.lock();
+            state.h2.cancel_flight_participant(waiter);
+            state.h2.cancel_peer_activation(waiter);
             state
                 .waiters
                 .cancel_waiter(waiter, &cell.eligibility_group)
@@ -871,6 +948,7 @@ impl OriginCell {
         };
 
         if let Some(admission) = &cell.admission {
+            let suppress_active = cell.state.lock().h2.has_visible_h2();
             for snapshot in cancelled
                 .demand_updates
                 .into_iter()
@@ -881,6 +959,7 @@ impl OriginCell {
                         .flat_map(|install| install.demand_updates.iter().cloned()),
                 )
                 .flatten()
+                .filter(|snapshot| !suppress_active || !snapshot.is_active())
             {
                 OriginAdmission::publish_demand(admission, cell.id.partition(), snapshot);
             }
@@ -904,6 +983,7 @@ impl OriginCell {
             state.take_h1_availability_update()
         };
         cell.publish_h1_availability(availability);
+        Self::service_peer_h2_waiters(cell);
         true
     }
 
@@ -991,6 +1071,9 @@ impl OriginCell {
     fn take_ready_h1(&self, waiter: WaiterId) -> Option<H1Selection> {
         match self.take_ready_event(waiter)? {
             AcquisitionEvent::Complete(AcquisitionResult::H1(selection)) => Some(selection),
+            AcquisitionEvent::Complete(AcquisitionResult::H2(_)) => {
+                panic!("HTTP/1 ownership test received an HTTP/2 activation")
+            }
             AcquisitionEvent::Complete(AcquisitionResult::Failed(_)) => {
                 panic!("HTTP/1 ownership test received establishment failure")
             }
@@ -1303,7 +1386,7 @@ mod tests {
         let cell = unbounded_cell();
         let (connection, _physical) = unbounded_connection(1);
         let selection = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
         drop(selection);
 
@@ -1323,7 +1406,7 @@ mod tests {
         let lease = OriginAdmission::lease_for_test(&admission);
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
         let selection = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         assert_eq!(1, admission.ordered_demand_count_for_test());
 
         drop(selection);
@@ -1345,7 +1428,8 @@ mod tests {
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
         OriginCell::install_idle_h1(&connection_cell, connection, H1Sender::test(11));
 
-        let waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter =
+            OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
         let borrowed = requesting_cell
             .take_ready_h1(waiter)
             .expect("eligible peer did not receive the idle HTTP/1 sender");
@@ -1368,7 +1452,8 @@ mod tests {
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
         OriginCell::install_idle_h1(&connection_cell, connection.clone(), H1Sender::test(11));
 
-        let waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter =
+            OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
         let replacement = OriginCell::take_ready_lease(&requesting_cell, waiter)
             .expect("ineligible peer did not receive reclaimed capacity");
 
@@ -1390,7 +1475,8 @@ mod tests {
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
         let selected =
             OriginCell::install_selected_h1(&connection_cell, connection, H1Sender::test(11));
-        let waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter =
+            OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
 
         drop(selected);
 
@@ -1410,7 +1496,8 @@ mod tests {
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
         let selected =
             OriginCell::install_selected_h1(&connection_cell, connection, H1Sender::test(11));
-        let waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter =
+            OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
 
         assert!(OriginCell::cancel_waiter(&requesting_cell, waiter));
         assert!(
@@ -1432,8 +1519,10 @@ mod tests {
         let selected =
             OriginCell::install_selected_h1(&connection_cell, connection, H1Sender::test(11));
 
-        let requesting_waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let local_waiter = connection_cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let requesting_waiter =
+            OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
+        let local_waiter =
+            OriginCell::register_waiter(&connection_cell, ProtocolRequirement::H1Compatible);
         drop(selected);
 
         let borrowed = requesting_cell
@@ -1455,7 +1544,7 @@ mod tests {
         let cell = unbounded_cell();
         let (connection, _physical) = unbounded_connection(1);
         let selection = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         drop(selection);
 
         assert!(OriginCell::cancel_waiter(&cell, waiter));
@@ -1471,7 +1560,7 @@ mod tests {
     #[test]
     fn returned_h1_and_establishment_complete_one_acquisition_attempt() {
         let cell = unbounded_cell();
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("unbounded miss did not start establishment")
@@ -1506,7 +1595,7 @@ mod tests {
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), installed_lease);
         let returning = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
 
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("bounded miss received no capacity")
@@ -1535,7 +1624,7 @@ mod tests {
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), installed_lease);
         let returning = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
 
-        let older = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let older = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(older)
             .expect("older waiter received no establishment capacity")
@@ -1546,7 +1635,7 @@ mod tests {
             .into_lease()
             .expect("bounded establishment carried no capacity");
 
-        let younger = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let younger = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         assert!(cell.take_ready_event(younger).is_none());
 
         drop(returning);
@@ -1567,7 +1656,7 @@ mod tests {
     #[test]
     fn establishment_failure_is_a_terminal_acquisition_result() {
         let cell = unbounded_cell();
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("unbounded miss did not start establishment")
@@ -1603,7 +1692,7 @@ mod tests {
             assert!(state.reuse.install_resolving(reuse_id));
             assert!(state.reuse.complete_transfer(reuse_id, true));
         }
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("unbounded miss did not prepare establishment")
@@ -1633,7 +1722,7 @@ mod tests {
             assert!(state.reuse.install_resolving(reuse_id));
             assert!(state.reuse.complete_transfer(reuse_id, true));
         }
-        let failed = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let failed = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(failed)
             .expect("unbounded miss did not prepare establishment")
@@ -1642,7 +1731,7 @@ mod tests {
         };
         assert!(cell.start_establishment(failed));
         drop(permit);
-        let successor = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let successor = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
         cell.complete_establishment(
             failed,
@@ -1669,7 +1758,7 @@ mod tests {
             assert!(state.reuse.install_resolving(reuse_id));
             assert!(state.reuse.complete_transfer(reuse_id, true));
         }
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("unbounded miss did not prepare establishment")
@@ -1696,7 +1785,7 @@ mod tests {
     #[test]
     fn completion_after_waiter_cancellation_returns_the_new_h1() {
         let cell = unbounded_cell();
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("unbounded miss did not start establishment")
@@ -1723,7 +1812,7 @@ mod tests {
     #[test]
     fn returned_h1_prevents_the_first_establishment_poll() {
         let cell = unbounded_cell();
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let AcquisitionEvent::Establish(permit) = cell
             .take_ready_event(waiter)
             .expect("unbounded miss did not prepare establishment")
@@ -1747,7 +1836,7 @@ mod tests {
         let cell = unbounded_cell();
         let (connection, _physical) = unbounded_connection(1);
         let selection = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
-        let waiter = cell.register_waiter(ProtocolRequirement::H2Required);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
 
         drop(selection);
 
@@ -1768,8 +1857,8 @@ mod tests {
         let lease = OriginAdmission::lease_for_test(&admission);
         let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
         OriginCell::install_idle_h1(&cell, connection, H1Sender::test(11));
-        let h2_head = cell.register_waiter(ProtocolRequirement::H2Required);
-        let h1_successor = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let h2_head = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+        let h1_successor = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
         assert!(cell.take_ready_event(h2_head).is_none());
         assert!(OriginCell::cancel_waiter(&cell, h2_head));
@@ -1875,9 +1964,9 @@ mod tests {
     #[test]
     fn three_waiters_receive_capacity_in_fifo_order() {
         let (_admission, cell) = bounded_cell();
-        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let third = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let first = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let third = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
         let first_lease = OriginCell::take_ready_lease(&cell, first).unwrap();
         assert!(OriginCell::take_ready_lease(&cell, second).is_none());
@@ -1896,17 +1985,17 @@ mod tests {
     #[test]
     fn cancelling_middle_and_tail_waiters_repairs_fifo_links() {
         let (_admission, cell, held) = saturated_bounded_cell();
-        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let second = cell.register_waiter(ProtocolRequirement::H2Required);
-        let third = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let fourth = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let first = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+        let third = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let fourth = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let demand = cell.snapshot().demand;
 
         assert!(OriginCell::cancel_waiter(&cell, second));
         assert!(OriginCell::cancel_waiter(&cell, fourth));
         assert_eq!(demand, cell.snapshot().demand);
         assert_eq!(2, cell.snapshot().waiting);
-        let fifth = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let fifth = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         assert_eq!(3, cell.snapshot().waiting);
 
         drop(held);
@@ -1926,10 +2015,10 @@ mod tests {
     #[test]
     fn cancelling_head_waiter_preserves_remaining_fifo_order() {
         let (_admission, cell, held) = saturated_bounded_cell();
-        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let third = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let fourth = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let first = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let third = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let fourth = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
         assert!(OriginCell::cancel_waiter(&cell, first));
         drop(held);
@@ -1950,8 +2039,8 @@ mod tests {
     #[test]
     fn cancelling_ready_waiter_refunnels_capacity() {
         let (_admission, cell) = bounded_cell();
-        let first = cell.register_waiter(ProtocolRequirement::H1Compatible);
-        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let first = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
         assert!(OriginCell::cancel_waiter(&cell, first));
         let lease = OriginCell::take_ready_lease(&cell, second).unwrap();
@@ -2119,7 +2208,7 @@ mod tests {
         let (admission, cell) = bounded_cell();
         let (first, first_demand) =
             cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
-        let second = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let stale = OriginAdmission::publish_without_driving(
             &admission,
             cell.id().partition(),
@@ -2138,7 +2227,7 @@ mod tests {
     #[test]
     fn cancelling_the_only_waiter_retires_admission_demand() {
         let (admission, cell, held) = saturated_bounded_cell();
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         assert_eq!(1, admission.ordered_demand_count_for_test());
 
         assert!(OriginCell::cancel_waiter(&cell, waiter));
@@ -2162,7 +2251,7 @@ mod tests {
             None,
         ));
 
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         assert_eq!(0, cell.snapshot().waiting);
         assert_eq!(1, cell.snapshot().retained);
         assert!(OriginCell::cancel_waiter(&cell, waiter));
@@ -2172,7 +2261,7 @@ mod tests {
     #[test]
     fn delivered_waiter_is_woken_once() {
         let (_admission, cell, held) = saturated_bounded_cell();
-        let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
         let counter = StdArc::new(WakeCounter(AtomicUsize::new(0)));
         let waker = Waker::from(counter.clone());
         let mut context = Context::from_waker(&waker);
@@ -2182,6 +2271,188 @@ mod tests {
         assert_eq!(1, counter.0.load(Ordering::Relaxed));
         drop(OriginCell::take_ready_lease(&cell, waiter).expect("woken waiter had no capacity"));
         assert_eq!(1, counter.0.load(Ordering::Relaxed));
+    }
+
+    fn install_bounded_h2(
+        admission: &Arc<OriginAdmission>,
+        cell: &Arc<OriginCell>,
+        connection_id: u64,
+    ) -> (
+        h2::H2GenerationId,
+        Arc<ConnectionState>,
+        super::super::connection::PhysicalConnectionGuard,
+    ) {
+        let lease = OriginAdmission::lease_for_test(admission);
+        let (connection, physical) = ConnectionState::bounded(
+            ConnectionInfo::for_test(ConnectionId::new(connection_id), cell.id().partition()),
+            lease,
+        );
+        let generation =
+            OriginCell::install_h2_for_test(cell, connection.clone(), connection_id, None);
+        (generation, connection, physical)
+    }
+
+    fn take_ready_h2(cell: &OriginCell, waiter: WaiterId) -> h2::H2Activation {
+        match cell
+            .take_ready_event(waiter)
+            .expect("HTTP/2 waiter did not receive an activation")
+        {
+            AcquisitionEvent::Complete(AcquisitionResult::H2(activation)) => activation,
+            AcquisitionEvent::Establish(_) => {
+                panic!("HTTP/2 waiter received establishment capacity")
+            }
+            AcquisitionEvent::Complete(AcquisitionResult::H1(_)) => {
+                panic!("HTTP/2 waiter received an HTTP/1 sender")
+            }
+            AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
+                panic!("HTTP/2 waiter received an establishment failure: {error}")
+            }
+        }
+    }
+
+    #[test]
+    fn eligible_peer_h2_generation_satisfies_bounded_demand() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (generation, connection, _physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+
+        let waiter = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H2Required);
+        let activation = take_ready_h2(&requesting_cell, waiter);
+
+        assert_eq!(generation, activation.generation());
+        assert!(Arc::ptr_eq(&connection, activation.connection()));
+        assert_eq!(0, admission.available_capacity_for_test());
+        assert_eq!(Some(generation), connection_cell.accepting_h2_generation());
+        drop(activation);
+        assert_eq!(0, requesting_cell.snapshot().retained);
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+        assert_eq!(1, admission.available_capacity_for_test());
+    }
+
+    #[test]
+    fn peer_h2_publication_respects_eligibility_group() {
+        let groups = [
+            (
+                EligibilityGroup::Partition(PartitionId::from_index(1)),
+                EligibilityGroup::Partition(PartitionId::from_index(2)),
+            ),
+            (
+                EligibilityGroup::NetworkInterface(Some(Arc::from("eth0"))),
+                EligibilityGroup::NetworkInterface(Some(Arc::from("eth1"))),
+            ),
+        ];
+        for (connection_group, requesting_group) in groups {
+            let (admission, connection_cell, requesting_cell) =
+                bounded_peer_cells(1, connection_group, requesting_group);
+            let (generation, _connection, _physical) =
+                install_bounded_h2(&admission, &connection_cell, 1);
+            let waiter =
+                OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H2Required);
+
+            assert!(requesting_cell.take_ready_event(waiter).is_none());
+            assert_eq!(1, admission.ordered_demand_count_for_test());
+            assert!(OriginCell::cancel_waiter(&requesting_cell, waiter));
+            assert!(OriginCell::close_h2(
+                &connection_cell,
+                generation,
+                CloseReason::PoolDropped,
+            ));
+            assert_eq!(1, admission.available_capacity_for_test());
+        }
+    }
+
+    #[test]
+    fn dropped_publication_guard_retries_the_same_demand() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (generation, _connection, _physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let (waiter, demand) =
+            requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+        let action = OriginAdmission::publish_action_without_driving(
+            &admission,
+            requesting_cell.id().partition(),
+            demand,
+        )
+        .expect("peer demand did not prepare publication");
+
+        drop(action);
+
+        drop(take_ready_h2(&requesting_cell, waiter));
+        assert_eq!(0, admission.ordered_demand_count_for_test());
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+    }
+
+    #[test]
+    fn requesting_cell_cancellation_closes_an_in_flight_publication_fence() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (generation, _connection, _physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let (waiter, demand) =
+            requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+        let action = OriginAdmission::publish_action_without_driving(
+            &admission,
+            requesting_cell.id().partition(),
+            demand,
+        )
+        .expect("peer demand did not prepare publication");
+
+        assert!(OriginCell::cancel_waiter(&requesting_cell, waiter));
+        OriginAdmission::drive(Some(action));
+
+        assert_eq!(0, requesting_cell.snapshot().retained);
+        assert_eq!(0, admission.ordered_demand_count_for_test());
+        assert_eq!(0, admission.available_capacity_for_test());
+        assert_eq!(Some(generation), connection_cell.accepting_h2_generation());
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+    }
+
+    #[test]
+    fn peer_generation_gate_preserves_prepublication_order() {
+        let (admission, connection_cell, requesting_cell) =
+            bounded_peer_cells(1, EligibilityGroup::Pool, EligibilityGroup::Pool);
+        let (generation, _connection, _physical) =
+            install_bounded_h2(&admission, &connection_cell, 1);
+        let (first, demand) =
+            requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+        let second = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H2Required);
+        let action = OriginAdmission::publish_action_without_driving(
+            &admission,
+            requesting_cell.id().partition(),
+            demand,
+        )
+        .expect("peer demand did not prepare publication");
+        OriginAdmission::drive(Some(action));
+        let third = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H2Required);
+
+        let first_activation = take_ready_h2(&requesting_cell, first);
+        assert!(requesting_cell.take_ready_event(second).is_none());
+        assert!(requesting_cell.take_ready_event(third).is_none());
+        drop(first_activation);
+
+        let second_activation = take_ready_h2(&requesting_cell, second);
+        assert!(requesting_cell.take_ready_event(third).is_none());
+        drop(second_activation);
+        drop(take_ready_h2(&requesting_cell, third));
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
     }
 }
 
@@ -2312,7 +2583,7 @@ mod loom_tests {
             let cell = unbounded_cell();
             let (connection, _physical) = ConnectionState::unbounded(connection_info(1));
             let selection = OriginCell::install_selected_h1(&cell, connection, H1Sender::test(11));
-            let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+            let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
 
             let returning = loom::thread::spawn(move || drop(selection));
             let cancel_cell = cell.clone();
@@ -2336,7 +2607,7 @@ mod loom_tests {
     fn returned_h1_and_establishment_race_for_one_waiter() {
         loom::model(|| {
             let cell = unbounded_cell();
-            let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+            let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
             let AcquisitionEvent::Establish(permit) = cell
                 .take_ready_event(waiter)
                 .expect("unbounded miss did not start establishment")
@@ -2377,7 +2648,7 @@ mod loom_tests {
     fn first_establishment_poll_races_returned_h1() {
         loom::model(|| {
             let cell = unbounded_cell();
-            let waiter = cell.register_waiter(ProtocolRequirement::H1Compatible);
+            let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
             let AcquisitionEvent::Establish(permit) = cell
                 .take_ready_event(waiter)
                 .expect("unbounded miss did not prepare establishment")
@@ -2464,7 +2735,8 @@ mod loom_tests {
             let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
             let returning =
                 OriginCell::install_selected_h1(&connection_cell, connection, H1Sender::test(11));
-            let waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
+            let waiter =
+                OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
 
             let returning = loom::thread::spawn(move || drop(returning));
             let cancel_requesting_cell = requesting_cell.clone();
@@ -2580,6 +2852,9 @@ mod loom_tests {
                 AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
                     panic!("unexpected establishment failure: {error}")
                 }
+                AcquisitionEvent::Complete(AcquisitionResult::H2(_)) => {
+                    panic!("HTTP/1 reuse model received an HTTP/2 activation")
+                }
             }
             assert_eq!(0, requesting_cell.snapshot().retained);
             assert_eq!(1, admission.available_capacity_for_test());
@@ -2604,8 +2879,10 @@ mod loom_tests {
                 H1Sender::test(11),
             );
             let close = H1CloseHandle::new(&connection_cell, &connection);
-            let waiter = requesting_cell.register_waiter(ProtocolRequirement::H1Compatible);
-            let local_waiter = connection_cell.register_waiter(ProtocolRequirement::H1Compatible);
+            let waiter =
+                OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Compatible);
+            let local_waiter =
+                OriginCell::register_waiter(&connection_cell, ProtocolRequirement::H1Compatible);
 
             let returning = loom::thread::spawn(move || drop(returning));
             let closing = loom::thread::spawn(move || close.close(CloseReason::Poisoned));
@@ -2653,6 +2930,85 @@ mod loom_tests {
             deliver.join().unwrap();
             cancel.join().unwrap();
 
+            assert_eq!(1, admission.available_capacity_for_test());
+            admission.clear_modeled_cells_for_test();
+        });
+    }
+
+    #[test]
+    fn h2_route_installation_races_requesting_cell_cancellation() {
+        let mut model = loom::model::Builder::new();
+        model.preemption_bound = Some(2);
+        model.check(|| {
+            let (admission, connection_cell, requesting_cell) =
+                bounded_peer_cells(EligibilityGroup::Pool, EligibilityGroup::Pool);
+            let lease = OriginAdmission::lease_for_test(&admission);
+            let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
+            let generation = OriginCell::install_h2_for_test(&connection_cell, connection, 1, None);
+            let (waiter, demand) =
+                requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+            let route = h2::H2Route::new(&connection_cell, generation);
+
+            let install_cell = requesting_cell.clone();
+            let installing = loom::thread::spawn(move || {
+                OriginCell::install_h2_route(
+                    &install_cell,
+                    route,
+                    &EligibilityGroup::Pool,
+                    demand.id_for_test(),
+                )
+            });
+            let cancel_cell = requesting_cell.clone();
+            let cancelling =
+                loom::thread::spawn(move || OriginCell::cancel_waiter(&cancel_cell, waiter));
+            let _installed = installing.join().unwrap();
+            assert!(cancelling.join().unwrap());
+
+            assert_eq!(0, requesting_cell.snapshot().retained);
+            assert_eq!(0, admission.ordered_demand_count_for_test());
+            assert_eq!(0, admission.available_capacity_for_test());
+            assert!(OriginCell::close_h2(
+                &connection_cell,
+                generation,
+                CloseReason::PoolDropped,
+            ));
+            assert_eq!(1, admission.available_capacity_for_test());
+            admission.clear_modeled_cells_for_test();
+        });
+    }
+
+    #[test]
+    fn h2_publication_races_connection_cell_close_without_stranding_demand() {
+        let mut model = loom::model::Builder::new();
+        model.preemption_bound = Some(2);
+        model.check(|| {
+            let (admission, connection_cell, requesting_cell) =
+                bounded_peer_cells(EligibilityGroup::Pool, EligibilityGroup::Pool);
+            let lease = OriginAdmission::lease_for_test(&admission);
+            let (connection, _physical) = ConnectionState::bounded(connection_info(1), lease);
+            let generation = OriginCell::install_h2_for_test(&connection_cell, connection, 1, None);
+            let (waiter, demand) =
+                requesting_cell.register_waiter_without_publish(ProtocolRequirement::H2Required);
+            let action = OriginAdmission::publish_action_without_driving(
+                &admission,
+                requesting_cell.id().partition(),
+                demand,
+            )
+            .expect("peer demand did not prepare publication");
+
+            let publishing = loom::thread::spawn(move || {
+                OriginAdmission::drive(Some(action));
+            });
+            let closing_cell = connection_cell.clone();
+            let closing = loom::thread::spawn(move || {
+                OriginCell::close_h2(&closing_cell, generation, CloseReason::Poisoned)
+            });
+            publishing.join().unwrap();
+            assert!(closing.join().unwrap());
+
+            assert!(OriginCell::cancel_waiter(&requesting_cell, waiter));
+            assert_eq!(0, requesting_cell.snapshot().retained);
+            assert_eq!(0, admission.ordered_demand_count_for_test());
             assert_eq!(1, admission.available_capacity_for_test());
             admission.clear_modeled_cells_for_test();
         });

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h1.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h1.rs
@@ -51,9 +51,12 @@
 //! temporarily be the ready result in that same cell; cell teardown makes the
 //! fallback close the connection directly.
 
-use super::super::admission::reuse::ReuseId;
+use super::super::admission::reuse::{
+    H1AvailabilitySnapshot, PreparedReuseInstall, ReuseCandidate, ReuseId, ReuseInstallResult,
+};
+use super::super::admission::{AdmissionAction, OriginAdmission};
 use super::super::connection::{CloseReason, ConnectionState};
-use super::OriginCell;
+use super::{AcquisitionResult, OriginCell, ReuseInstall};
 use crate::sync::{Arc, Weak};
 use aws_smithy_runtime_api::client::connection::ConnectionId;
 use std::collections::{HashMap, VecDeque};
@@ -250,11 +253,16 @@ impl H1ReuseReservation {
     /// Checks relationships that are not already encoded by the state enum.
     pub(super) fn assert_consistent(&self, _supports_installed_reuse: bool) {
         #[cfg(debug_assertions)]
-        if matches!(self.state, H1ReuseReservationState::Installed(_)) {
-            assert!(
-                _supports_installed_reuse,
-                "installed HTTP/1 reuse operation had no externally owned connection-owning cell record to settle it"
-            );
+        {
+            if std::thread::panicking() {
+                return;
+            }
+            if matches!(self.state, H1ReuseReservationState::Installed(_)) {
+                assert!(
+                    _supports_installed_reuse,
+                    "installed HTTP/1 reuse operation had no externally owned connection-owning cell record to settle it"
+                );
+            }
         }
     }
 
@@ -611,6 +619,9 @@ impl H1Records {
     pub(super) fn assert_consistent(&self) {
         #[cfg(debug_assertions)]
         {
+            if std::thread::panicking() {
+                return;
+            }
             let idle_records = self
                 .records
                 .values()
@@ -1008,7 +1019,7 @@ impl Drop for ProvisionalH1 {
     }
 }
 
-/// Non-retaining authority to retire one installed H1 generation.
+/// Non-retaining authority to retire one installed H1 record.
 #[derive(Clone, Debug)]
 pub(in crate::client::pool) struct H1CloseHandle {
     /// Connection-owning cell used to remove dispatch eligibility before
@@ -1044,7 +1055,7 @@ impl H1CloseHandle {
     }
 }
 
-/// Driver-owned fallback that closes its H1 generation on termination.
+/// Driver-owned fallback that closes its H1 record on termination.
 #[derive(Debug)]
 pub(in crate::client::pool) struct H1DriverGuard {
     /// Non-retaining generation close authority.
@@ -1054,7 +1065,7 @@ pub(in crate::client::pool) struct H1DriverGuard {
 }
 
 impl H1DriverGuard {
-    /// Arms driver-lifecycle cleanup for an installed H1 generation.
+    /// Arms driver-lifecycle cleanup for an installed H1 record.
     pub(in crate::client::pool) fn new(close: H1CloseHandle) -> Self {
         Self {
             close,
@@ -1074,6 +1085,463 @@ impl Drop for H1DriverGuard {
         if self.active {
             self.close.close(CloseReason::OwnerRuntimeShutdown);
         }
+    }
+}
+
+impl OriginCell {
+    /// Installs a fresh H1 record selected by its launching request.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this cell already contains the connection identity.
+    pub(in crate::client::pool) fn install_selected_h1(
+        cell: &Arc<Self>,
+        connection: Arc<ConnectionState>,
+        sender: H1Sender,
+    ) -> H1Selection {
+        let (installed, availability) = {
+            let mut state = cell.state.lock();
+            let installed = state.h1.install_selected(connection, sender);
+            state.assert_consistent();
+            (installed, state.take_h1_availability_update())
+        };
+        cell.publish_h1_availability(availability);
+        match installed {
+            Ok(owner) => H1Selection::new(cell, owner),
+            Err(owner) => {
+                owner
+                    .connection()
+                    .logical_close(CloseReason::ProtocolClosed);
+                drop(owner);
+                panic!("duplicate HTTP/1 connection identity installed in one cell");
+            }
+        }
+    }
+
+    /// Installs an H1 record whose launching acquisition already completed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this cell already contains the connection identity.
+    #[cfg(test)]
+    pub(in crate::client::pool) fn install_idle_h1(
+        cell: &Arc<Self>,
+        connection: Arc<ConnectionState>,
+        sender: H1Sender,
+    ) {
+        let deadline = cell.idle_deadline();
+        let (installed, availability) = {
+            let mut state = cell.state.lock();
+            let installed = state.h1.install_idle(connection, sender, deadline);
+            state.assert_consistent();
+            (installed, state.take_h1_availability_update())
+        };
+        cell.publish_h1_availability(availability);
+        if let Err(owner) = installed {
+            owner
+                .connection()
+                .logical_close(CloseReason::ProtocolClosed);
+            drop(owner);
+            panic!("duplicate HTTP/1 connection identity installed in one cell");
+        }
+        cell.notify_maintenance(deadline);
+    }
+
+    /// Selects the newest reusable H1 sender without origin-wide coordination.
+    pub(in crate::client::pool) fn select_h1(cell: &Arc<Self>) -> Option<H1Selection> {
+        let (owner, availability) = {
+            let mut state = cell.state.lock();
+            let owner = state.h1.select_idle();
+            if owner.is_some() {
+                state.reuse.consume_local_turn();
+            }
+            state.assert_consistent();
+            let availability = cell
+                .admission
+                .as_ref()
+                .and_then(|_| state.take_h1_availability_update());
+            (owner, availability)
+        };
+        cell.publish_h1_availability(availability);
+        let owner = owner?;
+        Some(H1Selection::new(cell, owner))
+    }
+
+    /// Reserves this cell's selected connection for one peer reuse operation.
+    pub(in crate::client::pool) fn install_h1_reuse(
+        cell: &Arc<Self>,
+        origin: Arc<OriginAdmission>,
+        prepared: PreparedReuseInstall,
+    ) -> Option<AdmissionAction> {
+        let decision = {
+            let mut state = cell.state.lock();
+            state.install_reuse(prepared.id)
+        };
+
+        let result = match decision {
+            ReuseInstall::Installed => ReuseInstallResult::Installed,
+            ReuseInstall::Candidate(owner) => {
+                let provisional = ProvisionalH1::new(cell, owner);
+                ReuseInstallResult::Candidate(ReuseCandidate::new(
+                    origin.clone(),
+                    prepared.id,
+                    cell.id.partition(),
+                    provisional,
+                ))
+            }
+            ReuseInstall::Rejected(availability) => ReuseInstallResult::Rejected(availability),
+        };
+        OriginAdmission::finish_h1_reuse_install(&origin, prepared.id, cell.id.partition(), result)
+    }
+
+    /// Clears an installed or resolving reservation after request cancellation.
+    pub(in crate::client::pool) fn cancel_h1_reuse(
+        &self,
+        reuse_id: ReuseId,
+    ) -> H1AvailabilitySnapshot {
+        self.state.lock().cancel_reuse(reuse_id)
+    }
+
+    /// Returns a rejected provisional sender through ordinary connection-owning cell handling.
+    pub(in crate::client::pool) fn reject_h1_reuse_candidate(
+        cell: &Arc<Self>,
+        reuse_id: ReuseId,
+        provisional: ProvisionalH1,
+    ) -> H1AvailabilitySnapshot {
+        {
+            let mut state = cell.state.lock();
+            state.reject_reuse_candidate(reuse_id);
+        }
+        drop(provisional);
+        let mut state = cell.state.lock();
+        state.assert_consistent();
+        state.report_h1_availability()
+    }
+
+    /// Revalidates a reuse operation and commits its provisional sender for dispatch.
+    pub(in crate::client::pool) fn commit_h1_reuse(
+        cell: &Arc<Self>,
+        reuse_id: ReuseId,
+        provisional: ProvisionalH1,
+    ) -> Result<H1Selection, ProvisionalH1> {
+        let (connection_cell, owner) = provisional.into_parts();
+        let committed = cell.state.lock().commit_reuse(reuse_id, &owner);
+        if committed {
+            Ok(H1Selection::new(cell, owner))
+        } else {
+            Err(ProvisionalH1::from_parts(connection_cell, owner))
+        }
+    }
+
+    /// Closes a selected sender and records fairness only if close wins.
+    pub(in crate::client::pool) fn reclaim_h1_reuse(
+        cell: &Arc<Self>,
+        reuse_id: ReuseId,
+        provisional: ProvisionalH1,
+    ) -> Result<(H1AvailabilitySnapshot, bool), ProvisionalH1> {
+        let (connection_cell, owner) = provisional.into_parts();
+        if !cell.state.lock().reuse.names(reuse_id) {
+            return Err(ProvisionalH1::from_parts(connection_cell, owner));
+        }
+
+        let close_won = Self::retire_h1_owner(cell, owner, CloseReason::Reclaimed);
+        let availability = {
+            let mut state = cell.state.lock();
+            let availability = state.finish_reuse(reuse_id, close_won);
+            state.assert_consistent();
+            availability
+        };
+        Ok((availability, close_won))
+    }
+
+    /// Completes local reuse state after a requesting cell accepts the sender.
+    pub(in crate::client::pool) fn complete_h1_reuse(
+        &self,
+        reuse_id: ReuseId,
+        transferred: bool,
+    ) -> H1AvailabilitySnapshot {
+        self.state.lock().finish_reuse(reuse_id, transferred)
+    }
+
+    /// Publishes this cell's HTTP/1 availability when the origin is bounded.
+    pub(super) fn publish_h1_availability(&self, availability: Option<H1AvailabilitySnapshot>) {
+        if let (Some(admission), Some(availability)) = (&self.admission, availability) {
+            OriginAdmission::update_h1_availability(
+                admission,
+                self.id.partition(),
+                self.eligibility_group.clone(),
+                availability,
+            );
+        }
+    }
+
+    /// Returns a reusable sender to the oldest compatible waiter or idle set.
+    ///
+    /// Demand publication, task wakeup, and any rejected-result fallback all
+    /// run after the cell lock is released. `owner` remains outside the locked
+    /// scope so sender or connection drop cannot run while the cell guard is
+    /// live.
+    fn return_h1_owner(cell: &Arc<Self>, owner: OwnedH1) {
+        let connection_id = owner.id();
+        let mut owner = Some(owner);
+        let mut installation = None;
+        let mut intercepted = None;
+        let mut rejected_reuse = None;
+        let idle_deadline = cell.idle_deadline();
+        let should_retire = {
+            let mut state = cell.state.lock();
+            let returnable = state
+                .h1
+                .accepts_return(owner.as_ref().expect("HTTP/1 owner disappeared"));
+            if !returnable {
+                if let Some(reuse_id) = state.reuse.intercept_return() {
+                    let snapshot = state.finish_reuse(reuse_id, false);
+                    rejected_reuse = Some((reuse_id, snapshot));
+                } else {
+                    state.assert_consistent();
+                }
+                true
+            } else if let Some(reuse_id) = state.reuse.intercept_return() {
+                if state
+                    .h1
+                    .reserve_for_reuse(owner.as_ref().expect("HTTP/1 owner disappeared"))
+                {
+                    state.assert_consistent();
+                    intercepted = Some((
+                        reuse_id,
+                        ProvisionalH1::new(cell, owner.take().expect("HTTP/1 owner disappeared")),
+                    ));
+                    false
+                } else {
+                    let snapshot = state.finish_reuse(reuse_id, false);
+                    rejected_reuse = Some((reuse_id, snapshot));
+                    true
+                }
+            } else if state.waiters.can_accept_h1()
+                && state
+                    .h1
+                    .commit_return_to_waiter(owner.as_ref().expect("HTTP/1 owner disappeared"))
+            {
+                state.reuse.consume_local_turn();
+                state.assert_consistent();
+                let mut returned = owner.take().expect("HTTP/1 owner disappeared");
+                returned.mark_reused();
+                installation = Some(state.waiters.install_returned_h1(
+                    || AcquisitionResult::H1(H1Selection::new(cell, returned)),
+                    &cell.eligibility_group,
+                ));
+                let install = installation
+                    .as_mut()
+                    .expect("HTTP/1 installation disappeared");
+                if let Some(waiter) = install.waiter {
+                    state.h2.cancel_pending_waiter(waiter);
+                }
+                install.demand_updates =
+                    state.publishable_demand_updates(std::mem::take(&mut install.demand_updates));
+                false
+            } else {
+                let returned = state.h1.return_idle(
+                    owner.take().expect("HTTP/1 owner disappeared"),
+                    idle_deadline,
+                );
+                match returned {
+                    Ok(()) => {
+                        state.assert_consistent();
+                        false
+                    }
+                    Err(returned) => {
+                        owner = Some(returned);
+                        true
+                    }
+                }
+            }
+        };
+
+        if should_retire {
+            if tracing::level_enabled!(tracing::Level::TRACE) {
+                trace_h1_return(cell, connection_id, H1ReturnTrace::Rejected);
+            }
+            if let Some((reuse_id, snapshot)) = rejected_reuse {
+                let admission = cell
+                    .admission
+                    .as_ref()
+                    .expect("an HTTP/1 reuse operation requires bounded admission");
+                OriginAdmission::reject_returned_h1_reuse(
+                    admission,
+                    reuse_id,
+                    cell.id.partition(),
+                    snapshot,
+                );
+            }
+            Self::retire_h1_owner(
+                cell,
+                owner.take().expect("retired HTTP/1 owner disappeared"),
+                CloseReason::ProtocolClosed,
+            );
+            return;
+        }
+
+        if let Some((reuse_id, provisional)) = intercepted {
+            if tracing::level_enabled!(tracing::Level::TRACE) {
+                trace_h1_return(cell, connection_id, H1ReturnTrace::ReuseIntercepted);
+            }
+            let admission = cell
+                .admission
+                .as_ref()
+                .expect("an HTTP/1 reuse operation requires bounded admission");
+            let candidate = ReuseCandidate::new(
+                admission.clone(),
+                reuse_id,
+                cell.id.partition(),
+                provisional,
+            );
+            let action = OriginAdmission::resolve_h1_reuse(admission, reuse_id, candidate);
+            OriginAdmission::drive(action);
+            return;
+        }
+
+        let Some(installation) = installation else {
+            if tracing::level_enabled!(tracing::Level::TRACE) {
+                trace_h1_return(cell, connection_id, H1ReturnTrace::Idle);
+            }
+            cell.notify_maintenance(idle_deadline);
+            if cell.admission.is_some() {
+                let availability = cell.state.lock().take_h1_availability_update();
+                cell.publish_h1_availability(availability);
+            }
+            return;
+        };
+        if tracing::level_enabled!(tracing::Level::TRACE) {
+            trace_h1_return(cell, connection_id, H1ReturnTrace::LocalDemand);
+        }
+        if let Some(admission) = &cell.admission {
+            for snapshot in installation.demand_updates.into_iter().flatten() {
+                OriginAdmission::publish_demand(admission, cell.id.partition(), snapshot);
+            }
+        }
+        drop(installation.returned_event);
+        if let Some(waker) = installation.waker {
+            waker.wake();
+        }
+        if cell.admission.is_some() {
+            let availability = cell.state.lock().take_h1_availability_update();
+            cell.publish_h1_availability(availability);
+        }
+    }
+
+    /// Retires an externally owned H1 sender and removes its connection-owning cell record.
+    ///
+    /// Returns whether this path won the connection's logical-close race.
+    fn retire_h1_owner(cell: &Arc<Self>, owner: OwnedH1, reason: CloseReason) -> bool {
+        let should_close = {
+            let mut state = cell.state.lock();
+            let should_close = state.h1.close_owned(&owner);
+            state.assert_consistent();
+            should_close
+        };
+
+        let id = owner.id();
+        let won = should_close && owner.connection().logical_close(reason);
+        drop(owner);
+
+        let mut state = cell.state.lock();
+        state.h1.finish_close(id);
+        state.assert_consistent();
+        let availability = state.take_h1_availability_update();
+        drop(state);
+        cell.publish_h1_availability(availability);
+        won
+    }
+
+    /// Begins close for an installed H1 record named without its sender.
+    ///
+    /// Returns whether this signal won the connection's logical-close race.
+    pub(super) fn close_h1(cell: &Arc<Self>, id: ConnectionId, reason: CloseReason) -> bool {
+        let Some((close, availability)) = ({
+            let mut state = cell.state.lock();
+            let close = state.h1.begin_close(id);
+            state.assert_consistent();
+            close.map(|close| (close, state.take_h1_availability_update()))
+        }) else {
+            return false;
+        };
+
+        cell.publish_h1_availability(availability);
+        let remove_record = close.sender.is_some();
+        let won = close.connection.logical_close(reason);
+        drop(close.sender);
+        if remove_record {
+            let mut state = cell.state.lock();
+            state.h1.finish_close(id);
+            state.assert_consistent();
+        }
+        won
+    }
+
+    /// Returns H1 record counts for focused ownership tests.
+    #[cfg(test)]
+    pub(super) fn h1_counts(&self) -> (usize, usize) {
+        self.state.lock().h1.counts()
+    }
+
+    /// Returns the sole installed HTTP/1 connection for focused dispatch tests.
+    #[cfg(all(test, feature = "rt-tokio"))]
+    pub(in crate::client::pool) fn only_h1_connection_for_test(&self) -> Arc<ConnectionState> {
+        self.state.lock().h1.only_connection_for_test()
+    }
+}
+
+/// Terminal outcome for one reusable HTTP/1 sender return.
+enum H1ReturnTrace {
+    /// The owning cell no longer accepts the sender.
+    Rejected,
+    /// Origin admission reserved the sender for peer demand.
+    ReuseIntercepted,
+    /// No compatible demand exists, so the sender became idle.
+    Idle,
+    /// A waiter in the owning cell accepted the sender.
+    LocalDemand,
+}
+
+/// Emits a committed HTTP/1 return outcome outside the cell lock.
+// Keep field formatting out of a return transition that can synchronously
+// enter admission and sender fallbacks.
+#[inline(never)]
+fn trace_h1_return(cell: &OriginCell, connection_id: ConnectionId, outcome: H1ReturnTrace) {
+    match outcome {
+        H1ReturnTrace::Rejected => tracing::trace!(
+            connection_id = %connection_id,
+            connection_partition = ?cell.id.partition(),
+            origin_scheme = %cell.id.origin().scheme(),
+            origin_host = cell.id.origin().host(),
+            origin_port = ?cell.id.origin().port(),
+            "HTTP/1 return was rejected by its connection-owning cell"
+        ),
+        H1ReturnTrace::ReuseIntercepted => tracing::trace!(
+            connection_id = %connection_id,
+            connection_partition = ?cell.id.partition(),
+            origin_scheme = %cell.id.origin().scheme(),
+            origin_host = cell.id.origin().host(),
+            origin_port = ?cell.id.origin().port(),
+            "HTTP/1 return was intercepted by a cross-cell reuse operation"
+        ),
+        H1ReturnTrace::Idle => tracing::trace!(
+            connection_id = %connection_id,
+            connection_partition = ?cell.id.partition(),
+            origin_scheme = %cell.id.origin().scheme(),
+            origin_host = cell.id.origin().host(),
+            origin_port = ?cell.id.origin().port(),
+            "HTTP/1 connection returned to idle storage"
+        ),
+        H1ReturnTrace::LocalDemand => tracing::trace!(
+            connection_id = %connection_id,
+            request_partition = ?cell.id.partition(),
+            connection_partition = ?cell.id.partition(),
+            origin_scheme = %cell.id.origin().scheme(),
+            origin_host = cell.id.origin().host(),
+            origin_port = ?cell.id.origin().port(),
+            "HTTP/1 return satisfied local demand"
+        ),
     }
 }
 

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h2.rs
@@ -3114,7 +3114,7 @@ mod tests {
             )),
         );
         let info = ConnectionInfo::for_test(ConnectionId::new(1), PartitionId::from_index(1));
-        let (bounded_connection, physical) = ConnectionState::establishing(info);
+        let (bounded_connection, physical) = ConnectionState::pending_open(info);
         bounded_connection
             .open(Some(OriginAdmission::lease_for_test(&admission)))
             .expect("bounded test connection did not open");
@@ -3209,7 +3209,7 @@ mod tests {
         let connection_cell = bounded_cell(&admission, 1);
         let requesting_cell = bounded_cell(&admission, 2);
         let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
-        let (connection, _physical) = ConnectionState::establishing(info);
+        let (connection, _physical) = ConnectionState::pending_open(info);
         connection
             .open(Some(OriginAdmission::lease_for_test(&admission)))
             .expect("bounded HTTP/2 connection did not open");
@@ -3245,11 +3245,11 @@ mod tests {
         use crate::client::pool::admission::OriginAdmission;
         use std::num::NonZeroUsize;
 
-        let admission = OriginAdmission::for_test_with_http1_guarantee(NonZeroUsize::MIN, false);
+        let admission = OriginAdmission::for_test_with_h2_reclaim(NonZeroUsize::MIN, false);
         let connection_cell = bounded_cell(&admission, 1);
         let requesting_cell = bounded_cell(&admission, 2);
         let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
-        let (connection, _physical) = ConnectionState::establishing(info);
+        let (connection, _physical) = ConnectionState::pending_open(info);
         connection
             .open(Some(OriginAdmission::lease_for_test(&admission)))
             .expect("bounded HTTP/2 connection did not open");
@@ -3288,7 +3288,7 @@ mod tests {
         let connection_cell = bounded_cell(&admission, 1);
         let requesting_cell = bounded_cell(&admission, 2);
         let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
-        let (connection, _physical) = ConnectionState::establishing(info);
+        let (connection, _physical) = ConnectionState::pending_open(info);
         connection
             .open(Some(OriginAdmission::lease_for_test(&admission)))
             .expect("bounded HTTP/2 connection did not open");
@@ -3320,7 +3320,7 @@ mod tests {
         let connection_cell = bounded_cell(&admission, 1);
         let requesting_cell = bounded_cell(&admission, 2);
         let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
-        let (connection, _physical) = ConnectionState::establishing(info);
+        let (connection, _physical) = ConnectionState::pending_open(info);
         connection
             .open(Some(OriginAdmission::lease_for_test(&admission)))
             .expect("bounded HTTP/2 connection did not open");

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h2.rs
@@ -26,12 +26,23 @@
 //! ```
 //!
 //! ```text
-//! no flight -- post-ALPN driver --------------------------> Flight
-//! Flight -- successful handshake ------------------------> Accepting
-//! Flight -- failure or task drop -------------------------> no flight
-//! Accepting -- poison, GOAWAY, timeout, or shutdown ------> Draining
+//! no flight -- post-ALPN owner task ----------------------> Flight
+//! Flight -- successful handshake and install ------------> Accepting
+//! Flight -- failure, stale completion, or task drop ------> no flight
+//! Accepting -- close with retained request leases --------> Draining
+//! Accepting -- close without retained request leases -----> removed
 //! Draining -- last prospective or accepted lease --------> removed
 //! ```
+//!
+//! ```text
+//! no peer route -- publication ---------------------------> PeerRoute(generation)
+//! PeerRoute(A) -- replacement publication ---------------> PeerRoute(B)
+//! PeerRoute -- stale activation or local generation -----> no peer route
+//! ```
+//!
+//! Generation installation makes the sender visible before the owner task
+//! submits the Hyper driver. An activation in that interval is accepted by
+//! Hyper's dispatch channel and remains pending until the driver is polled.
 //!
 //! Activation reserves a prospective lease before a sender clone leaves the
 //! cell lock. Hyper acceptance converts that reservation to one accepted
@@ -40,9 +51,10 @@
 
 use super::super::connection::{ConnectionInfo, ConnectionState, DispatchGuard};
 use super::super::partition::PartitionId;
-use super::waiters::{AcquisitionQueue, H2WaiterInstall};
+use super::waiters::{AcquisitionQueue, WaiterInstall};
 use super::{AcquisitionEvent, AcquisitionResult, CellState, OriginCell, WaiterId};
 use crate::sync::{Arc, Mutex, Weak};
+use aws_smithy_runtime_api::client::connection::ConnectionId;
 use aws_smithy_types::body::SdkBody;
 use std::collections::{BTreeSet, HashMap};
 use std::time::SystemTime;
@@ -191,52 +203,73 @@ impl H2Route {
 /// - every other generation is `Draining`;
 /// - prospective and accepted request counts are checked and non-wrapping;
 /// - a draining record remains until both counts reach zero; and
-/// - flight participants name distinct live waiter identities.
+/// - each flight participant identity appears at most once.
 #[derive(Debug, Default)]
 pub(super) struct H2Records {
+    /// Post-ALPN convergence in progress for this cell.
     flight: Option<H2Flight>,
+    /// Installed accepting and draining generations by exact identity.
     generations: HashMap<H2GenerationId, H2Generation>,
+    /// Sole generation permitted to issue new activations.
     accepting: Option<H2GenerationId>,
     /// Identity-only route to one peer cell's accepting generation.
     peer_route: Option<PeerH2Route>,
     /// Local activation order for the accepting generation.
     gate: GenerationGate,
+    /// Next cell-local flight identity.
     next_flight: u64,
+    /// Next cell-local generation identity.
     next_generation: u64,
 }
 
 /// One post-ALPN flight and the waiters awaiting its result.
 #[derive(Debug)]
 struct H2Flight {
+    /// Identity checked by the owner task at completion.
     id: H2FlightId,
+    /// Waiters that receive the shared handshake result.
     participants: BTreeSet<WaiterId>,
 }
 
 /// One installed multiplexed connection generation.
 #[derive(Debug)]
 struct H2Generation {
+    /// Establishment waiters transferred to this generation but not yet served.
+    pending_waiters: BTreeSet<WaiterId>,
+    /// Protocol-neutral connection and capacity owner.
     connection: Arc<ConnectionState>,
+    /// Authoritative Hyper sender cloned only after generation validation.
     sender: H2Sender,
+    /// Whether new activations may be issued.
     residence: H2Residence,
+    /// Activations selected but not yet accepted by Hyper.
     prospective: usize,
     /// Whether Hyper has accepted a request on this generation.
     has_dispatched: bool,
+    /// Accepted requests whose two lease endpoints have not both terminated.
     accepted: usize,
+    /// Expiration deadline while the generation remains accepting.
     idle_deadline: Option<SystemTime>,
 }
 
 /// Whether an installed generation may accept new requests.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum H2Residence {
+    /// New requests may reserve prospective leases.
     Accepting,
+    /// No new requests are admitted; retained leases may finish.
     Draining,
 }
 
 /// Peer route visibility and requesting-cell activation order.
 #[derive(Debug)]
 struct PeerH2Route {
+    /// Exact connection-cell generation visible to this requesting cell.
     route: H2Route,
+    /// Local waiter priority for uses of this route.
     gate: GenerationGate,
+    /// Waiter whose route activation is crossing the connection-cell lock.
+    crossing: Option<WaiterId>,
 }
 
 /// Local priority state for one accepting generation.
@@ -247,15 +280,26 @@ enum GenerationGate {
     Closed,
     /// Waiters committed through `cutoff` precede later arrivals.
     Prioritizing {
+        /// Exact generation governed by this gate.
         generation: H2GenerationId,
+        /// Newest waiter committed before generation visibility.
         cutoff: WaiterId,
+        /// Prioritized waiter whose activation has not accepted or cancelled.
         activating: Option<WaiterId>,
     },
     /// The publication cutoff drained; queued work still precedes direct arrivals.
-    Open {
-        generation: H2GenerationId,
-        activating: Option<WaiterId>,
-    },
+    Open { generation: H2GenerationId },
+}
+
+/// One activation opportunity returned by a generation gate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GateTurn {
+    /// The gate cannot issue another activation.
+    Unavailable,
+    /// Any oldest compatible acquisition may activate.
+    Open,
+    /// Only an acquisition at or before this waiter may activate.
+    Through(WaiterId),
 }
 
 impl GenerationGate {
@@ -267,61 +311,55 @@ impl GenerationGate {
                 cutoff,
                 activating: None,
             },
-            None => Self::Open {
-                generation,
-                activating: None,
-            },
+            None => Self::Open { generation },
         }
     }
 
     fn generation(&self) -> Option<H2GenerationId> {
         match self {
             Self::Closed => None,
-            Self::Prioritizing { generation, .. } | Self::Open { generation, .. } => {
-                Some(*generation)
-            }
+            Self::Prioritizing { generation, .. } | Self::Open { generation } => Some(*generation),
         }
     }
 
-    /// Returns the cutoff for the next activation, or `None` when open.
-    fn service_cutoff(&mut self, has_prioritized: bool) -> Option<Option<WaiterId>> {
+    /// Returns the next activation opportunity and opens a drained priority gate.
+    fn next_turn(&mut self, has_prioritized: bool) -> GateTurn {
         match self {
-            Self::Closed => None,
+            Self::Closed => GateTurn::Unavailable,
             Self::Prioritizing {
                 cutoff,
                 activating,
                 generation,
             } => {
                 if activating.is_some() {
-                    return None;
+                    return GateTurn::Unavailable;
                 }
                 if !has_prioritized {
                     let generation = *generation;
-                    *self = Self::Open {
-                        generation,
-                        activating: None,
-                    };
-                    Some(None)
+                    *self = Self::Open { generation };
+                    GateTurn::Open
                 } else {
-                    Some(Some(*cutoff))
+                    GateTurn::Through(*cutoff)
                 }
             }
-            Self::Open { activating, .. } => activating.is_none().then_some(None),
+            Self::Open { .. } => GateTurn::Open,
         }
     }
 
-    /// Records the waiter whose activation must accept or cancel next.
-    fn begin_gate_activation(&mut self, waiter: WaiterId) {
+    /// Records a prioritized activation until it accepts or cancels.
+    fn begin_gate_activation(&mut self, waiter: WaiterId) -> bool {
         let activating = match self {
             Self::Closed => {
                 unreachable!("started an HTTP/2 activation while its gate was closed")
             }
-            Self::Prioritizing { activating, .. } | Self::Open { activating, .. } => activating,
+            Self::Prioritizing { activating, .. } => activating,
+            Self::Open { .. } => return false,
         };
         assert!(
             activating.replace(waiter).is_none(),
             "HTTP/2 generation gate admitted two activation opportunities"
         );
+        true
     }
 
     /// Discharges one exact activation opportunity.
@@ -331,7 +369,8 @@ impl GenerationGate {
         }
         let activating = match self {
             Self::Closed => return false,
-            Self::Prioritizing { activating, .. } | Self::Open { activating, .. } => activating,
+            Self::Prioritizing { activating, .. } => activating,
+            Self::Open { .. } => return false,
         };
         if *activating != Some(waiter) {
             return false;
@@ -349,18 +388,36 @@ impl GenerationGate {
 
     fn activating(&self) -> Option<WaiterId> {
         match self {
-            Self::Closed => None,
-            Self::Prioritizing { activating, .. } | Self::Open { activating, .. } => *activating,
+            Self::Prioritizing { activating, .. } => *activating,
+            Self::Closed | Self::Open { .. } => None,
         }
+    }
+
+    fn is_open_for(&self, generation: H2GenerationId) -> bool {
+        matches!(self, Self::Open { generation: current } if *current == generation)
     }
 }
 
 /// Result of atomically converging one post-ALPN attempt.
 #[derive(Debug)]
 pub(in crate::client::pool) enum H2FlightInstall {
+    /// An installed generation can serve this waiter.
     Accepting(H2GenerationId),
+    /// The waiter joined the current flight as a result participant.
     Joined,
+    /// The caller owns the task that must drive this new flight.
     Driver(H2FlightId),
+}
+
+/// Result of joining an accepting generation after ALPN selected HTTP/2.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::client::pool) enum H2GenerationJoin {
+    /// The waiter was transferred to the named generation.
+    Joined,
+    /// The named generation stopped accepting before the transfer.
+    GenerationChanged,
+    /// Another transition already installed the waiter's result.
+    WaiterCompleted,
 }
 
 impl H2Records {
@@ -388,14 +445,23 @@ impl H2Records {
     }
 
     /// Removes one cancelled waiter from its current flight, when present.
-    pub(super) fn cancel_flight_participant(&mut self, waiter: WaiterId) -> Option<H2FlightId> {
-        let flight = self.flight.as_mut()?;
-        if !flight.participants.remove(&waiter) {
-            return None;
+    pub(super) fn cancel_flight_participant(&mut self, waiter: WaiterId) {
+        if let Some(flight) = &mut self.flight {
+            flight.participants.remove(&waiter);
         }
-        let id = flight.id;
         self.assert_consistent();
-        Some(id)
+    }
+
+    /// Removes a waiter that no longer awaits an accepting generation.
+    pub(super) fn cancel_pending_waiter(&mut self, waiter: WaiterId) {
+        if let Some(generation) = self.accepting {
+            self.generations
+                .get_mut(&generation)
+                .expect("accepting HTTP/2 generation disappeared")
+                .pending_waiters
+                .remove(&waiter);
+        }
+        self.assert_consistent();
     }
 
     /// Installs the generation produced by the named flight.
@@ -415,10 +481,25 @@ impl H2Records {
             .flight
             .take()
             .expect("validated HTTP/2 flight disappeared");
+        let generation =
+            self.install_generation(flight.participants, connection, sender, idle_deadline);
+        self.assert_consistent();
+        Ok(generation)
+    }
+
+    /// Installs one accepting generation with its transferred waiters.
+    fn install_generation(
+        &mut self,
+        pending_waiters: BTreeSet<WaiterId>,
+        connection: Arc<ConnectionState>,
+        sender: H2Sender,
+        idle_deadline: Option<SystemTime>,
+    ) -> H2GenerationId {
         let generation = self.take_generation_id();
         let replaced = self.generations.insert(
             generation,
             H2Generation {
+                pending_waiters,
                 connection,
                 sender,
                 residence: H2Residence::Accepting,
@@ -432,13 +513,8 @@ impl H2Records {
         self.accepting = Some(generation);
         self.peer_route = None;
         debug_assert!(matches!(self.gate, GenerationGate::Closed));
-        self.gate = GenerationGate::Open {
-            generation,
-            activating: None,
-        };
-        self.assert_consistent();
-        drop(flight);
-        Ok(generation)
+        self.gate = GenerationGate::Open { generation };
+        generation
     }
 
     /// Retires a failed or dropped flight and returns its participants.
@@ -482,28 +558,40 @@ impl H2Records {
             GenerationGate::Prioritizing { cutoff, .. } => {
                 *cutoff = (*cutoff).max(waiter);
             }
-            GenerationGate::Open { activating, .. } => {
-                let activating = *activating;
+            GenerationGate::Open { .. } => {
                 self.gate = GenerationGate::Prioritizing {
                     generation,
                     cutoff: waiter,
-                    activating,
+                    activating: None,
                 };
             }
         }
+        self.generations
+            .get_mut(&generation)
+            .expect("accepting HTTP/2 generation disappeared")
+            .pending_waiters
+            .insert(waiter);
         self.assert_consistent();
         true
     }
 
-    /// Returns the cutoff for the next queued activation, or `None` when open.
-    pub(super) fn service_cutoff(&mut self, has_prioritized: bool) -> Option<Option<WaiterId>> {
-        self.gate.service_cutoff(has_prioritized)
+    /// Returns the next queued activation opportunity.
+    fn next_gate_turn(&mut self, has_prioritized: bool) -> GateTurn {
+        self.gate.next_turn(has_prioritized)
     }
 
-    /// Records the one waiter whose activation must accept or cancel next.
-    pub(super) fn begin_gate_activation(&mut self, waiter: WaiterId) {
-        self.gate.begin_gate_activation(waiter);
+    /// Records a prioritized activation and releases its transferred waiter.
+    pub(super) fn begin_gate_activation(&mut self, waiter: WaiterId) -> bool {
+        let gated = self.gate.begin_gate_activation(waiter);
+        if let Some(generation) = self.accepting {
+            self.generations
+                .get_mut(&generation)
+                .expect("accepting HTTP/2 generation disappeared")
+                .pending_waiters
+                .remove(&waiter);
+        }
         self.assert_consistent();
+        gated
     }
 
     /// Discharges one accepted or cancelled activation opportunity.
@@ -519,14 +607,7 @@ impl H2Records {
 
     /// Returns whether a direct arrival may use the accepting generation.
     pub(super) fn direct_is_allowed(&self, queued: bool) -> bool {
-        !queued
-            && matches!(
-                self.gate,
-                GenerationGate::Open {
-                    activating: None,
-                    ..
-                }
-            )
+        !queued && matches!(self.gate, GenerationGate::Open { .. })
     }
 
     /// Returns the publication cutoff while older waiters remain prioritized.
@@ -574,38 +655,48 @@ impl H2Records {
         true
     }
 
-    /// Cancels one prospective reservation and removes an empty drain record.
-    fn cancel(&mut self, generation: H2GenerationId) {
-        let Some(record) = self.generations.get_mut(&generation) else {
-            return;
-        };
-        if record.prospective == 0 {
-            return;
-        }
+    /// Cancels one prospective reservation and detaches an empty drain record.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the activation's exact generation or prospective count is
+    /// missing.
+    #[must_use]
+    fn cancel(&mut self, generation: H2GenerationId) -> Option<H2Generation> {
+        let record = self
+            .generations
+            .get_mut(&generation)
+            .expect("HTTP/2 activation generation disappeared before cancellation");
+        assert!(
+            record.prospective > 0,
+            "HTTP/2 prospective request count underflowed"
+        );
         record.prospective -= 1;
-        self.remove_finished_drain(generation);
-        self.assert_consistent();
+        self.remove_finished_drain(generation)
     }
 
-    /// Releases one accepted request after both endpoints terminate.
-    fn complete_request(&mut self, generation: H2GenerationId) {
-        let Some(record) = self.generations.get_mut(&generation) else {
-            return;
-        };
+    /// Releases one accepted request and detaches an empty drain record.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lease's exact generation or accepted count is missing.
+    #[must_use]
+    fn complete_request(&mut self, generation: H2GenerationId) -> Option<H2Generation> {
+        let record = self
+            .generations
+            .get_mut(&generation)
+            .expect("HTTP/2 request generation disappeared before lease completion");
         assert!(
             record.accepted > 0,
             "HTTP/2 accepted request count underflowed"
         );
         record.accepted -= 1;
-        self.remove_finished_drain(generation);
-        self.assert_consistent();
+        self.remove_finished_drain(generation)
     }
 
     /// Moves one exact accepting generation to draining.
-    pub(super) fn begin_close(
-        &mut self,
-        generation: H2GenerationId,
-    ) -> Option<Arc<ConnectionState>> {
+    #[must_use]
+    fn begin_close(&mut self, generation: H2GenerationId) -> Option<H2CloseTransition> {
         if self.accepting != Some(generation) {
             return None;
         }
@@ -616,12 +707,25 @@ impl H2Records {
         record.residence = H2Residence::Draining;
         self.accepting = None;
         self.gate = GenerationGate::Closed;
+        let pending_waiters = std::mem::take(&mut record.pending_waiters);
         let remove_record = record.prospective == 0 && record.accepted == 0;
         let connection = record.connection.clone();
-        if remove_record {
-            self.generations.remove(&generation);
-        }
-        Some(connection)
+        let removed_generation = remove_record
+            .then(|| self.generations.remove(&generation))
+            .flatten();
+        Some(H2CloseTransition {
+            connection,
+            pending_waiters,
+            removed_generation,
+        })
+    }
+
+    /// Detaches an exact accepting generation only while it has no request work.
+    #[must_use]
+    fn begin_idle_reclaim(&mut self, generation: H2GenerationId) -> Option<H2CloseTransition> {
+        self.is_idle(generation)
+            .then(|| self.begin_close(generation))
+            .flatten()
     }
 
     /// Returns the accepting generation when one is locally reusable.
@@ -639,12 +743,19 @@ impl H2Records {
         let generation = self.accepting?;
         matches!(
             self.gate,
-            GenerationGate::Open {
-                generation: gate_generation,
-                ..
-            } if gate_generation == generation
+            GenerationGate::Open { generation: gate_generation } if gate_generation == generation
         )
         .then_some(generation)
+    }
+
+    /// Returns whether an exact publishable generation has no request work.
+    pub(super) fn is_idle(&self, generation: H2GenerationId) -> bool {
+        if self.publishable_generation() != Some(generation) {
+            return false;
+        }
+        self.generations.get(&generation).is_some_and(|record| {
+            record.pending_waiters.is_empty() && record.prospective == 0 && record.accepted == 0
+        })
     }
 
     /// Returns whether a local generation or peer route suppresses admission demand.
@@ -670,14 +781,11 @@ impl H2Records {
                         GenerationGate::Prioritizing {
                             cutoff: current, ..
                         } => *current = (*current).max(cutoff),
-                        GenerationGate::Open {
-                            generation,
-                            activating,
-                        } => {
+                        GenerationGate::Open { generation } => {
                             current.gate = GenerationGate::Prioritizing {
                                 generation: *generation,
                                 cutoff,
-                                activating: *activating,
+                                activating: None,
                             };
                         }
                     }
@@ -687,6 +795,7 @@ impl H2Records {
                 self.peer_route = Some(PeerH2Route {
                     gate: GenerationGate::for_generation(id.generation, cutoff),
                     route,
+                    crossing: None,
                 });
             }
         }
@@ -699,20 +808,29 @@ impl H2Records {
         waiters: &AcquisitionQueue,
     ) -> Option<PreparedPeerActivation> {
         let peer = self.peer_route.as_mut()?;
+        if peer.crossing.is_some() {
+            return None;
+        }
         let has_prioritized = peer
             .gate
             .priority_cutoff()
             .is_some_and(|cutoff| waiters.has_h2_candidate_through(cutoff));
-        let cutoff = peer.gate.service_cutoff(has_prioritized)?;
+        let cutoff = match peer.gate.next_turn(has_prioritized) {
+            GateTurn::Unavailable => return None,
+            GateTurn::Open => None,
+            GateTurn::Through(cutoff) => Some(cutoff),
+        };
         let waiter = waiters.oldest_h2_candidate()?;
         if cutoff.is_some_and(|cutoff| waiter > cutoff) {
             return None;
         }
-        peer.gate.begin_gate_activation(waiter);
+        let gated = peer.gate.begin_gate_activation(waiter);
+        peer.crossing = Some(waiter);
         Some(PreparedPeerActivation {
             route: peer.route.clone(),
             waiter,
             cutoff,
+            gated,
         })
     }
 
@@ -724,13 +842,27 @@ impl H2Records {
     ) -> bool {
         self.peer_route.as_ref().is_some_and(|peer| {
             peer.route.id() == prepared.route.id()
-                && peer.gate.activating() == Some(prepared.waiter)
+                && peer.crossing == Some(prepared.waiter)
+                && (!prepared.gated || peer.gate.activating() == Some(prepared.waiter))
                 && waiters.is_oldest_h2_candidate(prepared.waiter)
         })
     }
 
-    /// Discharges one exact peer-route activation opportunity.
-    fn finish_peer_activation(&mut self, route: H2RouteId, waiter: WaiterId) -> bool {
+    /// Ends one route crossing after its result is installed or rejected.
+    fn finish_peer_crossing(&mut self, route: H2RouteId, waiter: WaiterId) -> bool {
+        let Some(peer) = &mut self.peer_route else {
+            return false;
+        };
+        if peer.route.id() != route || peer.crossing != Some(waiter) {
+            return false;
+        }
+        peer.crossing = None;
+        self.assert_consistent();
+        true
+    }
+
+    /// Discharges one prioritized peer-route activation opportunity.
+    fn finish_peer_gate(&mut self, route: H2RouteId, waiter: WaiterId) -> bool {
         let Some(peer) = &mut self.peer_route else {
             return false;
         };
@@ -755,7 +887,21 @@ impl H2Records {
         {
             return false;
         }
-        self.finish_peer_activation(route, waiter)
+        self.finish_peer_gate(route, waiter)
+    }
+
+    /// Returns an open peer route when no queued acquisition precedes it.
+    fn open_peer_route(&self, queued: bool) -> Option<H2Route> {
+        let peer = self.peer_route.as_ref()?;
+        (!queued && peer.gate.is_open_for(peer.route.id().generation)).then(|| peer.route.clone())
+    }
+
+    /// Revalidates a direct peer route after its connection-cell crossing.
+    fn direct_peer_route_is_current(&self, route: H2RouteId, queued: bool) -> bool {
+        !queued
+            && self.peer_route.as_ref().is_some_and(|peer| {
+                peer.route.id() == route && peer.gate.is_open_for(route.generation)
+            })
     }
 
     /// Removes one stale exact peer route.
@@ -805,16 +951,17 @@ impl H2Records {
         true
     }
 
-    /// Removes a draining generation after its last retained request ends.
-    fn remove_finished_drain(&mut self, generation: H2GenerationId) {
+    /// Detaches a draining generation after its last retained request ends.
+    #[must_use]
+    fn remove_finished_drain(&mut self, generation: H2GenerationId) -> Option<H2Generation> {
         let remove = self.generations.get(&generation).is_some_and(|record| {
             record.residence == H2Residence::Draining
                 && record.prospective == 0
                 && record.accepted == 0
         });
-        if remove {
-            self.generations.remove(&generation);
-        }
+        remove
+            .then(|| self.generations.remove(&generation))
+            .flatten()
     }
 
     fn take_flight_id(&mut self) -> H2FlightId {
@@ -837,6 +984,9 @@ impl H2Records {
     pub(super) fn assert_consistent(&self) {
         #[cfg(any(debug_assertions, test))]
         {
+            if std::thread::panicking() {
+                return;
+            }
             let accepting_records = self
                 .generations
                 .iter()
@@ -881,7 +1031,24 @@ impl H2Records {
                         record.prospective > 0 || record.accepted > 0,
                         "empty HTTP/2 draining generation was retained"
                     );
+                    assert!(
+                        record.pending_waiters.is_empty(),
+                        "draining HTTP/2 generation retained unserved waiters"
+                    );
                 }
+            }
+        }
+    }
+
+    /// Checks transferred waiter identities against the cell's acquisition state.
+    #[cfg(any(debug_assertions, test))]
+    pub(super) fn assert_pending_waiters(&self, waiters: &AcquisitionQueue) {
+        for record in self.generations.values() {
+            for waiter in &record.pending_waiters {
+                assert!(
+                    waiters.is_launching_h2_candidate(*waiter),
+                    "HTTP/2 generation retained a waiter that was no longer launchable"
+                );
             }
         }
     }
@@ -889,15 +1056,33 @@ impl H2Records {
 
 /// One requesting-cell activation prepared before crossing to its connection cell.
 struct PreparedPeerActivation {
+    /// Route validated in the requesting cell before the lock crossing.
     route: H2Route,
+    /// Oldest waiter selected for this activation.
     waiter: WaiterId,
+    /// Publication cutoff that this waiter must satisfy.
     cutoff: Option<WaiterId>,
+    /// Whether acceptance or cancellation must discharge a priority turn.
+    gated: bool,
+}
+
+/// State detached when an accepting generation begins draining.
+struct H2CloseTransition {
+    /// Connection whose logical close follows cell unlock.
+    connection: Arc<ConnectionState>,
+    /// Unserved transferred waiters that must re-enter acquisition.
+    pending_waiters: BTreeSet<WaiterId>,
+    /// Removed record retained until the cell lock is released.
+    removed_generation: Option<H2Generation>,
 }
 
 /// Sender and connection cloned while a prospective lease is state-owned.
 struct H2ActivationParts {
+    /// Transient sender clone for one activation.
     sender: H2Sender,
+    /// Whether the generation has accepted an earlier request.
     reused: bool,
+    /// Connection retained through prospective dispatch.
     connection: Arc<ConnectionState>,
 }
 
@@ -917,15 +1102,23 @@ pub(in crate::client::pool) struct H2DispatchParts {
 /// prospective reservation. Acceptance creates endpoint guards and transfers
 /// dispatch accounting to the response lifecycle.
 pub(in crate::client::pool) struct H2Activation {
+    /// Cell that owns the selected generation.
     cell: Arc<OriginCell>,
+    /// Partition issuing this request.
     request_partition: PartitionId,
+    /// Exact generation that owns the prospective count.
     generation: H2GenerationId,
+    /// Transient sender transferred at most once into dispatch.
     sender: Option<H2Sender>,
+    /// Whether the generation has accepted an earlier request.
     reused: bool,
+    /// Connection retained until acceptance or cancellation.
     connection: Arc<ConnectionState>,
+    /// Shared state for the request's send and receive endpoints.
     lease: Arc<H2LeaseCore>,
     /// Requesting-cell priority discharged only at acceptance or cancellation.
     gate: Option<H2GateToken>,
+    /// Whether drop must cancel the prospective generation count.
     active: bool,
 }
 
@@ -1092,14 +1285,19 @@ impl Drop for H2Activation {
 
 /// One activation opportunity retained until Hyper acceptance or cancellation.
 struct H2GateToken {
+    /// Requesting cell whose gate owns this turn.
     cell: Weak<OriginCell>,
+    /// Waiter that received the activation opportunity.
     waiter: WaiterId,
+    /// Local-generation or peer-route gate identity.
     kind: H2GateKind,
 }
 
 /// Cell transition run when an activation accepts or cancels.
 enum H2GateKind {
+    /// Gate attached to the connection cell's local generation.
     Local { generation: H2GenerationId },
+    /// Gate attached to a requesting cell's peer route.
     Peer { route: H2RouteId },
 }
 
@@ -1137,28 +1335,41 @@ impl H2GateToken {
 /// One terminal side of an accepted HTTP/2 request lease.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum H2Endpoint {
+    /// Request-body upload lifetime.
     Send,
+    /// Response future and response-body lifetime.
     Receive,
 }
 
 /// Shared request-lease phase and endpoint bits.
 enum H2LeaseState {
+    /// Generation count reserved before Hyper accepts the request.
     Prospective {
+        /// Whether upload ownership already terminated.
         send_complete: bool,
+        /// Whether response ownership already terminated.
         receive_complete: bool,
     },
+    /// Hyper accepted the request and connection dispatch is retained.
     Accepted {
+        /// Whether upload ownership already terminated.
         send_complete: bool,
+        /// Whether response ownership already terminated.
         receive_complete: bool,
+        /// Accepted-dispatch accounting released with the second endpoint.
         dispatch: DispatchGuard,
     },
+    /// Both endpoints terminated or prospective dispatch was cancelled.
     Complete,
 }
 
 /// Shared endpoint state for one prospective or accepted request.
 struct H2LeaseCore {
+    /// Connection cell updated after both accepted endpoints terminate.
     cell: Weak<OriginCell>,
+    /// Exact generation whose request count this lease owns.
     generation: H2GenerationId,
+    /// Endpoint phase; never held while locking the cell or connection state.
     state: Mutex<H2LeaseState>,
 }
 
@@ -1265,8 +1476,11 @@ impl H2LeaseCore {
 /// Structured identity retained by one request-lease endpoint.
 #[derive(Clone)]
 struct H2EndpointTrace {
+    /// Partition that issued the request.
     request_partition: PartitionId,
+    /// Stable connection identity and origin metadata.
     connection: Arc<ConnectionInfo>,
+    /// Generation that owns the endpoint.
     generation: H2GenerationId,
 }
 
@@ -1282,9 +1496,13 @@ impl H2EndpointTrace {
 
 /// Linear guard for one request-lease endpoint.
 pub(in crate::client::pool) struct H2LeaseEndpoint {
+    /// Shared request-lease state.
     core: Arc<H2LeaseCore>,
+    /// Send or receive side owned by this guard.
     endpoint: H2Endpoint,
+    /// Structured fields emitted on terminal completion.
     trace: Option<H2EndpointTrace>,
+    /// Whether drop must finish this endpoint.
     active: bool,
 }
 
@@ -1365,6 +1583,7 @@ impl Drop for H2LeaseEndpoint {
 /// Test observation of a request-lease endpoint's production state.
 #[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
 pub(in crate::client::pool) struct H2LeaseProbe {
+    /// Production lease state observed by the test.
     core: Arc<H2LeaseCore>,
 }
 
@@ -1375,6 +1594,9 @@ impl H2LeaseProbe {
         matches!(
             &*self.core.state.lock(),
             H2LeaseState::Prospective {
+                send_complete: true,
+                ..
+            } | H2LeaseState::Accepted {
                 send_complete: true,
                 ..
             } | H2LeaseState::Complete
@@ -1388,6 +1610,9 @@ impl H2LeaseProbe {
             H2LeaseState::Prospective {
                 receive_complete: true,
                 ..
+            } | H2LeaseState::Accepted {
+                receive_complete: true,
+                ..
             } | H2LeaseState::Complete
         )
     }
@@ -1399,12 +1624,14 @@ impl OriginCell {
         cell: &Arc<Self>,
         generation: H2GenerationId,
     ) -> Option<H2Activation> {
-        let parts = {
+        let (parts, advertisement) = {
             let mut state = cell.state.lock();
             let parts = state.h2.activate(generation)?;
             state.assert_consistent();
-            parts
+            let advertisement = state.take_h2_advertisement_update();
+            (parts, advertisement)
         };
+        Self::publish_h2_advertisement(cell, advertisement);
         Some(H2Activation::new(cell.clone(), generation, parts, None))
     }
 
@@ -1426,16 +1653,33 @@ impl OriginCell {
 
     /// Cancels one prospective activation after sender rejection or task drop.
     fn cancel_h2_activation(cell: &Arc<Self>, generation: H2GenerationId) {
-        let mut state = cell.state.lock();
-        state.h2.cancel(generation);
-        state.assert_consistent();
+        // Keep the detached generation outside the lock's unwind scope. Its
+        // sender drop may wake Hyper's driver.
+        let (removed, advertisement) = {
+            let mut state = cell.state.lock();
+            let removed = state.h2.cancel(generation);
+            state.assert_consistent();
+            let advertisement = state.take_h2_advertisement_update();
+            (removed, advertisement)
+        };
+        drop(removed);
+        Self::publish_h2_advertisement(cell, advertisement);
+        Self::service_h2_waiters(cell);
     }
 
     /// Releases one accepted lease after its second endpoint terminates.
     fn complete_h2_request(cell: &Arc<Self>, generation: H2GenerationId) {
-        let mut state = cell.state.lock();
-        state.h2.complete_request(generation);
-        state.assert_consistent();
+        // Keep the detached generation outside the lock's unwind scope. Its
+        // sender drop may wake Hyper's driver.
+        let (removed, advertisement) = {
+            let mut state = cell.state.lock();
+            let removed = state.h2.complete_request(generation);
+            state.assert_consistent();
+            let advertisement = state.take_h2_advertisement_update();
+            (removed, advertisement)
+        };
+        drop(removed);
+        Self::publish_h2_advertisement(cell, advertisement);
     }
 
     /// Offers one local activation while preserving the generation cutoff.
@@ -1443,13 +1687,17 @@ impl OriginCell {
         cell: &Arc<Self>,
         state: &mut CellState,
         returned_event: &mut Option<AcquisitionEvent>,
-    ) -> Option<H2WaiterInstall> {
+    ) -> Option<WaiterInstall> {
         let generation = state.h2.accepting()?;
         let has_prioritized = state
             .h2
             .priority_cutoff()
             .is_some_and(|cutoff| state.waiters.has_h2_candidate_through(cutoff));
-        let cutoff = state.h2.service_cutoff(has_prioritized)?;
+        let cutoff = match state.h2.next_gate_turn(has_prioritized) {
+            GateTurn::Unavailable => return None,
+            GateTurn::Open => None,
+            GateTurn::Through(cutoff) => Some(cutoff),
+        };
         state.waiters.oldest_h2_candidate()?;
 
         let h2 = &mut state.h2;
@@ -1460,34 +1708,29 @@ impl OriginCell {
                 let parts = h2
                     .activate(generation)
                     .expect("accepting HTTP/2 generation could not create a gated activation");
-                h2.begin_gate_activation(waiter);
+                let gated = h2.begin_gate_activation(waiter);
                 AcquisitionResult::H2(H2Activation::new(
                     cell.clone(),
                     generation,
                     parts,
-                    Some(H2GateToken::local(cell, generation, waiter)),
+                    gated.then(|| H2GateToken::local(cell, generation, waiter)),
                 ))
             },
             &cell.eligibility_group,
         );
         *returned_event = install.returned_event.take();
+        install.demand_updates = state.publishable_demand_updates(install.demand_updates);
         state.assert_consistent();
         install.waiter.is_some().then_some(install)
     }
 
     /// Runs publication, fallback, and wake work after the cell lock is released.
-    fn finish_h2_install(cell: &Arc<Self>, install: Option<H2WaiterInstall>) {
+    fn finish_h2_install(cell: &Arc<Self>, install: Option<WaiterInstall>) {
         let Some(install) = install else {
             return;
         };
-        let suppress_active = cell.state.lock().h2.has_visible_h2();
         if let Some(admission) = &cell.admission {
-            for snapshot in install
-                .demand_updates
-                .into_iter()
-                .flatten()
-                .filter(|snapshot| !suppress_active || !snapshot.is_active())
-            {
+            for snapshot in install.demand_updates.into_iter().flatten() {
                 super::super::admission::OriginAdmission::publish_demand(
                     admission,
                     cell.id.partition(),
@@ -1642,14 +1885,19 @@ impl OriginCell {
                     .h2
                     .peer_activation_is_current(&prepared, &state.waiters);
                 if !current {
-                    state.h2.finish_peer_activation(route_id, prepared.waiter);
+                    state.h2.finish_peer_crossing(route_id, prepared.waiter);
+                    if prepared.gated {
+                        state.h2.finish_peer_gate(route_id, prepared.waiter);
+                    }
                     state.assert_consistent();
                     None
                 } else {
-                    activation
-                        .as_mut()
-                        .expect("peer HTTP/2 activation disappeared")
-                        .attach_peer_gate(cell, route_id, prepared.waiter);
+                    if prepared.gated {
+                        activation
+                            .as_mut()
+                            .expect("peer HTTP/2 activation disappeared")
+                            .attach_peer_gate(cell, route_id, prepared.waiter);
+                    }
                     let mut install = state.waiters.install_h2(
                         prepared.cutoff,
                         |_| {
@@ -1662,8 +1910,11 @@ impl OriginCell {
                         &cell.eligibility_group,
                     );
                     returned_event = install.returned_event.take();
-                    if install.waiter.is_none() {
-                        state.h2.finish_peer_activation(route_id, prepared.waiter);
+                    install.demand_updates =
+                        state.publishable_demand_updates(install.demand_updates);
+                    state.h2.finish_peer_crossing(route_id, prepared.waiter);
+                    if install.waiter.is_none() && prepared.gated {
+                        state.h2.finish_peer_gate(route_id, prepared.waiter);
                     }
                     state.assert_consistent();
                     install.waiter.is_some().then_some(install)
@@ -1682,7 +1933,7 @@ impl OriginCell {
     fn finish_peer_h2_gate(cell: &Arc<Self>, route: H2RouteId, waiter: WaiterId) {
         let finished = {
             let mut state = cell.state.lock();
-            let finished = state.h2.finish_peer_activation(route, waiter);
+            let finished = state.h2.finish_peer_gate(route, waiter);
             state.assert_consistent();
             finished
         };
@@ -1695,7 +1946,9 @@ impl OriginCell {
 /// Generation-specific close authority that does not retain the cell.
 #[derive(Clone, Debug)]
 pub(in crate::client::pool) struct H2CloseHandle {
+    /// Cell weak reference so driver lifetime does not retain the pool.
     cell: Weak<OriginCell>,
+    /// Exact generation this handle may close.
     generation: H2GenerationId,
 }
 
@@ -1721,7 +1974,9 @@ impl H2CloseHandle {
 
 /// Closes an H2 generation if its owner-runtime driver ends or is dropped.
 pub(in crate::client::pool) struct H2DriverGuard {
+    /// Exact-generation close authority.
     close: H2CloseHandle,
+    /// Whether drop must report owner-runtime shutdown.
     active: bool,
 }
 
@@ -1752,20 +2007,58 @@ impl Drop for H2DriverGuard {
 }
 
 impl OriginCell {
-    /// Selects an accepting local generation without admission coordination.
+    /// Selects an accepting local generation before consulting a peer route.
     pub(in crate::client::pool) fn select_h2(cell: &Arc<Self>) -> Option<H2Activation> {
-        let (generation, parts) = {
+        let local = {
             let mut state = cell.state.lock();
             let queued = state.waiters.has_h2_candidate();
-            if !state.h2.direct_is_allowed(queued) {
-                return None;
+            if state.h2.direct_is_allowed(queued) {
+                let generation = state.h2.accepting()?;
+                let parts = state.h2.activate(generation)?;
+                state.assert_consistent();
+                let advertisement = state.take_h2_advertisement_update();
+                Some((generation, parts, advertisement))
+            } else {
+                None
             }
-            let generation = state.h2.accepting()?;
-            let parts = state.h2.activate(generation)?;
-            state.assert_consistent();
-            (generation, parts)
         };
-        Some(H2Activation::new(cell.clone(), generation, parts, None))
+        if let Some((generation, parts, advertisement)) = local {
+            Self::publish_h2_advertisement(cell, advertisement);
+            return Some(H2Activation::new(cell.clone(), generation, parts, None));
+        }
+
+        let route = {
+            let state = cell.state.lock();
+            state.h2.open_peer_route(state.waiters.has_h2_candidate())?
+        };
+        let route_id = route.id();
+        let Some(activation) = route.activate(cell.id.partition()) else {
+            Self::clear_stale_peer_route(cell, route_id);
+            return None;
+        };
+        let current = {
+            let state = cell.state.lock();
+            state
+                .h2
+                .direct_peer_route_is_current(route_id, state.waiters.has_h2_candidate())
+        };
+        current.then_some(activation)
+    }
+
+    /// Removes one exact stale route and republishes the requesting demand.
+    fn clear_stale_peer_route(cell: &Arc<Self>, route: H2RouteId) {
+        let snapshot = {
+            let mut state = cell.state.lock();
+            if !state.h2.clear_peer_route(route) {
+                return;
+            }
+            let snapshot = state
+                .waiters
+                .current_demand_snapshot(&cell.eligibility_group);
+            state.assert_consistent();
+            snapshot
+        };
+        Self::publish_current_demand(cell, snapshot);
     }
 
     /// Places a post-ALPN waiter behind an already accepting generation.
@@ -1773,20 +2066,25 @@ impl OriginCell {
         cell: &Arc<Self>,
         waiter: WaiterId,
         generation: H2GenerationId,
-    ) -> bool {
+    ) -> H2GenerationJoin {
         let mut returned_event = None;
-        let install = {
+        let (install, advertisement) = {
             let mut state = cell.state.lock();
+            if !state.waiters.is_launching_h2_candidate(waiter) {
+                return H2GenerationJoin::WaiterCompleted;
+            }
             if !state.h2.prioritize_waiter(generation, waiter) {
-                return false;
+                return H2GenerationJoin::GenerationChanged;
             }
             let install = Self::service_h2_gate_locked(cell, &mut state, &mut returned_event);
             state.assert_consistent();
-            install
+            let advertisement = state.take_h2_advertisement_update();
+            (install, advertisement)
         };
         drop(returned_event);
+        Self::publish_h2_advertisement(cell, advertisement);
         Self::finish_h2_install(cell, install);
-        true
+        H2GenerationJoin::Joined
     }
 
     /// Atomically selects, joins, or installs the cell's post-ALPN flight.
@@ -1845,6 +2143,58 @@ impl OriginCell {
         participants
     }
 
+    /// Returns the complete current advertisement for an unlocked crossing.
+    pub(in crate::client::pool) fn report_h2_advertisement(
+        &self,
+    ) -> super::super::admission::H2AdvertisementSnapshot {
+        let mut state = self.state.lock();
+        let snapshot = state.report_h2_advertisement();
+        state.assert_consistent();
+        snapshot
+    }
+
+    /// Reclaims one exact idle generation and reports its resulting availability.
+    pub(in crate::client::pool) fn reclaim_idle_h2(
+        cell: &Arc<Self>,
+        generation: H2GenerationId,
+    ) -> (
+        super::super::admission::H2AdvertisementSnapshot,
+        Option<ConnectionId>,
+    ) {
+        // A zero-request generation may hold the last capacity-owning
+        // connection reference. Keep it outside the cell-lock unwind scope.
+        let detached;
+        let (advertisement, demand) = {
+            let mut state = cell.state.lock();
+            detached = state.h2.begin_idle_reclaim(generation);
+            let advertisement = state.report_h2_advertisement();
+            let demand = detached.as_ref().and_then(|_| {
+                state
+                    .waiters
+                    .current_demand_snapshot(&cell.eligibility_group)
+            });
+            state.assert_consistent();
+            (advertisement, demand)
+        };
+        let Some(detached) = detached else {
+            return (advertisement, None);
+        };
+        let H2CloseTransition {
+            connection,
+            pending_waiters,
+            removed_generation,
+        } = detached;
+        assert!(
+            pending_waiters.is_empty(),
+            "idle HTTP/2 reclaim detached pending generation waiters"
+        );
+        let connection_id = connection.id();
+        drop(removed_generation);
+        Self::publish_current_demand(cell, demand);
+        let reclaimed = connection.logical_close(super::super::connection::CloseReason::Reclaimed);
+        (advertisement, reclaimed.then_some(connection_id))
+    }
+
     /// Moves one exact generation to draining and closes its connection.
     pub(super) fn close_h2(
         cell: &Arc<Self>,
@@ -1853,14 +2203,14 @@ impl OriginCell {
     ) -> bool {
         // A zero-request generation may hold the last capacity-owning
         // connection reference. Keep it outside the cell-lock unwind scope.
-        let detached_connection;
+        let detached;
         let (advertisement, demand) = {
             let mut state = cell.state.lock();
-            detached_connection = state.h2.begin_close(generation);
-            let advertisement = detached_connection
+            detached = state.h2.begin_close(generation);
+            let advertisement = detached
                 .as_ref()
                 .and_then(|_| state.take_h2_advertisement_update());
-            let demand = detached_connection.as_ref().and_then(|_| {
+            let demand = detached.as_ref().and_then(|_| {
                 state
                     .waiters
                     .current_demand_snapshot(&cell.eligibility_group)
@@ -1868,11 +2218,20 @@ impl OriginCell {
             state.assert_consistent();
             (advertisement, demand)
         };
-        let Some(connection) = detached_connection else {
+        let Some(detached) = detached else {
             return false;
         };
+        let H2CloseTransition {
+            connection,
+            pending_waiters,
+            removed_generation,
+        } = detached;
+        drop(removed_generation);
         Self::publish_h2_advertisement(cell, advertisement);
         Self::publish_current_demand(cell, demand);
+        for waiter in pending_waiters {
+            cell.complete_establishment(waiter, AcquisitionResult::Reacquire);
+        }
         connection.logical_close(reason)
     }
 
@@ -1880,6 +2239,20 @@ impl OriginCell {
     #[cfg(test)]
     pub(in crate::client::pool) fn accepting_h2_generation(&self) -> Option<H2GenerationId> {
         self.state.lock().h2.accepting()
+    }
+
+    /// Returns the prospective and accepted request counts for one generation.
+    #[cfg(test)]
+    pub(in crate::client::pool) fn h2_request_counts(
+        &self,
+        generation: H2GenerationId,
+    ) -> Option<(usize, usize)> {
+        self.state
+            .lock()
+            .h2
+            .generations
+            .get(&generation)
+            .map(|record| (record.prospective, record.accepted))
     }
 
     /// Installs an accepting generation without a Hyper handshake.
@@ -1890,20 +2263,21 @@ impl OriginCell {
         sender_id: u64,
         idle_deadline: Option<SystemTime>,
     ) -> H2GenerationId {
-        let flight = match cell.install_or_join_h2_flight(WaiterId(u64::MAX)) {
-            H2FlightInstall::Driver(flight) => flight,
-            H2FlightInstall::Accepting(_) | H2FlightInstall::Joined => {
-                panic!("HTTP/2 test fixture requires an empty cell")
-            }
+        let (generation, advertisement) = {
+            let mut state = cell.state.lock();
+            let generation = state.h2.install_generation(
+                BTreeSet::new(),
+                connection,
+                H2Sender::test(sender_id),
+                idle_deadline,
+            );
+            state.assert_consistent();
+            let advertisement = state.take_h2_advertisement_update();
+            (generation, advertisement)
         };
-        Self::complete_h2_flight(
-            cell,
-            flight,
-            connection,
-            H2Sender::test(sender_id),
-            idle_deadline,
-        )
-        .expect("HTTP/2 test fixture flight did not install")
+        Self::publish_h2_advertisement(cell, advertisement);
+        cell.notify_maintenance(idle_deadline);
+        generation
     }
 }
 
@@ -1925,6 +2299,22 @@ mod tests {
             None,
             None,
         ))
+    }
+
+    fn bounded_cell(
+        admission: &Arc<crate::client::pool::admission::OriginAdmission>,
+        partition: usize,
+    ) -> Arc<OriginCell> {
+        crate::client::pool::admission::OriginAdmission::register_cell(
+            admission,
+            Arc::new(OriginCell::new(
+                PartitionId::from_index(partition),
+                OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                EligibilityGroup::Pool,
+                Some(admission.clone()),
+                None,
+            )),
+        )
     }
 
     fn connection(
@@ -1987,13 +2377,8 @@ mod tests {
     }
 
     fn generation_counts(cell: &OriginCell, generation: H2GenerationId) -> (usize, usize) {
-        let state = cell.state.lock();
-        let record = state
-            .h2
-            .generations
-            .get(&generation)
-            .expect("HTTP/2 generation disappeared");
-        (record.prospective, record.accepted)
+        cell.h2_request_counts(generation)
+            .expect("generation was not installed")
     }
 
     #[test]
@@ -2009,9 +2394,69 @@ mod tests {
             records.install_or_join_flight(second),
             H2FlightInstall::Joined
         ));
-        assert_eq!(Some(flight), records.cancel_flight_participant(second));
+        records.cancel_flight_participant(second);
         assert_eq!(Some(vec![first]), records.fail_flight(flight));
         assert!(records.flight.is_none());
+    }
+
+    #[test]
+    fn accepting_generation_prevents_a_second_flight() {
+        let mut records = H2Records::default();
+        let (connection, _physical) = connection(1);
+        let generation =
+            records.install_generation(BTreeSet::new(), connection, H2Sender::test(1), None);
+
+        assert!(matches!(
+            records.install_or_join_flight(WaiterId(1)),
+            H2FlightInstall::Accepting(current) if current == generation
+        ));
+        assert!(records.flight.is_none());
+    }
+
+    #[test]
+    fn generation_join_does_not_retain_a_waiter_already_served_by_the_gate() {
+        let cell = cell();
+        let first = begin_waiter(&cell);
+        let second = begin_waiter(&cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first waiter did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+
+        let (connection, _physical) = connection(1);
+        let generation =
+            OriginCell::complete_h2_flight(&cell, flight, connection, H2Sender::test(1), None)
+                .expect("flight did not install");
+
+        assert_eq!(
+            H2GenerationJoin::WaiterCompleted,
+            OriginCell::join_h2_generation(&cell, first, generation)
+        );
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("generation gate did not serve the first waiter")
+        else {
+            panic!("first waiter received a non-H2 result");
+        };
+
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+        drop(activation);
+        assert!(matches!(
+            cell.take_ready_event(second),
+            Some(super::super::AcquisitionEvent::Complete(
+                super::super::AcquisitionResult::Reacquire
+            ))
+        ));
+        assert_eq!(0, cell.retained_waiters_for_test());
     }
 
     #[test]
@@ -2065,6 +2510,163 @@ mod tests {
     }
 
     #[test]
+    fn cancelling_an_open_gate_activation_services_the_next_waiter() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+
+        let admission = OriginAdmission::for_test(NonZeroUsize::new(1).unwrap());
+        let cell = OriginAdmission::register_cell(
+            &admission,
+            Arc::new(OriginCell::new(
+                PartitionId::from_index(1),
+                OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                EligibilityGroup::Pool,
+                Some(admission.clone()),
+                None,
+            )),
+        );
+        let (connection, _physical) = ConnectionState::bounded(
+            ConnectionInfo::for_test(ConnectionId::new(1), cell.id().partition()),
+            OriginAdmission::lease_for_test(&admission),
+        );
+        let generation = OriginCell::install_h2_for_test(&cell, connection, 1, None);
+        cell.state.lock().h2.prioritize_through(Some(WaiterId(0)));
+
+        let first = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            first_activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("first waiter was not served")
+        else {
+            panic!("first waiter received a non-H2 result");
+        };
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+        let third = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+        assert_eq!((1, 0), generation_counts(&cell, generation));
+
+        drop(first_activation);
+        assert_eq!((1, 0), generation_counts(&cell, generation));
+        assert!(OriginCell::cancel_waiter(&cell, second));
+        assert_eq!(
+            (1, 0),
+            generation_counts(&cell, generation),
+            "cancelling an open-gate activation stranded its successor"
+        );
+
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            third_activation,
+        )) = cell
+            .take_ready_event(third)
+            .expect("successor was not served after cancellation")
+        else {
+            panic!("successor received a non-H2 result");
+        };
+        drop(third_activation);
+        assert_eq!((0, 0), generation_counts(&cell, generation));
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+    }
+
+    #[test]
+    fn cancelling_an_unserved_flight_participant_prunes_the_generation() {
+        let cell = cell();
+        let first = begin_waiter(&cell);
+        let second = begin_waiter(&cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+        let (connection, _physical) = connection(1);
+        let generation =
+            OriginCell::complete_h2_flight(&cell, flight, connection, H2Sender::test(1), None)
+                .expect("flight did not install");
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            first_activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("first participant was not served")
+        else {
+            panic!("first participant received a non-H2 result");
+        };
+
+        assert!(OriginCell::cancel_waiter(&cell, second));
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+        drop(first_activation);
+        assert_eq!(0, cell.retained_waiters_for_test());
+    }
+
+    #[test]
+    fn returned_h1_prunes_a_transferred_h2_waiter() {
+        let cell = cell();
+        let first = begin_waiter(&cell);
+        let second = OriginCell::register_waiter(&cell, ProtocolRequirement::H1Compatible);
+        let super::super::AcquisitionEvent::Establish(permit) = cell
+            .take_ready_event(second)
+            .expect("second participant did not receive establishment authority")
+        else {
+            panic!("second participant completed before establishment");
+        };
+        assert!(cell.start_establishment(second));
+        drop(permit);
+
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+        let (h2_connection, _h2_physical) = connection(1);
+        let generation =
+            OriginCell::complete_h2_flight(&cell, flight, h2_connection, H2Sender::test(1), None)
+                .expect("flight did not install");
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            first_activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("first participant was not served")
+        else {
+            panic!("first participant received a non-H2 result");
+        };
+
+        let (h1_connection, _h1_physical) = connection(2);
+        let returning = OriginCell::install_selected_h1(
+            &cell,
+            h1_connection,
+            super::super::h1::H1Sender::test(2),
+        );
+        drop(returning);
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H1(
+            selection,
+        )) = cell
+            .take_ready_event(second)
+            .expect("returned HTTP/1 sender did not serve the compatible waiter")
+        else {
+            panic!("compatible waiter received a non-H1 result");
+        };
+        drop(selection);
+
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+        drop(first_activation);
+        assert_eq!(0, cell.retained_waiters_for_test());
+    }
+
+    #[test]
     fn later_local_activation_does_not_hide_an_open_generation_from_peers() {
         let mut records = H2Records::default();
         let committed = WaiterId(1);
@@ -2079,21 +2681,135 @@ mod tests {
         records.prioritize_through(Some(committed));
 
         assert_eq!(
-            Some(Some(committed)),
-            records.service_cutoff(true),
+            GateTurn::Through(committed),
+            records.next_gate_turn(true),
             "committed waiter did not retain initial priority"
         );
         records.begin_gate_activation(committed);
         assert_eq!(None, records.publishable_generation());
         assert!(records.finish_gate_activation(generation, committed));
 
-        assert_eq!(Some(None), records.service_cutoff(false));
+        assert_eq!(GateTurn::Open, records.next_gate_turn(false));
         records.begin_gate_activation(later);
         assert_eq!(
             Some(generation),
             records.publishable_generation(),
             "a post-cutoff local activation hid the generation from peers"
         );
+    }
+
+    #[test]
+    fn generation_close_reacquires_unserved_flight_participant() {
+        let cell = cell();
+        let first = begin_waiter(&cell);
+        let second = begin_waiter(&cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+        let (connection, _physical) = connection(1);
+        let generation =
+            OriginCell::complete_h2_flight(&cell, flight, connection, H2Sender::test(1), None)
+                .expect("flight did not install");
+
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            first_activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("first participant was not served")
+        else {
+            panic!("first participant received a non-H2 result");
+        };
+        assert!(cell.take_ready_event(second).is_none());
+
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::Poisoned
+        ));
+        assert!(matches!(
+            cell.take_ready_event(second),
+            Some(super::super::AcquisitionEvent::Complete(
+                super::super::AcquisitionResult::Reacquire
+            ))
+        ));
+        drop(first_activation);
+        assert_eq!(0, cell.retained_waiters_for_test());
+    }
+
+    #[test]
+    fn bounded_generation_close_returns_capacity_and_reacquires_participant() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+
+        let admission = OriginAdmission::for_test(NonZeroUsize::new(2).unwrap());
+        let cell = OriginAdmission::register_cell(
+            &admission,
+            Arc::new(OriginCell::new(
+                PartitionId::from_index(1),
+                OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                EligibilityGroup::Pool,
+                Some(admission.clone()),
+                None,
+            )),
+        );
+        let mut participants = Vec::new();
+        for _ in 0..2 {
+            let waiter = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+            let super::super::AcquisitionEvent::Establish(permit) = cell
+                .take_ready_event(waiter)
+                .expect("bounded participant did not receive capacity")
+            else {
+                panic!("bounded participant completed before establishment");
+            };
+            assert!(cell.start_establishment(waiter));
+            participants.push((waiter, permit));
+        }
+        let (first, first_permit) = participants.remove(0);
+        let (second, second_permit) = participants.remove(0);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+        drop(second_permit);
+        let (connection, _physical) = ConnectionState::bounded(
+            ConnectionInfo::for_test(ConnectionId::new(1), cell.id().partition()),
+            first_permit
+                .into_lease()
+                .expect("bounded permit had no lease"),
+        );
+        let generation =
+            OriginCell::complete_h2_flight(&cell, flight, connection, H2Sender::test(1), None)
+                .expect("bounded flight did not install");
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            first_activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("first participant was not served")
+        else {
+            panic!("first participant received a non-H2 result");
+        };
+
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::Poisoned
+        ));
+        assert!(matches!(
+            cell.take_ready_event(second),
+            Some(super::super::AcquisitionEvent::Complete(
+                super::super::AcquisitionResult::Reacquire
+            ))
+        ));
+        drop(first_activation);
+        assert_eq!(2, admission.available_capacity_for_test());
+        assert_eq!(0, cell.retained_waiters_for_test());
     }
 
     #[test]
@@ -2178,7 +2894,191 @@ mod tests {
     }
 
     #[test]
-    fn stale_generation_cannot_activate_or_close_its_successor() {
+    fn stale_route_cannot_activate_a_replacement_or_retained_drain() {
+        let cell = cell();
+        let (first, _first_connection, _first_physical) = install_generation(&cell, 1);
+        let stale_route = H2Route::new(&cell, first);
+        let retained = OriginCell::select_h2(&cell).expect("first generation was not selectable");
+        assert!(OriginCell::close_h2(
+            &cell,
+            first,
+            CloseReason::ProtocolClosed
+        ));
+
+        let (second, _second_connection, _second_physical) = install_generation(&cell, 2);
+        assert_ne!(first, second);
+        assert!(
+            stale_route.activate(PartitionId::from_index(2)).is_none(),
+            "stale route activated a draining or replacement generation"
+        );
+        drop(retained);
+    }
+
+    #[test]
+    fn accepting_identity_rejects_a_retained_draining_generation() {
+        let cell = cell();
+        let (first, _first_connection, _first_physical) = install_generation(&cell, 1);
+        let retained = OriginCell::select_h2(&cell).expect("first generation was not selectable");
+        assert!(OriginCell::close_h2(
+            &cell,
+            first,
+            CloseReason::ProtocolClosed
+        ));
+        let (second, _second_connection, _second_physical) = install_generation(&cell, 2);
+
+        assert!(cell.state.lock().h2.is_accepting(second));
+        assert!(!cell.state.lock().h2.is_accepting(first));
+        drop(retained);
+    }
+
+    #[test]
+    fn activation_requires_the_exact_accepting_generation() {
+        let cell = cell();
+        let (first, _first_connection, _first_physical) = install_generation(&cell, 1);
+        let retained = OriginCell::select_h2(&cell).expect("first generation was not selectable");
+        assert!(OriginCell::close_h2(
+            &cell,
+            first,
+            CloseReason::ProtocolClosed
+        ));
+        let (second, _second_connection, _second_physical) = install_generation(&cell, 2);
+
+        {
+            let mut state = cell.state.lock();
+            let first_record = state
+                .h2
+                .generations
+                .get_mut(&first)
+                .expect("retained generation disappeared");
+            assert_eq!(H2Residence::Draining, first_record.residence);
+            first_record.residence = H2Residence::Accepting;
+            assert!(
+                state.h2.activate(first).is_none(),
+                "non-current generation accepted an activation"
+            );
+            state
+                .h2
+                .generations
+                .get_mut(&first)
+                .expect("retained generation disappeared")
+                .residence = H2Residence::Draining;
+            state.assert_consistent();
+        }
+
+        assert!(cell.state.lock().h2.is_accepting(second));
+        drop(retained);
+    }
+
+    #[test]
+    fn activation_requires_accepting_residence() {
+        let cell = cell();
+        let (first, _first_connection, _first_physical) = install_generation(&cell, 1);
+        let retained = OriginCell::select_h2(&cell).expect("first generation was not selectable");
+        assert!(OriginCell::close_h2(
+            &cell,
+            first,
+            CloseReason::ProtocolClosed
+        ));
+        let (second, _second_connection, _second_physical) = install_generation(&cell, 2);
+
+        {
+            let mut state = cell.state.lock();
+            assert_eq!(
+                H2Residence::Draining,
+                state.h2.generations[&first].residence
+            );
+            state.h2.accepting = Some(first);
+            assert!(
+                state.h2.activate(first).is_none(),
+                "draining generation accepted an activation"
+            );
+            state.h2.accepting = Some(second);
+            state.assert_consistent();
+        }
+
+        drop(retained);
+    }
+
+    #[test]
+    fn local_generation_excludes_a_peer_route() {
+        let local_cell = cell();
+        let (generation, _connection, _physical) = install_generation(&local_cell, 1);
+        let peer_cell = Arc::new(OriginCell::new(
+            PartitionId::from_index(2),
+            local_cell.id().origin().clone(),
+            EligibilityGroup::Pool,
+            None,
+            None,
+        ));
+        let route = H2Route::new(&peer_cell, H2GenerationId::for_test(99));
+
+        let mut state = local_cell.state.lock();
+        state.h2.install_peer_route(route, None);
+        assert!(state.h2.peer_route.is_none());
+        assert_eq!(Some(generation), state.h2.accepting());
+    }
+
+    #[test]
+    fn open_generation_allows_concurrent_prospective_activations() {
+        let cell = cell();
+        let (generation, _connection, _physical) = install_generation(&cell, 1);
+
+        let first = OriginCell::select_h2(&cell).expect("first activation was not selected");
+        let second =
+            OriginCell::select_h2(&cell).expect("open generation serialized the second activation");
+        assert_eq!((2, 0), generation_counts(&cell, generation));
+        drop(first);
+        drop(second);
+        assert_eq!((0, 0), generation_counts(&cell, generation));
+    }
+
+    #[test]
+    fn consistency_checks_do_not_repanic_during_unwind() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        let cell = cell();
+        let (generation, _connection, _physical) = install_generation(&cell, 1);
+        let activation =
+            OriginCell::select_h2(&cell).expect("accepting generation did not activate");
+        let (corrupt_connection, corrupt_physical) = connection(2);
+        {
+            let mut state = cell.state.lock();
+            state.h2.generations.insert(
+                H2GenerationId(99),
+                H2Generation {
+                    pending_waiters: BTreeSet::new(),
+                    connection: corrupt_connection,
+                    sender: H2Sender::test(2),
+                    residence: H2Residence::Draining,
+                    prospective: 0,
+                    has_dispatched: false,
+                    accepted: 0,
+                    idle_deadline: None,
+                },
+            );
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(move || {
+            let _activation = activation;
+            panic!("primary test panic");
+        }));
+        assert!(result.is_err(), "primary panic was not observed");
+
+        let removed = {
+            let mut state = cell.state.lock();
+            state.h2.generations.remove(&H2GenerationId(99))
+        };
+        drop(removed);
+        drop(corrupt_physical);
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+    }
+
+    #[test]
+    fn removed_generation_id_cannot_activate_or_close_the_current_generation() {
         let cell = cell();
         let (first, first_connection, _first_physical) = install_generation(&cell, 1);
         let stale = H2CloseHandle::new(&cell, first);
@@ -2231,6 +3131,7 @@ mod tests {
             state.h2.generations.insert(
                 H2GenerationId(99),
                 H2Generation {
+                    pending_waiters: BTreeSet::new(),
                     connection: corrupt_connection,
                     sender: H2Sender::test(2),
                     residence: H2Residence::Draining,
@@ -2300,6 +3201,157 @@ mod tests {
     }
 
     #[test]
+    fn local_selection_withdraws_idle_h2_from_reclaim() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+
+        let admission = OriginAdmission::for_test(NonZeroUsize::MIN);
+        let connection_cell = bounded_cell(&admission, 1);
+        let requesting_cell = bounded_cell(&admission, 2);
+        let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
+        let (connection, _physical) = ConnectionState::establishing(info);
+        connection
+            .open(Some(OriginAdmission::lease_for_test(&admission)))
+            .expect("bounded HTTP/2 connection did not open");
+        let generation =
+            OriginCell::install_h2_for_test(&connection_cell, connection.clone(), 1, None);
+        let activation = OriginCell::select_h2(&connection_cell)
+            .expect("local accepting generation did not activate");
+
+        let (waiter, demand) =
+            requesting_cell.register_waiter_without_publish(ProtocolRequirement::H1Required);
+        let action = OriginAdmission::publish_action_without_driving(
+            &admission,
+            requesting_cell.id().partition(),
+            demand,
+        );
+        assert!(
+            action.is_none(),
+            "busy local HTTP/2 generation remained eligible for reclaim"
+        );
+
+        assert!(OriginCell::cancel_waiter(&requesting_cell, waiter));
+        drop(activation);
+        assert_eq!(None, connection.snapshot().close_reason);
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::PoolDropped,
+        ));
+    }
+
+    #[test]
+    fn h1_required_demand_preserves_h2_without_an_http1_guarantee() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+
+        let admission = OriginAdmission::for_test_with_http1_guarantee(NonZeroUsize::MIN, false);
+        let connection_cell = bounded_cell(&admission, 1);
+        let requesting_cell = bounded_cell(&admission, 2);
+        let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
+        let (connection, _physical) = ConnectionState::establishing(info);
+        connection
+            .open(Some(OriginAdmission::lease_for_test(&admission)))
+            .expect("bounded HTTP/2 connection did not open");
+        let generation =
+            OriginCell::install_h2_for_test(&connection_cell, connection.clone(), 1, None);
+
+        let waiter = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Required);
+        assert!(
+            requesting_cell.take_ready_event(waiter).is_none(),
+            "H1-required demand reclaimed capacity without an HTTP/1 guarantee"
+        );
+        assert_eq!(None, connection.snapshot().close_reason);
+        assert_eq!(Some(generation), connection_cell.accepting_h2_generation());
+
+        assert!(OriginCell::close_h2(
+            &connection_cell,
+            generation,
+            CloseReason::ProtocolClosed,
+        ));
+        let super::super::AcquisitionEvent::Establish(permit) = requesting_cell
+            .take_ready_event(waiter)
+            .expect("ordinary H2 close did not release capacity")
+        else {
+            panic!("released capacity produced a non-establishment result");
+        };
+        drop(permit);
+        assert_eq!(1, admission.available_capacity_for_test());
+    }
+
+    #[test]
+    fn h1_required_demand_reclaims_idle_h2_capacity() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+
+        let admission = OriginAdmission::for_test(NonZeroUsize::MIN);
+        let connection_cell = bounded_cell(&admission, 1);
+        let requesting_cell = bounded_cell(&admission, 2);
+        let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
+        let (connection, _physical) = ConnectionState::establishing(info);
+        connection
+            .open(Some(OriginAdmission::lease_for_test(&admission)))
+            .expect("bounded HTTP/2 connection did not open");
+        OriginCell::install_h2_for_test(&connection_cell, connection.clone(), 1, None);
+
+        let waiter = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Required);
+        let super::super::AcquisitionEvent::Establish(permit) = requesting_cell
+            .take_ready_event(waiter)
+            .expect("idle HTTP/2 reclaim did not deliver capacity")
+        else {
+            panic!("idle HTTP/2 reclaim produced a non-capacity result");
+        };
+
+        assert_eq!(
+            Some(CloseReason::Reclaimed),
+            connection.snapshot().close_reason
+        );
+        assert_eq!(None, connection_cell.accepting_h2_generation());
+        drop(permit);
+        assert_eq!(1, admission.available_capacity_for_test());
+    }
+
+    #[test]
+    fn h1_required_demand_waits_for_active_h2_before_reclaim() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+
+        let admission = OriginAdmission::for_test(NonZeroUsize::MIN);
+        let connection_cell = bounded_cell(&admission, 1);
+        let requesting_cell = bounded_cell(&admission, 2);
+        let info = ConnectionInfo::for_test(ConnectionId::new(1), connection_cell.id().partition());
+        let (connection, _physical) = ConnectionState::establishing(info);
+        connection
+            .open(Some(OriginAdmission::lease_for_test(&admission)))
+            .expect("bounded HTTP/2 connection did not open");
+        let generation =
+            OriginCell::install_h2_for_test(&connection_cell, connection.clone(), 1, None);
+        let activation = OriginCell::activate_h2(&connection_cell, generation)
+            .expect("accepting HTTP/2 generation did not activate");
+
+        let waiter = OriginCell::register_waiter(&requesting_cell, ProtocolRequirement::H1Required);
+        assert!(
+            requesting_cell.take_ready_event(waiter).is_none(),
+            "active HTTP/2 generation was reclaimed"
+        );
+        assert_eq!(None, connection.snapshot().close_reason);
+
+        drop(activation);
+        let super::super::AcquisitionEvent::Establish(permit) = requesting_cell
+            .take_ready_event(waiter)
+            .expect("idle transition did not resume H1-required demand")
+        else {
+            panic!("idle HTTP/2 reclaim produced a non-capacity result");
+        };
+        assert_eq!(
+            Some(CloseReason::Reclaimed),
+            connection.snapshot().close_reason
+        );
+        drop(permit);
+        assert_eq!(1, admission.available_capacity_for_test());
+    }
+
+    #[test]
     fn pool_shutdown_closes_an_accepting_generation() {
         let cell = cell();
         let (_generation, connection, _physical) = install_generation(&cell, 1);
@@ -2334,21 +3386,11 @@ mod loom_tests {
     }
 
     fn install_generation(cell: &Arc<OriginCell>) -> (H2GenerationId, Arc<ConnectionState>) {
-        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(WaiterId(0)) else {
-            panic!("fresh cell did not create an HTTP/2 flight");
-        };
         let (connection, _physical) = ConnectionState::unbounded(ConnectionInfo::for_test(
             ConnectionId::new(1),
             PartitionId::from_index(1),
         ));
-        let generation = OriginCell::complete_h2_flight(
-            cell,
-            flight,
-            connection.clone(),
-            H2Sender::test(1),
-            None,
-        )
-        .expect("flight did not install");
+        let generation = OriginCell::install_h2_for_test(cell, connection.clone(), 1, None);
         (generation, connection)
     }
 
@@ -2376,7 +3418,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn lease_endpoints_release_one_dispatch_under_race() {
+    fn concurrent_lease_endpoint_completion_releases_one_dispatch() {
         loom::model(|| {
             let cell = cell();
             let (generation, connection) = install_generation(&cell);
@@ -2404,6 +3446,50 @@ mod loom_tests {
                 .get(&generation)
                 .expect("accepting generation disappeared");
             assert_eq!(0, record.accepted);
+        });
+    }
+
+    #[test]
+    fn generation_close_waits_for_both_lease_endpoints() {
+        loom::model(|| {
+            let cell = cell();
+            let (connection, _physical) = ConnectionState::unbounded(ConnectionInfo::for_test(
+                ConnectionId::new(1),
+                PartitionId::from_index(1),
+            ));
+            let generation = OriginCell::install_h2_for_test(&cell, connection.clone(), 1, None);
+            let mut activation =
+                OriginCell::activate_h2(&cell, generation).expect("generation did not activate");
+            let H2DispatchParts {
+                sender: _sender,
+                send_endpoint: send,
+                receive_endpoint: receive,
+            } = activation.take_dispatch_parts();
+            let dispatch = ConnectionState::try_commit_dispatch(&connection)
+                .expect("open connection rejected dispatch");
+            activation.accept(dispatch);
+
+            let first_endpoint = loom::thread::spawn(move || drop(send));
+            let closing_cell = cell.clone();
+            let close = loom::thread::spawn(move || {
+                OriginCell::close_h2(&closing_cell, generation, CloseReason::ProtocolClosed)
+            });
+            first_endpoint.join().unwrap();
+            assert!(close.join().unwrap());
+
+            assert_eq!(1, connection.snapshot().in_flight);
+            assert_eq!(
+                Some((0, 1)),
+                cell.h2_request_counts(generation),
+                "draining generation released before its second endpoint"
+            );
+            drop(receive);
+            assert_eq!(0, connection.snapshot().in_flight);
+            assert_eq!(
+                None,
+                cell.h2_request_counts(generation),
+                "finished draining generation remained installed"
+            );
         });
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/h2.rs
@@ -1,0 +1,2409 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! HTTP/2 flight, generation, route, and request-lease ownership.
+//!
+//! One connection-owning cell stores the authoritative HTTP/2 generation.
+//! Other cells store only [`H2Route`] identities and revalidate them at the
+//! connection-owning cell before dispatch. A generation may stop accepting
+//! new requests while prospective and accepted requests still drain.
+//!
+//! [`H2Records`] is the invariant owner under the cell lock. It stores one
+//! post-ALPN flight, the accepting and draining generations, a local generation
+//! gate, and at most one peer route. A route carries only connection partition
+//! and generation identity. [`H2Activation`] is the unlocked value that carries
+//! a prospective lease and transient sender from selection to Hyper acceptance.
+//!
+//! ```text
+//! requesting cell                        connection-owning cell
+//! peer route + local gate --identity---> exact accepting generation
+//!                                      |-- increment prospective count
+//!                                      `-- clone transient sender
+//!                                               |
+//!                                               `--> H2Activation
+//! ```
+//!
+//! ```text
+//! no flight -- post-ALPN driver --------------------------> Flight
+//! Flight -- successful handshake ------------------------> Accepting
+//! Flight -- failure or task drop -------------------------> no flight
+//! Accepting -- poison, GOAWAY, timeout, or shutdown ------> Draining
+//! Draining -- last prospective or accepted lease --------> removed
+//! ```
+//!
+//! Activation reserves a prospective lease before a sender clone leaves the
+//! cell lock. Hyper acceptance converts that reservation to one accepted
+//! lease. The accepted lease is released only after both request-send and
+//! response-receive endpoints terminate.
+
+use super::super::connection::{ConnectionInfo, ConnectionState, DispatchGuard};
+use super::super::partition::PartitionId;
+use super::waiters::{AcquisitionQueue, H2WaiterInstall};
+use super::{AcquisitionEvent, AcquisitionResult, CellState, OriginCell, WaiterId};
+use crate::sync::{Arc, Mutex, Weak};
+use aws_smithy_types::body::SdkBody;
+use std::collections::{BTreeSet, HashMap};
+use std::time::SystemTime;
+
+/// Identity of one post-ALPN HTTP/2 establishment flight.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(in crate::client::pool) struct H2FlightId(u64);
+
+/// Identity of one installed HTTP/2 generation within a cell.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(in crate::client::pool) struct H2GenerationId(u64);
+
+#[cfg(test)]
+impl H2GenerationId {
+    /// Creates a generation identity for admission-index tests.
+    pub(in crate::client::pool) fn for_test(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Cloneable Hyper request sender retained only by its owning generation.
+///
+/// The test-only variant exercises generation and lease transitions without a
+/// parallel fake generation implementation.
+#[derive(Clone)]
+pub(in crate::client::pool) enum H2Sender {
+    /// Sender returned by a successful Hyper HTTP/2 handshake.
+    Hyper(hyper::client::conn::http2::SendRequest<SdkBody>),
+    /// Synthetic sender identity used by state-machine tests.
+    #[cfg(test)]
+    Test(u64),
+}
+
+impl H2Sender {
+    /// Wraps a sender produced by a successful Hyper HTTP/2 handshake.
+    pub(in crate::client::pool) fn from_hyper(
+        inner: hyper::client::conn::http2::SendRequest<SdkBody>,
+    ) -> Self {
+        Self::Hyper(inner)
+    }
+
+    /// Returns whether Hyper has observed connection closure.
+    pub(in crate::client::pool) fn is_closed(&self) -> bool {
+        match self {
+            Self::Hyper(sender) => sender.is_closed(),
+            #[cfg(test)]
+            Self::Test(_) => false,
+        }
+    }
+
+    /// Returns mutable access to a transient sender clone for dispatch.
+    ///
+    /// # Panics
+    ///
+    /// Panics when a test-only sender reaches real dispatch.
+    pub(in crate::client::pool) fn hyper_mut(
+        &mut self,
+    ) -> &mut hyper::client::conn::http2::SendRequest<SdkBody> {
+        match self {
+            Self::Hyper(sender) => sender,
+            #[cfg(test)]
+            Self::Test(_) => panic!("test HTTP/2 sender reached Hyper dispatch"),
+        }
+    }
+
+    /// Creates a synthetic sender for state-machine tests.
+    #[cfg(test)]
+    fn test(id: u64) -> Self {
+        Self::Test(id)
+    }
+}
+
+impl std::fmt::Debug for H2Sender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hyper(_) => f.write_str("H2Sender::Hyper"),
+            #[cfg(test)]
+            Self::Test(id) => f.debug_tuple("H2Sender::Test").field(id).finish(),
+        }
+    }
+}
+
+/// Identity-only reference to one accepting generation.
+///
+/// The route owns no sender, connection capacity, driver, or socket. Every
+/// activation upgrades the cell reference and checks the generation identity.
+#[derive(Clone, Debug)]
+pub(in crate::client::pool) struct H2Route {
+    id: H2RouteId,
+    connection_cell: Weak<OriginCell>,
+}
+
+/// Exact connection-owning generation named by one peer route.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) struct H2RouteId {
+    connection_partition: PartitionId,
+    generation: H2GenerationId,
+}
+
+impl H2Route {
+    /// Creates a route after its generation has been installed.
+    pub(in crate::client::pool) fn new(
+        connection_cell: &Arc<OriginCell>,
+        generation: H2GenerationId,
+    ) -> Self {
+        Self {
+            connection_cell: Weak::from_arc(connection_cell),
+            id: H2RouteId {
+                connection_partition: connection_cell.id().partition(),
+                generation,
+            },
+        }
+    }
+
+    /// Returns the exact connection-owning generation named by this route.
+    fn id(&self) -> H2RouteId {
+        self.id
+    }
+
+    /// Returns the partition that owns the advertised generation.
+    pub(super) fn connection_partition(&self) -> PartitionId {
+        self.id.connection_partition
+    }
+
+    /// Returns the advertised generation identity.
+    #[cfg(any(debug_assertions, test))]
+    pub(in crate::client::pool) fn generation(&self) -> H2GenerationId {
+        self.id.generation
+    }
+
+    /// Attempts to reserve a prospective request lease for one requesting partition.
+    pub(super) fn activate(&self, request_partition: PartitionId) -> Option<H2Activation> {
+        let cell = self.connection_cell.upgrade()?;
+        let mut activation = OriginCell::activate_h2(&cell, self.id.generation)?;
+        activation.request_partition = request_partition;
+        Some(activation)
+    }
+}
+
+/// Cell-local ownership of one HTTP/2 flight and installed generations.
+///
+/// At every completed transition:
+///
+/// - at most one flight and one accepting generation exist;
+/// - the accepting identity names an `Accepting` record;
+/// - every other generation is `Draining`;
+/// - prospective and accepted request counts are checked and non-wrapping;
+/// - a draining record remains until both counts reach zero; and
+/// - flight participants name distinct live waiter identities.
+#[derive(Debug, Default)]
+pub(super) struct H2Records {
+    flight: Option<H2Flight>,
+    generations: HashMap<H2GenerationId, H2Generation>,
+    accepting: Option<H2GenerationId>,
+    /// Identity-only route to one peer cell's accepting generation.
+    peer_route: Option<PeerH2Route>,
+    /// Local activation order for the accepting generation.
+    gate: GenerationGate,
+    next_flight: u64,
+    next_generation: u64,
+}
+
+/// One post-ALPN flight and the waiters awaiting its result.
+#[derive(Debug)]
+struct H2Flight {
+    id: H2FlightId,
+    participants: BTreeSet<WaiterId>,
+}
+
+/// One installed multiplexed connection generation.
+#[derive(Debug)]
+struct H2Generation {
+    connection: Arc<ConnectionState>,
+    sender: H2Sender,
+    residence: H2Residence,
+    prospective: usize,
+    /// Whether Hyper has accepted a request on this generation.
+    has_dispatched: bool,
+    accepted: usize,
+    idle_deadline: Option<SystemTime>,
+}
+
+/// Whether an installed generation may accept new requests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum H2Residence {
+    Accepting,
+    Draining,
+}
+
+/// Peer route visibility and requesting-cell activation order.
+#[derive(Debug)]
+struct PeerH2Route {
+    route: H2Route,
+    gate: GenerationGate,
+}
+
+/// Local priority state for one accepting generation.
+#[derive(Debug, Default)]
+enum GenerationGate {
+    /// No accepting generation is visible.
+    #[default]
+    Closed,
+    /// Waiters committed through `cutoff` precede later arrivals.
+    Prioritizing {
+        generation: H2GenerationId,
+        cutoff: WaiterId,
+        activating: Option<WaiterId>,
+    },
+    /// The publication cutoff drained; queued work still precedes direct arrivals.
+    Open {
+        generation: H2GenerationId,
+        activating: Option<WaiterId>,
+    },
+}
+
+impl GenerationGate {
+    /// Creates a gate over every waiter committed through `cutoff`.
+    fn for_generation(generation: H2GenerationId, cutoff: Option<WaiterId>) -> Self {
+        match cutoff {
+            Some(cutoff) => Self::Prioritizing {
+                generation,
+                cutoff,
+                activating: None,
+            },
+            None => Self::Open {
+                generation,
+                activating: None,
+            },
+        }
+    }
+
+    fn generation(&self) -> Option<H2GenerationId> {
+        match self {
+            Self::Closed => None,
+            Self::Prioritizing { generation, .. } | Self::Open { generation, .. } => {
+                Some(*generation)
+            }
+        }
+    }
+
+    /// Returns the cutoff for the next activation, or `None` when open.
+    fn service_cutoff(&mut self, has_prioritized: bool) -> Option<Option<WaiterId>> {
+        match self {
+            Self::Closed => None,
+            Self::Prioritizing {
+                cutoff,
+                activating,
+                generation,
+            } => {
+                if activating.is_some() {
+                    return None;
+                }
+                if !has_prioritized {
+                    let generation = *generation;
+                    *self = Self::Open {
+                        generation,
+                        activating: None,
+                    };
+                    Some(None)
+                } else {
+                    Some(Some(*cutoff))
+                }
+            }
+            Self::Open { activating, .. } => activating.is_none().then_some(None),
+        }
+    }
+
+    /// Records the waiter whose activation must accept or cancel next.
+    fn begin_gate_activation(&mut self, waiter: WaiterId) {
+        let activating = match self {
+            Self::Closed => {
+                unreachable!("started an HTTP/2 activation while its gate was closed")
+            }
+            Self::Prioritizing { activating, .. } | Self::Open { activating, .. } => activating,
+        };
+        assert!(
+            activating.replace(waiter).is_none(),
+            "HTTP/2 generation gate admitted two activation opportunities"
+        );
+    }
+
+    /// Discharges one exact activation opportunity.
+    fn finish_gate_activation(&mut self, generation: H2GenerationId, waiter: WaiterId) -> bool {
+        if self.generation() != Some(generation) {
+            return false;
+        }
+        let activating = match self {
+            Self::Closed => return false,
+            Self::Prioritizing { activating, .. } | Self::Open { activating, .. } => activating,
+        };
+        if *activating != Some(waiter) {
+            return false;
+        }
+        *activating = None;
+        true
+    }
+
+    fn priority_cutoff(&self) -> Option<WaiterId> {
+        match self {
+            Self::Prioritizing { cutoff, .. } => Some(*cutoff),
+            Self::Closed | Self::Open { .. } => None,
+        }
+    }
+
+    fn activating(&self) -> Option<WaiterId> {
+        match self {
+            Self::Closed => None,
+            Self::Prioritizing { activating, .. } | Self::Open { activating, .. } => *activating,
+        }
+    }
+}
+
+/// Result of atomically converging one post-ALPN attempt.
+#[derive(Debug)]
+pub(in crate::client::pool) enum H2FlightInstall {
+    Accepting(H2GenerationId),
+    Joined,
+    Driver(H2FlightId),
+}
+
+impl H2Records {
+    /// Installs or joins the one current flight after ALPN selected HTTP/2.
+    pub(super) fn install_or_join_flight(&mut self, waiter: WaiterId) -> H2FlightInstall {
+        if let Some(generation) = self.accepting {
+            return H2FlightInstall::Accepting(generation);
+        }
+        if let Some(flight) = &mut self.flight {
+            assert!(
+                flight.participants.insert(waiter),
+                "HTTP/2 waiter joined one flight more than once"
+            );
+            self.assert_consistent();
+            return H2FlightInstall::Joined;
+        }
+
+        let id = self.take_flight_id();
+        self.flight = Some(H2Flight {
+            id,
+            participants: BTreeSet::from([waiter]),
+        });
+        self.assert_consistent();
+        H2FlightInstall::Driver(id)
+    }
+
+    /// Removes one cancelled waiter from its current flight, when present.
+    pub(super) fn cancel_flight_participant(&mut self, waiter: WaiterId) -> Option<H2FlightId> {
+        let flight = self.flight.as_mut()?;
+        if !flight.participants.remove(&waiter) {
+            return None;
+        }
+        let id = flight.id;
+        self.assert_consistent();
+        Some(id)
+    }
+
+    /// Installs the generation produced by the named flight.
+    pub(in crate::client::pool) fn complete_flight(
+        &mut self,
+        flight: H2FlightId,
+        connection: Arc<ConnectionState>,
+        sender: H2Sender,
+        idle_deadline: Option<SystemTime>,
+    ) -> Result<H2GenerationId, (Arc<ConnectionState>, H2Sender)> {
+        if self.flight.as_ref().map(|current| current.id) != Some(flight)
+            || self.accepting.is_some()
+        {
+            return Err((connection, sender));
+        }
+        let flight = self
+            .flight
+            .take()
+            .expect("validated HTTP/2 flight disappeared");
+        let generation = self.take_generation_id();
+        let replaced = self.generations.insert(
+            generation,
+            H2Generation {
+                connection,
+                sender,
+                residence: H2Residence::Accepting,
+                prospective: 0,
+                has_dispatched: false,
+                accepted: 0,
+                idle_deadline,
+            },
+        );
+        assert!(replaced.is_none(), "HTTP/2 generation identity was reused");
+        self.accepting = Some(generation);
+        self.peer_route = None;
+        debug_assert!(matches!(self.gate, GenerationGate::Closed));
+        self.gate = GenerationGate::Open {
+            generation,
+            activating: None,
+        };
+        self.assert_consistent();
+        drop(flight);
+        Ok(generation)
+    }
+
+    /// Retires a failed or dropped flight and returns its participants.
+    pub(super) fn fail_flight(&mut self, flight: H2FlightId) -> Option<Vec<WaiterId>> {
+        if self.flight.as_ref().map(|current| current.id) != Some(flight) {
+            return None;
+        }
+        let participants = self
+            .flight
+            .take()
+            .expect("validated HTTP/2 flight disappeared")
+            .participants
+            .into_iter()
+            .collect();
+        self.assert_consistent();
+        Some(participants)
+    }
+
+    /// Closes the gate over waiters committed when a generation became visible.
+    pub(super) fn prioritize_through(&mut self, cutoff: Option<WaiterId>) {
+        let generation = self
+            .accepting
+            .expect("HTTP/2 generation gate opened without an accepting generation");
+        self.gate = GenerationGate::for_generation(generation, cutoff);
+        self.assert_consistent();
+    }
+
+    /// Extends priority to a post-ALPN waiter that found this generation.
+    pub(super) fn prioritize_waiter(
+        &mut self,
+        generation: H2GenerationId,
+        waiter: WaiterId,
+    ) -> bool {
+        if self.accepting != Some(generation) {
+            return false;
+        }
+        match &mut self.gate {
+            GenerationGate::Closed => {
+                unreachable!("accepting HTTP/2 generation had no generation gate")
+            }
+            GenerationGate::Prioritizing { cutoff, .. } => {
+                *cutoff = (*cutoff).max(waiter);
+            }
+            GenerationGate::Open { activating, .. } => {
+                let activating = *activating;
+                self.gate = GenerationGate::Prioritizing {
+                    generation,
+                    cutoff: waiter,
+                    activating,
+                };
+            }
+        }
+        self.assert_consistent();
+        true
+    }
+
+    /// Returns the cutoff for the next queued activation, or `None` when open.
+    pub(super) fn service_cutoff(&mut self, has_prioritized: bool) -> Option<Option<WaiterId>> {
+        self.gate.service_cutoff(has_prioritized)
+    }
+
+    /// Records the one waiter whose activation must accept or cancel next.
+    pub(super) fn begin_gate_activation(&mut self, waiter: WaiterId) {
+        self.gate.begin_gate_activation(waiter);
+        self.assert_consistent();
+    }
+
+    /// Discharges one accepted or cancelled activation opportunity.
+    pub(super) fn finish_gate_activation(
+        &mut self,
+        generation: H2GenerationId,
+        waiter: WaiterId,
+    ) -> bool {
+        let finished = self.gate.finish_gate_activation(generation, waiter);
+        self.assert_consistent();
+        finished
+    }
+
+    /// Returns whether a direct arrival may use the accepting generation.
+    pub(super) fn direct_is_allowed(&self, queued: bool) -> bool {
+        !queued
+            && matches!(
+                self.gate,
+                GenerationGate::Open {
+                    activating: None,
+                    ..
+                }
+            )
+    }
+
+    /// Returns the publication cutoff while older waiters remain prioritized.
+    fn priority_cutoff(&self) -> Option<WaiterId> {
+        self.gate.priority_cutoff()
+    }
+
+    /// Reserves one prospective lease against an accepting generation.
+    fn activate(&mut self, generation: H2GenerationId) -> Option<H2ActivationParts> {
+        if self.accepting != Some(generation) {
+            return None;
+        }
+        let record = self.generations.get_mut(&generation)?;
+        if record.residence != H2Residence::Accepting {
+            return None;
+        }
+        record.prospective = record
+            .prospective
+            .checked_add(1)
+            .expect("HTTP/2 prospective request count exhausted");
+        let parts = H2ActivationParts {
+            sender: record.sender.clone(),
+            reused: record.has_dispatched,
+            connection: record.connection.clone(),
+        };
+        self.assert_consistent();
+        Some(parts)
+    }
+
+    /// Converts one prospective reservation to an accepted request lease.
+    fn accept(&mut self, generation: H2GenerationId) -> bool {
+        let Some(record) = self.generations.get_mut(&generation) else {
+            return false;
+        };
+        if record.prospective == 0 {
+            return false;
+        }
+        record.prospective -= 1;
+        record.accepted = record
+            .accepted
+            .checked_add(1)
+            .expect("HTTP/2 accepted request count exhausted");
+        record.has_dispatched = true;
+        self.assert_consistent();
+        true
+    }
+
+    /// Cancels one prospective reservation and removes an empty drain record.
+    fn cancel(&mut self, generation: H2GenerationId) {
+        let Some(record) = self.generations.get_mut(&generation) else {
+            return;
+        };
+        if record.prospective == 0 {
+            return;
+        }
+        record.prospective -= 1;
+        self.remove_finished_drain(generation);
+        self.assert_consistent();
+    }
+
+    /// Releases one accepted request after both endpoints terminate.
+    fn complete_request(&mut self, generation: H2GenerationId) {
+        let Some(record) = self.generations.get_mut(&generation) else {
+            return;
+        };
+        assert!(
+            record.accepted > 0,
+            "HTTP/2 accepted request count underflowed"
+        );
+        record.accepted -= 1;
+        self.remove_finished_drain(generation);
+        self.assert_consistent();
+    }
+
+    /// Moves one exact accepting generation to draining.
+    pub(super) fn begin_close(
+        &mut self,
+        generation: H2GenerationId,
+    ) -> Option<Arc<ConnectionState>> {
+        if self.accepting != Some(generation) {
+            return None;
+        }
+        let record = self.generations.get_mut(&generation)?;
+        if record.residence != H2Residence::Accepting {
+            return None;
+        }
+        record.residence = H2Residence::Draining;
+        self.accepting = None;
+        self.gate = GenerationGate::Closed;
+        let remove_record = record.prospective == 0 && record.accepted == 0;
+        let connection = record.connection.clone();
+        if remove_record {
+            self.generations.remove(&generation);
+        }
+        Some(connection)
+    }
+
+    /// Returns the accepting generation when one is locally reusable.
+    pub(in crate::client::pool) fn accepting(&self) -> Option<H2GenerationId> {
+        self.accepting
+    }
+
+    /// Returns whether an exact generation remains accepting.
+    pub(super) fn is_accepting(&self, generation: H2GenerationId) -> bool {
+        self.accepting == Some(generation)
+    }
+
+    /// Returns the generation peers may discover after the local cutoff drains.
+    pub(super) fn publishable_generation(&self) -> Option<H2GenerationId> {
+        let generation = self.accepting?;
+        matches!(
+            self.gate,
+            GenerationGate::Open {
+                generation: gate_generation,
+                ..
+            } if gate_generation == generation
+        )
+        .then_some(generation)
+    }
+
+    /// Returns whether a local generation or peer route suppresses admission demand.
+    pub(super) fn has_visible_h2(&self) -> bool {
+        self.accepting.is_some() || self.peer_route.is_some()
+    }
+
+    /// Installs or refreshes one identity-only peer route.
+    pub(super) fn install_peer_route(&mut self, route: H2Route, cutoff: Option<WaiterId>) {
+        if self.accepting.is_some() {
+            self.peer_route = None;
+            self.assert_consistent();
+            return;
+        }
+        let id = route.id();
+        match &mut self.peer_route {
+            Some(current) if current.route.id() == id => {
+                if let Some(cutoff) = cutoff {
+                    match &mut current.gate {
+                        GenerationGate::Closed => {
+                            unreachable!("visible peer HTTP/2 route had a closed gate")
+                        }
+                        GenerationGate::Prioritizing {
+                            cutoff: current, ..
+                        } => *current = (*current).max(cutoff),
+                        GenerationGate::Open {
+                            generation,
+                            activating,
+                        } => {
+                            current.gate = GenerationGate::Prioritizing {
+                                generation: *generation,
+                                cutoff,
+                                activating: *activating,
+                            };
+                        }
+                    }
+                }
+            }
+            _ => {
+                self.peer_route = Some(PeerH2Route {
+                    gate: GenerationGate::for_generation(id.generation, cutoff),
+                    route,
+                });
+            }
+        }
+        self.assert_consistent();
+    }
+
+    /// Marks one requesting waiter as the route's current activation opportunity.
+    fn prepare_peer_activation(
+        &mut self,
+        waiters: &AcquisitionQueue,
+    ) -> Option<PreparedPeerActivation> {
+        let peer = self.peer_route.as_mut()?;
+        let has_prioritized = peer
+            .gate
+            .priority_cutoff()
+            .is_some_and(|cutoff| waiters.has_h2_candidate_through(cutoff));
+        let cutoff = peer.gate.service_cutoff(has_prioritized)?;
+        let waiter = waiters.oldest_h2_candidate()?;
+        if cutoff.is_some_and(|cutoff| waiter > cutoff) {
+            return None;
+        }
+        peer.gate.begin_gate_activation(waiter);
+        Some(PreparedPeerActivation {
+            route: peer.route.clone(),
+            waiter,
+            cutoff,
+        })
+    }
+
+    /// Revalidates one peer activation after the connection-cell crossing.
+    fn peer_activation_is_current(
+        &self,
+        prepared: &PreparedPeerActivation,
+        waiters: &AcquisitionQueue,
+    ) -> bool {
+        self.peer_route.as_ref().is_some_and(|peer| {
+            peer.route.id() == prepared.route.id()
+                && peer.gate.activating() == Some(prepared.waiter)
+                && waiters.is_oldest_h2_candidate(prepared.waiter)
+        })
+    }
+
+    /// Discharges one exact peer-route activation opportunity.
+    fn finish_peer_activation(&mut self, route: H2RouteId, waiter: WaiterId) -> bool {
+        let Some(peer) = &mut self.peer_route else {
+            return false;
+        };
+        if peer.route.id() != route {
+            return false;
+        }
+        let finished = peer.gate.finish_gate_activation(route.generation, waiter);
+        self.assert_consistent();
+        finished
+    }
+
+    /// Clears a peer activation marker when its requesting waiter is cancelled.
+    pub(super) fn cancel_peer_activation(&mut self, waiter: WaiterId) -> bool {
+        let Some(route) = self.peer_route.as_ref().map(|peer| peer.route.id()) else {
+            return false;
+        };
+        if self
+            .peer_route
+            .as_ref()
+            .and_then(|peer| peer.gate.activating())
+            != Some(waiter)
+        {
+            return false;
+        }
+        self.finish_peer_activation(route, waiter)
+    }
+
+    /// Removes one stale exact peer route.
+    fn clear_peer_route(&mut self, route: H2RouteId) -> bool {
+        if self.peer_route.as_ref().map(|peer| peer.route.id()) != Some(route) {
+            return false;
+        }
+        self.peer_route = None;
+        self.assert_consistent();
+        true
+    }
+
+    /// Returns all installed generation identities for shutdown.
+    pub(super) fn generation_ids(&self) -> Vec<H2GenerationId> {
+        self.generations.keys().copied().collect()
+    }
+
+    /// Returns the accepting generation's idle deadline.
+    pub(super) fn nearest_idle_deadline(&self) -> Option<SystemTime> {
+        self.accepting
+            .and_then(|generation| self.generations.get(&generation))
+            .and_then(|record| record.idle_deadline)
+    }
+
+    /// Returns an accepting generation whose idle deadline elapsed.
+    pub(super) fn expired(&self, now: SystemTime) -> Option<H2GenerationId> {
+        let generation = self.accepting?;
+        let deadline = self.generations.get(&generation)?.idle_deadline?;
+        (deadline <= now).then_some(generation)
+    }
+
+    /// Replaces the accepting generation's idle deadline after dispatch.
+    pub(super) fn reset_idle_deadline(
+        &mut self,
+        generation: H2GenerationId,
+        deadline: Option<SystemTime>,
+    ) -> bool {
+        if self.accepting != Some(generation) {
+            return false;
+        }
+        let record = self
+            .generations
+            .get_mut(&generation)
+            .expect("accepting HTTP/2 generation disappeared");
+        record.idle_deadline = deadline;
+        self.assert_consistent();
+        true
+    }
+
+    /// Removes a draining generation after its last retained request ends.
+    fn remove_finished_drain(&mut self, generation: H2GenerationId) {
+        let remove = self.generations.get(&generation).is_some_and(|record| {
+            record.residence == H2Residence::Draining
+                && record.prospective == 0
+                && record.accepted == 0
+        });
+        if remove {
+            self.generations.remove(&generation);
+        }
+    }
+
+    fn take_flight_id(&mut self) -> H2FlightId {
+        let value = self.next_flight;
+        self.next_flight = value
+            .checked_add(1)
+            .expect("HTTP/2 flight identity exhausted");
+        H2FlightId(value)
+    }
+
+    fn take_generation_id(&mut self) -> H2GenerationId {
+        let value = self.next_generation;
+        self.next_generation = value
+            .checked_add(1)
+            .expect("HTTP/2 generation identity exhausted");
+        H2GenerationId(value)
+    }
+
+    /// Checks flight, generation, residence, and request-count relationships.
+    pub(super) fn assert_consistent(&self) {
+        #[cfg(any(debug_assertions, test))]
+        {
+            let accepting_records = self
+                .generations
+                .iter()
+                .filter(|(_, record)| record.residence == H2Residence::Accepting)
+                .map(|(generation, _)| *generation)
+                .collect::<Vec<_>>();
+            match self.accepting {
+                Some(generation) => assert_eq!(
+                    vec![generation],
+                    accepting_records,
+                    "HTTP/2 accepting identity did not match generation residence"
+                ),
+                None => assert!(
+                    accepting_records.is_empty(),
+                    "HTTP/2 accepting generation lacked an accepting identity"
+                ),
+            }
+            assert_eq!(
+                self.accepting,
+                self.gate.generation(),
+                "HTTP/2 generation gate did not name the accepting generation"
+            );
+            assert!(
+                self.flight.is_none() || self.accepting.is_none(),
+                "HTTP/2 flight coexisted with an accepting generation"
+            );
+            if let Some(peer) = &self.peer_route {
+                assert!(
+                    self.accepting.is_none(),
+                    "local accepting generation retained a peer route"
+                );
+                assert_eq!(
+                    Some(peer.route.generation()),
+                    peer.gate.generation(),
+                    "peer route gate did not name the advertised generation"
+                );
+            }
+
+            for record in self.generations.values() {
+                if record.residence == H2Residence::Draining {
+                    assert!(
+                        record.prospective > 0 || record.accepted > 0,
+                        "empty HTTP/2 draining generation was retained"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// One requesting-cell activation prepared before crossing to its connection cell.
+struct PreparedPeerActivation {
+    route: H2Route,
+    waiter: WaiterId,
+    cutoff: Option<WaiterId>,
+}
+
+/// Sender and connection cloned while a prospective lease is state-owned.
+struct H2ActivationParts {
+    sender: H2Sender,
+    reused: bool,
+    connection: Arc<ConnectionState>,
+}
+
+/// Values transferred together when an activation begins Hyper dispatch.
+pub(in crate::client::pool) struct H2DispatchParts {
+    /// Transient sender clone for one dispatch attempt.
+    pub(in crate::client::pool) sender: H2Sender,
+    /// Request-send endpoint retained by the request body.
+    pub(in crate::client::pool) send_endpoint: H2LeaseEndpoint,
+    /// Response-receive endpoint retained by the response body.
+    pub(in crate::client::pool) receive_endpoint: H2LeaseEndpoint,
+}
+
+/// Prospective request reservation against one exact generation.
+///
+/// Dropping the activation before Hyper accepts the request cancels the
+/// prospective reservation. Acceptance creates endpoint guards and transfers
+/// dispatch accounting to the response lifecycle.
+pub(in crate::client::pool) struct H2Activation {
+    cell: Arc<OriginCell>,
+    request_partition: PartitionId,
+    generation: H2GenerationId,
+    sender: Option<H2Sender>,
+    reused: bool,
+    connection: Arc<ConnectionState>,
+    lease: Arc<H2LeaseCore>,
+    /// Requesting-cell priority discharged only at acceptance or cancellation.
+    gate: Option<H2GateToken>,
+    active: bool,
+}
+
+impl std::fmt::Debug for H2Activation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("H2Activation")
+            .field("generation", &self.generation)
+            .field("connection_id", &self.connection.id())
+            .field("active", &self.active)
+            .finish()
+    }
+}
+
+impl H2Activation {
+    /// Builds an activation after the generation records its prospective lease.
+    fn new(
+        cell: Arc<OriginCell>,
+        generation: H2GenerationId,
+        parts: H2ActivationParts,
+        gate: Option<H2GateToken>,
+    ) -> Self {
+        let request_partition = cell.id().partition();
+        let lease = Arc::new(H2LeaseCore {
+            cell: Weak::from_arc(&cell),
+            generation,
+            state: Mutex::new(H2LeaseState::Prospective {
+                send_complete: false,
+                receive_complete: false,
+            }),
+        });
+        Self {
+            cell,
+            request_partition,
+            generation,
+            sender: Some(parts.sender),
+            reused: parts.reused,
+            connection: parts.connection,
+            lease,
+            gate,
+            active: true,
+        }
+    }
+
+    /// Returns the exact selected generation.
+    #[cfg(test)]
+    pub(in crate::client::pool) fn generation(&self) -> H2GenerationId {
+        self.generation
+    }
+
+    /// Returns whether Hyper previously accepted a request on this generation.
+    pub(in crate::client::pool) fn is_reused(&self) -> bool {
+        self.reused
+    }
+
+    /// Returns the selected protocol-neutral connection.
+    pub(in crate::client::pool) fn connection(&self) -> &Arc<ConnectionState> {
+        &self.connection
+    }
+
+    /// Transfers the sender and both lease endpoints into one dispatch attempt.
+    ///
+    /// # Panics
+    ///
+    /// Panics if dispatch parts were already taken.
+    pub(in crate::client::pool) fn take_dispatch_parts(&mut self) -> H2DispatchParts {
+        let sender = self
+            .sender
+            .take()
+            .expect("HTTP/2 activation dispatch parts already taken");
+        let trace = H2EndpointTrace::new(self);
+        H2DispatchParts {
+            sender,
+            send_endpoint: H2LeaseEndpoint::new(
+                self.lease.clone(),
+                H2Endpoint::Send,
+                Some(trace.clone()),
+            ),
+            receive_endpoint: H2LeaseEndpoint::new(
+                self.lease.clone(),
+                H2Endpoint::Receive,
+                Some(trace),
+            ),
+        }
+    }
+
+    /// Retains a requesting-cell route opportunity until acceptance or cancellation.
+    fn attach_peer_gate(
+        &mut self,
+        requesting_cell: &Arc<OriginCell>,
+        route: H2RouteId,
+        waiter: WaiterId,
+    ) {
+        debug_assert_eq!(
+            self.request_partition,
+            requesting_cell.id().partition(),
+            "peer HTTP/2 activation changed requesting partition"
+        );
+        assert!(
+            self.gate.is_none(),
+            "HTTP/2 activation acquired two requesting-cell gates"
+        );
+        self.gate = Some(H2GateToken::peer(requesting_cell, route, waiter));
+    }
+
+    /// Returns close authority for the connection-owning generation.
+    pub(in crate::client::pool) fn close_handle(&self) -> H2CloseHandle {
+        H2CloseHandle::new(&self.cell, self.generation)
+    }
+
+    /// Converts the prospective reservation after Hyper accepts the request.
+    ///
+    /// # Panics
+    ///
+    /// Panics if dispatch parts were not transferred or the prospective
+    /// reservation disappeared before acceptance.
+    pub(in crate::client::pool) fn accept(mut self, dispatch: DispatchGuard) {
+        assert!(
+            self.sender.is_none(),
+            "HTTP/2 activation accepted before dispatch parts were taken"
+        );
+        assert!(
+            OriginCell::accept_h2_activation(&self.cell, self.generation),
+            "prospective HTTP/2 activation disappeared before acceptance"
+        );
+        self.active = false;
+        self.lease.accept(dispatch);
+        if let Some(gate) = self.gate.take() {
+            gate.finish();
+        }
+        tracing::trace!(
+            connection_id = %self.connection.id(),
+            request_partition = ?self.request_partition,
+            connection_partition = ?self.connection.owner_partition(),
+            origin_scheme = %self.connection.info().origin().scheme(),
+            origin_host = self.connection.info().origin().host(),
+            origin_port = ?self.connection.info().origin().port(),
+            h2_generation = ?self.generation,
+            "HTTP/2 request accepted"
+        );
+    }
+}
+
+impl Drop for H2Activation {
+    fn drop(&mut self) {
+        if self.active {
+            OriginCell::cancel_h2_activation(&self.cell, self.generation);
+            self.lease.cancel();
+            if let Some(gate) = self.gate.take() {
+                gate.finish();
+            }
+            tracing::trace!(
+                connection_id = %self.connection.id(),
+                request_partition = ?self.request_partition,
+                connection_partition = ?self.connection.owner_partition(),
+                origin_scheme = %self.connection.info().origin().scheme(),
+                origin_host = self.connection.info().origin().host(),
+                origin_port = ?self.connection.info().origin().port(),
+                h2_generation = ?self.generation,
+                "HTTP/2 activation cancelled before request acceptance"
+            );
+        }
+    }
+}
+
+/// One activation opportunity retained until Hyper acceptance or cancellation.
+struct H2GateToken {
+    cell: Weak<OriginCell>,
+    waiter: WaiterId,
+    kind: H2GateKind,
+}
+
+/// Cell transition run when an activation accepts or cancels.
+enum H2GateKind {
+    Local { generation: H2GenerationId },
+    Peer { route: H2RouteId },
+}
+
+impl H2GateToken {
+    fn local(cell: &Arc<OriginCell>, generation: H2GenerationId, waiter: WaiterId) -> Self {
+        Self {
+            cell: Weak::from_arc(cell),
+            waiter,
+            kind: H2GateKind::Local { generation },
+        }
+    }
+
+    fn peer(cell: &Arc<OriginCell>, route: H2RouteId, waiter: WaiterId) -> Self {
+        Self {
+            cell: Weak::from_arc(cell),
+            waiter,
+            kind: H2GateKind::Peer { route },
+        }
+    }
+
+    fn finish(self) {
+        if let Some(cell) = self.cell.upgrade() {
+            match self.kind {
+                H2GateKind::Local { generation } => {
+                    OriginCell::finish_h2_gate(&cell, generation, self.waiter)
+                }
+                H2GateKind::Peer { route } => {
+                    OriginCell::finish_peer_h2_gate(&cell, route, self.waiter)
+                }
+            }
+        }
+    }
+}
+
+/// One terminal side of an accepted HTTP/2 request lease.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum H2Endpoint {
+    Send,
+    Receive,
+}
+
+/// Shared request-lease phase and endpoint bits.
+enum H2LeaseState {
+    Prospective {
+        send_complete: bool,
+        receive_complete: bool,
+    },
+    Accepted {
+        send_complete: bool,
+        receive_complete: bool,
+        dispatch: DispatchGuard,
+    },
+    Complete,
+}
+
+/// Shared endpoint state for one prospective or accepted request.
+struct H2LeaseCore {
+    cell: Weak<OriginCell>,
+    generation: H2GenerationId,
+    state: Mutex<H2LeaseState>,
+}
+
+impl H2LeaseCore {
+    /// Converts prospective endpoint state to accepted state.
+    fn accept(&self, dispatch: DispatchGuard) {
+        let mut dispatch = Some(dispatch);
+        let complete = {
+            let mut state = self.state.lock();
+            let (send_complete, receive_complete) = match &*state {
+                H2LeaseState::Prospective {
+                    send_complete,
+                    receive_complete,
+                } => (*send_complete, *receive_complete),
+                H2LeaseState::Accepted { .. } | H2LeaseState::Complete => {
+                    drop(state);
+                    panic!("HTTP/2 request lease accepted outside prospective state");
+                }
+            };
+            if send_complete && receive_complete {
+                *state = H2LeaseState::Complete;
+                true
+            } else {
+                *state = H2LeaseState::Accepted {
+                    send_complete,
+                    receive_complete,
+                    dispatch: dispatch
+                        .take()
+                        .expect("HTTP/2 dispatch guard disappeared before acceptance"),
+                };
+                false
+            }
+        };
+        drop(dispatch);
+        if complete {
+            self.complete_generation();
+        }
+    }
+
+    /// Cancels endpoint state after the prospective reservation ends.
+    fn cancel(&self) {
+        let mut state = self.state.lock();
+        if matches!(*state, H2LeaseState::Prospective { .. }) {
+            *state = H2LeaseState::Complete;
+        }
+    }
+
+    /// Marks one endpoint terminal and releases the accepted lease on the second.
+    fn complete_endpoint(&self, endpoint: H2Endpoint) -> bool {
+        let dispatch = {
+            let mut state = self.state.lock();
+            match &mut *state {
+                H2LeaseState::Prospective {
+                    send_complete,
+                    receive_complete,
+                } => {
+                    match endpoint {
+                        H2Endpoint::Send => *send_complete = true,
+                        H2Endpoint::Receive => *receive_complete = true,
+                    }
+                    None
+                }
+                H2LeaseState::Accepted {
+                    send_complete,
+                    receive_complete,
+                    ..
+                } => {
+                    match endpoint {
+                        H2Endpoint::Send => *send_complete = true,
+                        H2Endpoint::Receive => *receive_complete = true,
+                    }
+                    if *send_complete && *receive_complete {
+                        let previous = std::mem::replace(&mut *state, H2LeaseState::Complete);
+                        let H2LeaseState::Accepted { dispatch, .. } = previous else {
+                            unreachable!("completed HTTP/2 lease changed state under its lock");
+                        };
+                        Some(dispatch)
+                    } else {
+                        None
+                    }
+                }
+                H2LeaseState::Complete => None,
+            }
+        };
+        let request_complete = dispatch.is_some();
+        if let Some(dispatch) = dispatch {
+            // Dispatch completion takes the connection lifecycle lock. Keep it
+            // outside the request-lease lock so endpoint completion cannot
+            // nest pool synchronization.
+            drop(dispatch);
+            self.complete_generation();
+        }
+        request_complete
+    }
+
+    /// Releases the generation count after the lease lock is released.
+    fn complete_generation(&self) {
+        if let Some(cell) = self.cell.upgrade() {
+            OriginCell::complete_h2_request(&cell, self.generation);
+        }
+    }
+}
+
+/// Structured identity retained by one request-lease endpoint.
+#[derive(Clone)]
+struct H2EndpointTrace {
+    request_partition: PartitionId,
+    connection: Arc<ConnectionInfo>,
+    generation: H2GenerationId,
+}
+
+impl H2EndpointTrace {
+    fn new(activation: &H2Activation) -> Self {
+        Self {
+            request_partition: activation.request_partition,
+            connection: activation.connection.info().clone(),
+            generation: activation.generation,
+        }
+    }
+}
+
+/// Linear guard for one request-lease endpoint.
+pub(in crate::client::pool) struct H2LeaseEndpoint {
+    core: Arc<H2LeaseCore>,
+    endpoint: H2Endpoint,
+    trace: Option<H2EndpointTrace>,
+    active: bool,
+}
+
+impl H2LeaseEndpoint {
+    fn new(core: Arc<H2LeaseCore>, endpoint: H2Endpoint, trace: Option<H2EndpointTrace>) -> Self {
+        Self {
+            core,
+            endpoint,
+            trace,
+            active: true,
+        }
+    }
+
+    /// Creates a detached endpoint and observation handle for body tests.
+    #[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
+    fn for_test(cell: &Arc<OriginCell>, endpoint: H2Endpoint) -> (Self, H2LeaseProbe) {
+        let core = Arc::new(H2LeaseCore {
+            cell: Weak::from_arc(cell),
+            generation: H2GenerationId(0),
+            state: Mutex::new(H2LeaseState::Prospective {
+                send_complete: false,
+                receive_complete: false,
+            }),
+        });
+        (
+            Self::new(core.clone(), endpoint, None),
+            H2LeaseProbe { core },
+        )
+    }
+
+    /// Creates a detached send endpoint and observation handle for body tests.
+    #[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
+    pub(in crate::client::pool) fn send_for_test(cell: &Arc<OriginCell>) -> (Self, H2LeaseProbe) {
+        Self::for_test(cell, H2Endpoint::Send)
+    }
+
+    /// Creates a detached receive endpoint and observation handle for body tests.
+    #[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
+    pub(in crate::client::pool) fn receive_for_test(
+        cell: &Arc<OriginCell>,
+    ) -> (Self, H2LeaseProbe) {
+        Self::for_test(cell, H2Endpoint::Receive)
+    }
+
+    /// Completes this endpoint before dropping the guard.
+    pub(in crate::client::pool) fn complete(mut self) {
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        if self.active {
+            self.active = false;
+            let request_complete = self.core.complete_endpoint(self.endpoint);
+            if let Some(trace) = self.trace.take() {
+                tracing::trace!(
+                    connection_id = %trace.connection.id(),
+                    request_partition = ?trace.request_partition,
+                    connection_partition = ?trace.connection.owner_partition(),
+                    origin_scheme = %trace.connection.origin().scheme(),
+                    origin_host = trace.connection.origin().host(),
+                    origin_port = ?trace.connection.origin().port(),
+                    h2_generation = ?trace.generation,
+                    endpoint = ?self.endpoint,
+                    request_complete,
+                    "HTTP/2 request endpoint completed"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for H2LeaseEndpoint {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// Test observation of a request-lease endpoint's production state.
+#[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
+pub(in crate::client::pool) struct H2LeaseProbe {
+    core: Arc<H2LeaseCore>,
+}
+
+#[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
+impl H2LeaseProbe {
+    /// Returns whether the send endpoint reached its terminal transition.
+    pub(in crate::client::pool) fn send_complete(&self) -> bool {
+        matches!(
+            &*self.core.state.lock(),
+            H2LeaseState::Prospective {
+                send_complete: true,
+                ..
+            } | H2LeaseState::Complete
+        )
+    }
+
+    /// Returns whether the receive endpoint reached its terminal transition.
+    pub(in crate::client::pool) fn receive_complete(&self) -> bool {
+        matches!(
+            &*self.core.state.lock(),
+            H2LeaseState::Prospective {
+                receive_complete: true,
+                ..
+            } | H2LeaseState::Complete
+        )
+    }
+}
+
+impl OriginCell {
+    /// Reserves a prospective request lease from one exact local generation.
+    pub(in crate::client::pool) fn activate_h2(
+        cell: &Arc<Self>,
+        generation: H2GenerationId,
+    ) -> Option<H2Activation> {
+        let parts = {
+            let mut state = cell.state.lock();
+            let parts = state.h2.activate(generation)?;
+            state.assert_consistent();
+            parts
+        };
+        Some(H2Activation::new(cell.clone(), generation, parts, None))
+    }
+
+    /// Converts a prospective activation to an accepted generation lease.
+    fn accept_h2_activation(cell: &Arc<Self>, generation: H2GenerationId) -> bool {
+        let deadline = cell.idle_deadline();
+        let (accepted, reset_deadline) = {
+            let mut state = cell.state.lock();
+            let accepted = state.h2.accept(generation);
+            let reset_deadline = accepted && state.h2.reset_idle_deadline(generation, deadline);
+            state.assert_consistent();
+            (accepted, reset_deadline)
+        };
+        if reset_deadline {
+            cell.notify_maintenance(deadline);
+        }
+        accepted
+    }
+
+    /// Cancels one prospective activation after sender rejection or task drop.
+    fn cancel_h2_activation(cell: &Arc<Self>, generation: H2GenerationId) {
+        let mut state = cell.state.lock();
+        state.h2.cancel(generation);
+        state.assert_consistent();
+    }
+
+    /// Releases one accepted lease after its second endpoint terminates.
+    fn complete_h2_request(cell: &Arc<Self>, generation: H2GenerationId) {
+        let mut state = cell.state.lock();
+        state.h2.complete_request(generation);
+        state.assert_consistent();
+    }
+
+    /// Offers one local activation while preserving the generation cutoff.
+    fn service_h2_gate_locked(
+        cell: &Arc<Self>,
+        state: &mut CellState,
+        returned_event: &mut Option<AcquisitionEvent>,
+    ) -> Option<H2WaiterInstall> {
+        let generation = state.h2.accepting()?;
+        let has_prioritized = state
+            .h2
+            .priority_cutoff()
+            .is_some_and(|cutoff| state.waiters.has_h2_candidate_through(cutoff));
+        let cutoff = state.h2.service_cutoff(has_prioritized)?;
+        state.waiters.oldest_h2_candidate()?;
+
+        let h2 = &mut state.h2;
+        let waiters = &mut state.waiters;
+        let mut install = waiters.install_h2(
+            cutoff,
+            |waiter| {
+                let parts = h2
+                    .activate(generation)
+                    .expect("accepting HTTP/2 generation could not create a gated activation");
+                h2.begin_gate_activation(waiter);
+                AcquisitionResult::H2(H2Activation::new(
+                    cell.clone(),
+                    generation,
+                    parts,
+                    Some(H2GateToken::local(cell, generation, waiter)),
+                ))
+            },
+            &cell.eligibility_group,
+        );
+        *returned_event = install.returned_event.take();
+        state.assert_consistent();
+        install.waiter.is_some().then_some(install)
+    }
+
+    /// Runs publication, fallback, and wake work after the cell lock is released.
+    fn finish_h2_install(cell: &Arc<Self>, install: Option<H2WaiterInstall>) {
+        let Some(install) = install else {
+            return;
+        };
+        let suppress_active = cell.state.lock().h2.has_visible_h2();
+        if let Some(admission) = &cell.admission {
+            for snapshot in install
+                .demand_updates
+                .into_iter()
+                .flatten()
+                .filter(|snapshot| !suppress_active || !snapshot.is_active())
+            {
+                super::super::admission::OriginAdmission::publish_demand(
+                    admission,
+                    cell.id.partition(),
+                    snapshot,
+                );
+            }
+        }
+        drop(install.returned_event);
+        if let Some(waker) = install.waker {
+            waker.wake();
+        }
+    }
+
+    /// Publishes one complete local-generation report after cell unlock.
+    fn publish_h2_advertisement(
+        cell: &Arc<Self>,
+        snapshot: Option<super::super::admission::H2AdvertisementSnapshot>,
+    ) {
+        if let (Some(admission), Some(snapshot)) = (&cell.admission, snapshot) {
+            super::super::admission::OriginAdmission::update_h2_advertisement(
+                admission,
+                cell.id.partition(),
+                cell.eligibility_group.clone(),
+                snapshot,
+            );
+        }
+    }
+
+    /// Publishes the current local demand after its last H2 route disappears.
+    fn publish_current_demand(
+        cell: &Arc<Self>,
+        snapshot: Option<super::super::admission::DemandSnapshot>,
+    ) {
+        if let (Some(admission), Some(snapshot)) = (&cell.admission, snapshot) {
+            super::super::admission::OriginAdmission::publish_demand(
+                admission,
+                cell.id.partition(),
+                snapshot,
+            );
+        }
+    }
+
+    /// Advances a generation gate after one activation accepts or cancels.
+    fn finish_h2_gate(cell: &Arc<Self>, generation: H2GenerationId, waiter: WaiterId) {
+        let mut returned_event = None;
+        let (install, advertisement) = {
+            let mut state = cell.state.lock();
+            if !state.h2.finish_gate_activation(generation, waiter) {
+                return;
+            }
+            let install = Self::service_h2_gate_locked(cell, &mut state, &mut returned_event);
+            state.assert_consistent();
+            let advertisement = state.take_h2_advertisement_update();
+            (install, advertisement)
+        };
+        drop(returned_event);
+        Self::publish_h2_advertisement(cell, advertisement);
+        Self::finish_h2_install(cell, install);
+    }
+
+    /// Offers the accepting local generation to one queued acquisition.
+    pub(in crate::client::pool) fn service_h2_waiters(cell: &Arc<Self>) {
+        let mut returned_event = None;
+        let (install, advertisement) = {
+            let mut state = cell.state.lock();
+            let install = Self::service_h2_gate_locked(cell, &mut state, &mut returned_event);
+            state.assert_consistent();
+            let advertisement = state.take_h2_advertisement_update();
+            (install, advertisement)
+        };
+        drop(returned_event);
+        Self::publish_h2_advertisement(cell, advertisement);
+        Self::finish_h2_install(cell, install);
+    }
+
+    /// Returns whether one exact connection generation still accepts activations.
+    pub(in crate::client::pool) fn h2_generation_is_accepting(
+        cell: &Arc<Self>,
+        generation: H2GenerationId,
+    ) -> bool {
+        cell.state.lock().h2.is_accepting(generation)
+    }
+
+    /// Installs requesting-cell visibility for one peer generation publication.
+    ///
+    /// The named local demand remains queued behind the route gate. Advancing
+    /// its snapshot version makes admission acknowledgement authoritative
+    /// without losing the demand if this exact route later becomes stale.
+    pub(in crate::client::pool) fn install_h2_route(
+        cell: &Arc<Self>,
+        route: H2Route,
+        group: &super::super::partition::EligibilityGroup,
+        demand: super::super::admission::DemandId,
+    ) -> bool {
+        if &cell.eligibility_group != group || route.connection_partition() == cell.id.partition() {
+            return false;
+        }
+        let mut state = cell.state.lock();
+        if !state.waiters.suppress_published_demand(demand) {
+            return false;
+        }
+        let cutoff = state.waiters.publication_cutoff();
+        state.h2.install_peer_route(route, cutoff);
+        state.assert_consistent();
+        true
+    }
+
+    /// Activates queued requests through the currently visible peer route.
+    ///
+    /// Preparing the requesting-cell opportunity, activating the connection
+    /// generation, and committing the result each use a separate lock scope.
+    pub(in crate::client::pool) fn service_peer_h2_waiters(cell: &Arc<Self>) {
+        loop {
+            let prepared = {
+                let mut state = cell.state.lock();
+                let CellState { h2, waiters, .. } = &mut *state;
+                let prepared = h2.prepare_peer_activation(waiters);
+                state.assert_consistent();
+                prepared
+            };
+            let Some(prepared) = prepared else {
+                return;
+            };
+            let route_id = prepared.route.id();
+            let Some(activation) = prepared.route.activate(cell.id.partition()) else {
+                let snapshot = {
+                    let mut state = cell.state.lock();
+                    if !state.h2.clear_peer_route(route_id) {
+                        return;
+                    }
+                    let snapshot = state
+                        .waiters
+                        .current_demand_snapshot(&cell.eligibility_group);
+                    state.assert_consistent();
+                    snapshot
+                };
+                if let (Some(admission), Some(snapshot)) = (&cell.admission, snapshot) {
+                    super::super::admission::OriginAdmission::publish_demand(
+                        admission,
+                        cell.id.partition(),
+                        snapshot,
+                    );
+                }
+                return;
+            };
+
+            let mut activation = Some(activation);
+            let mut returned_event = None;
+            let install = {
+                let mut state = cell.state.lock();
+                let current = state
+                    .h2
+                    .peer_activation_is_current(&prepared, &state.waiters);
+                if !current {
+                    state.h2.finish_peer_activation(route_id, prepared.waiter);
+                    state.assert_consistent();
+                    None
+                } else {
+                    activation
+                        .as_mut()
+                        .expect("peer HTTP/2 activation disappeared")
+                        .attach_peer_gate(cell, route_id, prepared.waiter);
+                    let mut install = state.waiters.install_h2(
+                        prepared.cutoff,
+                        |_| {
+                            AcquisitionResult::H2(
+                                activation
+                                    .take()
+                                    .expect("peer HTTP/2 activation was installed twice"),
+                            )
+                        },
+                        &cell.eligibility_group,
+                    );
+                    returned_event = install.returned_event.take();
+                    if install.waiter.is_none() {
+                        state.h2.finish_peer_activation(route_id, prepared.waiter);
+                    }
+                    state.assert_consistent();
+                    install.waiter.is_some().then_some(install)
+                }
+            };
+            drop(activation);
+            drop(returned_event);
+            if install.is_some() {
+                Self::finish_h2_install(cell, install);
+                return;
+            }
+        }
+    }
+
+    /// Advances an exact peer-route gate after acceptance or cancellation.
+    fn finish_peer_h2_gate(cell: &Arc<Self>, route: H2RouteId, waiter: WaiterId) {
+        let finished = {
+            let mut state = cell.state.lock();
+            let finished = state.h2.finish_peer_activation(route, waiter);
+            state.assert_consistent();
+            finished
+        };
+        if finished {
+            Self::service_peer_h2_waiters(cell);
+        }
+    }
+}
+
+/// Generation-specific close authority that does not retain the cell.
+#[derive(Clone, Debug)]
+pub(in crate::client::pool) struct H2CloseHandle {
+    cell: Weak<OriginCell>,
+    generation: H2GenerationId,
+}
+
+impl H2CloseHandle {
+    /// Creates close authority for one installed generation.
+    pub(in crate::client::pool) fn new(cell: &Arc<OriginCell>, generation: H2GenerationId) -> Self {
+        Self {
+            cell: Weak::from_arc(cell),
+            generation,
+        }
+    }
+
+    /// Begins drain when the cell still contains this generation.
+    pub(in crate::client::pool) fn close(
+        &self,
+        reason: super::super::connection::CloseReason,
+    ) -> bool {
+        self.cell
+            .upgrade()
+            .is_some_and(|cell| OriginCell::close_h2(&cell, self.generation, reason))
+    }
+}
+
+/// Closes an H2 generation if its owner-runtime driver ends or is dropped.
+pub(in crate::client::pool) struct H2DriverGuard {
+    close: H2CloseHandle,
+    active: bool,
+}
+
+impl H2DriverGuard {
+    /// Arms generation cleanup before driver submission.
+    pub(in crate::client::pool) fn new(close: H2CloseHandle) -> Self {
+        Self {
+            close,
+            active: true,
+        }
+    }
+
+    /// Records ordinary driver completion.
+    pub(in crate::client::pool) fn protocol_closed(mut self) {
+        self.active = false;
+        self.close
+            .close(super::super::connection::CloseReason::ProtocolClosed);
+    }
+}
+
+impl Drop for H2DriverGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.close
+                .close(super::super::connection::CloseReason::OwnerRuntimeShutdown);
+        }
+    }
+}
+
+impl OriginCell {
+    /// Selects an accepting local generation without admission coordination.
+    pub(in crate::client::pool) fn select_h2(cell: &Arc<Self>) -> Option<H2Activation> {
+        let (generation, parts) = {
+            let mut state = cell.state.lock();
+            let queued = state.waiters.has_h2_candidate();
+            if !state.h2.direct_is_allowed(queued) {
+                return None;
+            }
+            let generation = state.h2.accepting()?;
+            let parts = state.h2.activate(generation)?;
+            state.assert_consistent();
+            (generation, parts)
+        };
+        Some(H2Activation::new(cell.clone(), generation, parts, None))
+    }
+
+    /// Places a post-ALPN waiter behind an already accepting generation.
+    pub(in crate::client::pool) fn join_h2_generation(
+        cell: &Arc<Self>,
+        waiter: WaiterId,
+        generation: H2GenerationId,
+    ) -> bool {
+        let mut returned_event = None;
+        let install = {
+            let mut state = cell.state.lock();
+            if !state.h2.prioritize_waiter(generation, waiter) {
+                return false;
+            }
+            let install = Self::service_h2_gate_locked(cell, &mut state, &mut returned_event);
+            state.assert_consistent();
+            install
+        };
+        drop(returned_event);
+        Self::finish_h2_install(cell, install);
+        true
+    }
+
+    /// Atomically selects, joins, or installs the cell's post-ALPN flight.
+    pub(in crate::client::pool) fn install_or_join_h2_flight(
+        &self,
+        waiter: WaiterId,
+    ) -> H2FlightInstall {
+        let mut state = self.state.lock();
+        let result = state.h2.install_or_join_flight(waiter);
+        state.assert_consistent();
+        result
+    }
+
+    /// Installs one successful flight as the accepting generation.
+    pub(in crate::client::pool) fn complete_h2_flight(
+        cell: &Arc<Self>,
+        flight: H2FlightId,
+        connection: Arc<ConnectionState>,
+        sender: H2Sender,
+        idle_deadline: Option<SystemTime>,
+    ) -> Result<H2GenerationId, (Arc<ConnectionState>, H2Sender)> {
+        let mut returned_event = None;
+        let (completion, install, advertisement) = {
+            let mut state = cell.state.lock();
+            let completion = state
+                .h2
+                .complete_flight(flight, connection, sender, idle_deadline);
+            let install = if completion.is_ok() {
+                let cutoff = state.waiters.publication_cutoff();
+                state.h2.prioritize_through(cutoff);
+                Self::service_h2_gate_locked(cell, &mut state, &mut returned_event)
+            } else {
+                None
+            };
+            state.assert_consistent();
+            let advertisement = state.take_h2_advertisement_update();
+            (completion, install, advertisement)
+        };
+        drop(returned_event);
+        Self::publish_h2_advertisement(cell, advertisement);
+        Self::finish_h2_install(cell, install);
+        if completion.is_ok() {
+            cell.notify_maintenance(idle_deadline);
+        }
+        completion
+    }
+
+    /// Retires one failed flight and returns its retained participants.
+    pub(in crate::client::pool) fn fail_h2_flight(
+        &self,
+        flight: H2FlightId,
+    ) -> Option<Vec<WaiterId>> {
+        let mut state = self.state.lock();
+        let participants = state.h2.fail_flight(flight);
+        state.assert_consistent();
+        participants
+    }
+
+    /// Moves one exact generation to draining and closes its connection.
+    pub(super) fn close_h2(
+        cell: &Arc<Self>,
+        generation: H2GenerationId,
+        reason: super::super::connection::CloseReason,
+    ) -> bool {
+        // A zero-request generation may hold the last capacity-owning
+        // connection reference. Keep it outside the cell-lock unwind scope.
+        let detached_connection;
+        let (advertisement, demand) = {
+            let mut state = cell.state.lock();
+            detached_connection = state.h2.begin_close(generation);
+            let advertisement = detached_connection
+                .as_ref()
+                .and_then(|_| state.take_h2_advertisement_update());
+            let demand = detached_connection.as_ref().and_then(|_| {
+                state
+                    .waiters
+                    .current_demand_snapshot(&cell.eligibility_group)
+            });
+            state.assert_consistent();
+            (advertisement, demand)
+        };
+        let Some(connection) = detached_connection else {
+            return false;
+        };
+        Self::publish_h2_advertisement(cell, advertisement);
+        Self::publish_current_demand(cell, demand);
+        connection.logical_close(reason)
+    }
+
+    /// Returns the exact accepting generation for publication.
+    #[cfg(test)]
+    pub(in crate::client::pool) fn accepting_h2_generation(&self) -> Option<H2GenerationId> {
+        self.state.lock().h2.accepting()
+    }
+
+    /// Installs an accepting generation without a Hyper handshake.
+    #[cfg(test)]
+    pub(in crate::client::pool) fn install_h2_for_test(
+        cell: &Arc<Self>,
+        connection: Arc<ConnectionState>,
+        sender_id: u64,
+        idle_deadline: Option<SystemTime>,
+    ) -> H2GenerationId {
+        let flight = match cell.install_or_join_h2_flight(WaiterId(u64::MAX)) {
+            H2FlightInstall::Driver(flight) => flight,
+            H2FlightInstall::Accepting(_) | H2FlightInstall::Joined => {
+                panic!("HTTP/2 test fixture requires an empty cell")
+            }
+        };
+        Self::complete_h2_flight(
+            cell,
+            flight,
+            connection,
+            H2Sender::test(sender_id),
+            idle_deadline,
+        )
+        .expect("HTTP/2 test fixture flight did not install")
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use crate::client::pool::admission::ProtocolRequirement;
+    use crate::client::pool::connection::{CloseReason, ConnectionInfo};
+    use crate::client::pool::origin::OriginKey;
+    use crate::client::pool::partition::EligibilityGroup;
+    use aws_smithy_runtime_api::client::connection::ConnectionId;
+    use http_1x::uri::Scheme;
+
+    fn cell() -> Arc<OriginCell> {
+        Arc::new(OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            None,
+            None,
+        ))
+    }
+
+    fn connection(
+        id: u64,
+    ) -> (
+        Arc<ConnectionState>,
+        super::super::super::connection::PhysicalConnectionGuard,
+    ) {
+        ConnectionState::unbounded(ConnectionInfo::for_test(
+            ConnectionId::new(id),
+            PartitionId::from_index(1),
+        ))
+    }
+
+    fn begin_waiter(cell: &Arc<OriginCell>) -> WaiterId {
+        let waiter = OriginCell::register_waiter(cell, ProtocolRequirement::H2Required);
+        let event = cell
+            .take_ready_event(waiter)
+            .expect("unbounded H2 waiter did not receive establishment authority");
+        let super::super::AcquisitionEvent::Establish(permit) = event else {
+            panic!("new H2 waiter completed before establishment");
+        };
+        assert!(cell.start_establishment(waiter));
+        drop(permit);
+        waiter
+    }
+
+    fn install_generation(
+        cell: &Arc<OriginCell>,
+        connection_id: u64,
+    ) -> (
+        H2GenerationId,
+        Arc<ConnectionState>,
+        super::super::super::connection::PhysicalConnectionGuard,
+    ) {
+        let waiter = begin_waiter(cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(waiter) else {
+            panic!("fresh cell did not create an HTTP/2 flight");
+        };
+        let (connection, physical) = connection(connection_id);
+        let generation = OriginCell::complete_h2_flight(
+            cell,
+            flight,
+            connection.clone(),
+            H2Sender::test(connection_id),
+            None,
+        )
+        .expect("fresh flight did not install");
+        let event = cell
+            .take_ready_event(waiter)
+            .expect("flight completion did not satisfy its waiter");
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            activation,
+        )) = event
+        else {
+            panic!("flight completion produced a non-H2 result");
+        };
+        drop(activation);
+        (generation, connection, physical)
+    }
+
+    fn generation_counts(cell: &OriginCell, generation: H2GenerationId) -> (usize, usize) {
+        let state = cell.state.lock();
+        let record = state
+            .h2
+            .generations
+            .get(&generation)
+            .expect("HTTP/2 generation disappeared");
+        (record.prospective, record.accepted)
+    }
+
+    #[test]
+    fn flight_converges_participants_and_cancellation() {
+        let mut records = H2Records::default();
+        let first = WaiterId(1);
+        let second = WaiterId(2);
+
+        let H2FlightInstall::Driver(flight) = records.install_or_join_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            records.install_or_join_flight(second),
+            H2FlightInstall::Joined
+        ));
+        assert_eq!(Some(flight), records.cancel_flight_participant(second));
+        assert_eq!(Some(vec![first]), records.fail_flight(flight));
+        assert!(records.flight.is_none());
+    }
+
+    #[test]
+    fn generation_gate_services_committed_waiters_before_direct_arrivals() {
+        let cell = cell();
+        let first = begin_waiter(&cell);
+        let second = begin_waiter(&cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+        let (connection, _physical) = connection(1);
+        OriginCell::complete_h2_flight(&cell, flight, connection, H2Sender::test(1), None)
+            .expect("flight did not install");
+
+        assert!(
+            OriginCell::select_h2(&cell).is_none(),
+            "direct arrival bypassed committed waiters"
+        );
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            first_activation,
+        )) = cell
+            .take_ready_event(first)
+            .expect("first waiter was not served")
+        else {
+            panic!("first waiter received a non-H2 result");
+        };
+        drop(first_activation);
+
+        assert!(
+            OriginCell::select_h2(&cell).is_none(),
+            "direct arrival bypassed the second committed waiter"
+        );
+        let super::super::AcquisitionEvent::Complete(super::super::AcquisitionResult::H2(
+            second_activation,
+        )) = cell
+            .take_ready_event(second)
+            .expect("second waiter was not served")
+        else {
+            panic!("second waiter received a non-H2 result");
+        };
+        drop(second_activation);
+
+        assert!(
+            OriginCell::select_h2(&cell).is_some(),
+            "gate did not open after committed waiters drained"
+        );
+    }
+
+    #[test]
+    fn later_local_activation_does_not_hide_an_open_generation_from_peers() {
+        let mut records = H2Records::default();
+        let committed = WaiterId(1);
+        let later = WaiterId(2);
+        let H2FlightInstall::Driver(flight) = records.install_or_join_flight(committed) else {
+            panic!("first participant did not become the flight driver");
+        };
+        let (connection, _physical) = connection(1);
+        let generation = records
+            .complete_flight(flight, connection, H2Sender::test(1), None)
+            .expect("flight did not install");
+        records.prioritize_through(Some(committed));
+
+        assert_eq!(
+            Some(Some(committed)),
+            records.service_cutoff(true),
+            "committed waiter did not retain initial priority"
+        );
+        records.begin_gate_activation(committed);
+        assert_eq!(None, records.publishable_generation());
+        assert!(records.finish_gate_activation(generation, committed));
+
+        assert_eq!(Some(None), records.service_cutoff(false));
+        records.begin_gate_activation(later);
+        assert_eq!(
+            Some(generation),
+            records.publishable_generation(),
+            "a post-cutoff local activation hid the generation from peers"
+        );
+    }
+
+    #[test]
+    fn generation_is_reused_only_after_hyper_acceptance() {
+        let cell = cell();
+        let (_generation, connection, _physical) = install_generation(&cell, 1);
+
+        let mut activation =
+            OriginCell::select_h2(&cell).expect("accepting generation was not selected");
+        assert!(!activation.is_reused());
+        let H2DispatchParts {
+            sender: _sender,
+            send_endpoint: send,
+            receive_endpoint: receive,
+        } = activation.take_dispatch_parts();
+        let dispatch = ConnectionState::try_commit_dispatch(&connection)
+            .expect("open connection rejected dispatch");
+        activation.accept(dispatch);
+        drop(send);
+        drop(receive);
+
+        let reused = OriginCell::select_h2(&cell).expect("accepted generation was not reusable");
+        assert!(reused.is_reused());
+        drop(reused);
+    }
+
+    #[test]
+    #[should_panic(expected = "HTTP/2 activation dispatch parts already taken")]
+    fn activation_transfers_dispatch_parts_once() {
+        let cell = cell();
+        let (_generation, _connection, _physical) = install_generation(&cell, 1);
+        let mut activation =
+            OriginCell::select_h2(&cell).expect("accepting generation was not selected");
+
+        let _first = activation.take_dispatch_parts();
+        let _second = activation.take_dispatch_parts();
+    }
+
+    #[test]
+    fn prospective_activation_cancellation_returns_its_generation_count() {
+        let cell = cell();
+        let (generation, _connection, _physical) = install_generation(&cell, 1);
+
+        let activation =
+            OriginCell::select_h2(&cell).expect("accepting generation was not selected");
+        assert_eq!((1, 0), generation_counts(&cell, generation));
+        drop(activation);
+        assert_eq!((0, 0), generation_counts(&cell, generation));
+    }
+
+    #[test]
+    fn accepted_lease_waits_for_both_endpoints_in_either_order() {
+        for send_first in [true, false] {
+            let cell = cell();
+            let (generation, connection, _physical) = install_generation(&cell, 1);
+            let mut activation =
+                OriginCell::select_h2(&cell).expect("accepting generation was not selected");
+            let H2DispatchParts {
+                sender: _sender,
+                send_endpoint: send,
+                receive_endpoint: receive,
+            } = activation.take_dispatch_parts();
+            let dispatch = ConnectionState::try_commit_dispatch(&connection)
+                .expect("open connection rejected dispatch");
+            activation.accept(dispatch);
+            assert_eq!((0, 1), generation_counts(&cell, generation));
+            assert_eq!(1, connection.snapshot().in_flight);
+
+            if send_first {
+                drop(send);
+                assert_eq!((0, 1), generation_counts(&cell, generation));
+                receive.complete();
+            } else {
+                receive.complete();
+                assert_eq!((0, 1), generation_counts(&cell, generation));
+                drop(send);
+            }
+
+            assert_eq!((0, 0), generation_counts(&cell, generation));
+            assert_eq!(0, connection.snapshot().in_flight);
+        }
+    }
+
+    #[test]
+    fn stale_generation_cannot_activate_or_close_its_successor() {
+        let cell = cell();
+        let (first, first_connection, _first_physical) = install_generation(&cell, 1);
+        let stale = H2CloseHandle::new(&cell, first);
+        assert!(stale.close(CloseReason::ProtocolClosed));
+        assert_eq!(
+            Some(CloseReason::ProtocolClosed),
+            first_connection.snapshot().close_reason
+        );
+
+        let (second, second_connection, _second_physical) = install_generation(&cell, 2);
+        assert_ne!(first, second);
+        assert!(OriginCell::activate_h2(&cell, first).is_none());
+        assert!(!stale.close(CloseReason::Poisoned));
+        assert_eq!(None, second_connection.snapshot().close_reason);
+        assert_eq!(Some(second), cell.accepting_h2_generation());
+    }
+
+    #[test]
+    fn close_drops_detached_capacity_only_after_cell_unlock() {
+        use crate::client::pool::admission::OriginAdmission;
+        use std::num::NonZeroUsize;
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        let admission = OriginAdmission::for_test(NonZeroUsize::MIN);
+        let cell = OriginAdmission::register_cell(
+            &admission,
+            Arc::new(OriginCell::new(
+                PartitionId::from_index(1),
+                OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+                EligibilityGroup::Pool,
+                Some(admission.clone()),
+                None,
+            )),
+        );
+        let info = ConnectionInfo::for_test(ConnectionId::new(1), PartitionId::from_index(1));
+        let (bounded_connection, physical) = ConnectionState::establishing(info);
+        bounded_connection
+            .open(Some(OriginAdmission::lease_for_test(&admission)))
+            .expect("bounded test connection did not open");
+        let generation =
+            OriginCell::install_h2_for_test(&cell, bounded_connection.clone(), 1, None);
+        drop(bounded_connection);
+        drop(physical);
+
+        // Keep an unrelated empty drain so the close transition's final
+        // consistency check panics after detaching the bounded connection.
+        let (corrupt_connection, corrupt_physical) = connection(2);
+        {
+            let mut state = cell.state.lock();
+            state.h2.generations.insert(
+                H2GenerationId(99),
+                H2Generation {
+                    connection: corrupt_connection,
+                    sender: H2Sender::test(2),
+                    residence: H2Residence::Draining,
+                    prospective: 0,
+                    has_dispatched: false,
+                    accepted: 0,
+                    idle_deadline: None,
+                },
+            );
+        }
+        drop(corrupt_physical);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            OriginCell::close_h2(&cell, generation, CloseReason::ProtocolClosed);
+        }));
+        assert!(
+            result.is_err(),
+            "corrupt H2 state did not reach its consistency assertion"
+        );
+
+        // This second lease exists only if unwinding dropped the connection
+        // after the cell guard, allowing capacity to return through admission.
+        drop(OriginAdmission::lease_for_test(&admission));
+    }
+
+    #[test]
+    fn close_retains_an_accepted_generation_until_both_endpoints_finish() {
+        let cell = cell();
+        let (generation, connection, _physical) = install_generation(&cell, 1);
+        let mut activation =
+            OriginCell::select_h2(&cell).expect("accepting generation was not selected");
+        let H2DispatchParts {
+            sender: _sender,
+            send_endpoint: send,
+            receive_endpoint: receive,
+        } = activation.take_dispatch_parts();
+        let dispatch = ConnectionState::try_commit_dispatch(&connection)
+            .expect("open connection rejected dispatch");
+        activation.accept(dispatch);
+
+        assert!(OriginCell::close_h2(
+            &cell,
+            generation,
+            CloseReason::ProtocolClosed
+        ));
+        assert!(cell.state.lock().h2.generations.contains_key(&generation));
+        drop(send);
+        assert!(cell.state.lock().h2.generations.contains_key(&generation));
+        drop(receive);
+        assert!(!cell.state.lock().h2.generations.contains_key(&generation));
+        assert_eq!(0, connection.snapshot().in_flight);
+    }
+
+    #[test]
+    fn driver_task_drop_closes_its_exact_generation() {
+        let cell = cell();
+        let (generation, connection, _physical) = install_generation(&cell, 1);
+        let guard = H2DriverGuard::new(H2CloseHandle::new(&cell, generation));
+
+        drop(guard);
+
+        assert_eq!(
+            Some(CloseReason::OwnerRuntimeShutdown),
+            connection.snapshot().close_reason
+        );
+        assert_eq!(None, cell.accepting_h2_generation());
+    }
+
+    #[test]
+    fn pool_shutdown_closes_an_accepting_generation() {
+        let cell = cell();
+        let (_generation, connection, _physical) = install_generation(&cell, 1);
+
+        OriginCell::close_all(&cell, CloseReason::PoolDropped);
+
+        assert_eq!(
+            Some(CloseReason::PoolDropped),
+            connection.snapshot().close_reason
+        );
+        assert_eq!(None, cell.accepting_h2_generation());
+    }
+}
+
+#[cfg(all(test, smithy_http_client_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::client::pool::connection::{CloseReason, ConnectionInfo};
+    use crate::client::pool::origin::OriginKey;
+    use crate::client::pool::partition::EligibilityGroup;
+    use aws_smithy_runtime_api::client::connection::ConnectionId;
+    use http_1x::uri::Scheme;
+
+    fn cell() -> Arc<OriginCell> {
+        Arc::new(OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            None,
+            None,
+        ))
+    }
+
+    fn install_generation(cell: &Arc<OriginCell>) -> (H2GenerationId, Arc<ConnectionState>) {
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(WaiterId(0)) else {
+            panic!("fresh cell did not create an HTTP/2 flight");
+        };
+        let (connection, _physical) = ConnectionState::unbounded(ConnectionInfo::for_test(
+            ConnectionId::new(1),
+            PartitionId::from_index(1),
+        ));
+        let generation = OriginCell::complete_h2_flight(
+            cell,
+            flight,
+            connection.clone(),
+            H2Sender::test(1),
+            None,
+        )
+        .expect("flight did not install");
+        (generation, connection)
+    }
+
+    #[test]
+    fn activation_linearizes_against_generation_close() {
+        loom::model(|| {
+            let cell = cell();
+            let (generation, connection) = install_generation(&cell);
+            let activating_cell = cell.clone();
+            let activation =
+                loom::thread::spawn(move || OriginCell::activate_h2(&activating_cell, generation));
+            let closing_cell = cell.clone();
+            let close = loom::thread::spawn(move || {
+                OriginCell::close_h2(&closing_cell, generation, CloseReason::Poisoned)
+            });
+
+            drop(activation.join().unwrap());
+            assert!(close.join().unwrap());
+            assert_eq!(
+                Some(CloseReason::Poisoned),
+                connection.snapshot().close_reason
+            );
+            assert!(!cell.state.lock().h2.generations.contains_key(&generation));
+        });
+    }
+
+    #[test]
+    fn lease_endpoints_release_one_dispatch_under_race() {
+        loom::model(|| {
+            let cell = cell();
+            let (generation, connection) = install_generation(&cell);
+            let mut activation =
+                OriginCell::activate_h2(&cell, generation).expect("generation did not activate");
+            let H2DispatchParts {
+                sender: _sender,
+                send_endpoint: send,
+                receive_endpoint: receive,
+            } = activation.take_dispatch_parts();
+            let dispatch = ConnectionState::try_commit_dispatch(&connection)
+                .expect("open connection rejected dispatch");
+            activation.accept(dispatch);
+
+            let send = loom::thread::spawn(move || drop(send));
+            let receive = loom::thread::spawn(move || drop(receive));
+            send.join().unwrap();
+            receive.join().unwrap();
+
+            assert_eq!(0, connection.snapshot().in_flight);
+            let state = cell.state.lock();
+            let record = state
+                .h2
+                .generations
+                .get(&generation)
+                .expect("accepting generation disappeared");
+            assert_eq!(0, record.accepted);
+        });
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/waiters.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/waiters.rs
@@ -25,6 +25,9 @@
 //! ReadyToEstablish --poll----------------------------> Launching(Submitted)
 //! Launching(Submitted) --first owner-runtime poll----> Launching(Started)
 //! Launching --local H1 or establishment result------> Ready
+//! Waiting --local or peer H2 activation--------------> Ready
+//! DeliveryPending --H2 activation--------------------> pending H2; delivery loses
+//! ReadyToEstablish / Launching --H2 activation-------> Ready; permit/task loses
 //! Ready --poll---------------------------------------> removed; result transferred
 //! ```
 //!
@@ -64,6 +67,9 @@ pub(in crate::client::pool) struct WaiterId(pub(in crate::client::pool) u64);
 /// - `h1_candidates` contains exactly each H1-compatible
 ///   [`WaiterState::DeliveryPending`] without a pending H1,
 ///   [`WaiterState::ReadyToEstablish`], or [`WaiterState::Launching`] attempt.
+/// - `h2_candidates` contains every delivery-pending, ready-to-establish, or
+///   launching attempt that has not received another result. The waiting FIFO
+///   head is compared with this set without duplicating its queue residence.
 /// - Delivery-pending, ready-to-establish, launching, delivery-cancelled, and
 ///   ready attempts remain in `records` but never in the bounded FIFO.
 ///
@@ -77,6 +83,8 @@ pub(super) struct AcquisitionQueue {
     waiting: WaitingQueueState,
     /// H1-compatible attempts still competing with a returned sender.
     h1_candidates: BTreeSet<WaiterId>,
+    /// Attempts outside the FIFO that may accept an H2 activation.
+    h2_candidates: BTreeSet<WaiterId>,
     /// Next cell-local waiter identity.
     next_waiter: u64,
     /// Next identity for a head-waiter demand generation.
@@ -137,16 +145,16 @@ enum WaiterState {
     DeliveryPending {
         /// Latest task waiting for the crossing delivery.
         waker: Option<Waker>,
-        /// H1 return that won while capacity was crossing.
-        pending_h1: Option<AcquisitionResult>,
+        /// Local protocol result that won while delivery was crossing.
+        pending_result: Option<AcquisitionResult>,
     },
     /// Cancellation won after reservation while the committed delivery was
     /// outside the lock.
     DeliveryCancelled {
         /// Task detached for wake after the crossing payload is returned.
         waker: Option<Waker>,
-        /// H1 result returned after the crossing closes, if one arrived first.
-        pending_h1: Option<AcquisitionResult>,
+        /// Protocol result returned after the crossing closes, if one arrived first.
+        pending_result: Option<AcquisitionResult>,
     },
     /// Capacity is ready to start an establishment attempt.
     ReadyToEstablish {
@@ -213,6 +221,7 @@ impl AcquisitionQueue {
             if requirement == ProtocolRequirement::H1Compatible {
                 self.h1_candidates.insert(waiter);
             }
+            self.h2_candidates.insert(waiter);
             self.assert_consistent();
             return (waiter, None);
         }
@@ -305,6 +314,80 @@ impl AcquisitionQueue {
         !self.h1_candidates.is_empty()
     }
 
+    /// Returns the oldest attempt that may accept an HTTP/2 activation.
+    pub(super) fn oldest_h2_candidate(&self) -> Option<WaiterId> {
+        let waiting = match &self.waiting {
+            WaitingQueueState::Active { head, .. } => Some(*head),
+            WaitingQueueState::Empty => None,
+        };
+        match (waiting, self.h2_candidates.first().copied()) {
+            (Some(waiting), Some(active)) => Some(waiting.min(active)),
+            (Some(waiting), None) => Some(waiting),
+            (None, active) => active,
+        }
+    }
+
+    /// Advances the active demand beyond an accepted route publication.
+    ///
+    /// Admission retires the published version when it acknowledges route
+    /// visibility. The waiter remains queued locally while the route gate
+    /// offers activations. Reserving the following version here ensures that
+    /// route invalidation can republish the same demand generation without an
+    /// older inactive snapshot winning.
+    pub(super) fn suppress_published_demand(&mut self, demand: DemandId) -> bool {
+        let WaitingQueueState::Active {
+            demand: current, ..
+        } = &mut self.waiting
+        else {
+            return false;
+        };
+        if current.id != demand {
+            return false;
+        }
+        let acknowledged = current.version.next();
+        current.version = acknowledged.next();
+        self.assert_consistent();
+        true
+    }
+
+    /// Returns the current head demand for publication after route loss.
+    pub(super) fn current_demand_snapshot(
+        &self,
+        eligibility_group: &EligibilityGroup,
+    ) -> Option<DemandSnapshot> {
+        match &self.waiting {
+            WaitingQueueState::Empty => None,
+            WaitingQueueState::Active { demand, .. } => Some(demand.snapshot(eligibility_group)),
+        }
+    }
+
+    /// Returns whether `waiter` is still the oldest H2 activation candidate.
+    pub(super) fn is_oldest_h2_candidate(&self, waiter: WaiterId) -> bool {
+        self.oldest_h2_candidate() == Some(waiter)
+    }
+
+    /// Returns the newest waiter identity committed before a publication.
+    pub(super) fn publication_cutoff(&self) -> Option<WaiterId> {
+        (!self.records.is_empty()).then(|| {
+            WaiterId(
+                self.next_waiter
+                    .checked_sub(1)
+                    .expect("nonempty waiter set had no allocated identity"),
+            )
+        })
+    }
+
+    /// Returns whether an acquisition at or before `cutoff` still needs H2.
+    pub(super) fn has_h2_candidate_through(&self, cutoff: WaiterId) -> bool {
+        self.oldest_h2_candidate()
+            .is_some_and(|waiter| waiter <= cutoff)
+    }
+
+    /// Returns whether any acquisition must precede a new direct H2 arrival.
+    pub(super) fn has_h2_candidate(&self) -> bool {
+        self.oldest_h2_candidate().is_some()
+    }
+
     /// Commits a returned HTTP/1 sender to the oldest compatible attempt.
     ///
     /// Payload construction is delayed until all panic-capable requesting-cell checks
@@ -351,10 +434,10 @@ impl AcquisitionQueue {
         let (returned_event, waker) = match &mut record.state {
             WaiterState::DeliveryPending {
                 waker: _,
-                pending_h1,
+                pending_result,
             } => {
-                debug_assert!(pending_h1.is_none());
-                *pending_h1 = Some(result());
+                debug_assert!(pending_result.is_none());
+                *pending_result = Some(result());
                 (None, None)
             }
             WaiterState::ReadyToEstablish { .. } | WaiterState::Launching { .. } => {
@@ -374,6 +457,7 @@ impl AcquisitionQueue {
             }
         };
         self.h1_candidates.remove(&waiter);
+        self.h2_candidates.remove(&waiter);
         if returned_event.is_none() {
             // The incoming H1 is state-owned and no permit is detached, so an
             // invariant failure cannot drop a pool value under this lock.
@@ -424,13 +508,21 @@ impl AcquisitionQueue {
             }
         } else if matches!(state, WaiterState::DeliveryPending { .. }) {
             self.h1_candidates.remove(&waiter);
+            self.h2_candidates.remove(&waiter);
             let record = self.records.get_mut(&waiter)?;
-            let WaiterState::DeliveryPending { waker, pending_h1 } = &mut record.state else {
+            let WaiterState::DeliveryPending {
+                waker,
+                pending_result,
+            } = &mut record.state
+            else {
                 unreachable!("delivery-pending waiter changed state under the cell lock");
             };
             let waker = waker.take();
-            let pending_h1 = pending_h1.take();
-            record.state = WaiterState::DeliveryCancelled { waker, pending_h1 };
+            let pending_result = pending_result.take();
+            record.state = WaiterState::DeliveryCancelled {
+                waker,
+                pending_result,
+            };
             WaiterCancellation {
                 demand_updates: [None, None],
                 returned_events: [None, None],
@@ -444,6 +536,7 @@ impl AcquisitionQueue {
             self.assert_consistent();
             let record = self.records.remove(&waiter)?;
             self.h1_candidates.remove(&waiter);
+            self.h2_candidates.remove(&waiter);
             let event = match record.state {
                 WaiterState::ReadyToEstablish { permit } => AcquisitionEvent::Establish(permit),
                 WaiterState::Ready(result) => AcquisitionEvent::Complete(result),
@@ -456,6 +549,7 @@ impl AcquisitionQueue {
         } else if matches!(state, WaiterState::Launching { .. }) {
             self.assert_consistent();
             self.h1_candidates.remove(&waiter);
+            self.h2_candidates.remove(&waiter);
             self.records.remove(&waiter)?;
             return Some(WaiterCancellation {
                 demand_updates: [None, None],
@@ -552,7 +646,7 @@ impl AcquisitionQueue {
                 self.assert_consistent();
                 true
             }
-            WaiterState::Ready(AcquisitionResult::H1(_)) => false,
+            WaiterState::Ready(_) => false,
             WaiterState::Launching {
                 phase: EstablishmentPhase::Started,
                 ..
@@ -600,11 +694,12 @@ impl AcquisitionQueue {
         let accepts_h1 = record.requirement == ProtocolRequirement::H1Compatible;
         record.state = WaiterState::DeliveryPending {
             waker,
-            pending_h1: None,
+            pending_result: None,
         };
         if accepts_h1 {
             self.h1_candidates.insert(removed.waiter);
         }
+        self.h2_candidates.insert(removed.waiter);
 
         self.assert_consistent();
         DeliveryReservation::Reserved {
@@ -632,11 +727,15 @@ impl AcquisitionQueue {
         };
 
         match &mut record.state {
-            WaiterState::DeliveryPending { waker, pending_h1 } => {
+            WaiterState::DeliveryPending {
+                waker,
+                pending_result,
+            } => {
                 let waker = waker.take();
-                if let Some(h1) = pending_h1.take() {
-                    record.state = WaiterState::Ready(h1);
+                if let Some(result) = pending_result.take() {
+                    record.state = WaiterState::Ready(result);
                     self.h1_candidates.remove(&waiter);
+                    self.h2_candidates.remove(&waiter);
                     // The rejected permit must cross the lock boundary even
                     // if other state is already inconsistent.
                     return ResultInstall {
@@ -656,13 +755,16 @@ impl AcquisitionQueue {
                     accepted: true,
                 }
             }
-            WaiterState::DeliveryCancelled { waker, pending_h1 } => {
+            WaiterState::DeliveryCancelled {
+                waker,
+                pending_result,
+            } => {
                 let waker = waker.take();
-                let pending_h1 = pending_h1.take();
+                let pending_result = pending_result.take();
                 self.records.remove(&waiter);
                 ResultInstall {
                     returned_events: [
-                        pending_h1.map(AcquisitionEvent::Complete),
+                        pending_result.map(AcquisitionEvent::Complete),
                         Some(AcquisitionEvent::Establish(permit)),
                     ],
                     waker,
@@ -698,11 +800,15 @@ impl AcquisitionQueue {
         };
 
         match &mut record.state {
-            WaiterState::DeliveryPending { waker, pending_h1 } => {
+            WaiterState::DeliveryPending {
+                waker,
+                pending_result,
+            } => {
                 let waker = waker.take();
-                if let Some(local_h1) = pending_h1.take() {
-                    record.state = WaiterState::Ready(local_h1);
+                if let Some(local_result) = pending_result.take() {
+                    record.state = WaiterState::Ready(local_result);
                     self.h1_candidates.remove(&waiter);
+                    self.h2_candidates.remove(&waiter);
                     // The rejected borrowed sender must cross the lock
                     // boundary before any panic-capable consistency check.
                     return ResultInstall {
@@ -714,6 +820,7 @@ impl AcquisitionQueue {
                 }
                 record.state = WaiterState::Ready(result);
                 self.h1_candidates.remove(&waiter);
+                self.h2_candidates.remove(&waiter);
                 self.assert_consistent();
                 ResultInstall {
                     returned_events: [None, None],
@@ -722,13 +829,16 @@ impl AcquisitionQueue {
                     accepted: true,
                 }
             }
-            WaiterState::DeliveryCancelled { waker, pending_h1 } => {
+            WaiterState::DeliveryCancelled {
+                waker,
+                pending_result,
+            } => {
                 let waker = waker.take();
-                let pending_h1 = pending_h1.take();
+                let pending_result = pending_result.take();
                 self.records.remove(&waiter);
                 ResultInstall {
                     returned_events: [
-                        pending_h1.map(AcquisitionEvent::Complete),
+                        pending_result.map(AcquisitionEvent::Complete),
                         Some(AcquisitionEvent::Complete(result)),
                     ],
                     waker,
@@ -759,7 +869,7 @@ impl AcquisitionQueue {
         let Some(record) = self.records.get_mut(&waiter) else {
             return ResultInstall::rejected(AcquisitionEvent::Complete(result));
         };
-        if matches!(record.state, WaiterState::Ready(AcquisitionResult::H1(_))) {
+        if matches!(record.state, WaiterState::Ready(_)) {
             return ResultInstall::rejected(AcquisitionEvent::Complete(result));
         }
         let WaiterState::Launching { waker, .. } = &mut record.state else {
@@ -771,6 +881,7 @@ impl AcquisitionQueue {
         let waker = waker.take();
         record.state = WaiterState::Ready(result);
         self.h1_candidates.remove(&waiter);
+        self.h2_candidates.remove(&waiter);
         self.assert_consistent();
         ResultInstall {
             returned_events: [None, None],
@@ -797,6 +908,93 @@ impl AcquisitionQueue {
             unreachable!("ready waiter changed state under the cell lock");
         };
         Some(result)
+    }
+
+    /// Offers an H2 activation to the oldest compatible acquisition.
+    ///
+    /// `cutoff` retains publication priority. A later waiter is left pending
+    /// until every live acquisition at or before the cutoff has received an
+    /// activation opportunity.
+    pub(super) fn install_h2(
+        &mut self,
+        cutoff: Option<WaiterId>,
+        result: impl FnOnce(WaiterId) -> AcquisitionResult,
+        eligibility_group: &EligibilityGroup,
+    ) -> H2WaiterInstall {
+        let Some(waiter) = self.oldest_h2_candidate() else {
+            return H2WaiterInstall::empty();
+        };
+        if cutoff.is_some_and(|cutoff| waiter > cutoff) {
+            return H2WaiterInstall::empty();
+        }
+
+        if matches!(
+            self.records.get(&waiter).map(|record| &record.state),
+            Some(WaiterState::Waiting { .. })
+        ) {
+            let removed = self.pop_head(eligibility_group);
+            debug_assert_eq!(removed.waiter, waiter);
+            let record = self
+                .records
+                .get_mut(&waiter)
+                .expect("HTTP/2 requesting waiter disappeared");
+            let WaiterState::Waiting { waker, .. } = &mut record.state else {
+                unreachable!("HTTP/2 requesting waiter left the waiting state");
+            };
+            let waker = waker.take();
+            record.state = WaiterState::Ready(result(waiter));
+            let retired =
+                DemandSnapshot::inactive(removed.demand.id, removed.demand.version.next());
+            self.assert_consistent();
+            return H2WaiterInstall {
+                waiter: Some(waiter),
+                demand_updates: [Some(retired), removed.successor],
+                returned_event: None,
+                waker,
+            };
+        }
+
+        let record = self
+            .records
+            .get_mut(&waiter)
+            .expect("HTTP/2 candidate waiter disappeared");
+        let (returned_event, waker) = match &mut record.state {
+            WaiterState::DeliveryPending {
+                waker: _,
+                pending_result,
+            } => {
+                debug_assert!(pending_result.is_none());
+                *pending_result = Some(result(waiter));
+                (None, None)
+            }
+            WaiterState::ReadyToEstablish { .. } | WaiterState::Launching { .. } => {
+                let previous =
+                    std::mem::replace(&mut record.state, WaiterState::Ready(result(waiter)));
+                match previous {
+                    WaiterState::ReadyToEstablish { permit } => {
+                        (Some(AcquisitionEvent::Establish(permit)), None)
+                    }
+                    WaiterState::Launching { waker, .. } => (None, waker),
+                    _ => unreachable!("HTTP/2 candidate changed state under the cell lock"),
+                }
+            }
+            WaiterState::Waiting { .. }
+            | WaiterState::DeliveryCancelled { .. }
+            | WaiterState::Ready(_) => {
+                unreachable!("HTTP/2 candidate was not eligible for activation")
+            }
+        };
+        self.h1_candidates.remove(&waiter);
+        self.h2_candidates.remove(&waiter);
+        if returned_event.is_none() {
+            self.assert_consistent();
+        }
+        H2WaiterInstall {
+            waiter: Some(waiter),
+            demand_updates: [None, None],
+            returned_event,
+            waker,
+        }
     }
 
     /// Unlinks the FIFO head and installs any successor demand.
@@ -1031,7 +1229,7 @@ impl AcquisitionQueue {
                     && matches!(
                         record.state,
                         WaiterState::DeliveryPending {
-                            pending_h1: None,
+                            pending_result: None,
                             ..
                         } | WaiterState::ReadyToEstablish { .. }
                             | WaiterState::Launching { .. }
@@ -1042,6 +1240,26 @@ impl AcquisitionQueue {
         assert_eq!(
             expected_h1_candidates, self.h1_candidates,
             "HTTP/1 acquisition candidates did not match waiter state"
+        );
+
+        let expected_h2_candidates = self
+            .records
+            .iter()
+            .filter_map(|(waiter, record)| {
+                matches!(
+                    record.state,
+                    WaiterState::DeliveryPending {
+                        pending_result: None,
+                        ..
+                    } | WaiterState::ReadyToEstablish { .. }
+                        | WaiterState::Launching { .. }
+                )
+                .then_some(*waiter)
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            expected_h2_candidates, self.h2_candidates,
+            "HTTP/2 acquisition candidates did not match waiter state"
         );
     }
 
@@ -1218,5 +1436,28 @@ mod tests {
             queue.reserve_delivery_waiter(DemandId::from_u64(0), &EligibilityGroup::Pool),
             DeliveryReservation::Rejected
         ));
+    }
+}
+
+/// Result of offering one activation through the HTTP/2 generation gate.
+pub(super) struct H2WaiterInstall {
+    /// Waiter receiving the prospective activation.
+    pub(super) waiter: Option<WaiterId>,
+    /// Demand retirement and successor publication produced by FIFO removal.
+    pub(super) demand_updates: [Option<DemandSnapshot>; 2],
+    /// Permit displaced by the activation and returned after unlock.
+    pub(super) returned_event: Option<AcquisitionEvent>,
+    /// Task to wake after the activation becomes visible.
+    pub(super) waker: Option<Waker>,
+}
+
+impl H2WaiterInstall {
+    fn empty() -> Self {
+        Self {
+            waiter: None,
+            demand_updates: [None, None],
+            returned_event: None,
+            waker: None,
+        }
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/cell/waiters.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/cell/waiters.rs
@@ -26,8 +26,8 @@
 //! Launching(Submitted) --first owner-runtime poll----> Launching(Started)
 //! Launching --local H1 or establishment result------> Ready
 //! Waiting --local or peer H2 activation--------------> Ready
-//! DeliveryPending --H2 activation--------------------> pending H2; delivery loses
-//! ReadyToEstablish / Launching --H2 activation-------> Ready; permit/task loses
+//! DeliveryPending --H2 activation--------------------> DeliveryPending(pending H2)
+//! ReadyToEstablish / Launching --H2 activation-------> Ready
 //! Ready --poll---------------------------------------> removed; result transferred
 //! ```
 //!
@@ -67,7 +67,7 @@ pub(in crate::client::pool) struct WaiterId(pub(in crate::client::pool) u64);
 /// - `h1_candidates` contains exactly each H1-compatible
 ///   [`WaiterState::DeliveryPending`] without a pending H1,
 ///   [`WaiterState::ReadyToEstablish`], or [`WaiterState::Launching`] attempt.
-/// - `h2_candidates` contains every delivery-pending, ready-to-establish, or
+/// - `h2_activation_candidates` contains every delivery-pending, ready-to-establish, or
 ///   launching attempt that has not received another result. The waiting FIFO
 ///   head is compared with this set without duplicating its queue residence.
 /// - Delivery-pending, ready-to-establish, launching, delivery-cancelled, and
@@ -84,7 +84,7 @@ pub(super) struct AcquisitionQueue {
     /// H1-compatible attempts still competing with a returned sender.
     h1_candidates: BTreeSet<WaiterId>,
     /// Attempts outside the FIFO that may accept an H2 activation.
-    h2_candidates: BTreeSet<WaiterId>,
+    h2_activation_candidates: BTreeSet<WaiterId>,
     /// Next cell-local waiter identity.
     next_waiter: u64,
     /// Next identity for a head-waiter demand generation.
@@ -218,10 +218,7 @@ impl AcquisitionQueue {
                     },
                 },
             );
-            if requirement == ProtocolRequirement::H1Compatible {
-                self.h1_candidates.insert(waiter);
-            }
-            self.h2_candidates.insert(waiter);
+            self.add_protocol_candidates(waiter, requirement);
             self.assert_consistent();
             return (waiter, None);
         }
@@ -288,7 +285,7 @@ impl AcquisitionQueue {
     fn oldest_h1_candidate(&self) -> Option<WaiterId> {
         let waiting = match &self.waiting {
             WaitingQueueState::Active { head, .. }
-                if self.records[head].requirement == ProtocolRequirement::H1Compatible =>
+                if self.records[head].requirement.accepts_h1() =>
             {
                 Some(*head)
             }
@@ -317,10 +314,15 @@ impl AcquisitionQueue {
     /// Returns the oldest attempt that may accept an HTTP/2 activation.
     pub(super) fn oldest_h2_candidate(&self) -> Option<WaiterId> {
         let waiting = match &self.waiting {
-            WaitingQueueState::Active { head, .. } => Some(*head),
+            WaitingQueueState::Active { head, .. }
+                if self.records[head].requirement.accepts_h2() =>
+            {
+                Some(*head)
+            }
+            WaitingQueueState::Active { .. } => None,
             WaitingQueueState::Empty => None,
         };
-        match (waiting, self.h2_candidates.first().copied()) {
+        match (waiting, self.h2_activation_candidates.first().copied()) {
             (Some(waiting), Some(active)) => Some(waiting.min(active)),
             (Some(waiting), None) => Some(waiting),
             (None, active) => active,
@@ -388,6 +390,31 @@ impl AcquisitionQueue {
         self.oldest_h2_candidate().is_some()
     }
 
+    /// Returns whether one transferred generation waiter remains launchable.
+    pub(super) fn is_launching_h2_candidate(&self, waiter: WaiterId) -> bool {
+        self.h2_activation_candidates.contains(&waiter)
+            && self.records.get(&waiter).is_some_and(|record| {
+                record.requirement.accepts_h2()
+                    && matches!(record.state, WaiterState::Launching { .. })
+            })
+    }
+
+    /// Adds one waiter to each protocol index its requirement accepts.
+    fn add_protocol_candidates(&mut self, waiter: WaiterId, requirement: ProtocolRequirement) {
+        if requirement.accepts_h1() {
+            self.h1_candidates.insert(waiter);
+        }
+        if requirement.accepts_h2() {
+            self.h2_activation_candidates.insert(waiter);
+        }
+    }
+
+    /// Removes one waiter from both protocol candidate indexes.
+    fn remove_protocol_candidates(&mut self, waiter: WaiterId) {
+        self.h1_candidates.remove(&waiter);
+        self.h2_activation_candidates.remove(&waiter);
+    }
+
     /// Commits a returned HTTP/1 sender to the oldest compatible attempt.
     ///
     /// Payload construction is delayed until all panic-capable requesting-cell checks
@@ -397,11 +424,20 @@ impl AcquisitionQueue {
         &mut self,
         result: impl FnOnce() -> AcquisitionResult,
         eligibility_group: &EligibilityGroup,
-    ) -> H1Install {
+    ) -> WaiterInstall {
         let Some(waiter) = self.oldest_h1_candidate() else {
-            return H1Install::rejected(result());
+            return WaiterInstall::rejected(result());
         };
+        self.install_protocol_result(waiter, result, eligibility_group)
+    }
 
+    /// Installs a selected protocol result through the shared waiter transition.
+    fn install_protocol_result(
+        &mut self,
+        waiter: WaiterId,
+        result: impl FnOnce() -> AcquisitionResult,
+        eligibility_group: &EligibilityGroup,
+    ) -> WaiterInstall {
         if matches!(
             self.records.get(&waiter).map(|record| &record.state),
             Some(WaiterState::Waiting { .. })
@@ -411,16 +447,17 @@ impl AcquisitionQueue {
             let record = self
                 .records
                 .get_mut(&waiter)
-                .expect("HTTP/1 requesting waiter disappeared");
+                .expect("selected requesting waiter disappeared");
             let WaiterState::Waiting { waker, .. } = &mut record.state else {
-                unreachable!("HTTP/1 requesting waiter left the waiting state");
+                unreachable!("selected requesting waiter left the waiting state");
             };
             let waker = waker.take();
             record.state = WaiterState::Ready(result());
             let retired =
                 DemandSnapshot::inactive(removed.demand.id, removed.demand.version.next());
             self.assert_consistent();
-            return H1Install {
+            return WaiterInstall {
+                waiter: Some(waiter),
                 demand_updates: [Some(retired), removed.successor],
                 returned_event: None,
                 waker,
@@ -430,7 +467,7 @@ impl AcquisitionQueue {
         let record = self
             .records
             .get_mut(&waiter)
-            .expect("HTTP/1 candidate waiter disappeared");
+            .expect("selected candidate waiter disappeared");
         let (returned_event, waker) = match &mut record.state {
             WaiterState::DeliveryPending {
                 waker: _,
@@ -447,23 +484,23 @@ impl AcquisitionQueue {
                         (Some(AcquisitionEvent::Establish(permit)), None)
                     }
                     WaiterState::Launching { waker, .. } => (None, waker),
-                    _ => unreachable!("HTTP/1 candidate changed state under the cell lock"),
+                    _ => unreachable!("selected candidate changed state under the cell lock"),
                 }
             }
             WaiterState::Waiting { .. }
             | WaiterState::DeliveryCancelled { .. }
             | WaiterState::Ready(_) => {
-                unreachable!("HTTP/1 candidate was not eligible for a returned sender")
+                unreachable!("selected waiter was not eligible for a protocol result")
             }
         };
-        self.h1_candidates.remove(&waiter);
-        self.h2_candidates.remove(&waiter);
+        self.remove_protocol_candidates(waiter);
         if returned_event.is_none() {
-            // The incoming H1 is state-owned and no permit is detached, so an
+            // The result is state-owned and no permit is detached, so an
             // invariant failure cannot drop a pool value under this lock.
             self.assert_consistent();
         }
-        H1Install {
+        WaiterInstall {
+            waiter: Some(waiter),
             demand_updates: [None, None],
             returned_event,
             waker,
@@ -507,8 +544,7 @@ impl AcquisitionQueue {
                 returned_events: [None, None],
             }
         } else if matches!(state, WaiterState::DeliveryPending { .. }) {
-            self.h1_candidates.remove(&waiter);
-            self.h2_candidates.remove(&waiter);
+            self.remove_protocol_candidates(waiter);
             let record = self.records.get_mut(&waiter)?;
             let WaiterState::DeliveryPending {
                 waker,
@@ -535,8 +571,7 @@ impl AcquisitionQueue {
             // this method must return without another panic-capable check.
             self.assert_consistent();
             let record = self.records.remove(&waiter)?;
-            self.h1_candidates.remove(&waiter);
-            self.h2_candidates.remove(&waiter);
+            self.remove_protocol_candidates(waiter);
             let event = match record.state {
                 WaiterState::ReadyToEstablish { permit } => AcquisitionEvent::Establish(permit),
                 WaiterState::Ready(result) => AcquisitionEvent::Complete(result),
@@ -548,8 +583,7 @@ impl AcquisitionQueue {
             });
         } else if matches!(state, WaiterState::Launching { .. }) {
             self.assert_consistent();
-            self.h1_candidates.remove(&waiter);
-            self.h2_candidates.remove(&waiter);
+            self.remove_protocol_candidates(waiter);
             self.records.remove(&waiter)?;
             return Some(WaiterCancellation {
                 demand_updates: [None, None],
@@ -691,15 +725,12 @@ impl AcquisitionQueue {
             unreachable!("reserved queue head left the waiting state");
         };
         let waker = waker.take();
-        let accepts_h1 = record.requirement == ProtocolRequirement::H1Compatible;
+        let requirement = record.requirement;
         record.state = WaiterState::DeliveryPending {
             waker,
             pending_result: None,
         };
-        if accepts_h1 {
-            self.h1_candidates.insert(removed.waiter);
-        }
-        self.h2_candidates.insert(removed.waiter);
+        self.add_protocol_candidates(removed.waiter, requirement);
 
         self.assert_consistent();
         DeliveryReservation::Reserved {
@@ -734,8 +765,7 @@ impl AcquisitionQueue {
                 let waker = waker.take();
                 if let Some(result) = pending_result.take() {
                     record.state = WaiterState::Ready(result);
-                    self.h1_candidates.remove(&waiter);
-                    self.h2_candidates.remove(&waiter);
+                    self.remove_protocol_candidates(waiter);
                     // The rejected permit must cross the lock boundary even
                     // if other state is already inconsistent.
                     return ResultInstall {
@@ -807,8 +837,7 @@ impl AcquisitionQueue {
                 let waker = waker.take();
                 if let Some(local_result) = pending_result.take() {
                     record.state = WaiterState::Ready(local_result);
-                    self.h1_candidates.remove(&waiter);
-                    self.h2_candidates.remove(&waiter);
+                    self.remove_protocol_candidates(waiter);
                     // The rejected borrowed sender must cross the lock
                     // boundary before any panic-capable consistency check.
                     return ResultInstall {
@@ -819,8 +848,7 @@ impl AcquisitionQueue {
                     };
                 }
                 record.state = WaiterState::Ready(result);
-                self.h1_candidates.remove(&waiter);
-                self.h2_candidates.remove(&waiter);
+                self.remove_protocol_candidates(waiter);
                 self.assert_consistent();
                 ResultInstall {
                     returned_events: [None, None],
@@ -872,16 +900,18 @@ impl AcquisitionQueue {
         if matches!(record.state, WaiterState::Ready(_)) {
             return ResultInstall::rejected(AcquisitionEvent::Complete(result));
         }
-        let WaiterState::Launching { waker, .. } = &mut record.state else {
+        if !matches!(record.state, WaiterState::Launching { .. }) {
             return ResultInstall::invalid(
                 AcquisitionEvent::Complete(result),
                 ResultInstallError::UnexpectedState,
             );
+        }
+        let WaiterState::Launching { waker, .. } = &mut record.state else {
+            unreachable!("validated launching waiter changed state")
         };
         let waker = waker.take();
         record.state = WaiterState::Ready(result);
-        self.h1_candidates.remove(&waiter);
-        self.h2_candidates.remove(&waiter);
+        self.remove_protocol_candidates(waiter);
         self.assert_consistent();
         ResultInstall {
             returned_events: [None, None],
@@ -920,81 +950,15 @@ impl AcquisitionQueue {
         cutoff: Option<WaiterId>,
         result: impl FnOnce(WaiterId) -> AcquisitionResult,
         eligibility_group: &EligibilityGroup,
-    ) -> H2WaiterInstall {
+    ) -> WaiterInstall {
         let Some(waiter) = self.oldest_h2_candidate() else {
-            return H2WaiterInstall::empty();
+            return WaiterInstall::empty();
         };
         if cutoff.is_some_and(|cutoff| waiter > cutoff) {
-            return H2WaiterInstall::empty();
+            return WaiterInstall::empty();
         }
 
-        if matches!(
-            self.records.get(&waiter).map(|record| &record.state),
-            Some(WaiterState::Waiting { .. })
-        ) {
-            let removed = self.pop_head(eligibility_group);
-            debug_assert_eq!(removed.waiter, waiter);
-            let record = self
-                .records
-                .get_mut(&waiter)
-                .expect("HTTP/2 requesting waiter disappeared");
-            let WaiterState::Waiting { waker, .. } = &mut record.state else {
-                unreachable!("HTTP/2 requesting waiter left the waiting state");
-            };
-            let waker = waker.take();
-            record.state = WaiterState::Ready(result(waiter));
-            let retired =
-                DemandSnapshot::inactive(removed.demand.id, removed.demand.version.next());
-            self.assert_consistent();
-            return H2WaiterInstall {
-                waiter: Some(waiter),
-                demand_updates: [Some(retired), removed.successor],
-                returned_event: None,
-                waker,
-            };
-        }
-
-        let record = self
-            .records
-            .get_mut(&waiter)
-            .expect("HTTP/2 candidate waiter disappeared");
-        let (returned_event, waker) = match &mut record.state {
-            WaiterState::DeliveryPending {
-                waker: _,
-                pending_result,
-            } => {
-                debug_assert!(pending_result.is_none());
-                *pending_result = Some(result(waiter));
-                (None, None)
-            }
-            WaiterState::ReadyToEstablish { .. } | WaiterState::Launching { .. } => {
-                let previous =
-                    std::mem::replace(&mut record.state, WaiterState::Ready(result(waiter)));
-                match previous {
-                    WaiterState::ReadyToEstablish { permit } => {
-                        (Some(AcquisitionEvent::Establish(permit)), None)
-                    }
-                    WaiterState::Launching { waker, .. } => (None, waker),
-                    _ => unreachable!("HTTP/2 candidate changed state under the cell lock"),
-                }
-            }
-            WaiterState::Waiting { .. }
-            | WaiterState::DeliveryCancelled { .. }
-            | WaiterState::Ready(_) => {
-                unreachable!("HTTP/2 candidate was not eligible for activation")
-            }
-        };
-        self.h1_candidates.remove(&waiter);
-        self.h2_candidates.remove(&waiter);
-        if returned_event.is_none() {
-            self.assert_consistent();
-        }
-        H2WaiterInstall {
-            waiter: Some(waiter),
-            demand_updates: [None, None],
-            returned_event,
-            waker,
-        }
+        self.install_protocol_result(waiter, || result(waiter), eligibility_group)
     }
 
     /// Unlinks the FIFO head and installs any successor demand.
@@ -1153,7 +1117,12 @@ impl AcquisitionQueue {
     /// Checks map, FIFO, and demand relationships in debug and test builds.
     pub(super) fn assert_consistent(&self) {
         #[cfg(debug_assertions)]
-        self.assert_consistent_debug();
+        {
+            if std::thread::panicking() {
+                return;
+            }
+            self.assert_consistent_debug();
+        }
     }
 
     #[cfg(debug_assertions)]
@@ -1225,7 +1194,7 @@ impl AcquisitionQueue {
             .records
             .iter()
             .filter_map(|(waiter, record)| {
-                (record.requirement == ProtocolRequirement::H1Compatible
+                (record.requirement.accepts_h1()
                     && matches!(
                         record.state,
                         WaiterState::DeliveryPending {
@@ -1242,23 +1211,24 @@ impl AcquisitionQueue {
             "HTTP/1 acquisition candidates did not match waiter state"
         );
 
-        let expected_h2_candidates = self
+        let expected_h2_activation_candidates = self
             .records
             .iter()
             .filter_map(|(waiter, record)| {
-                matches!(
-                    record.state,
-                    WaiterState::DeliveryPending {
-                        pending_result: None,
-                        ..
-                    } | WaiterState::ReadyToEstablish { .. }
-                        | WaiterState::Launching { .. }
-                )
+                (record.requirement.accepts_h2()
+                    && matches!(
+                        record.state,
+                        WaiterState::DeliveryPending {
+                            pending_result: None,
+                            ..
+                        } | WaiterState::ReadyToEstablish { .. }
+                            | WaiterState::Launching { .. }
+                    ))
                 .then_some(*waiter)
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(
-            expected_h2_candidates, self.h2_candidates,
+            expected_h2_activation_candidates, self.h2_activation_candidates,
             "HTTP/2 acquisition candidates did not match waiter state"
         );
     }
@@ -1296,22 +1266,35 @@ pub(super) struct WaiterCancellation {
     pub(super) returned_events: [Option<AcquisitionEvent>; 2],
 }
 
-/// Values detached after attempting cell-local HTTP/1 service.
-pub(super) struct H1Install {
+/// Values detached after installing a selected protocol result.
+pub(super) struct WaiterInstall {
+    /// Waiter that accepted the result, when one remained eligible.
+    pub(super) waiter: Option<WaiterId>,
     /// Demand retirement and optional successor published after unlocking.
     pub(super) demand_updates: [Option<DemandSnapshot>; 2],
-    /// Establishment permit or rejected H1 returned after unlocking.
+    /// Establishment permit or rejected result returned after unlocking.
     pub(super) returned_event: Option<AcquisitionEvent>,
     /// Waiting task woken after demand publication.
     pub(super) waker: Option<Waker>,
 }
 
-impl H1Install {
+impl WaiterInstall {
     /// Preserves a result when no live attempt can accept HTTP/1.
     fn rejected(result: AcquisitionResult) -> Self {
         Self {
+            waiter: None,
             demand_updates: [None, None],
             returned_event: Some(AcquisitionEvent::Complete(result)),
+            waker: None,
+        }
+    }
+
+    /// Reports that no live attempt can accept an HTTP/2 activation.
+    fn empty() -> Self {
+        Self {
+            waiter: None,
+            demand_updates: [None, None],
+            returned_event: None,
             waker: None,
         }
     }
@@ -1386,6 +1369,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn h1_required_waiter_is_not_an_h2_candidate() {
+        let mut queue = AcquisitionQueue::default();
+        let (waiter, snapshot) = queue.register_waiter(
+            ProtocolRequirement::H1Required,
+            &EligibilityGroup::Pool,
+            false,
+        );
+
+        assert!(snapshot.is_none());
+        assert_eq!(Some(waiter), queue.oldest_h1_candidate());
+        assert_eq!(None, queue.oldest_h2_candidate());
+    }
+
+    #[test]
     fn head_cancellation_uses_the_successors_protocol_requirement() {
         let mut queue = AcquisitionQueue::default();
         let (head, initial) = queue.register_waiter(
@@ -1436,28 +1433,5 @@ mod tests {
             queue.reserve_delivery_waiter(DemandId::from_u64(0), &EligibilityGroup::Pool),
             DeliveryReservation::Rejected
         ));
-    }
-}
-
-/// Result of offering one activation through the HTTP/2 generation gate.
-pub(super) struct H2WaiterInstall {
-    /// Waiter receiving the prospective activation.
-    pub(super) waiter: Option<WaiterId>,
-    /// Demand retirement and successor publication produced by FIFO removal.
-    pub(super) demand_updates: [Option<DemandSnapshot>; 2],
-    /// Permit displaced by the activation and returned after unlock.
-    pub(super) returned_event: Option<AcquisitionEvent>,
-    /// Task to wake after the activation becomes visible.
-    pub(super) waker: Option<Waker>,
-}
-
-impl H2WaiterInstall {
-    fn empty() -> Self {
-        Self {
-            waiter: None,
-            demand_updates: [None, None],
-            returned_event: None,
-            waker: None,
-        }
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
@@ -62,7 +62,7 @@ pub(super) enum NegotiatedProtocol {
 
 /// Immutable identity and transport facts shared by a connection's owners.
 ///
-/// The protocol record, request metadata, tracing, and future lifecycle events
+/// The protocol record, request metadata, tracing, and lifecycle events
 /// all retain this one allocation rather than reconstructing origin or address
 /// data at each transition.
 #[derive(Debug)]
@@ -86,7 +86,7 @@ pub(super) struct ConnectionInfo {
 }
 
 impl ConnectionInfo {
-    /// Captures immutable facts when protocol establishment succeeds.
+    /// Captures immutable facts after transport negotiation selects a protocol.
     pub(super) fn new(
         id: ConnectionId,
         origin: OriginKey,
@@ -193,7 +193,7 @@ impl ConnectionInfo {
     }
 }
 
-/// Shared protocol-independent ownership for one installed connection.
+/// Shared connection ownership from negotiated transport through close.
 pub(super) struct ConnectionState {
     /// Identity and transport facts shared with metadata and lifecycle events.
     info: Arc<ConnectionInfo>,
@@ -215,8 +215,9 @@ struct LifecycleState {
 /// Whether a connection may accept dispatch and still owns bounded capacity.
 #[derive(Debug)]
 enum LogicalState {
-    /// Protocol handshake or cell installation has not committed.
-    Establishing,
+    /// The transport exists, but protocol handshake and installation have not
+    /// committed.
+    PendingOpen,
     /// Dispatch may commit.
     Open {
         /// Bounded-origin slot released by logical close, when configured.
@@ -230,16 +231,16 @@ enum LogicalState {
 }
 
 impl ConnectionState {
-    /// Creates state before a protocol handshake consumes the root I/O.
+    /// Creates state after transport establishment and before protocol setup.
     ///
     /// The returned guard is the unique physical-lifetime owner. Dispatch is
     /// rejected until [`Self::open`] transfers optional bounded capacity after
-    /// a successful handshake.
-    pub(super) fn establishing(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
+    /// a successful Hyper handshake and pool installation.
+    pub(super) fn pending_open(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
         let connection = Arc::new(Self {
             info,
             lifecycle: Mutex::new(LifecycleState {
-                logical: LogicalState::Establishing,
+                logical: LogicalState::PendingOpen,
                 in_flight: 0,
                 physical_complete: false,
             }),
@@ -256,7 +257,7 @@ impl ConnectionState {
     /// Returns `lease` when logical close won before installation.
     pub(super) fn open(&self, lease: Option<CapacityLease>) -> Result<(), Option<CapacityLease>> {
         let mut lifecycle = self.lifecycle.lock();
-        if !matches!(lifecycle.logical, LogicalState::Establishing) {
+        if !matches!(lifecycle.logical, LogicalState::PendingOpen) {
             return Err(lease);
         }
         lifecycle.logical = LogicalState::Open { lease };
@@ -269,7 +270,7 @@ impl ConnectionState {
     /// with the root I/O task.
     #[cfg(test)]
     pub(super) fn unbounded(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
-        let (connection, physical) = Self::establishing(info);
+        let (connection, physical) = Self::pending_open(info);
         connection
             .open(None)
             .expect("new unbounded connection could not open");
@@ -286,7 +287,7 @@ impl ConnectionState {
         info: Arc<ConnectionInfo>,
         lease: CapacityLease,
     ) -> (Arc<Self>, PhysicalConnectionGuard) {
-        let (connection, physical) = Self::establishing(info);
+        let (connection, physical) = Self::pending_open(info);
         connection
             .open(Some(lease))
             .expect("new bounded connection could not open");
@@ -341,7 +342,7 @@ impl ConnectionState {
         let lease = {
             let mut lifecycle = self.lifecycle.lock();
             match &mut lifecycle.logical {
-                LogicalState::Establishing => {
+                LogicalState::PendingOpen => {
                     lifecycle.logical = LogicalState::Closed { reason };
                     None
                 }
@@ -408,7 +409,7 @@ impl ConnectionState {
     pub(super) fn debug_assert_close_reason(&self, expected: CloseReason) {
         let lifecycle = self.lifecycle.lock();
         let actual = match lifecycle.logical {
-            LogicalState::Establishing => None,
+            LogicalState::PendingOpen => None,
             LogicalState::Open { .. } => None,
             LogicalState::Closed { reason } => Some(reason),
         };
@@ -454,7 +455,7 @@ impl ConnectionState {
         let lifecycle = self.lifecycle.lock();
         ConnectionSnapshot {
             close_reason: match lifecycle.logical {
-                LogicalState::Establishing => None,
+                LogicalState::PendingOpen => None,
                 LogicalState::Open { .. } => None,
                 LogicalState::Closed { reason } => Some(reason),
             },

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
@@ -151,7 +151,7 @@ impl ConnectionInfo {
         self.connected.get_extras(extensions);
     }
 
-    /// Builds Smithy metadata with close authority for this H1 generation.
+    /// Builds Smithy metadata with close authority for this H1 record.
     pub(super) fn metadata(&self, close: super::cell::h1::H1CloseHandle) -> ConnectionMetadata {
         let mut builder = ConnectionMetadata::builder()
             .proxied(self.proxied)

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
@@ -57,10 +57,6 @@ pub(super) enum NegotiatedProtocol {
     /// HTTP/1.1 with one exclusive request sender.
     Http1,
     /// HTTP/2 with a multiplexed request sender.
-    #[allow(
-        dead_code,
-        reason = "constructed once HTTP/2 generations are implemented"
-    )]
     Http2,
 }
 
@@ -78,10 +74,6 @@ pub(super) struct ConnectionInfo {
     /// Partition that retains the transport and protocol driver.
     owner_partition: PartitionId,
     /// Protocol selected by configuration or ALPN.
-    #[allow(
-        dead_code,
-        reason = "read when HTTP/2 generation selection is implemented"
-    )]
     protocol: NegotiatedProtocol,
     /// Local socket address reported by the connector, when available.
     local_addr: Option<SocketAddr>,
@@ -133,7 +125,6 @@ impl ConnectionInfo {
     }
 
     /// Returns the established HTTP protocol.
-    #[cfg(test)]
     pub(super) fn protocol(&self) -> NegotiatedProtocol {
         self.protocol
     }
@@ -162,6 +153,20 @@ impl ConnectionInfo {
 
     /// Builds Smithy metadata with close authority for this H1 generation.
     pub(super) fn metadata(&self, close: super::cell::h1::H1CloseHandle) -> ConnectionMetadata {
+        let mut builder = ConnectionMetadata::builder()
+            .proxied(self.proxied)
+            .connection_id(self.id)
+            .poison_fn(move || {
+                close.close(CloseReason::Poisoned);
+            });
+        builder
+            .set_local_addr(self.local_addr)
+            .set_remote_addr(self.remote_addr);
+        builder.build()
+    }
+
+    /// Builds Smithy metadata with close authority for this H2 generation.
+    pub(super) fn h2_metadata(&self, close: super::cell::h2::H2CloseHandle) -> ConnectionMetadata {
         let mut builder = ConnectionMetadata::builder()
             .proxied(self.proxied)
             .connection_id(self.id)
@@ -210,6 +215,8 @@ struct LifecycleState {
 /// Whether a connection may accept dispatch and still owns bounded capacity.
 #[derive(Debug)]
 enum LogicalState {
+    /// Protocol handshake or cell installation has not committed.
+    Establishing,
     /// Dispatch may commit.
     Open {
         /// Bounded-origin slot released by logical close, when configured.
@@ -223,35 +230,16 @@ enum LogicalState {
 }
 
 impl ConnectionState {
-    /// Creates a connection whose origin has no admission bound.
+    /// Creates state before a protocol handshake consumes the root I/O.
     ///
-    /// The returned guard is the unique physical-lifetime owner and must move
-    /// with the root I/O task.
-    pub(super) fn unbounded(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
-        Self::new(info, None)
-    }
-
-    /// Creates a connection that takes ownership of one bounded-origin slot.
-    ///
-    /// The returned guard is the unique physical-lifetime owner and must move
-    /// with the root I/O task. Logical close returns `lease` independently of
-    /// that guard.
-    pub(super) fn bounded(
-        info: Arc<ConnectionInfo>,
-        lease: CapacityLease,
-    ) -> (Arc<Self>, PhysicalConnectionGuard) {
-        Self::new(info, Some(lease))
-    }
-
-    /// Builds shared connection state and its unique physical-lifetime guard.
-    fn new(
-        info: Arc<ConnectionInfo>,
-        lease: Option<CapacityLease>,
-    ) -> (Arc<Self>, PhysicalConnectionGuard) {
+    /// The returned guard is the unique physical-lifetime owner. Dispatch is
+    /// rejected until [`Self::open`] transfers optional bounded capacity after
+    /// a successful handshake.
+    pub(super) fn establishing(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
         let connection = Arc::new(Self {
             info,
             lifecycle: Mutex::new(LifecycleState {
-                logical: LogicalState::Open { lease },
+                logical: LogicalState::Establishing,
                 in_flight: 0,
                 physical_complete: false,
             }),
@@ -260,6 +248,48 @@ impl ConnectionState {
             connection: connection.clone(),
             active: true,
         };
+        (connection, physical)
+    }
+
+    /// Commits protocol establishment and transfers optional bounded capacity.
+    ///
+    /// Returns `lease` when logical close won before installation.
+    pub(super) fn open(&self, lease: Option<CapacityLease>) -> Result<(), Option<CapacityLease>> {
+        let mut lifecycle = self.lifecycle.lock();
+        if !matches!(lifecycle.logical, LogicalState::Establishing) {
+            return Err(lease);
+        }
+        lifecycle.logical = LogicalState::Open { lease };
+        Ok(())
+    }
+
+    /// Creates a connection whose origin has no admission bound.
+    ///
+    /// The returned guard is the unique physical-lifetime owner and must move
+    /// with the root I/O task.
+    #[cfg(test)]
+    pub(super) fn unbounded(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
+        let (connection, physical) = Self::establishing(info);
+        connection
+            .open(None)
+            .expect("new unbounded connection could not open");
+        (connection, physical)
+    }
+
+    /// Creates a connection that takes ownership of one bounded-origin slot.
+    ///
+    /// The returned guard is the unique physical-lifetime owner and must move
+    /// with the root I/O task. Logical close returns `lease` independently of
+    /// that guard.
+    #[cfg(test)]
+    pub(super) fn bounded(
+        info: Arc<ConnectionInfo>,
+        lease: CapacityLease,
+    ) -> (Arc<Self>, PhysicalConnectionGuard) {
+        let (connection, physical) = Self::establishing(info);
+        connection
+            .open(Some(lease))
+            .expect("new bounded connection could not open");
         (connection, physical)
     }
 
@@ -310,17 +340,24 @@ impl ConnectionState {
     pub(super) fn logical_close(&self, reason: CloseReason) -> bool {
         let lease = {
             let mut lifecycle = self.lifecycle.lock();
-            let LogicalState::Open { lease } = &mut lifecycle.logical else {
-                return false;
-            };
-            let lease = lease.take();
-            lifecycle.logical = LogicalState::Closed { reason };
-            lease
+            match &mut lifecycle.logical {
+                LogicalState::Establishing => {
+                    lifecycle.logical = LogicalState::Closed { reason };
+                    None
+                }
+                LogicalState::Open { lease } => {
+                    let lease = lease.take();
+                    lifecycle.logical = LogicalState::Closed { reason };
+                    lease
+                }
+                LogicalState::Closed { .. } => return false,
+            }
         };
         drop(lease);
         tracing::debug!(
             connection_id = %self.id(),
             connection_partition = ?self.owner_partition(),
+            protocol = ?self.info.protocol(),
             origin_scheme = %self.info.origin().scheme(),
             origin_host = self.info.origin().host(),
             origin_port = ?self.info.origin().port(),
@@ -371,6 +408,7 @@ impl ConnectionState {
     pub(super) fn debug_assert_close_reason(&self, expected: CloseReason) {
         let lifecycle = self.lifecycle.lock();
         let actual = match lifecycle.logical {
+            LogicalState::Establishing => None,
             LogicalState::Open { .. } => None,
             LogicalState::Closed { reason } => Some(reason),
         };
@@ -416,6 +454,7 @@ impl ConnectionState {
         let lifecycle = self.lifecycle.lock();
         ConnectionSnapshot {
             close_reason: match lifecycle.logical {
+                LogicalState::Establishing => None,
                 LogicalState::Open { .. } => None,
                 LogicalState::Closed { reason } => Some(reason),
             },

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/connection.rs
@@ -215,8 +215,8 @@ struct LifecycleState {
 /// Whether a connection may accept dispatch and still owns bounded capacity.
 #[derive(Debug)]
 enum LogicalState {
-    /// The transport exists, but protocol handshake and installation have not
-    /// committed.
+    /// The connector returned connected I/O and selected the HTTP protocol,
+    /// but Hyper has not produced the request handle required for dispatch.
     PendingOpen,
     /// Dispatch may commit.
     Open {
@@ -231,11 +231,14 @@ enum LogicalState {
 }
 
 impl ConnectionState {
-    /// Creates state after transport establishment and before protocol setup.
+    /// Creates state after transport establishment and protocol selection.
     ///
-    /// The returned guard is the unique physical-lifetime owner. Dispatch is
-    /// rejected until [`Self::open`] transfers optional bounded capacity after
-    /// a successful Hyper handshake and pool installation.
+    /// For TLS transports, the connector has completed TLS and ALPN before this
+    /// call. Hyper protocol setup and cell installation have not occurred.
+    ///
+    /// The returned guard is the unique physical-lifetime owner. After Hyper
+    /// returns a request handle, [`Self::open`] attaches optional bounded
+    /// capacity before cell installation makes the connection discoverable.
     pub(super) fn pending_open(info: Arc<ConnectionInfo>) -> (Arc<Self>, PhysicalConnectionGuard) {
         let connection = Arc::new(Self {
             info,
@@ -252,9 +255,13 @@ impl ConnectionState {
         (connection, physical)
     }
 
-    /// Commits protocol establishment and transfers optional bounded capacity.
+    /// Opens dispatch commitment and transfers optional bounded capacity.
     ///
-    /// Returns `lease` when logical close won before installation.
+    /// The caller performs this transition after Hyper protocol setup and
+    /// before publishing the connection through its cell. Opening first
+    /// ensures that a newly visible request handle can commit dispatch.
+    ///
+    /// Returns `lease` when logical close won before opening.
     pub(super) fn open(&self, lease: Option<CapacityLease>) -> Result<(), Option<CapacityLease>> {
         let mut lifecycle = self.lifecycle.lock();
         if !matches!(lifecycle.logical, LogicalState::PendingOpen) {

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch.rs
@@ -25,9 +25,12 @@ use super::{ConnectionPool, PoolInner};
 use crate::sync::Arc;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_types::body::SdkBody;
-use http_1x::{Method, Request, Response, Uri, Version};
+use http_1x::{header, Method, Request, Response, Uri, Version};
 use std::future::poll_fn;
 use std::sync::Arc as StdArc;
+
+/// Replacement selections allowed after the initial HTTP/2 dispatch attempt.
+const MAX_H2_REACQUISITIONS: usize = 2;
 
 /// Stable state shared by acquisition and protocol dispatch for one request.
 ///
@@ -101,11 +104,8 @@ impl ConnectionPool {
         context: AcquisitionContext,
         mut request: Request<SdkBody>,
     ) -> Result<Response<SdkBody>, ConnectorError> {
-        let requirement = if request.version() == Version::HTTP_2 {
-            ProtocolRequirement::H2Required
-        } else {
-            ProtocolRequirement::H1Compatible
-        };
+        let requirement = protocol_requirement(&request);
+        let mut h2_reacquisitions = H2ReacquisitionBudget::default();
 
         loop {
             match Self::acquire(&context, requirement).await? {
@@ -116,13 +116,22 @@ impl ConnectionPool {
                     }
                 }
                 AcquisitionResult::H2(activation) => {
-                    match self.dispatch_h2(request, activation).await? {
+                    match self.dispatch_h2(&context, request, activation).await? {
                         H2DispatchResult::Response(response) => return Ok(response),
-                        H2DispatchResult::Reacquire(returned) => request = returned,
+                        H2DispatchResult::Reacquire(reacquisition) => {
+                            let (returned, error) = reacquisition.into_parts();
+                            if !h2_reacquisitions.admit_replacement() {
+                                return Err(error);
+                            }
+                            request = returned;
+                        }
                     }
                 }
                 AcquisitionResult::Failed(_) => {
                     unreachable!("failed acquisition returned as a successful result")
+                }
+                AcquisitionResult::Reacquire => {
+                    unreachable!("internal reacquisition escaped the acquisition loop")
                 }
             }
         }
@@ -137,51 +146,9 @@ impl ConnectionPool {
         context: &AcquisitionContext,
         requirement: ProtocolRequirement,
     ) -> Result<AcquisitionResult, ConnectorError> {
-        if let Some(activation) = OriginCell::select_h2(&context.cell) {
-            tracing::trace!(
-                connection_id = %activation.connection().id(),
-                request_partition = ?context.partition.id(),
-                connection_partition = ?activation.connection().owner_partition(),
-                origin_scheme = %context.cell.id().origin().scheme(),
-                origin_host = context.cell.id().origin().host(),
-                origin_port = ?context.cell.id().origin().port(),
-                "HTTP/2 pool hit; activating local generation"
-            );
-            return Ok(AcquisitionResult::H2(activation));
-        }
-        if requirement == ProtocolRequirement::H1Compatible {
-            if let Some(selection) = OriginCell::select_h1(&context.cell) {
-                tracing::trace!(
-                    connection_id = %selection.connection_id(),
-                    request_partition = ?context.partition.id(),
-                    connection_partition = ?selection.connection().owner_partition(),
-                    origin_scheme = %selection.connection().info().origin().scheme(),
-                    origin_host = selection.connection().info().origin().host(),
-                    origin_port = ?selection.connection().info().origin().port(),
-                    "HTTP/1 pool hit; reusing idle connection"
-                );
-                return Ok(AcquisitionResult::H1(selection));
-            }
-        }
-
-        let waiter = OriginCell::register_waiter(&context.cell, requirement);
-        tracing::trace!(
-            request_partition = ?context.partition.id(),
-            origin_scheme = %context.cell.id().origin().scheme(),
-            origin_host = context.cell.id().origin().host(),
-            origin_port = ?context.cell.id().origin().port(),
-            protocol_requirement = ?requirement,
-            "connection acquisition queued"
-        );
-        let mut waiter_guard = WaiterGuard::new(context.cell.clone(), waiter);
-        loop {
-            match poll_fn(|cx| context.cell.poll_waiter(waiter, cx)).await {
-                AcquisitionEvent::Complete(AcquisitionResult::H1(selection)) => {
-                    waiter_guard.disarm();
-                    return Ok(AcquisitionResult::H1(selection));
-                }
-                AcquisitionEvent::Complete(AcquisitionResult::H2(activation)) => {
-                    waiter_guard.disarm();
+        'acquire: loop {
+            if requirement.accepts_h2() {
+                if let Some(activation) = OriginCell::select_h2(&context.cell) {
                     tracing::trace!(
                         connection_id = %activation.connection().id(),
                         request_partition = ?context.partition.id(),
@@ -189,42 +156,113 @@ impl ConnectionPool {
                         origin_scheme = %context.cell.id().origin().scheme(),
                         origin_host = context.cell.id().origin().host(),
                         origin_port = ?context.cell.id().origin().port(),
-                        "HTTP/2 acquisition completed"
+                        "HTTP/2 pool hit; activating local generation"
                     );
                     return Ok(AcquisitionResult::H2(activation));
                 }
-                AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
-                    waiter_guard.disarm();
-                    return Err(error);
-                }
-                AcquisitionEvent::Establish(permit) => {
+            }
+            if requirement.accepts_h1() {
+                if let Some(selection) = OriginCell::select_h1(&context.cell) {
                     tracing::trace!(
+                        connection_id = %selection.connection_id(),
                         request_partition = ?context.partition.id(),
-                        origin_scheme = %context.cell.id().origin().scheme(),
-                        origin_host = context.cell.id().origin().host(),
-                        origin_port = ?context.cell.id().origin().port(),
-                        "connection establishment starting"
+                        connection_partition = ?selection.connection().owner_partition(),
+                        origin_scheme = %selection.connection().info().origin().scheme(),
+                        origin_host = selection.connection().info().origin().host(),
+                        origin_port = ?selection.connection().info().origin().port(),
+                        "HTTP/1 pool hit; reusing idle connection"
                     );
-                    let attempt = establish::establish(context.clone(), waiter, permit);
-                    let completion =
-                        EstablishmentCompletionGuard::new(context.cell.clone(), waiter);
-                    context.owner_spawner.spawn(Box::pin(async move {
-                        let mut completion = completion;
-                        if !completion.start() {
-                            drop(attempt);
-                            completion.disarm();
-                            return;
-                        }
-                        match attempt.await {
-                            establish::EstablishmentOutcome::Complete(result) => {
-                                completion.complete(result);
+                    return Ok(AcquisitionResult::H1(selection));
+                }
+            }
+
+            let waiter = OriginCell::register_waiter(&context.cell, requirement);
+            tracing::trace!(
+                request_partition = ?context.partition.id(),
+                origin_scheme = %context.cell.id().origin().scheme(),
+                origin_host = context.cell.id().origin().host(),
+                origin_port = ?context.cell.id().origin().port(),
+                protocol_requirement = ?requirement,
+                "connection acquisition queued"
+            );
+            let mut waiter_guard = WaiterGuard::new(context.cell.clone(), waiter);
+            loop {
+                match poll_fn(|cx| context.cell.poll_waiter(waiter, cx)).await {
+                    AcquisitionEvent::Complete(AcquisitionResult::H1(selection)) => {
+                        waiter_guard.disarm();
+                        return Ok(AcquisitionResult::H1(selection));
+                    }
+                    AcquisitionEvent::Complete(AcquisitionResult::H2(activation)) => {
+                        waiter_guard.disarm();
+                        OriginCell::service_h2_waiters(&context.cell);
+                        OriginCell::service_peer_h2_waiters(&context.cell);
+                        tracing::trace!(
+                            connection_id = %activation.connection().id(),
+                            request_partition = ?context.partition.id(),
+                            connection_partition = ?activation.connection().owner_partition(),
+                            origin_scheme = %context.cell.id().origin().scheme(),
+                            origin_host = context.cell.id().origin().host(),
+                            origin_port = ?context.cell.id().origin().port(),
+                            "HTTP/2 acquisition completed"
+                        );
+                        return Ok(AcquisitionResult::H2(activation));
+                    }
+                    AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
+                        waiter_guard.disarm();
+                        return Err(error);
+                    }
+                    AcquisitionEvent::Complete(AcquisitionResult::Reacquire) => {
+                        waiter_guard.disarm();
+                        continue 'acquire;
+                    }
+                    AcquisitionEvent::Establish(permit) => {
+                        tracing::trace!(
+                            request_partition = ?context.partition.id(),
+                            origin_scheme = %context.cell.id().origin().scheme(),
+                            origin_host = context.cell.id().origin().host(),
+                            origin_port = ?context.cell.id().origin().port(),
+                            "connection establishment starting"
+                        );
+                        let attempt =
+                            establish::establish(context.clone(), waiter, permit, requirement);
+                        let completion =
+                            EstablishmentCompletionGuard::new(context.cell.clone(), waiter);
+                        context.owner_spawner.spawn(Box::pin(async move {
+                            let mut completion = completion;
+                            if !completion.start() {
+                                drop(attempt);
+                                completion.disarm();
+                                return;
                             }
-                            establish::EstablishmentOutcome::Transferred => completion.disarm(),
-                        }
-                    }));
+                            match attempt.await {
+                                establish::EstablishmentOutcome::Complete(result) => {
+                                    completion.complete(result);
+                                }
+                                establish::EstablishmentOutcome::Transferred => completion.disarm(),
+                            }
+                        }));
+                    }
                 }
             }
         }
+    }
+}
+
+/// Per-request bound on replacement HTTP/2 selections.
+#[derive(Default)]
+struct H2ReacquisitionBudget {
+    /// Replacement selections admitted after the initial selection.
+    completed: usize,
+}
+
+impl H2ReacquisitionBudget {
+    /// Returns whether one more replacement selection may proceed.
+    fn admit_replacement(&mut self) -> bool {
+        if self.completed >= MAX_H2_REACQUISITIONS {
+            return false;
+        }
+        self.completed += 1;
+        true
     }
 }
 
@@ -265,7 +303,7 @@ impl EstablishmentCompletionGuard {
 impl Drop for EstablishmentCompletionGuard {
     fn drop(&mut self) {
         if self.active {
-            let error = ConnectorError::other(EstablishmentTaskDropped.into(), None);
+            let error = ConnectorError::io(EstablishmentTaskDropped.into());
             self.cell
                 .complete_establishment(self.waiter, AcquisitionResult::Failed(error));
             tracing::debug!(
@@ -325,6 +363,12 @@ impl Drop for WaiterGuard {
 fn validate_request_before_acquisition(
     request: &Request<SdkBody>,
 ) -> Result<(), RequestDispatchError> {
+    if request.version() == Version::HTTP_2 && request.method() == Method::CONNECT {
+        return Err(RequestDispatchError::ExtendedConnectUnsupported);
+    }
+    if request.version() == Version::HTTP_2 && has_upgrade_semantics(request) {
+        return Err(RequestDispatchError::UpgradeOverHttp2);
+    }
     match request.version() {
         Version::HTTP_11 | Version::HTTP_2 => Ok(()),
         Version::HTTP_10 if request.method() == Method::CONNECT => {
@@ -334,6 +378,40 @@ fn validate_request_before_acquisition(
         version => Err(RequestDispatchError::UnsupportedVersion(version)),
     }
 }
+
+/// Returns the protocol capability needed to preserve the request's wire semantics.
+fn protocol_requirement(request: &Request<SdkBody>) -> ProtocolRequirement {
+    if request.version() == Version::HTTP_2 {
+        ProtocolRequirement::H2Required
+    } else if request.version() == Version::HTTP_10
+        || request.method() == Method::CONNECT
+        || has_upgrade_semantics(request)
+    {
+        ProtocolRequirement::H1Required
+    } else {
+        ProtocolRequirement::H1Compatible
+    }
+}
+
+/// Returns whether the request asks HTTP/1 to switch protocols.
+fn has_upgrade_semantics(request: &Request<SdkBody>) -> bool {
+    request.headers().contains_key(header::UPGRADE)
+        || request
+            .headers()
+            .get_all(header::CONNECTION)
+            .iter()
+            .any(|value| {
+                value.to_str().is_ok_and(|value| {
+                    value
+                        .split(',')
+                        .any(|token| token.trim().eq_ignore_ascii_case("upgrade"))
+                })
+            })
+}
+
+/// Marker for a `Host` header synthesized during an HTTP/1 dispatch attempt.
+#[derive(Clone, Copy, Debug)]
+struct H1HostHeaderInserted;
 
 /// A request rejected before Hyper accepts it for dispatch.
 #[derive(Debug)]
@@ -346,6 +424,10 @@ enum RequestDispatchError {
     ConnectOverHttp10,
     /// The request selected an HTTP version this client cannot dispatch.
     UnsupportedVersion(Version),
+    /// Extended CONNECT requires HTTP/2 stream-lifecycle support.
+    ExtendedConnectUnsupported,
+    /// HTTP/1 upgrade semantics cannot be represented by this HTTP/2 path.
+    UpgradeOverHttp2,
 }
 
 impl std::fmt::Display for RequestDispatchError {
@@ -359,6 +441,12 @@ impl std::fmt::Display for RequestDispatchError {
             Self::UnsupportedVersion(version) => {
                 write!(f, "unsupported HTTP version: {version:?}")
             }
+            Self::ExtendedConnectUnsupported => {
+                f.write_str("extended CONNECT over HTTP/2 is not supported")
+            }
+            Self::UpgradeOverHttp2 => {
+                f.write_str("HTTP/1 protocol upgrade semantics cannot use HTTP/2")
+            }
         }
     }
 }
@@ -369,5 +457,74 @@ impl std::error::Error for RequestDispatchError {
             Self::InvalidHostHeader(error) => Some(error),
             _ => None,
         }
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+
+    fn request(method: Method, version: Version) -> Request<SdkBody> {
+        Request::builder()
+            .method(method)
+            .uri("https://example.com/resource")
+            .version(version)
+            .body(SdkBody::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn request_semantics_select_protocol_capability() {
+        assert_eq!(
+            ProtocolRequirement::H1Compatible,
+            protocol_requirement(&request(Method::GET, Version::HTTP_11))
+        );
+        assert_eq!(
+            ProtocolRequirement::H2Required,
+            protocol_requirement(&request(Method::GET, Version::HTTP_2))
+        );
+        assert_eq!(
+            ProtocolRequirement::H1Required,
+            protocol_requirement(&request(Method::GET, Version::HTTP_10))
+        );
+        assert_eq!(
+            ProtocolRequirement::H1Required,
+            protocol_requirement(&request(Method::CONNECT, Version::HTTP_11))
+        );
+
+        let mut upgrade = request(Method::GET, Version::HTTP_11);
+        upgrade
+            .headers_mut()
+            .insert(header::CONNECTION, "keep-alive, Upgrade".parse().unwrap());
+        assert_eq!(
+            ProtocolRequirement::H1Required,
+            protocol_requirement(&upgrade)
+        );
+    }
+
+    #[test]
+    fn unsupported_h2_tunnel_and_upgrade_forms_are_rejected() {
+        assert!(matches!(
+            validate_request_before_acquisition(&request(Method::CONNECT, Version::HTTP_2)),
+            Err(RequestDispatchError::ExtendedConnectUnsupported)
+        ));
+
+        let mut upgrade = request(Method::GET, Version::HTTP_2);
+        upgrade
+            .headers_mut()
+            .insert(header::UPGRADE, "websocket".parse().unwrap());
+        assert!(matches!(
+            validate_request_before_acquisition(&upgrade),
+            Err(RequestDispatchError::UpgradeOverHttp2)
+        ));
+    }
+
+    #[test]
+    fn h2_reacquisition_is_bounded_after_two_replacements() {
+        let mut budget = H2ReacquisitionBudget::default();
+        for _ in 0..MAX_H2_REACQUISITIONS {
+            assert!(budget.admit_replacement());
+        }
+        assert!(!budget.admit_replacement());
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch.rs
@@ -7,15 +7,18 @@
 //!
 //! This module is the request entry point after a [`super::Client`] has
 //! resolved its partition. It rejects unsupported request forms, resolves the
-//! origin cell and partition runtime, and starts partition maintenance before
-//! handing the request to a protocol-specific dispatcher. Connection
-//! acquisition, wire-form preparation, and response ownership live in child
-//! modules.
+//! origin cell and partition runtime, and owns acquisition across protocol
+//! selection. Child modules prepare protocol wire forms and retain response
+//! ownership.
 
 mod h1;
+mod h2;
 
-use super::cell::OriginCell;
-use super::establish::TransportTimeout;
+use self::h1::H1DispatchResult;
+use self::h2::H2DispatchResult;
+use super::admission::ProtocolRequirement;
+use super::cell::{AcquisitionEvent, AcquisitionResult, OriginCell, WaiterId};
+use super::establish::{self, TransportTimeout};
 use super::partition::DriverSpawner;
 use super::registry::PartitionState;
 use super::{ConnectionPool, PoolInner};
@@ -23,6 +26,7 @@ use crate::sync::Arc;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_types::body::SdkBody;
 use http_1x::{Method, Request, Response, Uri, Version};
+use std::future::poll_fn;
 use std::sync::Arc as StdArc;
 
 /// Stable state shared by acquisition and protocol dispatch for one request.
@@ -85,7 +89,235 @@ impl ConnectionPool {
             connect_timeout,
         };
 
-        self.send_h1_request(context, request).await
+        self.dispatch_acquired(context, request).await
+    }
+
+    /// Acquires a compatible protocol value and dispatches the request.
+    ///
+    /// Reacquisition is allowed only while a protocol dispatcher returns the
+    /// original request envelope.
+    async fn dispatch_acquired(
+        &self,
+        context: AcquisitionContext,
+        mut request: Request<SdkBody>,
+    ) -> Result<Response<SdkBody>, ConnectorError> {
+        let requirement = if request.version() == Version::HTTP_2 {
+            ProtocolRequirement::H2Required
+        } else {
+            ProtocolRequirement::H1Compatible
+        };
+
+        loop {
+            match Self::acquire(&context, requirement).await? {
+                AcquisitionResult::H1(selection) => {
+                    match self.dispatch_h1(&context, request, selection).await? {
+                        H1DispatchResult::Response(response) => return Ok(response),
+                        H1DispatchResult::Reacquire(returned) => request = returned,
+                    }
+                }
+                AcquisitionResult::H2(activation) => {
+                    match self.dispatch_h2(request, activation).await? {
+                        H2DispatchResult::Response(response) => return Ok(response),
+                        H2DispatchResult::Reacquire(returned) => request = returned,
+                    }
+                }
+                AcquisitionResult::Failed(_) => {
+                    unreachable!("failed acquisition returned as a successful result")
+                }
+            }
+        }
+    }
+
+    /// Acquires one protocol value compatible with the request.
+    ///
+    /// Local reusable values complete immediately. Otherwise one waiter
+    /// remains registered while it receives a reusable protocol value, an
+    /// establishment failure, or authority to start establishment.
+    async fn acquire(
+        context: &AcquisitionContext,
+        requirement: ProtocolRequirement,
+    ) -> Result<AcquisitionResult, ConnectorError> {
+        if let Some(activation) = OriginCell::select_h2(&context.cell) {
+            tracing::trace!(
+                connection_id = %activation.connection().id(),
+                request_partition = ?context.partition.id(),
+                connection_partition = ?activation.connection().owner_partition(),
+                origin_scheme = %context.cell.id().origin().scheme(),
+                origin_host = context.cell.id().origin().host(),
+                origin_port = ?context.cell.id().origin().port(),
+                "HTTP/2 pool hit; activating local generation"
+            );
+            return Ok(AcquisitionResult::H2(activation));
+        }
+        if requirement == ProtocolRequirement::H1Compatible {
+            if let Some(selection) = OriginCell::select_h1(&context.cell) {
+                tracing::trace!(
+                    connection_id = %selection.connection_id(),
+                    request_partition = ?context.partition.id(),
+                    connection_partition = ?selection.connection().owner_partition(),
+                    origin_scheme = %selection.connection().info().origin().scheme(),
+                    origin_host = selection.connection().info().origin().host(),
+                    origin_port = ?selection.connection().info().origin().port(),
+                    "HTTP/1 pool hit; reusing idle connection"
+                );
+                return Ok(AcquisitionResult::H1(selection));
+            }
+        }
+
+        let waiter = OriginCell::register_waiter(&context.cell, requirement);
+        tracing::trace!(
+            request_partition = ?context.partition.id(),
+            origin_scheme = %context.cell.id().origin().scheme(),
+            origin_host = context.cell.id().origin().host(),
+            origin_port = ?context.cell.id().origin().port(),
+            protocol_requirement = ?requirement,
+            "connection acquisition queued"
+        );
+        let mut waiter_guard = WaiterGuard::new(context.cell.clone(), waiter);
+        loop {
+            match poll_fn(|cx| context.cell.poll_waiter(waiter, cx)).await {
+                AcquisitionEvent::Complete(AcquisitionResult::H1(selection)) => {
+                    waiter_guard.disarm();
+                    return Ok(AcquisitionResult::H1(selection));
+                }
+                AcquisitionEvent::Complete(AcquisitionResult::H2(activation)) => {
+                    waiter_guard.disarm();
+                    tracing::trace!(
+                        connection_id = %activation.connection().id(),
+                        request_partition = ?context.partition.id(),
+                        connection_partition = ?activation.connection().owner_partition(),
+                        origin_scheme = %context.cell.id().origin().scheme(),
+                        origin_host = context.cell.id().origin().host(),
+                        origin_port = ?context.cell.id().origin().port(),
+                        "HTTP/2 acquisition completed"
+                    );
+                    return Ok(AcquisitionResult::H2(activation));
+                }
+                AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
+                    waiter_guard.disarm();
+                    return Err(error);
+                }
+                AcquisitionEvent::Establish(permit) => {
+                    tracing::trace!(
+                        request_partition = ?context.partition.id(),
+                        origin_scheme = %context.cell.id().origin().scheme(),
+                        origin_host = context.cell.id().origin().host(),
+                        origin_port = ?context.cell.id().origin().port(),
+                        "connection establishment starting"
+                    );
+                    let attempt = establish::establish(context.clone(), waiter, permit);
+                    let completion =
+                        EstablishmentCompletionGuard::new(context.cell.clone(), waiter);
+                    context.owner_spawner.spawn(Box::pin(async move {
+                        let mut completion = completion;
+                        if !completion.start() {
+                            drop(attempt);
+                            completion.disarm();
+                            return;
+                        }
+                        match attempt.await {
+                            establish::EstablishmentOutcome::Complete(result) => {
+                                completion.complete(result);
+                            }
+                            establish::EstablishmentOutcome::Transferred => completion.disarm(),
+                        }
+                    }));
+                }
+            }
+        }
+    }
+}
+
+/// Guarantees a terminal result for one submitted establishment attempt.
+///
+/// The guard enters the owner-runtime future before submission. Runtime task
+/// drop reports failure to the waiter. A result that wins before the submitted
+/// future starts disarms the guard without polling the connector.
+struct EstablishmentCompletionGuard {
+    cell: Arc<OriginCell>,
+    waiter: WaiterId,
+    active: bool,
+}
+
+impl EstablishmentCompletionGuard {
+    fn new(cell: Arc<OriginCell>, waiter: WaiterId) -> Self {
+        Self {
+            cell,
+            waiter,
+            active: true,
+        }
+    }
+
+    fn start(&self) -> bool {
+        self.cell.start_establishment(self.waiter)
+    }
+
+    fn complete(mut self, result: AcquisitionResult) {
+        self.active = false;
+        self.cell.complete_establishment(self.waiter, result);
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for EstablishmentCompletionGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let error = ConnectorError::other(EstablishmentTaskDropped.into(), None);
+            self.cell
+                .complete_establishment(self.waiter, AcquisitionResult::Failed(error));
+            tracing::debug!(
+                request_partition = ?self.cell.id().partition(),
+                connection_partition = ?self.cell.id().partition(),
+                origin_scheme = %self.cell.id().origin().scheme(),
+                origin_host = self.cell.id().origin().host(),
+                origin_port = ?self.cell.id().origin().port(),
+                "connection establishment task dropped"
+            );
+        }
+    }
+}
+
+/// The owner runtime discarded an establishment future before completion.
+#[derive(Debug)]
+struct EstablishmentTaskDropped;
+
+impl std::fmt::Display for EstablishmentTaskDropped {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the owner-runtime connection establishment task was dropped")
+    }
+}
+
+impl std::error::Error for EstablishmentTaskDropped {}
+
+/// Cancels a request's waiter until it consumes a terminal acquisition result.
+struct WaiterGuard {
+    cell: Arc<OriginCell>,
+    waiter: WaiterId,
+    active: bool,
+}
+
+impl WaiterGuard {
+    fn new(cell: Arc<OriginCell>, waiter: WaiterId) -> Self {
+        Self {
+            cell,
+            waiter,
+            active: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for WaiterGuard {
+    fn drop(&mut self) {
+        if self.active {
+            OriginCell::cancel_waiter(&self.cell, self.waiter);
+        }
     }
 }
 

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h1.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h1.rs
@@ -16,7 +16,7 @@ use super::super::cell::h1::{H1Exchange, H1Selection};
 use super::super::connection::{CloseReason, ConnectionState, DispatchGuard};
 use super::super::partition::DriverSpawner;
 use super::super::ConnectionPool;
-use super::{AcquisitionContext, RequestDispatchError};
+use super::{AcquisitionContext, H1HostHeaderInserted, RequestDispatchError};
 use aws_smithy_runtime_api::client::connection::CaptureSmithyConnection;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_types::body::SdkBody;
@@ -405,6 +405,7 @@ fn add_host_header(
     let value =
         http_1x::HeaderValue::from_str(&host).map_err(RequestDispatchError::InvalidHostHeader)?;
     request.headers_mut().insert(http_1x::header::HOST, value);
+    request.extensions_mut().insert(H1HostHeaderInserted);
     Ok(())
 }
 
@@ -661,7 +662,7 @@ mod tests {
             .send_request(partition, request, None)
             .await
             .expect_err("dropped establishment task did not fail the request");
-        assert!(error.is_other());
+        assert!(error.is_io());
         assert_eq!(
             "the owner-runtime connection establishment task was dropped",
             std::error::Error::source(&error).unwrap().to_string()
@@ -1154,30 +1155,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incompatible_h1_selection_reports_connection_identity() {
+    async fn incompatible_h1_result_remains_reusable_for_compatible_demand() {
         let server = TestServer::start().await;
-        let pool = ConnectionPool::builder().build_http().unwrap();
+        let pool = ConnectionPool::builder()
+            .max_connections_per_host(1)
+            .build_http()
+            .unwrap();
         let partition = anonymous_partition(&pool);
         let capture = CaptureSmithyConnection::new();
-        let mut request = Request::get(server.uri("/h2"))
+        let mut h2_request = Request::get(server.uri("/h2"))
             .version(Version::HTTP_2)
             .body(SdkBody::empty())
             .unwrap();
-        request.extensions_mut().insert(capture.clone());
+        h2_request.extensions_mut().insert(capture.clone());
 
         let error = pool
-            .send_request(partition, request, None)
+            .send_request(partition.clone(), h2_request, None)
             .await
             .expect_err("an HTTP/2 request unexpectedly used HTTP/1");
         assert!(error.is_user());
-        assert!(error
+        let error_connection = error
             .connection_metadata()
-            .and_then(|metadata| metadata.connection_id())
-            .is_some());
-        assert!(capture
+            .expect("the mismatch error omitted connection metadata");
+        let captured_connection = capture
             .get()
-            .and_then(|metadata| metadata.connection_id())
-            .is_some());
+            .expect("the mismatch request did not capture its connection");
+        assert_eq!(
+            error_connection.connection_id(),
+            captured_connection.connection_id()
+        );
+
+        let response = request(&pool, partition, server.uri("/h1")).await;
+        assert_eq!(
+            hyper::body::Bytes::from_static(b"ok"),
+            consume(response).await
+        );
+        assert_eq!(
+            1,
+            server.accepted(),
+            "the rejected HTTP/2 request discarded a reusable HTTP/1 connection"
+        );
     }
 
     #[tokio::test]

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h1.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h1.rs
@@ -3,24 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! HTTP/1 acquisition, exclusive dispatch, and response completion.
+//! HTTP/1 wire preparation, exclusive dispatch, and response completion.
 //!
 //! The parent dispatcher has already validated the request, resolved its
-//! origin cell, and selected the partition runtime. This module prepares the
-//! HTTP/1 wire form, acquires Hyper's exclusive request sender, and owns that
+//! origin cell, acquired an HTTP/1 selection, and selected the partition
+//! runtime. This module prepares the HTTP/1 wire form and owns the exclusive
 //! sender until the response reaches a reusable message boundary. Every
-//! cancellation path either returns the sender to its connection-owning cell
-//! or retires the connection.
+//! cancellation path returns the sender to its connection cell or retires the
+//! connection.
 
-use super::super::admission::ProtocolRequirement;
 use super::super::cell::h1::{H1Exchange, H1Selection};
-use super::super::cell::{AcquisitionEvent, AcquisitionResult, OriginCell, WaiterId};
 use super::super::connection::{CloseReason, ConnectionState, DispatchGuard};
-use super::super::establish;
 use super::super::partition::DriverSpawner;
 use super::super::ConnectionPool;
 use super::{AcquisitionContext, RequestDispatchError};
-use crate::sync::Arc;
 use aws_smithy_runtime_api::client::connection::CaptureSmithyConnection;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_types::body::SdkBody;
@@ -31,117 +27,106 @@ use std::pin::Pin;
 use std::sync::Arc as StdArc;
 use std::task::{Context, Poll};
 
+/// Result of one HTTP/1 dispatch attempt while the pool owns the request.
+pub(super) enum H1DispatchResult {
+    /// Hyper accepted the request and produced a guarded response.
+    Response(Response<SdkBody>),
+    /// The selection became stale or Hyper returned the request unsent.
+    Reacquire(Request<SdkBody>),
+}
+
 impl ConnectionPool {
-    /// Acquires an HTTP/1 connection and sends one request.
+    /// Attempts one dispatch through an acquired HTTP/1 selection.
     ///
-    /// The reacquisition loop runs only while the pool still owns the request. A
-    /// selection that closes before dispatch can be replaced immediately.
-    /// Hyper may also return an unconsumed request when a reused connection
-    /// rejects it before writing. Once Hyper accepts a request on a fresh
-    /// connection, or begins an exchange on any connection, this function does
-    /// not reacquire.
-    pub(super) async fn send_h1_request(
+    /// The parent may reacquire only when this function returns the original
+    /// request. A fresh connection's send error is terminal even if Hyper
+    /// returns the request.
+    pub(super) async fn dispatch_h1(
         &self,
-        context: AcquisitionContext,
+        context: &AcquisitionContext,
         mut request: Request<SdkBody>,
-    ) -> Result<Response<SdkBody>, ConnectorError> {
+        mut selection: H1Selection,
+    ) -> Result<H1DispatchResult, ConnectorError> {
         let request_method = request.method().clone();
-        // Add the HTTP/1 header that depends on the absolute request URI.
+        let reused = selection.is_reused();
+        let connection = selection.connection().clone();
+        let close_handle = selection.close_handle();
+        let captured_metadata = request
+            .extensions()
+            .get::<CaptureSmithyConnection>()
+            .cloned()
+            .map(|capture| {
+                let metadata = connection.info().metadata(close_handle.clone());
+                let captured = metadata.clone();
+                capture.set_connection_retriever(move || Some(captured.clone()));
+                metadata
+            });
+
+        if request.version() == Version::HTTP_2 {
+            let metadata =
+                captured_metadata.unwrap_or_else(|| connection.info().metadata(close_handle));
+            return Err(ConnectorError::user(
+                "an HTTP/2 request cannot use an HTTP/1 connection".into(),
+            )
+            .with_connection(metadata));
+        }
+
         add_host_header(&mut request, &context.absolute_uri)
             .map_err(|error| ConnectorError::user(error.into()))?;
+        rewrite_h1_request_target(&mut request, connection.info().is_proxied());
 
-        // Redispatch is valid only when the original request is recovered intact.
-        loop {
-            let mut selection = Self::acquire_h1(&context).await?;
-            let reused = selection.is_reused();
-            let connection = selection.connection().clone();
-            let close_handle = selection.close_handle();
-            let captured_metadata = request
-                .extensions()
-                .get::<CaptureSmithyConnection>()
-                .cloned()
-                .map(|capture| {
-                    let metadata = connection.info().metadata(close_handle.clone());
-                    let captured = metadata.clone();
-                    capture.set_connection_retriever(move || Some(captured.clone()));
-                    metadata
-                });
+        // Commit against logical close before transferring the request to
+        // Hyper. A close that wins this race leaves the request untouched.
+        let Some(dispatch) = ConnectionState::try_commit_dispatch(&connection) else {
+            tracing::trace!(
+                connection_id = %connection.id(),
+                request_partition = ?context.partition.id(),
+                connection_partition = ?connection.owner_partition(),
+                origin_scheme = %connection.info().origin().scheme(),
+                origin_host = connection.info().origin().host(),
+                origin_port = ?connection.info().origin().port(),
+                "HTTP/1 selection became stale before dispatch"
+            );
+            *request.uri_mut() = context.absolute_uri.clone();
+            selection.retire_connection(CloseReason::ProtocolClosed);
+            return Ok(H1DispatchResult::Reacquire(request));
+        };
+        let send = selection.sender_mut().hyper_mut().try_send_request(request);
 
-            if request.version() == Version::HTTP_2 {
-                let metadata =
-                    captured_metadata.unwrap_or_else(|| connection.info().metadata(close_handle));
-                return Err(ConnectorError::user(
-                    "an HTTP/2 request cannot use an HTTP/1 connection".into(),
-                )
-                .with_connection(metadata));
+        let exchange = selection.into_exchange();
+        match send.await {
+            Ok(mut response) => {
+                // Response-body ownership keeps both the accepted dispatch
+                // and exclusive request handle out of the pool until Hyper
+                // proves a complete message boundary.
+                connection
+                    .info()
+                    .apply_connector_extras(response.extensions_mut());
+                Ok(H1DispatchResult::Response(guard_response(
+                    response,
+                    request_method,
+                    exchange,
+                    dispatch,
+                    context.owner_spawner.clone(),
+                )))
             }
-
-            rewrite_h1_request_target(&mut request, connection.info().is_proxied());
-
-            // Commit against logical close before transferring the request to
-            // Hyper. A close that wins this race leaves the request untouched.
-            let Some(dispatch) = ConnectionState::try_commit_dispatch(&connection) else {
-                tracing::trace!(
-                    connection_id = %connection.id(),
-                    request_partition = ?context.partition.id(),
-                    connection_partition = ?connection.owner_partition(),
-                    origin_scheme = %connection.info().origin().scheme(),
-                    origin_host = connection.info().origin().host(),
-                    origin_port = ?connection.info().origin().port(),
-                    "HTTP/1 selection became stale before dispatch; reacquiring"
-                );
-                *request.uri_mut() = context.absolute_uri.clone();
-                selection.retire_connection(CloseReason::ProtocolClosed);
-                continue;
-            };
-            let send = selection.sender_mut().hyper_mut().try_send_request(request);
-
-            let exchange = selection.into_exchange();
-            match send.await {
-                Ok(mut response) => {
-                    // Response-body ownership keeps both the accepted dispatch
-                    // and exclusive request handle out of the pool until Hyper
-                    // proves a complete message boundary.
-                    connection
-                        .info()
-                        .apply_connector_extras(response.extensions_mut());
-                    return Ok(guard_response(
-                        response,
-                        request_method,
-                        exchange,
-                        dispatch,
-                        context.owner_spawner.clone(),
-                    ));
-                }
-                Err(mut error) => {
-                    if let Some(mut returned) = error.take_message() {
-                        exchange.retire_connection(CloseReason::ProtocolClosed);
-                        drop(dispatch);
-                        if reused {
-                            tracing::trace!(
-                                connection_id = %connection.id(),
-                                request_partition = ?context.partition.id(),
-                                connection_partition = ?connection.owner_partition(),
-                                origin_scheme = %connection.info().origin().scheme(),
-                                origin_host = connection.info().origin().host(),
-                                origin_port = ?connection.info().origin().port(),
-                                "reused HTTP/1 connection rejected request; reacquiring"
-                            );
-                            *returned.uri_mut() = context.absolute_uri.clone();
-                            // Hyper returned the original request without
-                            // consuming its body, so reacquisition is authoritative.
-                            request = returned;
-                            continue;
-                        }
-                        let metadata = captured_metadata
-                            .unwrap_or_else(|| connection.info().metadata(close_handle));
-                        return Err(super::super::super::downcast_error(Box::new(
-                            error.into_error(),
-                        ))
-                        .with_connection(metadata));
-                    }
-                    exchange.retire_connection(CloseReason::IncompleteH1Exchange);
+            Err(mut error) => {
+                if let Some(mut returned) = error.take_message() {
+                    exchange.retire_connection(CloseReason::ProtocolClosed);
                     drop(dispatch);
+                    if reused {
+                        tracing::trace!(
+                            connection_id = %connection.id(),
+                            request_partition = ?context.partition.id(),
+                            connection_partition = ?connection.owner_partition(),
+                            origin_scheme = %connection.info().origin().scheme(),
+                            origin_host = connection.info().origin().host(),
+                            origin_port = ?connection.info().origin().port(),
+                            "reused HTTP/1 connection returned request unsent"
+                        );
+                        *returned.uri_mut() = context.absolute_uri.clone();
+                        return Ok(H1DispatchResult::Reacquire(returned));
+                    }
                     let metadata = captured_metadata
                         .unwrap_or_else(|| connection.info().metadata(close_handle));
                     return Err(
@@ -149,197 +134,15 @@ impl ConnectionPool {
                             .with_connection(metadata),
                     );
                 }
+                exchange.retire_connection(CloseReason::IncompleteH1Exchange);
+                drop(dispatch);
+                let metadata =
+                    captured_metadata.unwrap_or_else(|| connection.info().metadata(close_handle));
+                Err(
+                    super::super::super::downcast_error(Box::new(error.into_error()))
+                        .with_connection(metadata),
+                )
             }
-        }
-    }
-
-    /// Returns one exclusive HTTP/1 request handle for this request.
-    ///
-    /// A local idle handle completes immediately. Otherwise one cell-local
-    /// waiter remains registered while it receives either a reusable handle,
-    /// an establishment failure, or capacity to start establishment. Starting
-    /// establishment does not complete the waiter: a returning connection may
-    /// still satisfy it first.
-    async fn acquire_h1(context: &AcquisitionContext) -> Result<H1Selection, ConnectorError> {
-        if let Some(selection) = OriginCell::select_h1(&context.cell) {
-            tracing::trace!(
-                connection_id = %selection.connection_id(),
-                request_partition = ?context.partition.id(),
-                connection_partition = ?selection.connection().owner_partition(),
-                origin_scheme = %selection.connection().info().origin().scheme(),
-                origin_host = selection.connection().info().origin().host(),
-                origin_port = ?selection.connection().info().origin().port(),
-                "HTTP/1 pool hit; reusing idle connection"
-            );
-            return Ok(selection);
-        }
-
-        let waiter = context
-            .cell
-            .register_waiter(ProtocolRequirement::H1Compatible);
-        tracing::trace!(
-            request_partition = ?context.partition.id(),
-            origin_scheme = %context.cell.id().origin().scheme(),
-            origin_host = context.cell.id().origin().host(),
-            origin_port = ?context.cell.id().origin().port(),
-            "HTTP/1 pool miss; acquisition queued"
-        );
-        let mut waiter_guard = WaiterGuard::new(context.cell.clone(), waiter);
-        loop {
-            match poll_fn(|cx| context.cell.poll_waiter(waiter, cx)).await {
-                AcquisitionEvent::Complete(AcquisitionResult::H1(selection)) => {
-                    tracing::trace!(
-                        connection_id = %selection.connection_id(),
-                        request_partition = ?context.partition.id(),
-                        connection_partition = ?selection.connection().owner_partition(),
-                        origin_scheme = %selection.connection().info().origin().scheme(),
-                        origin_host = selection.connection().info().origin().host(),
-                        origin_port = ?selection.connection().info().origin().port(),
-                        "HTTP/1 waiter acquired a reusable connection"
-                    );
-                    waiter_guard.disarm();
-                    return Ok(selection);
-                }
-                AcquisitionEvent::Complete(AcquisitionResult::Failed(error)) => {
-                    waiter_guard.disarm();
-                    return Err(error);
-                }
-                AcquisitionEvent::Establish(permit) => {
-                    tracing::trace!(
-                        request_partition = ?context.partition.id(),
-                        origin_scheme = %context.cell.id().origin().scheme(),
-                        origin_host = context.cell.id().origin().host(),
-                        origin_port = ?context.cell.id().origin().port(),
-                        "HTTP/1 waiter starting connection establishment"
-                    );
-                    let attempt = establish::establish_h1(context.clone(), permit);
-                    let completion = EstablishmentCompletion::new(context.cell.clone(), waiter);
-                    context.owner_spawner.spawn(Box::pin(async move {
-                        let mut completion = completion;
-                        if !completion.start() {
-                            drop(attempt);
-                            completion.disarm();
-                            return;
-                        }
-                        let result = attempt
-                            .await
-                            .map(AcquisitionResult::H1)
-                            .unwrap_or_else(AcquisitionResult::Failed);
-                        completion.complete(result);
-                    }));
-                }
-            }
-        }
-    }
-}
-
-/// Guarantees a terminal result for one submitted establishment attempt.
-///
-/// This guard moves into the owner-runtime future before it is submitted. If
-/// the runtime discards that future, [`Drop`] reports a failure to the waiter.
-/// If another connection satisfies the waiter before the submitted future
-/// starts, [`Self::start`] rejects the attempt and the guard is disarmed.
-struct EstablishmentCompletion {
-    /// Cell retaining the waiter and establishment state.
-    cell: Arc<OriginCell>,
-    /// Waiter that receives the attempt's terminal result.
-    waiter: WaiterId,
-    /// Whether task drop still owes a failure result.
-    active: bool,
-}
-
-impl EstablishmentCompletion {
-    /// Arms task-drop completion before the future is submitted.
-    fn new(cell: Arc<OriginCell>, waiter: WaiterId) -> Self {
-        Self {
-            cell,
-            waiter,
-            active: true,
-        }
-    }
-
-    /// Marks the waiter started immediately before the connector is first polled.
-    fn start(&self) -> bool {
-        self.cell.start_establishment(self.waiter)
-    }
-
-    /// Delivers the attempt result and disarms task-drop completion.
-    fn complete(mut self, result: AcquisitionResult) {
-        self.active = false;
-        self.cell.complete_establishment(self.waiter, result);
-    }
-
-    /// Disarms after another connection has already completed the waiter.
-    fn disarm(&mut self) {
-        self.active = false;
-    }
-}
-
-impl Drop for EstablishmentCompletion {
-    fn drop(&mut self) {
-        if self.active {
-            let error = ConnectorError::other(EstablishmentTaskDropped.into(), None);
-            self.cell
-                .complete_establishment(self.waiter, AcquisitionResult::Failed(error));
-            tracing::debug!(
-                request_partition = ?self.cell.id().partition(),
-                connection_partition = ?self.cell.id().partition(),
-                origin_scheme = %self.cell.id().origin().scheme(),
-                origin_host = self.cell.id().origin().host(),
-                origin_port = ?self.cell.id().origin().port(),
-                "HTTP/1 connection establishment task dropped"
-            );
-        }
-    }
-}
-
-/// The owner runtime discarded an establishment future before completion.
-#[derive(Debug)]
-struct EstablishmentTaskDropped;
-
-impl std::fmt::Display for EstablishmentTaskDropped {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("the owner-runtime connection establishment task was dropped")
-    }
-}
-
-impl std::error::Error for EstablishmentTaskDropped {}
-
-/// Cancels a request's retained waiter if acquisition does not complete.
-///
-/// The request future owns this guard from waiter registration until it
-/// consumes a terminal result. Dropping the future cancels the waiter; cell
-/// cancellation returns any crossing capacity or HTTP/1 handle after releasing
-/// the cell lock.
-struct WaiterGuard {
-    /// Cell retaining the waiter.
-    cell: Arc<OriginCell>,
-    /// Waiter cancelled if the request future does not consume a result.
-    waiter: WaiterId,
-    /// Whether request cancellation is still armed.
-    active: bool,
-}
-
-impl WaiterGuard {
-    /// Arms cancellation for a newly registered waiter.
-    fn new(cell: Arc<OriginCell>, waiter: WaiterId) -> Self {
-        Self {
-            cell,
-            waiter,
-            active: true,
-        }
-    }
-
-    /// Disarms after the request consumes its terminal result.
-    fn disarm(&mut self) {
-        self.active = false;
-    }
-}
-
-impl Drop for WaiterGuard {
-    fn drop(&mut self) {
-        if self.active {
-            OriginCell::cancel_waiter(&self.cell, self.waiter);
         }
     }
 }
@@ -629,6 +432,7 @@ fn rewrite_h1_request_target(request: &mut Request<SdkBody>, is_proxied: bool) {
 mod tests {
     use super::*;
     use crate::client::pool::cell::h1::H1Sender;
+    use crate::client::pool::cell::OriginCell;
     use crate::client::pool::connection::ConnectionInfo;
     use crate::client::pool::registry::PartitionState;
     use crate::client::pool::{
@@ -636,6 +440,7 @@ mod tests {
         TokioDriverSpawner,
     };
     use crate::client::timeout::test::{NeverConnects, NeverReplies};
+    use crate::sync::Arc;
     use aws_smithy_async::rt::sleep::TokioSleep;
     use aws_smithy_runtime_api::client::connection::CaptureSmithyConnection;
     use aws_smithy_runtime_api::client::http::{HttpClient, HttpConnector, HttpConnectorSettings};

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h2.rs
@@ -470,6 +470,21 @@ mod tests {
     use http_1x::uri::Scheme;
     use http_body_util::BodyExt;
 
+    /// Request body that fails on its first frame.
+    struct FailingBody;
+
+    impl Body for FailingBody {
+        type Data = hyper::body::Bytes;
+        type Error = std::io::Error;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+            Poll::Ready(Some(Err(std::io::Error::other("request body failed"))))
+        }
+    }
+
     fn cell() -> Arc<OriginCell> {
         Arc::new(OriginCell::new(
             PartitionId::from_index(1),
@@ -526,6 +541,35 @@ mod tests {
 
         H2RequestBodyHandle::arm(&mut request, endpoint);
 
+        assert!(probe.send_complete());
+    }
+    #[test]
+    fn dropping_request_body_completes_its_send_endpoint() {
+        let cell = cell();
+        let mut request = Request::new(SdkBody::from("payload"));
+        let (endpoint, probe) = H2LeaseEndpoint::send_for_test(&cell);
+
+        H2RequestBodyHandle::arm(&mut request, endpoint);
+        let body = std::mem::replace(request.body_mut(), SdkBody::empty());
+        drop(body);
+
+        assert!(probe.send_complete());
+    }
+
+    #[tokio::test]
+    async fn request_body_error_completes_its_send_endpoint() {
+        let cell = cell();
+        let mut request = Request::new(SdkBody::from_body_1_x(FailingBody));
+        let (endpoint, probe) = H2LeaseEndpoint::send_for_test(&cell);
+
+        H2RequestBodyHandle::arm(&mut request, endpoint);
+        let frame = request
+            .body_mut()
+            .frame()
+            .await
+            .expect("failing body omitted its error frame");
+
+        assert!(frame.is_err());
         assert!(probe.send_complete());
     }
 

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h2.rs
@@ -19,6 +19,7 @@
 use super::super::cell::h2::{H2Activation, H2CloseHandle, H2DispatchParts, H2LeaseEndpoint};
 use super::super::connection::ConnectionState;
 use super::super::ConnectionPool;
+use super::{AcquisitionContext, H1HostHeaderInserted};
 use crate::sync::{Arc, Mutex};
 use aws_smithy_runtime_api::client::connection::CaptureSmithyConnection;
 use aws_smithy_runtime_api::client::result::ConnectorError;
@@ -30,32 +31,59 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 /// Result of one checked HTTP/2 dispatch attempt.
+#[allow(
+    clippy::large_enum_variant,
+    reason = "boxing the successful response would allocate on every HTTP/2 request"
+)]
 pub(super) enum H2DispatchResult {
     /// Hyper accepted the request and produced a guarded response.
     Response(Response<SdkBody>),
-    /// Hyper returned the request envelope before accepting it.
-    Reacquire(Request<SdkBody>),
+    /// Hyper did not accept the request, so it may re-enter acquisition.
+    Reacquire(Box<H2Reacquisition>),
+}
+
+/// Request and terminal fallback retained for one replacement selection.
+pub(super) struct H2Reacquisition {
+    /// Original request Hyper did not accept.
+    request: Request<SdkBody>,
+    /// Error returned if the request exhausts its replacement budget.
+    error: ConnectorError,
+}
+
+impl H2Reacquisition {
+    /// Returns the original request and its terminal fallback.
+    pub(super) fn into_parts(self: Box<Self>) -> (Request<SdkBody>, ConnectorError) {
+        let Self { request, error } = *self;
+        (request, error)
+    }
 }
 
 /// State retained after Hyper accepts one request.
 struct H2AcceptedDispatch {
+    /// Connection retained through response creation.
     connection: Arc<ConnectionState>,
+    /// Generation close authority used for connection-wide failures.
     close: H2CloseHandle,
+    /// Metadata captured before the request moved into Hyper.
     captured_metadata: Option<aws_smithy_runtime_api::client::connection::ConnectionMetadata>,
+    /// Receive endpoint transferred to the guarded response body.
     receive_endpoint: H2LeaseEndpoint,
+    /// Whether the generation accepted an earlier request.
     reused: bool,
 }
 
 impl ConnectionPool {
     /// Dispatches one request through a prospective H2 generation lease.
     ///
-    /// A request returned by a reused generation may reacquire. Failure on a
-    /// fresh generation is terminal for this pool attempt.
+    /// Pool-side staleness reacquires before Hyper sees the request. Once
+    /// Hyper returns an envelope, only a reused generation may reacquire.
     pub(super) async fn dispatch_h2(
         &self,
+        context: &AcquisitionContext,
         mut request: Request<SdkBody>,
         mut activation: H2Activation,
     ) -> Result<H2DispatchResult, ConnectorError> {
+        prepare_h2_request(&mut request, &context.absolute_uri);
         let connection = activation.connection().clone();
         let reused = activation.is_reused();
         let close = activation.close_handle();
@@ -82,6 +110,7 @@ impl ConnectionPool {
             return finish_unaccepted_request(
                 request,
                 reused,
+                UnacceptedStage::BeforeHyper,
                 ConnectorError::other(H2ConnectionClosedBeforeDispatch.into(), None)
                     .with_connection(metadata),
             );
@@ -92,6 +121,7 @@ impl ConnectionPool {
             return finish_unaccepted_request(
                 request,
                 reused,
+                UnacceptedStage::BeforeHyper,
                 ConnectorError::other(H2ConnectionClosedBeforeDispatch.into(), None)
                     .with_connection(metadata),
             );
@@ -100,16 +130,10 @@ impl ConnectionPool {
         let body = H2RequestBodyHandle::arm(&mut request, send_endpoint);
 
         let mut send = Box::pin(sender.hyper_mut().try_send_request(request));
-        let first = poll_fn(|cx| {
-            Poll::Ready(match send.as_mut().poll(cx) {
-                Poll::Ready(result) => FirstPoll::Ready(result),
-                Poll::Pending => FirstPoll::Pending,
-            })
-        })
-        .await;
+        let first = poll_fn(|cx| Poll::Ready(send.as_mut().poll(cx))).await;
 
         match first {
-            FirstPoll::Ready(Err(mut error)) if error.message().is_some() => {
+            Poll::Ready(Err(mut error)) if error.message().is_some() => {
                 let returned = error
                     .take_message()
                     .expect("checked returned request disappeared");
@@ -123,11 +147,12 @@ impl ConnectionPool {
                 finish_unaccepted_request(
                     returned,
                     reused,
+                    UnacceptedStage::ReturnedByHyper,
                     super::super::super::downcast_error(Box::new(error.into_error()))
                         .with_connection(metadata),
                 )
             }
-            FirstPoll::Ready(result) => {
+            Poll::Ready(result) => {
                 activation.accept(dispatch);
                 let sender_closed = sender.is_closed();
                 self.finish_h2_send(
@@ -142,7 +167,7 @@ impl ConnectionPool {
                     },
                 )
             }
-            FirstPoll::Pending => {
+            Poll::Pending => {
                 activation.accept(dispatch);
                 let result = send.await;
                 let sender_closed = sender.is_closed();
@@ -194,6 +219,9 @@ impl ConnectionPool {
                 )))
             }
             Err(mut error) => {
+                // Hyper may return a queued envelope when its connection task
+                // drops after the first poll. The returned request is the
+                // authority for reacquisition; an error without it is terminal.
                 if let Some(request) = error.take_message() {
                     if let Some(body) = request.extensions().get::<H2RequestBodyHandle>() {
                         body.clear();
@@ -205,6 +233,7 @@ impl ConnectionPool {
                     return finish_unaccepted_request(
                         request,
                         reused,
+                        UnacceptedStage::ReturnedByHyper,
                         super::super::super::downcast_error(Box::new(error.into_error()))
                             .with_connection(metadata),
                     );
@@ -224,7 +253,32 @@ impl ConnectionPool {
     }
 }
 
-/// Reacquires only when a pooled generation returned the request unaccepted.
+/// Restores the absolute URI and removes only a pool-synthesized H1 `Host`.
+fn prepare_h2_request(request: &mut Request<SdkBody>, absolute_uri: &http_1x::Uri) {
+    *request.uri_mut() = absolute_uri.clone();
+    if request
+        .extensions_mut()
+        .remove::<H1HostHeaderInserted>()
+        .is_some()
+    {
+        request.headers_mut().remove(http_1x::header::HOST);
+    }
+}
+
+/// Point at which the pool learned that Hyper had not accepted the request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UnacceptedStage {
+    /// The pool rejected a stale generation before calling Hyper.
+    BeforeHyper,
+    /// Hyper returned the original request envelope.
+    ReturnedByHyper,
+}
+
+/// Applies retry authority to a request that Hyper did not accept.
+///
+/// Pool-side checks always reacquire because no protocol code observed the
+/// request. A returned Hyper envelope reacquires only after prior successful
+/// use proves that replacing a stale pooled generation is appropriate.
 #[allow(
     clippy::result_large_err,
     reason = "ConnectorError preserves SDK classification and connection metadata"
@@ -232,10 +286,14 @@ impl ConnectionPool {
 fn finish_unaccepted_request(
     request: Request<SdkBody>,
     reused: bool,
+    stage: UnacceptedStage,
     error: ConnectorError,
 ) -> Result<H2DispatchResult, ConnectorError> {
-    if reused {
-        Ok(H2DispatchResult::Reacquire(request))
+    if stage == UnacceptedStage::BeforeHyper || reused {
+        Ok(H2DispatchResult::Reacquire(Box::new(H2Reacquisition {
+            request,
+            error,
+        })))
     } else {
         Err(error)
     }
@@ -256,6 +314,7 @@ impl std::error::Error for H2ConnectionClosedBeforeDispatch {}
 /// Handle retained in a request extension after its body is wrapped once.
 #[derive(Clone)]
 struct H2RequestBodyHandle {
+    /// Re-armable send endpoint shared with the wrapped request body.
     slot: Arc<Mutex<Option<H2LeaseEndpoint>>>,
 }
 
@@ -281,25 +340,22 @@ impl H2RequestBodyHandle {
             });
         arm_send_endpoint(&handle.slot, endpoint);
         if is_end_stream {
-            complete_send_endpoint(&handle.slot);
+            finish_send_endpoint(&handle.slot);
         }
         handle
     }
 
     /// Disarms an endpoint after Hyper returns the request unaccepted.
     fn clear(&self) {
-        clear_send_endpoint(&self.slot);
+        finish_send_endpoint(&self.slot);
     }
-}
-
-enum FirstPoll<T> {
-    Ready(T),
-    Pending,
 }
 
 /// Request body whose endpoint can be re-armed after certified non-acceptance.
 struct H2RequestBody {
+    /// Original SDK body wrapped exactly once.
     inner: SdkBody,
+    /// Endpoint replaced when Hyper returns an unaccepted request.
     slot: Arc<Mutex<Option<H2LeaseEndpoint>>>,
 }
 
@@ -313,7 +369,7 @@ impl Body for H2RequestBody {
     ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
         let result = Pin::new(&mut self.inner).poll_frame(cx);
         if matches!(result, Poll::Ready(None) | Poll::Ready(Some(Err(_)))) {
-            complete_send_endpoint(&self.slot);
+            finish_send_endpoint(&self.slot);
         }
         result
     }
@@ -329,13 +385,15 @@ impl Body for H2RequestBody {
 
 impl Drop for H2RequestBody {
     fn drop(&mut self) {
-        complete_send_endpoint(&self.slot);
+        finish_send_endpoint(&self.slot);
     }
 }
 
 /// Response body that owns the receive endpoint through stream completion.
 struct H2ResponseBody {
+    /// Hyper response stream.
     inner: hyper::body::Incoming,
+    /// Receive endpoint completed on terminal frame, error, or drop.
     receive: Option<H2LeaseEndpoint>,
 }
 
@@ -394,12 +452,8 @@ fn arm_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>, endpoint: H2Lea
     drop(previous);
 }
 
-fn clear_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>) {
-    let endpoint = slot.lock().take();
-    drop(endpoint);
-}
-
-fn complete_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>) {
+/// Terminates the send endpoint after upload completion, error, or rejection.
+fn finish_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>) {
     let endpoint = slot.lock().take();
     if let Some(endpoint) = endpoint {
         endpoint.complete();
@@ -487,19 +541,58 @@ mod tests {
     }
 
     #[test]
-    fn only_reused_generation_reacquires_an_unaccepted_request() {
-        let fresh = finish_unaccepted_request(
+    fn h2_preparation_restores_uri_and_removes_only_synthesized_host() {
+        let absolute: http_1x::Uri = "https://example.com/resource".parse().unwrap();
+        let mut request = Request::get("/resource").body(SdkBody::empty()).unwrap();
+        request
+            .headers_mut()
+            .insert(http_1x::header::HOST, "example.com".parse().unwrap());
+        request.extensions_mut().insert(H1HostHeaderInserted);
+
+        prepare_h2_request(&mut request, &absolute);
+
+        assert_eq!(&absolute, request.uri());
+        assert!(!request.headers().contains_key(http_1x::header::HOST));
+        assert!(request.extensions().get::<H1HostHeaderInserted>().is_none());
+
+        let mut user_host = Request::get("/resource").body(SdkBody::empty()).unwrap();
+        user_host
+            .headers_mut()
+            .insert(http_1x::header::HOST, "signed.example".parse().unwrap());
+        prepare_h2_request(&mut user_host, &absolute);
+        assert_eq!("signed.example", user_host.headers()[http_1x::header::HOST]);
+    }
+
+    #[test]
+    fn retry_authority_distinguishes_pool_checks_from_hyper_returns() {
+        let checked_before_hyper = finish_unaccepted_request(
             Request::new(SdkBody::empty()),
             false,
-            ConnectorError::user("fresh failure".into()),
+            UnacceptedStage::BeforeHyper,
+            ConnectorError::user("pre-Hyper failure".into()),
         );
-        assert!(fresh.is_err());
+        assert!(matches!(
+            checked_before_hyper,
+            Ok(H2DispatchResult::Reacquire(_))
+        ));
 
-        let reused = finish_unaccepted_request(
+        let fresh_hyper_return = finish_unaccepted_request(
+            Request::new(SdkBody::empty()),
+            false,
+            UnacceptedStage::ReturnedByHyper,
+            ConnectorError::user("fresh Hyper failure".into()),
+        );
+        assert!(fresh_hyper_return.is_err());
+
+        let reused_hyper_return = finish_unaccepted_request(
             Request::new(SdkBody::empty()),
             true,
+            UnacceptedStage::ReturnedByHyper,
             ConnectorError::user("reused failure".into()),
         );
-        assert!(matches!(reused, Ok(H2DispatchResult::Reacquire(_))));
+        assert!(matches!(
+            reused_hyper_return,
+            Ok(H2DispatchResult::Reacquire(_))
+        ));
     }
 }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/dispatch/h2.rs
@@ -1,0 +1,505 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! HTTP/2 dispatch and two-ended request completion.
+//!
+//! [`H2Activation`] arrives with a prospective generation lease and a transient
+//! sender cloned from the connection-owning cell. Dispatch first checks sender
+//! and logical-connection state, then polls Hyper once. A request returned from
+//! that poll was not accepted and may re-enter protocol acquisition.
+//!
+//! After Hyper accepts the request, the activation becomes an accepted lease.
+//! [`H2RequestBody`] owns its send endpoint and [`H2ResponseBody`] owns its
+//! receive endpoint. Either may finish first; the generation request count is
+//! released only after both finish. A returned request re-arms the existing
+//! body wrapper rather than nesting wrappers around the original body.
+
+use super::super::cell::h2::{H2Activation, H2CloseHandle, H2DispatchParts, H2LeaseEndpoint};
+use super::super::connection::ConnectionState;
+use super::super::ConnectionPool;
+use crate::sync::{Arc, Mutex};
+use aws_smithy_runtime_api::client::connection::CaptureSmithyConnection;
+use aws_smithy_runtime_api::client::result::ConnectorError;
+use aws_smithy_types::body::SdkBody;
+use http_1x::{Request, Response};
+use hyper::body::Body;
+use std::future::{poll_fn, Future};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Result of one checked HTTP/2 dispatch attempt.
+pub(super) enum H2DispatchResult {
+    /// Hyper accepted the request and produced a guarded response.
+    Response(Response<SdkBody>),
+    /// Hyper returned the request envelope before accepting it.
+    Reacquire(Request<SdkBody>),
+}
+
+/// State retained after Hyper accepts one request.
+struct H2AcceptedDispatch {
+    connection: Arc<ConnectionState>,
+    close: H2CloseHandle,
+    captured_metadata: Option<aws_smithy_runtime_api::client::connection::ConnectionMetadata>,
+    receive_endpoint: H2LeaseEndpoint,
+    reused: bool,
+}
+
+impl ConnectionPool {
+    /// Dispatches one request through a prospective H2 generation lease.
+    ///
+    /// A request returned by a reused generation may reacquire. Failure on a
+    /// fresh generation is terminal for this pool attempt.
+    pub(super) async fn dispatch_h2(
+        &self,
+        mut request: Request<SdkBody>,
+        mut activation: H2Activation,
+    ) -> Result<H2DispatchResult, ConnectorError> {
+        let connection = activation.connection().clone();
+        let reused = activation.is_reused();
+        let close = activation.close_handle();
+        let captured_metadata = request
+            .extensions()
+            .get::<CaptureSmithyConnection>()
+            .cloned()
+            .map(|capture| {
+                let metadata = connection.info().h2_metadata(close.clone());
+                let captured = metadata.clone();
+                capture.set_connection_retriever(move || Some(captured.clone()));
+                metadata
+            });
+
+        let H2DispatchParts {
+            mut sender,
+            send_endpoint,
+            receive_endpoint,
+        } = activation.take_dispatch_parts();
+        if sender.is_closed() {
+            close.close(super::super::connection::CloseReason::ProtocolClosed);
+            let metadata =
+                captured_metadata.unwrap_or_else(|| connection.info().h2_metadata(close));
+            return finish_unaccepted_request(
+                request,
+                reused,
+                ConnectorError::other(H2ConnectionClosedBeforeDispatch.into(), None)
+                    .with_connection(metadata),
+            );
+        }
+        let Some(dispatch) = ConnectionState::try_commit_dispatch(&connection) else {
+            let metadata =
+                captured_metadata.unwrap_or_else(|| connection.info().h2_metadata(close));
+            return finish_unaccepted_request(
+                request,
+                reused,
+                ConnectorError::other(H2ConnectionClosedBeforeDispatch.into(), None)
+                    .with_connection(metadata),
+            );
+        };
+
+        let body = H2RequestBodyHandle::arm(&mut request, send_endpoint);
+
+        let mut send = Box::pin(sender.hyper_mut().try_send_request(request));
+        let first = poll_fn(|cx| {
+            Poll::Ready(match send.as_mut().poll(cx) {
+                Poll::Ready(result) => FirstPoll::Ready(result),
+                Poll::Pending => FirstPoll::Pending,
+            })
+        })
+        .await;
+
+        match first {
+            FirstPoll::Ready(Err(mut error)) if error.message().is_some() => {
+                let returned = error
+                    .take_message()
+                    .expect("checked returned request disappeared");
+                body.clear();
+                drop(receive_endpoint);
+                drop(dispatch);
+                drop(activation);
+                close.close(super::super::connection::CloseReason::ProtocolClosed);
+                let metadata =
+                    captured_metadata.unwrap_or_else(|| connection.info().h2_metadata(close));
+                finish_unaccepted_request(
+                    returned,
+                    reused,
+                    super::super::super::downcast_error(Box::new(error.into_error()))
+                        .with_connection(metadata),
+                )
+            }
+            FirstPoll::Ready(result) => {
+                activation.accept(dispatch);
+                let sender_closed = sender.is_closed();
+                self.finish_h2_send(
+                    sender_closed,
+                    result,
+                    H2AcceptedDispatch {
+                        connection,
+                        close,
+                        captured_metadata,
+                        receive_endpoint,
+                        reused,
+                    },
+                )
+            }
+            FirstPoll::Pending => {
+                activation.accept(dispatch);
+                let result = send.await;
+                let sender_closed = sender.is_closed();
+                self.finish_h2_send(
+                    sender_closed,
+                    result,
+                    H2AcceptedDispatch {
+                        connection,
+                        close,
+                        captured_metadata,
+                        receive_endpoint,
+                        reused,
+                    },
+                )
+            }
+        }
+    }
+
+    #[allow(
+        clippy::result_large_err,
+        reason = "ConnectorError preserves SDK classification and connection metadata"
+    )]
+    fn finish_h2_send(
+        &self,
+        sender_closed: bool,
+        result: Result<
+            Response<hyper::body::Incoming>,
+            hyper::client::conn::TrySendError<Request<SdkBody>>,
+        >,
+        accepted: H2AcceptedDispatch,
+    ) -> Result<H2DispatchResult, ConnectorError> {
+        let H2AcceptedDispatch {
+            connection,
+            close,
+            captured_metadata,
+            receive_endpoint,
+            reused,
+        } = accepted;
+        match result {
+            Ok(mut response) => {
+                connection
+                    .info()
+                    .apply_connector_extras(response.extensions_mut());
+                let (parts, body) = response.into_parts();
+                let body = H2ResponseBody::new(body, receive_endpoint);
+                Ok(H2DispatchResult::Response(Response::from_parts(
+                    parts,
+                    SdkBody::from_body_1_x(body),
+                )))
+            }
+            Err(mut error) => {
+                if let Some(request) = error.take_message() {
+                    if let Some(body) = request.extensions().get::<H2RequestBodyHandle>() {
+                        body.clear();
+                    }
+                    drop(receive_endpoint);
+                    close.close(super::super::connection::CloseReason::ProtocolClosed);
+                    let metadata =
+                        captured_metadata.unwrap_or_else(|| connection.info().h2_metadata(close));
+                    return finish_unaccepted_request(
+                        request,
+                        reused,
+                        super::super::super::downcast_error(Box::new(error.into_error()))
+                            .with_connection(metadata),
+                    );
+                }
+                if sender_closed {
+                    close.close(super::super::connection::CloseReason::ProtocolClosed);
+                }
+                drop(receive_endpoint);
+                let metadata =
+                    captured_metadata.unwrap_or_else(|| connection.info().h2_metadata(close));
+                Err(
+                    super::super::super::downcast_error(Box::new(error.into_error()))
+                        .with_connection(metadata),
+                )
+            }
+        }
+    }
+}
+
+/// Reacquires only when a pooled generation returned the request unaccepted.
+#[allow(
+    clippy::result_large_err,
+    reason = "ConnectorError preserves SDK classification and connection metadata"
+)]
+fn finish_unaccepted_request(
+    request: Request<SdkBody>,
+    reused: bool,
+    error: ConnectorError,
+) -> Result<H2DispatchResult, ConnectorError> {
+    if reused {
+        Ok(H2DispatchResult::Reacquire(request))
+    } else {
+        Err(error)
+    }
+}
+
+/// A fresh HTTP/2 generation closed before accepting its first request.
+#[derive(Debug)]
+struct H2ConnectionClosedBeforeDispatch;
+
+impl std::fmt::Display for H2ConnectionClosedBeforeDispatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the fresh HTTP/2 connection closed before request dispatch")
+    }
+}
+
+impl std::error::Error for H2ConnectionClosedBeforeDispatch {}
+
+/// Handle retained in a request extension after its body is wrapped once.
+#[derive(Clone)]
+struct H2RequestBodyHandle {
+    slot: Arc<Mutex<Option<H2LeaseEndpoint>>>,
+}
+
+impl H2RequestBodyHandle {
+    /// Wraps an unwrapped body and arms the current send endpoint.
+    fn arm(request: &mut Request<SdkBody>, endpoint: H2LeaseEndpoint) -> Self {
+        let is_end_stream = request.body().is_end_stream();
+        let handle = request
+            .extensions()
+            .get::<Self>()
+            .cloned()
+            .unwrap_or_else(|| {
+                let handle = Self {
+                    slot: Arc::new(Mutex::new(None)),
+                };
+                let body = std::mem::replace(request.body_mut(), SdkBody::taken());
+                *request.body_mut() = SdkBody::from_body_1_x(H2RequestBody {
+                    inner: body,
+                    slot: handle.slot.clone(),
+                });
+                request.extensions_mut().insert(handle.clone());
+                handle
+            });
+        arm_send_endpoint(&handle.slot, endpoint);
+        if is_end_stream {
+            complete_send_endpoint(&handle.slot);
+        }
+        handle
+    }
+
+    /// Disarms an endpoint after Hyper returns the request unaccepted.
+    fn clear(&self) {
+        clear_send_endpoint(&self.slot);
+    }
+}
+
+enum FirstPoll<T> {
+    Ready(T),
+    Pending,
+}
+
+/// Request body whose endpoint can be re-armed after certified non-acceptance.
+struct H2RequestBody {
+    inner: SdkBody,
+    slot: Arc<Mutex<Option<H2LeaseEndpoint>>>,
+}
+
+impl Body for H2RequestBody {
+    type Data = <SdkBody as Body>::Data;
+    type Error = <SdkBody as Body>::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let result = Pin::new(&mut self.inner).poll_frame(cx);
+        if matches!(result, Poll::Ready(None) | Poll::Ready(Some(Err(_)))) {
+            complete_send_endpoint(&self.slot);
+        }
+        result
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl Drop for H2RequestBody {
+    fn drop(&mut self) {
+        complete_send_endpoint(&self.slot);
+    }
+}
+
+/// Response body that owns the receive endpoint through stream completion.
+struct H2ResponseBody {
+    inner: hyper::body::Incoming,
+    receive: Option<H2LeaseEndpoint>,
+}
+
+impl H2ResponseBody {
+    /// Wraps a response and completes an endpoint already at end stream.
+    fn new(inner: hyper::body::Incoming, receive: H2LeaseEndpoint) -> Self {
+        let is_end_stream = inner.is_end_stream();
+        Self {
+            inner,
+            receive: retain_receive_endpoint(is_end_stream, receive),
+        }
+    }
+}
+
+/// Retains a receive endpoint only while response frames may remain.
+fn retain_receive_endpoint(
+    is_end_stream: bool,
+    receive: H2LeaseEndpoint,
+) -> Option<H2LeaseEndpoint> {
+    if is_end_stream {
+        receive.complete();
+        None
+    } else {
+        Some(receive)
+    }
+}
+
+impl Body for H2ResponseBody {
+    type Data = <hyper::body::Incoming as Body>::Data;
+    type Error = <hyper::body::Incoming as Body>::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let result = Pin::new(&mut self.inner).poll_frame(cx);
+        if matches!(result, Poll::Ready(None) | Poll::Ready(Some(Err(_)))) {
+            if let Some(endpoint) = self.receive.take() {
+                endpoint.complete();
+            }
+        }
+        result
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+fn arm_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>, endpoint: H2LeaseEndpoint) {
+    let previous = slot.lock().replace(endpoint);
+    drop(previous);
+}
+
+fn clear_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>) {
+    let endpoint = slot.lock().take();
+    drop(endpoint);
+}
+
+fn complete_send_endpoint(slot: &Arc<Mutex<Option<H2LeaseEndpoint>>>) {
+    let endpoint = slot.lock().take();
+    if let Some(endpoint) = endpoint {
+        endpoint.complete();
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom), feature = "rt-tokio"))]
+mod tests {
+    use super::*;
+    use crate::client::pool::cell::OriginCell;
+    use crate::client::pool::origin::OriginKey;
+    use crate::client::pool::partition::{EligibilityGroup, PartitionId};
+    use crate::sync::Arc;
+    use http_1x::uri::Scheme;
+    use http_body_util::BodyExt;
+
+    fn cell() -> Arc<OriginCell> {
+        Arc::new(OriginCell::new(
+            PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            None,
+            None,
+        ))
+    }
+
+    #[tokio::test]
+    async fn returned_request_rearms_one_body_wrapper() {
+        let cell = cell();
+        let mut request = Request::post("https://example.com/upload")
+            .body(SdkBody::from("payload"))
+            .unwrap();
+
+        let (first_endpoint, first_probe) = H2LeaseEndpoint::send_for_test(&cell);
+        let first = H2RequestBodyHandle::arm(&mut request, first_endpoint);
+        let first_slot = first.slot.clone();
+        assert!(!first_probe.send_complete());
+
+        let (second_endpoint, second_probe) = H2LeaseEndpoint::send_for_test(&cell);
+        let second = H2RequestBodyHandle::arm(&mut request, second_endpoint);
+        assert!(
+            Arc::ptr_eq(&first_slot, &second.slot),
+            "rearming replaced the request-body wrapper"
+        );
+        assert!(
+            first_probe.send_complete(),
+            "rearming did not cancel the prior prospective endpoint"
+        );
+        assert!(!second_probe.send_complete());
+
+        second.clear();
+        assert!(
+            second_probe.send_complete(),
+            "returned request retained its rejected send endpoint"
+        );
+        let body = request
+            .into_body()
+            .collect()
+            .await
+            .expect("wrapped request body failed")
+            .to_bytes();
+        assert_eq!(hyper::body::Bytes::from_static(b"payload"), body);
+    }
+
+    #[test]
+    fn empty_request_body_completes_its_send_endpoint_when_armed() {
+        let cell = cell();
+        let mut request = Request::new(SdkBody::empty());
+        let (endpoint, probe) = H2LeaseEndpoint::send_for_test(&cell);
+
+        H2RequestBodyHandle::arm(&mut request, endpoint);
+
+        assert!(probe.send_complete());
+    }
+
+    #[test]
+    fn bodyless_response_completes_its_receive_endpoint_without_drop() {
+        let cell = cell();
+        let (endpoint, probe) = H2LeaseEndpoint::receive_for_test(&cell);
+
+        let retained = retain_receive_endpoint(true, endpoint);
+
+        assert!(retained.is_none());
+        assert!(probe.receive_complete());
+    }
+
+    #[test]
+    fn only_reused_generation_reacquires_an_unaccepted_request() {
+        let fresh = finish_unaccepted_request(
+            Request::new(SdkBody::empty()),
+            false,
+            ConnectorError::user("fresh failure".into()),
+        );
+        assert!(fresh.is_err());
+
+        let reused = finish_unaccepted_request(
+            Request::new(SdkBody::empty()),
+            true,
+            ConnectorError::user("reused failure".into()),
+        );
+        assert!(matches!(reused, Ok(H2DispatchResult::Reacquire(_))));
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish.rs
@@ -8,6 +8,7 @@
 mod h1;
 mod h2;
 
+use super::admission::ProtocolRequirement;
 use super::cell::{AcquisitionResult, EstablishmentPermit, WaiterId};
 use super::dispatch::AcquisitionContext;
 use super::registry::PartitionState;
@@ -17,6 +18,7 @@ use crate::client::timeout::{self, TimeoutKind};
 use aws_smithy_async::rt::sleep::SharedAsyncSleep;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::connection::ConnectionId;
+use aws_smithy_runtime_api::client::result::ConnectorError;
 use http_1x::Uri;
 #[cfg(any(feature = "__rustls", feature = "s2n-tls"))]
 use std::collections::HashMap;
@@ -60,6 +62,9 @@ type TransportFuture = Pin<Box<dyn Future<Output = Result<BoxConn, BoxError>> + 
 /// and transport metadata. Protocol establishment consumes the resulting
 /// [`BoxConn`].
 pub(super) trait TransportFactory: Send + Sync + 'static {
+    /// Returns whether this factory can guarantee HTTP/1 for a required attempt.
+    fn guarantees_http1(&self) -> bool;
+
     /// Creates one partition-bound transport for `uri`.
     ///
     /// Connector readiness completes before `timeout` starts.
@@ -68,6 +73,7 @@ pub(super) trait TransportFactory: Send + Sync + 'static {
         partition: &PartitionState,
         uri: Uri,
         timeout: Option<TransportTimeout>,
+        alpn_protocols: AlpnProtocols,
     ) -> TransportFuture;
 }
 
@@ -75,6 +81,8 @@ pub(super) trait TransportFactory: Send + Sync + 'static {
 struct ServiceTransportFactory<F> {
     /// Builds a connector with the selected network-interface binding.
     connector_for_interface: F,
+    /// Whether every H1-required connection is guaranteed to negotiate H1.
+    guarantees_http1: bool,
 }
 
 impl<F, C, IO> TransportFactory for ServiceTransportFactory<F>
@@ -85,11 +93,16 @@ where
     C::Future: Send + 'static,
     IO: AsyncConn,
 {
+    fn guarantees_http1(&self) -> bool {
+        self.guarantees_http1
+    }
+
     fn connect(
         &self,
         partition: &PartitionState,
         uri: Uri,
         timeout: Option<TransportTimeout>,
+        _alpn_protocols: AlpnProtocols,
     ) -> TransportFuture {
         let interface = partition.interface().map(|interface| interface.as_ref());
         let mut connector = (self.connector_for_interface)(interface);
@@ -123,7 +136,7 @@ where
     C::Future: Send + 'static,
     IO: AsyncConn,
 {
-    transport_factory_for_interface(move |_| connector.clone())
+    service_transport_factory_for_interface(move |_| connector.clone(), false)
 }
 
 /// Erases a connector constructor that applies an optional interface binding.
@@ -140,22 +153,41 @@ where
     C::Future: Send + 'static,
     IO: AsyncConn,
 {
+    service_transport_factory_for_interface(connector_for_interface, true)
+}
+
+/// Erases a service connector and its HTTP/1 negotiation guarantee.
+fn service_transport_factory_for_interface<F, C, IO>(
+    connector_for_interface: F,
+    guarantees_http1: bool,
+) -> StdArc<dyn TransportFactory>
+where
+    F: Fn(Option<&str>) -> C + Send + Sync + 'static,
+    C: Service<Uri, Response = IO> + Send + 'static,
+    C::Error: Into<BoxError>,
+    C::Future: Send + 'static,
+    IO: AsyncConn,
+{
     StdArc::new(ServiceTransportFactory {
         connector_for_interface,
+        guarantees_http1,
     })
 }
 
 /// Erases and caches connectors whose construction carries TLS or other setup.
 ///
-/// Interface placement is immutable for a partition. Caching by the exact
-/// interface value keeps provider configuration and certificate loading off
-/// the request path while preserving one connector per placement.
+/// Interface placement is immutable for a partition. The first request for
+/// each `(interface, ALPN offer)` constructs its connector while holding the
+/// cache lock; later requests clone that retained connector. Provider
+/// configuration and certificate loading therefore occur at most once for
+/// each placement and offer rather than once per connection.
 #[cfg(any(feature = "__rustls", feature = "s2n-tls"))]
 pub(super) fn cached_transport_factory_for_interface<F, C, IO>(
     connector_for_interface: F,
+    guarantees_http1: bool,
 ) -> StdArc<dyn TransportFactory>
 where
-    F: Fn(Option<&str>) -> C + Send + Sync + 'static,
+    F: Fn(Option<&str>, AlpnProtocols) -> C + Send + Sync + 'static,
     C: Service<Uri, Response = IO> + Clone + Send + Sync + 'static,
     C::Error: Into<BoxError>,
     C::Future: Send + 'static,
@@ -163,29 +195,35 @@ where
 {
     struct Cached<F, C> {
         factory: F,
-        connectors: crate::sync::Mutex<HashMap<Option<String>, C>>,
+        guarantees_http1: bool,
+        connectors: crate::sync::Mutex<HashMap<(Option<String>, AlpnProtocols), C>>,
     }
 
     impl<F, C, IO> TransportFactory for Cached<F, C>
     where
-        F: Fn(Option<&str>) -> C + Send + Sync + 'static,
+        F: Fn(Option<&str>, AlpnProtocols) -> C + Send + Sync + 'static,
         C: Service<Uri, Response = IO> + Clone + Send + Sync + 'static,
         C::Error: Into<BoxError>,
         C::Future: Send + 'static,
         IO: AsyncConn,
     {
+        fn guarantees_http1(&self) -> bool {
+            self.guarantees_http1
+        }
+
         fn connect(
             &self,
             partition: &PartitionState,
             uri: Uri,
             timeout: Option<TransportTimeout>,
+            alpn_protocols: AlpnProtocols,
         ) -> TransportFuture {
             let interface = partition.interface().map(|value| value.to_string());
             let mut connector = self
                 .connectors
                 .lock()
-                .entry(interface.clone())
-                .or_insert_with(|| (self.factory)(interface.as_deref()))
+                .entry((interface.clone(), alpn_protocols))
+                .or_insert_with(|| (self.factory)(interface.as_deref(), alpn_protocols))
                 .clone();
             Box::pin(async move {
                 poll_fn(|cx| connector.poll_ready(cx))
@@ -206,6 +244,7 @@ where
 
     StdArc::new(Cached {
         factory: connector_for_interface,
+        guarantees_http1,
         connectors: crate::sync::Mutex::new(HashMap::new()),
     })
 }
@@ -223,6 +262,7 @@ pub(super) async fn establish(
     context: AcquisitionContext,
     waiter: WaiterId,
     permit: EstablishmentPermit,
+    requirement: ProtocolRequirement,
 ) -> EstablishmentOutcome {
     let io = match context
         .pool
@@ -231,6 +271,7 @@ pub(super) async fn establish(
             &context.partition,
             context.absolute_uri.clone(),
             context.connect_timeout.clone(),
+            alpn_protocols(requirement),
         )
         .await
     {
@@ -261,6 +302,14 @@ pub(super) async fn establish(
         negotiated_protocol = if negotiated_h2 { "HTTP/2" } else { "HTTP/1.1" },
         "transport protocol negotiated"
     );
+    if negotiated_h2 && !requirement.accepts_h2() {
+        drop(io);
+        drop(permit);
+        return EstablishmentOutcome::Complete(AcquisitionResult::Failed(ConnectorError::user(
+            NegotiatedProtocolMismatch { requirement }.into(),
+        )));
+    }
+
     if negotiated_h2 {
         h2::establish_h2(context, waiter, permit, io, connected).await
     } else {
@@ -272,6 +321,24 @@ pub(super) async fn establish(
         )
     }
 }
+
+/// An established transport selected a protocol incompatible with the request.
+#[derive(Debug)]
+struct NegotiatedProtocolMismatch {
+    requirement: ProtocolRequirement,
+}
+
+impl fmt::Display for NegotiatedProtocolMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "transport negotiated HTTP/2, which does not satisfy {:?} request semantics",
+            self.requirement
+        )
+    }
+}
+
+impl Error for NegotiatedProtocolMismatch {}
 
 /// Mints one non-wrapping physical-connection identity.
 fn next_connection_id(pool: &PoolInner) -> Result<ConnectionId, ConnectionIdExhausted> {
@@ -295,3 +362,19 @@ impl fmt::Display for ConnectionIdExhausted {
 }
 
 impl Error for ConnectionIdExhausted {}
+
+/// Static ALPN protocol offer used for one transport connection.
+pub(super) type AlpnProtocols = &'static [&'static [u8]];
+
+/// Default offer for requests that may use HTTP/2.
+pub(super) const HTTP_ALPN_PROTOCOLS: AlpnProtocols = &[b"h2", b"http/1.1"];
+
+/// Narrowed offer for requests that require HTTP/1 wire semantics.
+pub(super) const HTTP1_ALPN_PROTOCOLS: AlpnProtocols = &[b"http/1.1"];
+
+fn alpn_protocols(requirement: ProtocolRequirement) -> AlpnProtocols {
+    match requirement {
+        ProtocolRequirement::H1Required => HTTP1_ALPN_PROTOCOLS,
+        ProtocolRequirement::H1Compatible | ProtocolRequirement::H2Required => HTTP_ALPN_PROTOCOLS,
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish.rs
@@ -6,9 +6,10 @@
 //! Transport construction below HTTP protocol establishment.
 
 mod h1;
+mod h2;
 
-pub(super) use h1::establish_h1;
-
+use super::cell::{AcquisitionResult, EstablishmentPermit, WaiterId};
+use super::dispatch::AcquisitionContext;
 use super::registry::PartitionState;
 use super::PoolInner;
 use crate::client::connect::{AsyncConn, BoxConn};
@@ -17,6 +18,8 @@ use aws_smithy_async::rt::sleep::SharedAsyncSleep;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::connection::ConnectionId;
 use http_1x::Uri;
+#[cfg(any(feature = "__rustls", feature = "s2n-tls"))]
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::future::{poll_fn, Future};
@@ -140,6 +143,134 @@ where
     StdArc::new(ServiceTransportFactory {
         connector_for_interface,
     })
+}
+
+/// Erases and caches connectors whose construction carries TLS or other setup.
+///
+/// Interface placement is immutable for a partition. Caching by the exact
+/// interface value keeps provider configuration and certificate loading off
+/// the request path while preserving one connector per placement.
+#[cfg(any(feature = "__rustls", feature = "s2n-tls"))]
+pub(super) fn cached_transport_factory_for_interface<F, C, IO>(
+    connector_for_interface: F,
+) -> StdArc<dyn TransportFactory>
+where
+    F: Fn(Option<&str>) -> C + Send + Sync + 'static,
+    C: Service<Uri, Response = IO> + Clone + Send + Sync + 'static,
+    C::Error: Into<BoxError>,
+    C::Future: Send + 'static,
+    IO: AsyncConn,
+{
+    struct Cached<F, C> {
+        factory: F,
+        connectors: crate::sync::Mutex<HashMap<Option<String>, C>>,
+    }
+
+    impl<F, C, IO> TransportFactory for Cached<F, C>
+    where
+        F: Fn(Option<&str>) -> C + Send + Sync + 'static,
+        C: Service<Uri, Response = IO> + Clone + Send + Sync + 'static,
+        C::Error: Into<BoxError>,
+        C::Future: Send + 'static,
+        IO: AsyncConn,
+    {
+        fn connect(
+            &self,
+            partition: &PartitionState,
+            uri: Uri,
+            timeout: Option<TransportTimeout>,
+        ) -> TransportFuture {
+            let interface = partition.interface().map(|value| value.to_string());
+            let mut connector = self
+                .connectors
+                .lock()
+                .entry(interface.clone())
+                .or_insert_with(|| (self.factory)(interface.as_deref()))
+                .clone();
+            Box::pin(async move {
+                poll_fn(|cx| connector.poll_ready(cx))
+                    .await
+                    .map_err(Into::into)?;
+                let connect = connector.call(uri);
+                let io = timeout::maybe_timeout_future(
+                    connect,
+                    timeout.as_ref().map(|timeout| timeout.duration),
+                    timeout.as_ref().map(|timeout| &timeout.sleep),
+                    TimeoutKind::Connect,
+                )
+                .await?;
+                Ok(Box::new(io) as BoxConn)
+            })
+        }
+    }
+
+    StdArc::new(Cached {
+        factory: connector_for_interface,
+        connectors: crate::sync::Mutex::new(HashMap::new()),
+    })
+}
+
+/// Result of one owner-runtime establishment task.
+pub(super) enum EstablishmentOutcome {
+    /// The launching waiter receives this terminal result.
+    Complete(AcquisitionResult),
+    /// Waiter completion transferred to an H2 flight or generation.
+    Transferred,
+}
+
+/// Connects one transport and dispatches protocol establishment after ALPN.
+pub(super) async fn establish(
+    context: AcquisitionContext,
+    waiter: WaiterId,
+    permit: EstablishmentPermit,
+) -> EstablishmentOutcome {
+    let io = match context
+        .pool
+        .transport
+        .connect(
+            &context.partition,
+            context.absolute_uri.clone(),
+            context.connect_timeout.clone(),
+        )
+        .await
+    {
+        Ok(io) => io,
+        Err(error) => {
+            tracing::debug!(
+                request_partition = ?context.partition.id(),
+                connection_partition = ?context.cell.id().partition(),
+                origin_scheme = %context.cell.id().origin().scheme(),
+                origin_host = context.cell.id().origin().host(),
+                origin_port = ?context.cell.id().origin().port(),
+                error = ?error,
+                "transport establishment failed"
+            );
+            return EstablishmentOutcome::Complete(AcquisitionResult::Failed(
+                super::super::downcast_error(error),
+            ));
+        }
+    };
+    let connected = io.connected();
+    let negotiated_h2 = connected.is_negotiated_h2();
+    tracing::debug!(
+        request_partition = ?context.partition.id(),
+        connection_partition = ?context.cell.id().partition(),
+        origin_scheme = %context.cell.id().origin().scheme(),
+        origin_host = context.cell.id().origin().host(),
+        origin_port = ?context.cell.id().origin().port(),
+        negotiated_protocol = if negotiated_h2 { "HTTP/2" } else { "HTTP/1.1" },
+        "transport protocol negotiated"
+    );
+    if negotiated_h2 {
+        h2::establish_h2(context, waiter, permit, io, connected).await
+    } else {
+        EstablishmentOutcome::Complete(
+            h1::establish_h1(context, permit, io, connected)
+                .await
+                .map(AcquisitionResult::H1)
+                .unwrap_or_else(AcquisitionResult::Failed),
+        )
+    }
 }
 
 /// Mints one non-wrapping physical-connection identity.

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h1.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h1.rs
@@ -83,12 +83,10 @@ async fn handshake_and_install_h1(
         pool,
         partition,
         cell,
-        absolute_uri,
+        absolute_uri: _,
         owner_spawner,
-        connect_timeout,
+        connect_timeout: _,
     } = context;
-
-    drop((absolute_uri, connect_timeout));
 
     let id =
         next_connection_id(&pool).map_err(|error| ConnectorError::other(error.into(), None))?;
@@ -116,9 +114,8 @@ async fn handshake_and_install_h1(
     if let Err(lease) = connection.open(permit.into_lease()) {
         drop(lease);
         connection.logical_close(CloseReason::ProtocolClosed);
-        return Err(ConnectorError::other(
+        return Err(ConnectorError::io(
             "HTTP/1 connection closed before installation".into(),
-            None,
         ));
     }
 

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h1.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h1.rs
@@ -5,9 +5,9 @@
 
 //! HTTP/1 connection establishment.
 //!
-//! Establishment connects a transport, performs Hyper's client handshake,
-//! installs the resulting exclusive sender in the origin cell, and submits
-//! the protocol driver to the connection-owning partition.
+//! Establishment receives an already connected transport, performs Hyper's
+//! client handshake, installs the resulting exclusive sender in the origin
+//! cell, and submits the protocol driver to the connection-owning partition.
 
 use super::super::cell::h1::{H1CloseHandle, H1DriverGuard, H1Selection, H1Sender};
 use super::super::cell::{EstablishmentPermit, OriginCell};
@@ -16,12 +16,12 @@ use super::super::connection::{
 };
 use super::super::dispatch::AcquisitionContext;
 use super::next_connection_id;
+use crate::client::connect::BoxConn;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_types::body::SdkBody;
-use std::error::Error;
-use std::fmt;
+use hyper_util::client::legacy::connect::Connected;
 
-/// Connects, handshakes, installs, and starts the owner-partition driver.
+/// Handshakes, installs, and starts the owner-partition driver.
 ///
 /// `permit` remains the sole owner of optional bounded capacity until the
 /// connection state is created. An earlier failure returns that capacity
@@ -31,6 +31,8 @@ use std::fmt;
 pub(in crate::client::pool) async fn establish_h1(
     context: AcquisitionContext,
     permit: EstablishmentPermit,
+    io: BoxConn,
+    connected: Connected,
 ) -> Result<H1Selection, ConnectorError> {
     let request_partition = context.partition.id();
     let connection_cell = context.cell.clone();
@@ -43,7 +45,7 @@ pub(in crate::client::pool) async fn establish_h1(
         "HTTP/1 connection establishment started"
     );
 
-    let result = connect_handshake_and_install_h1(context, permit).await;
+    let result = handshake_and_install_h1(context, permit, io, connected).await;
     match &result {
         Ok(selection) => {
             let connection = selection.connection();
@@ -70,10 +72,12 @@ pub(in crate::client::pool) async fn establish_h1(
     result
 }
 
-/// Connects, handshakes, and installs one HTTP/1 connection.
-async fn connect_handshake_and_install_h1(
+/// Handshakes and installs one already connected HTTP/1 transport.
+async fn handshake_and_install_h1(
     context: AcquisitionContext,
     permit: EstablishmentPermit,
+    io: BoxConn,
+    connected: Connected,
 ) -> Result<H1Selection, ConnectorError> {
     let AcquisitionContext {
         pool,
@@ -84,15 +88,7 @@ async fn connect_handshake_and_install_h1(
         connect_timeout,
     } = context;
 
-    let io = pool
-        .transport
-        .connect(&partition, absolute_uri, connect_timeout)
-        .await
-        .map_err(super::super::super::downcast_error)?;
-    let connected = io.connected();
-    if connected.is_negotiated_h2() {
-        return Err(ConnectorError::user(UnsupportedNegotiatedProtocol.into()));
-    }
+    drop((absolute_uri, connect_timeout));
 
     let id =
         next_connection_id(&pool).map_err(|error| ConnectorError::other(error.into(), None))?;
@@ -103,10 +99,7 @@ async fn connect_handshake_and_install_h1(
         NegotiatedProtocol::Http1,
         connected,
     );
-    let (connection, physical) = match permit.into_lease() {
-        Some(lease) => ConnectionState::bounded(info, lease),
-        None => ConnectionState::unbounded(info),
-    };
+    let (connection, physical) = ConnectionState::establishing(info);
     let io = ConnectionIo::new(io, physical);
 
     let (sender, driver) = match hyper::client::conn::http1::Builder::new()
@@ -119,6 +112,15 @@ async fn connect_handshake_and_install_h1(
             return Err(super::super::super::downcast_error(Box::new(error)));
         }
     };
+
+    if let Err(lease) = connection.open(permit.into_lease()) {
+        drop(lease);
+        connection.logical_close(CloseReason::ProtocolClosed);
+        return Err(ConnectorError::other(
+            "HTTP/1 connection closed before installation".into(),
+            None,
+        ));
+    }
 
     let selection =
         OriginCell::install_selected_h1(&cell, connection.clone(), H1Sender::from_hyper(sender));
@@ -141,15 +143,3 @@ async fn connect_handshake_and_install_h1(
     }));
     Ok(selection)
 }
-
-/// The cleartext HTTP/1 path rejected a connector-selected HTTP/2 transport.
-#[derive(Debug)]
-struct UnsupportedNegotiatedProtocol;
-
-impl fmt::Display for UnsupportedNegotiatedProtocol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("the HTTP/1 pool path cannot install an HTTP/2 transport")
-    }
-}
-
-impl Error for UnsupportedNegotiatedProtocol {}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h1.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h1.rs
@@ -97,7 +97,7 @@ async fn handshake_and_install_h1(
         NegotiatedProtocol::Http1,
         connected,
     );
-    let (connection, physical) = ConnectionState::establishing(info);
+    let (connection, physical) = ConnectionState::pending_open(info);
     let io = ConnectionIo::new(io, physical);
 
     let (sender, driver) = match hyper::client::conn::http1::Builder::new()

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h2.rs
@@ -4,8 +4,20 @@
  */
 
 //! HTTP/2 flight convergence, handshake, and driver installation.
+//!
+//! ALPN-selected attempts first enter one cell-local transition: use an
+//! accepting generation, join the current flight, or become the flight's
+//! owner task. Only the owner performs Hyper's HTTP/2 handshake. It opens the
+//! connection, installs the generation, submits the driver on the partition
+//! spawner, and then disarms flight cleanup. Participants own only their
+//! waiter entries; losing attempts close their unused transport and return
+//! their capacity before this function reports transfer. The connector timeout
+//! ends before this phase; no separate pool timeout covers the HTTP/2
+//! handshake or driver submission.
 
-use super::super::cell::h2::{H2CloseHandle, H2DriverGuard, H2FlightId, H2FlightInstall, H2Sender};
+use super::super::cell::h2::{
+    H2CloseHandle, H2DriverGuard, H2FlightId, H2FlightInstall, H2GenerationJoin, H2Sender,
+};
 use super::super::cell::{AcquisitionResult, EstablishmentPermit, OriginCell, WaiterId};
 use super::super::connection::{
     CloseReason, ConnectionInfo, ConnectionIo, ConnectionState, NegotiatedProtocol,
@@ -17,6 +29,7 @@ use crate::client::connect::BoxConn;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::result::ConnectorError;
 use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::retry::ErrorKind;
 use hyper::rt::Executor;
 use hyper_util::client::legacy::connect::Connected;
 use std::future::Future;
@@ -25,6 +38,7 @@ use std::sync::Arc as StdArc;
 /// Hyper executor that keeps spawned HTTP/2 work on the connection partition.
 #[derive(Clone, Debug)]
 struct PartitionExecutor {
+    /// Runtime placement inherited from the connection-owning partition.
     spawner: StdArc<dyn DriverSpawner>,
 }
 
@@ -39,8 +53,11 @@ where
 
 /// Settles a flight if its owner-runtime task is discarded.
 struct FlightCompletionGuard {
+    /// Cell that owns the exact flight.
     cell: crate::sync::Arc<OriginCell>,
+    /// Flight identity protected from stale task completion.
     flight: H2FlightId,
+    /// Whether drop must fail remaining participants.
     active: bool,
 }
 
@@ -57,9 +74,9 @@ impl FlightCompletionGuard {
         self.active = false;
     }
 
-    fn fail(&mut self, error: BoxError) {
+    fn fail(&mut self, error: ConnectorError) {
         self.active = false;
-        fail_participants(&self.cell, self.flight, StdArc::new(error));
+        fail_participants(&self.cell, self.flight, error);
     }
 }
 
@@ -69,7 +86,7 @@ impl Drop for FlightCompletionGuard {
             fail_participants(
                 &self.cell,
                 self.flight,
-                StdArc::new(Box::new(std::io::Error::other(
+                ConnectorError::io(Box::new(std::io::Error::other(
                     "HTTP/2 establishment task was dropped",
                 ))),
             );
@@ -97,11 +114,14 @@ pub(super) async fn establish_h2(
                     h2_generation = ?generation,
                     "HTTP/2 establishment found an accepting generation"
                 );
-                if !OriginCell::join_h2_generation(&context.cell, waiter, generation) {
-                    continue;
+                match OriginCell::join_h2_generation(&context.cell, waiter, generation) {
+                    H2GenerationJoin::GenerationChanged => continue,
+                    H2GenerationJoin::Joined | H2GenerationJoin::WaiterCompleted => {
+                        drop(io);
+                        drop(permit);
+                        return EstablishmentOutcome::Transferred;
+                    }
                 }
-                drop((io, permit));
-                return EstablishmentOutcome::Transferred;
             }
             H2FlightInstall::Joined => {
                 tracing::trace!(
@@ -112,7 +132,8 @@ pub(super) async fn establish_h2(
                     origin_port = ?context.cell.id().origin().port(),
                     "HTTP/2 establishment joined the active flight"
                 );
-                drop((io, permit));
+                drop(io);
+                drop(permit);
                 return EstablishmentOutcome::Transferred;
             }
             H2FlightInstall::Driver(flight) => {
@@ -144,7 +165,7 @@ async fn drive_flight(
     let id = match next_connection_id(&context.pool) {
         Ok(id) => id,
         Err(error) => {
-            completion.fail(Box::new(error));
+            completion.fail(ConnectorError::other(Box::new(error), None));
             return;
         }
     };
@@ -167,7 +188,7 @@ async fn drive_flight(
         Ok(established) => established,
         Err(error) => {
             connection.logical_close(CloseReason::ProtocolClosed);
-            completion.fail(Box::new(error));
+            completion.fail(super::super::super::downcast_error(Box::new(error)));
             return;
         }
     };
@@ -175,9 +196,9 @@ async fn drive_flight(
     if let Err(lease) = connection.open(permit.into_lease()) {
         drop(lease);
         connection.logical_close(CloseReason::ProtocolClosed);
-        completion.fail(Box::new(std::io::Error::other(
+        completion.fail(ConnectorError::io(Box::new(std::io::Error::other(
             "HTTP/2 connection closed before installation",
-        )));
+        ))));
         return;
     }
 
@@ -192,9 +213,9 @@ async fn drive_flight(
         Ok(installed) => installed,
         Err((_connection, _sender)) => {
             connection.logical_close(CloseReason::ProtocolClosed);
-            completion.fail(Box::new(std::io::Error::other(
+            completion.fail(ConnectorError::io(Box::new(std::io::Error::other(
                 "HTTP/2 flight became stale before installation",
-            )));
+            ))));
             return;
         }
     };
@@ -230,34 +251,79 @@ async fn drive_flight(
     );
 }
 
+/// Connector classification copied to each participant in one failed flight.
+#[derive(Clone, Copy, Debug)]
+enum SharedFailureKind {
+    /// Connector timeout classification.
+    Timeout,
+    /// Caller or configuration error classification.
+    User,
+    /// Retryable transport I/O classification.
+    Io,
+    /// Other connector classification and optional retry kind.
+    Other(Option<ErrorKind>),
+}
+
 /// Cloneable wrapper that preserves one flight failure for every participant.
 #[derive(Clone, Debug)]
-struct SharedFlightFailure(StdArc<BoxError>);
+struct SharedFlightFailure {
+    /// Original source retained for every participant result.
+    source: StdArc<BoxError>,
+    /// Connector classification copied without consuming the source.
+    kind: SharedFailureKind,
+}
+
+impl SharedFlightFailure {
+    fn new(error: ConnectorError) -> Self {
+        let kind = if error.is_timeout() {
+            SharedFailureKind::Timeout
+        } else if error.is_user() {
+            SharedFailureKind::User
+        } else if error.is_io() {
+            SharedFailureKind::Io
+        } else {
+            debug_assert!(error.is_other());
+            SharedFailureKind::Other(error.as_other())
+        };
+        Self {
+            source: StdArc::new(error.into_source()),
+            kind,
+        }
+    }
+
+    fn connector_error(&self) -> ConnectorError {
+        let source: BoxError = Box::new(self.clone());
+        match self.kind {
+            SharedFailureKind::Timeout => ConnectorError::timeout(source),
+            SharedFailureKind::User => ConnectorError::user(source),
+            SharedFailureKind::Io => ConnectorError::io(source),
+            SharedFailureKind::Other(kind) => ConnectorError::other(source, kind),
+        }
+    }
+}
 
 impl std::fmt::Display for SharedFlightFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
+        std::fmt::Display::fmt(&self.source, f)
     }
 }
 
 impl std::error::Error for SharedFlightFailure {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.0.as_ref().as_ref())
+        Some(self.source.as_ref().as_ref())
     }
 }
 
 /// Fails every participant still retained by one exact flight.
-fn fail_participants(cell: &OriginCell, flight: H2FlightId, error: StdArc<BoxError>) {
+fn fail_participants(cell: &OriginCell, flight: H2FlightId, error: ConnectorError) {
     let Some(participants) = cell.fail_h2_flight(flight) else {
         return;
     };
+    let error = SharedFlightFailure::new(error);
     for participant in participants {
         cell.complete_establishment(
             participant,
-            AcquisitionResult::Failed(ConnectorError::other(
-                Box::new(SharedFlightFailure(error.clone())),
-                None,
-            )),
+            AcquisitionResult::Failed(error.connector_error()),
         );
     }
 }
@@ -318,13 +384,13 @@ mod tests {
         ));
 
         let mut completion = FlightCompletionGuard::new(cell.clone(), flight);
-        completion.fail(Box::new(std::io::Error::other(
+        completion.fail(ConnectorError::io(Box::new(std::io::Error::other(
             "synthetic HTTP/2 handshake failure",
-        )));
+        ))));
 
         for waiter in [first, second] {
             let error = failed_event(&cell, waiter);
-            assert!(error.is_other());
+            assert!(error.is_io());
             let source = error.source().expect("flight failure lost its source");
             assert_eq!("synthetic HTTP/2 handshake failure", source.to_string());
             assert!(
@@ -355,7 +421,7 @@ mod tests {
         drop(FlightCompletionGuard::new(cell.clone(), flight));
 
         let error = failed_event(&cell, live);
-        assert!(error.is_other());
+        assert!(error.is_io());
         assert_eq!(
             "HTTP/2 establishment task was dropped",
             error

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h2.rs
@@ -176,7 +176,7 @@ async fn drive_flight(
         NegotiatedProtocol::Http2,
         connected,
     );
-    let (connection, physical) = ConnectionState::establishing(info);
+    let (connection, physical) = ConnectionState::pending_open(info);
     let io = ConnectionIo::new(io, physical);
     let executor = PartitionExecutor {
         spawner: context.owner_spawner.clone(),

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/establish/h2.rs
@@ -1,0 +1,396 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! HTTP/2 flight convergence, handshake, and driver installation.
+
+use super::super::cell::h2::{H2CloseHandle, H2DriverGuard, H2FlightId, H2FlightInstall, H2Sender};
+use super::super::cell::{AcquisitionResult, EstablishmentPermit, OriginCell, WaiterId};
+use super::super::connection::{
+    CloseReason, ConnectionInfo, ConnectionIo, ConnectionState, NegotiatedProtocol,
+};
+use super::super::dispatch::AcquisitionContext;
+use super::super::partition::DriverSpawner;
+use super::{next_connection_id, EstablishmentOutcome};
+use crate::client::connect::BoxConn;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::result::ConnectorError;
+use aws_smithy_types::body::SdkBody;
+use hyper::rt::Executor;
+use hyper_util::client::legacy::connect::Connected;
+use std::future::Future;
+use std::sync::Arc as StdArc;
+
+/// Hyper executor that keeps spawned HTTP/2 work on the connection partition.
+#[derive(Clone, Debug)]
+struct PartitionExecutor {
+    spawner: StdArc<dyn DriverSpawner>,
+}
+
+impl<F> Executor<F> for PartitionExecutor
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    fn execute(&self, future: F) {
+        self.spawner.spawn(Box::pin(future));
+    }
+}
+
+/// Settles a flight if its owner-runtime task is discarded.
+struct FlightCompletionGuard {
+    cell: crate::sync::Arc<OriginCell>,
+    flight: H2FlightId,
+    active: bool,
+}
+
+impl FlightCompletionGuard {
+    fn new(cell: crate::sync::Arc<OriginCell>, flight: H2FlightId) -> Self {
+        Self {
+            cell,
+            flight,
+            active: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+
+    fn fail(&mut self, error: BoxError) {
+        self.active = false;
+        fail_participants(&self.cell, self.flight, StdArc::new(error));
+    }
+}
+
+impl Drop for FlightCompletionGuard {
+    fn drop(&mut self) {
+        if self.active {
+            fail_participants(
+                &self.cell,
+                self.flight,
+                StdArc::new(Box::new(std::io::Error::other(
+                    "HTTP/2 establishment task was dropped",
+                ))),
+            );
+        }
+    }
+}
+
+/// Converges after ALPN and performs at most one HTTP/2 handshake per cell.
+pub(super) async fn establish_h2(
+    context: AcquisitionContext,
+    waiter: WaiterId,
+    permit: EstablishmentPermit,
+    io: BoxConn,
+    connected: Connected,
+) -> EstablishmentOutcome {
+    loop {
+        match context.cell.install_or_join_h2_flight(waiter) {
+            H2FlightInstall::Accepting(generation) => {
+                tracing::trace!(
+                    request_partition = ?context.partition.id(),
+                    connection_partition = ?context.cell.id().partition(),
+                    origin_scheme = %context.cell.id().origin().scheme(),
+                    origin_host = context.cell.id().origin().host(),
+                    origin_port = ?context.cell.id().origin().port(),
+                    h2_generation = ?generation,
+                    "HTTP/2 establishment found an accepting generation"
+                );
+                if !OriginCell::join_h2_generation(&context.cell, waiter, generation) {
+                    continue;
+                }
+                drop((io, permit));
+                return EstablishmentOutcome::Transferred;
+            }
+            H2FlightInstall::Joined => {
+                tracing::trace!(
+                    request_partition = ?context.partition.id(),
+                    connection_partition = ?context.cell.id().partition(),
+                    origin_scheme = %context.cell.id().origin().scheme(),
+                    origin_host = context.cell.id().origin().host(),
+                    origin_port = ?context.cell.id().origin().port(),
+                    "HTTP/2 establishment joined the active flight"
+                );
+                drop((io, permit));
+                return EstablishmentOutcome::Transferred;
+            }
+            H2FlightInstall::Driver(flight) => {
+                tracing::trace!(
+                    request_partition = ?context.partition.id(),
+                    connection_partition = ?context.cell.id().partition(),
+                    origin_scheme = %context.cell.id().origin().scheme(),
+                    origin_host = context.cell.id().origin().host(),
+                    origin_port = ?context.cell.id().origin().port(),
+                    h2_flight = ?flight,
+                    "HTTP/2 establishment started a flight"
+                );
+                drive_flight(context, flight, permit, io, connected).await;
+                return EstablishmentOutcome::Transferred;
+            }
+        }
+    }
+}
+
+/// Handshakes, installs, and publishes one winning flight.
+async fn drive_flight(
+    context: AcquisitionContext,
+    flight: H2FlightId,
+    permit: EstablishmentPermit,
+    io: BoxConn,
+    connected: Connected,
+) {
+    let mut completion = FlightCompletionGuard::new(context.cell.clone(), flight);
+    let id = match next_connection_id(&context.pool) {
+        Ok(id) => id,
+        Err(error) => {
+            completion.fail(Box::new(error));
+            return;
+        }
+    };
+    let info = ConnectionInfo::new(
+        id,
+        context.cell.id().origin().clone(),
+        context.partition.id(),
+        NegotiatedProtocol::Http2,
+        connected,
+    );
+    let (connection, physical) = ConnectionState::establishing(info);
+    let io = ConnectionIo::new(io, physical);
+    let executor = PartitionExecutor {
+        spawner: context.owner_spawner.clone(),
+    };
+    let (sender, driver) = match hyper::client::conn::http2::Builder::new(executor)
+        .handshake::<_, SdkBody>(io)
+        .await
+    {
+        Ok(established) => established,
+        Err(error) => {
+            connection.logical_close(CloseReason::ProtocolClosed);
+            completion.fail(Box::new(error));
+            return;
+        }
+    };
+
+    if let Err(lease) = connection.open(permit.into_lease()) {
+        drop(lease);
+        connection.logical_close(CloseReason::ProtocolClosed);
+        completion.fail(Box::new(std::io::Error::other(
+            "HTTP/2 connection closed before installation",
+        )));
+        return;
+    }
+
+    let installed = OriginCell::complete_h2_flight(
+        &context.cell,
+        flight,
+        connection.clone(),
+        H2Sender::from_hyper(sender),
+        context.cell.idle_deadline(),
+    );
+    let installed = match installed {
+        Ok(installed) => installed,
+        Err((_connection, _sender)) => {
+            connection.logical_close(CloseReason::ProtocolClosed);
+            completion.fail(Box::new(std::io::Error::other(
+                "HTTP/2 flight became stale before installation",
+            )));
+            return;
+        }
+    };
+
+    let generation = installed;
+    let driver_guard = H2DriverGuard::new(H2CloseHandle::new(&context.cell, generation));
+    let driver_info = connection.info().clone();
+    context.owner_spawner.spawn(Box::pin(async move {
+        if let Err(error) = driver.await {
+            tracing::debug!(
+                connection_id = %driver_info.id(),
+                connection_partition = ?driver_info.owner_partition(),
+                origin_scheme = %driver_info.origin().scheme(),
+                origin_host = driver_info.origin().host(),
+                origin_port = ?driver_info.origin().port(),
+                error = ?error,
+                "HTTP/2 connection driver failed"
+            );
+        }
+        driver_guard.protocol_closed();
+    }));
+
+    completion.disarm();
+    tracing::debug!(
+        connection_id = %connection.id(),
+        request_partition = ?context.partition.id(),
+        connection_partition = ?connection.owner_partition(),
+        origin_scheme = %connection.info().origin().scheme(),
+        origin_host = connection.info().origin().host(),
+        origin_port = ?connection.info().origin().port(),
+        h2_generation = ?generation,
+        "HTTP/2 connection established"
+    );
+}
+
+/// Cloneable wrapper that preserves one flight failure for every participant.
+#[derive(Clone, Debug)]
+struct SharedFlightFailure(StdArc<BoxError>);
+
+impl std::fmt::Display for SharedFlightFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for SharedFlightFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref().as_ref())
+    }
+}
+
+/// Fails every participant still retained by one exact flight.
+fn fail_participants(cell: &OriginCell, flight: H2FlightId, error: StdArc<BoxError>) {
+    let Some(participants) = cell.fail_h2_flight(flight) else {
+        return;
+    };
+    for participant in participants {
+        cell.complete_establishment(
+            participant,
+            AcquisitionResult::Failed(ConnectorError::other(
+                Box::new(SharedFlightFailure(error.clone())),
+                None,
+            )),
+        );
+    }
+}
+
+#[cfg(all(test, not(smithy_http_client_loom)))]
+mod tests {
+    use super::*;
+    use crate::client::pool::admission::ProtocolRequirement;
+    use crate::client::pool::cell::AcquisitionEvent;
+    use crate::client::pool::origin::OriginKey;
+    use crate::client::pool::partition::EligibilityGroup;
+    use http_1x::uri::Scheme;
+    use std::error::Error as _;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Waker};
+
+    fn cell() -> crate::sync::Arc<OriginCell> {
+        crate::sync::Arc::new(OriginCell::new(
+            super::super::super::partition::PartitionId::from_index(1),
+            OriginKey::from_parts(Scheme::HTTPS, "example.com", None).unwrap(),
+            EligibilityGroup::Pool,
+            None,
+            None,
+        ))
+    }
+
+    fn launching_waiter(cell: &crate::sync::Arc<OriginCell>) -> WaiterId {
+        let waiter = OriginCell::register_waiter(cell, ProtocolRequirement::H2Required);
+        let event = cell.poll_waiter(waiter, &mut Context::from_waker(Waker::noop()));
+        let Poll::Ready(AcquisitionEvent::Establish(permit)) = event else {
+            panic!("new H2 waiter did not receive establishment authority");
+        };
+        assert!(cell.start_establishment(waiter));
+        drop(permit);
+        waiter
+    }
+
+    fn failed_event(cell: &OriginCell, waiter: WaiterId) -> ConnectorError {
+        let event = cell.poll_waiter(waiter, &mut Context::from_waker(Waker::noop()));
+        let Poll::Ready(AcquisitionEvent::Complete(AcquisitionResult::Failed(error))) = event
+        else {
+            panic!("flight participant did not receive a failure");
+        };
+        error
+    }
+
+    #[test]
+    fn flight_failure_reaches_every_live_participant() {
+        let cell = cell();
+        let first = launching_waiter(&cell);
+        let second = launching_waiter(&cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(first) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(second),
+            H2FlightInstall::Joined
+        ));
+
+        let mut completion = FlightCompletionGuard::new(cell.clone(), flight);
+        completion.fail(Box::new(std::io::Error::other(
+            "synthetic HTTP/2 handshake failure",
+        )));
+
+        for waiter in [first, second] {
+            let error = failed_event(&cell, waiter);
+            assert!(error.is_other());
+            let source = error.source().expect("flight failure lost its source");
+            assert_eq!("synthetic HTTP/2 handshake failure", source.to_string());
+            assert!(
+                source
+                    .source()
+                    .expect("flight failure lost its original source")
+                    .downcast_ref::<std::io::Error>()
+                    .is_some(),
+                "flight failure did not preserve the original error"
+            );
+        }
+    }
+
+    #[test]
+    fn task_drop_fails_only_participants_still_owned_by_the_flight() {
+        let cell = cell();
+        let live = launching_waiter(&cell);
+        let cancelled = launching_waiter(&cell);
+        let H2FlightInstall::Driver(flight) = cell.install_or_join_h2_flight(live) else {
+            panic!("first participant did not become the flight driver");
+        };
+        assert!(matches!(
+            cell.install_or_join_h2_flight(cancelled),
+            H2FlightInstall::Joined
+        ));
+        assert!(OriginCell::cancel_waiter(&cell, cancelled));
+
+        drop(FlightCompletionGuard::new(cell.clone(), flight));
+
+        let error = failed_event(&cell, live);
+        assert!(error.is_other());
+        assert_eq!(
+            "HTTP/2 establishment task was dropped",
+            error
+                .source()
+                .expect("task-drop failure lost its source")
+                .to_string()
+        );
+        let successor = OriginCell::register_waiter(&cell, ProtocolRequirement::H2Required);
+        assert_ne!(cancelled, successor);
+        assert!(OriginCell::cancel_waiter(&cell, successor));
+    }
+
+    #[derive(Debug)]
+    struct CountingSpawner {
+        submissions: StdArc<AtomicUsize>,
+    }
+
+    impl DriverSpawner for CountingSpawner {
+        fn spawn(&self, future: std::pin::Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            self.submissions.fetch_add(1, Ordering::Relaxed);
+            drop(future);
+        }
+    }
+
+    #[test]
+    fn hyper_executor_submits_work_to_the_partition_spawner() {
+        let submissions = StdArc::new(AtomicUsize::new(0));
+        let executor = PartitionExecutor {
+            spawner: StdArc::new(CountingSpawner {
+                submissions: submissions.clone(),
+            }),
+        };
+
+        executor.execute(async {});
+
+        assert_eq!(1, submissions.load(Ordering::Relaxed));
+    }
+}

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/maintenance.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/maintenance.rs
@@ -608,6 +608,18 @@ mod tests {
         connection
     }
 
+    fn h2_connection(id: u64) -> Arc<ConnectionState> {
+        let info = ConnectionInfo::new(
+            ConnectionId::new(id),
+            OriginKey::from_parts(Scheme::HTTP, "example.com", None).unwrap(),
+            PartitionId::from_index(1),
+            NegotiatedProtocol::Http2,
+            hyper_util::client::legacy::connect::Connected::new(),
+        );
+        let (connection, _physical) = ConnectionState::unbounded(info);
+        connection
+    }
+
     #[derive(Clone, Debug)]
     struct TrackingSpawner {
         submitted: Arc<AtomicU64>,
@@ -729,6 +741,31 @@ mod tests {
             Some(super::super::CloseReason::IdleTimeout),
             connection.snapshot().close_reason
         );
+    }
+    #[tokio::test]
+    async fn h2_generation_closes_at_its_fake_time_deadline() {
+        let timeout = Duration::from_secs(10);
+        let (maintenance, cell, mut gate) = managed_cell(timeout);
+        let connection = h2_connection(1);
+        OriginCell::install_h2_for_test(&cell, connection.clone(), 1, maintenance.idle_deadline());
+        PartitionMaintenance::start(&maintenance, &TokioDriverSpawner::current());
+
+        let sleep = gate.expect_sleep().await;
+        assert_eq!(timeout, sleep.duration());
+        assert_eq!(None, connection.snapshot().close_reason);
+        sleep.allow_progress();
+
+        for _ in 0..10 {
+            if connection.snapshot().close_reason == Some(super::super::CloseReason::IdleTimeout) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            Some(super::super::CloseReason::IdleTimeout),
+            connection.snapshot().close_reason
+        );
+        assert_eq!(None, cell.accepting_h2_generation());
     }
 
     #[tokio::test]

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/maintenance.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/maintenance.rs
@@ -768,6 +768,34 @@ mod tests {
         assert_eq!(None, cell.accepting_h2_generation());
     }
 
+    #[test]
+    fn accepted_h2_dispatch_resets_the_idle_deadline() {
+        let timeout = Duration::from_secs(10);
+        let time = RewindableTimeSource::new(0);
+        let (_unused_time, sleep, _gate) = controlled_time_and_sleep(UNIX_EPOCH);
+        let (maintenance, cell) = cell_with_maintenance(
+            timeout,
+            SharedTimeSource::new(time.clone()),
+            SharedAsyncSleep::new(sleep),
+        );
+        let connection = h2_connection(1);
+        OriginCell::install_h2_for_test(&cell, connection.clone(), 1, maintenance.idle_deadline());
+        assert_eq!(Some(UNIX_EPOCH + timeout), cell.nearest_idle_deadline());
+
+        time.set(20);
+        let mut activation =
+            OriginCell::select_h2(&cell).expect("HTTP/2 generation was not selectable");
+        let _dispatch_parts = activation.take_dispatch_parts();
+        let dispatch = ConnectionState::try_commit_dispatch(&connection)
+            .expect("HTTP/2 connection rejected dispatch");
+        activation.accept(dispatch);
+
+        assert_eq!(
+            Some(UNIX_EPOCH + Duration::from_secs(20) + timeout),
+            cell.nearest_idle_deadline()
+        );
+    }
+
     #[tokio::test]
     async fn selected_record_has_no_idle_deadline() {
         let timeout = Duration::from_secs(10);

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/partition.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/partition.rs
@@ -182,7 +182,12 @@ pub enum ConnectionReuseScope {
     Pool,
 }
 
-/// Identifies the exact set of partitions eligible to reuse a connection.
+/// Identifies the exact set of partitions allowed to share a connection.
+///
+/// The configured [`ConnectionReuseScope`] maps each partition to one group:
+/// partition-local scope creates a group for one partition, network-interface
+/// scope groups equal interface bindings, and pool scope creates one group for
+/// the whole pool.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum EligibilityGroup {
     /// Only the partition with this identity is eligible.

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/partition.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/partition.rs
@@ -105,7 +105,7 @@ impl fmt::Debug for Partition {
 }
 
 /// Identifies one declared connection partition.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PartitionId(usize);
 
 impl PartitionId {
@@ -183,7 +183,7 @@ pub enum ConnectionReuseScope {
 }
 
 /// Identifies the exact set of partitions eligible to reuse a connection.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum EligibilityGroup {
     /// Only the partition with this identity is eligible.
     Partition(PartitionId),

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
@@ -37,6 +37,8 @@ pub(crate) struct PartitionRegistry {
     reuse_scope: ConnectionReuseScope,
     /// Optional origin-wide bound used when admission is first created.
     max_connections_per_host: Option<NonZeroUsize>,
+    /// Whether H1-required demand may reclaim idle H2 capacity.
+    guarantees_http1: bool,
     /// Admission authorities retained by canonical origin.
     bounded_origins: Mutex<HashMap<OriginKey, Arc<OriginAdmission>>>,
 }
@@ -47,6 +49,7 @@ impl PartitionRegistry {
         partitions: Option<Vec<Partition>>,
         reuse_scope: ConnectionReuseScope,
         max_connections_per_host: Option<NonZeroUsize>,
+        guarantees_http1: bool,
         maintenance: MaintenanceConfig,
     ) -> Result<Self, PartitionRegistryError> {
         let Some(partitions) = partitions else {
@@ -57,6 +60,7 @@ impl PartitionRegistry {
                 partitions,
                 reuse_scope,
                 max_connections_per_host,
+                guarantees_http1,
                 bounded_origins: Mutex::new(HashMap::new()),
             });
         };
@@ -86,6 +90,7 @@ impl PartitionRegistry {
             partitions: by_id,
             reuse_scope,
             max_connections_per_host,
+            guarantees_http1,
             bounded_origins: Mutex::new(HashMap::new()),
         })
     }
@@ -135,7 +140,9 @@ impl PartitionRegistry {
             let mut origins = self.bounded_origins.lock();
             origins
                 .entry(origin.clone())
-                .or_insert_with(|| OriginAdmission::new(origin.clone(), limit))
+                .or_insert_with(|| {
+                    OriginAdmission::new(origin.clone(), limit, self.guarantees_http1)
+                })
                 .clone()
         };
         Some(admission)
@@ -425,6 +432,7 @@ mod tests {
             None,
             reuse_scope,
             max_connections_per_host,
+            true,
             MaintenanceConfig::default(),
         )
         .unwrap()
@@ -439,6 +447,7 @@ mod tests {
             Some(partitions.into_iter().collect()),
             reuse_scope,
             max_connections_per_host,
+            true,
             MaintenanceConfig::default(),
         )
     }
@@ -753,6 +762,7 @@ mod loom_tests {
             Some(partitions.into_iter().collect()),
             reuse_scope,
             max_connections_per_host,
+            true,
             MaintenanceConfig::default(),
         )
     }

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
@@ -163,7 +163,7 @@ impl PartitionRegistry {
             .flat_map(|partition| partition.cells())
             .collect::<Vec<_>>();
         for cell in cells {
-            OriginCell::close_all_h1(&cell, reason);
+            OriginCell::close_all(&cell, reason);
         }
     }
 }
@@ -722,7 +722,7 @@ mod tests {
             .all(|cell| Arc::ptr_eq(&cells[0], cell)));
         assert_eq!(1, partition.cell_count());
 
-        let waiter = cells[0].register_waiter(ProtocolRequirement::H1Compatible);
+        let waiter = OriginCell::register_waiter(&cells[0], ProtocolRequirement::H1Compatible);
         let lease = OriginCell::take_ready_lease(&cells[0], waiter)
             .expect("admission targeted a different cell than the registry retained");
         drop(lease);

--- a/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/pool/registry.rs
@@ -37,8 +37,8 @@ pub(crate) struct PartitionRegistry {
     reuse_scope: ConnectionReuseScope,
     /// Optional origin-wide bound used when admission is first created.
     max_connections_per_host: Option<NonZeroUsize>,
-    /// Whether H1-required demand may reclaim idle H2 capacity.
-    guarantees_http1: bool,
+    /// Whether admission may close idle H2 capacity for H1-required demand.
+    allow_h2_reclaim_for_h1: bool,
     /// Admission authorities retained by canonical origin.
     bounded_origins: Mutex<HashMap<OriginKey, Arc<OriginAdmission>>>,
 }
@@ -49,7 +49,7 @@ impl PartitionRegistry {
         partitions: Option<Vec<Partition>>,
         reuse_scope: ConnectionReuseScope,
         max_connections_per_host: Option<NonZeroUsize>,
-        guarantees_http1: bool,
+        allow_h2_reclaim_for_h1: bool,
         maintenance: MaintenanceConfig,
     ) -> Result<Self, PartitionRegistryError> {
         let Some(partitions) = partitions else {
@@ -60,7 +60,7 @@ impl PartitionRegistry {
                 partitions,
                 reuse_scope,
                 max_connections_per_host,
-                guarantees_http1,
+                allow_h2_reclaim_for_h1,
                 bounded_origins: Mutex::new(HashMap::new()),
             });
         };
@@ -90,7 +90,7 @@ impl PartitionRegistry {
             partitions: by_id,
             reuse_scope,
             max_connections_per_host,
-            guarantees_http1,
+            allow_h2_reclaim_for_h1,
             bounded_origins: Mutex::new(HashMap::new()),
         })
     }
@@ -141,7 +141,7 @@ impl PartitionRegistry {
             origins
                 .entry(origin.clone())
                 .or_insert_with(|| {
-                    OriginAdmission::new(origin.clone(), limit, self.guarantees_http1)
+                    OriginAdmission::new(origin.clone(), limit, self.allow_h2_reclaim_for_h1)
                 })
                 .clone()
         };

--- a/rust-runtime/aws-smithy-http-client/src/client/tls/rustls_provider.rs
+++ b/rust-runtime/aws-smithy-http-client/src/client/tls/rustls_provider.rs
@@ -309,19 +309,36 @@ pub(crate) mod build_connector {
     }
 
     pub(crate) fn wrap_connector<R>(
-        mut conn: HttpConnector<R>,
+        conn: HttpConnector<R>,
         crypto_mode: CryptoMode,
         tls_context: &TlsContext,
         proxy_config: crate::client::proxy::ProxyConfig,
     ) -> super::connect::RustTlsConnector<R> {
-        let client_config = create_rustls_client_config(crypto_mode, tls_context);
+        wrap_connector_with_alpn(
+            conn,
+            crypto_mode,
+            tls_context,
+            proxy_config,
+            &[b"h2", b"http/1.1"],
+        )
+    }
+
+    /// Wraps an HTTP connector with the ALPN offer selected for one pool attempt.
+    pub(crate) fn wrap_connector_with_alpn<R>(
+        mut conn: HttpConnector<R>,
+        crypto_mode: CryptoMode,
+        tls_context: &TlsContext,
+        proxy_config: crate::client::proxy::ProxyConfig,
+        alpn_protocols: &[&[u8]],
+    ) -> super::connect::RustTlsConnector<R> {
+        let mut client_config = create_rustls_client_config(crypto_mode, tls_context);
+        client_config.alpn_protocols = alpn_protocols
+            .iter()
+            .map(|protocol| protocol.to_vec())
+            .collect();
         conn.enforce_http(false);
-        let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(client_config.clone())
-            .https_or_http()
-            .enable_http1()
-            .enable_http2()
-            .wrap_connector(conn);
+        let https_connector =
+            hyper_rustls::HttpsConnector::from((conn, client_config.clone()));
 
         super::connect::RustTlsConnector::new(https_connector, client_config, proxy_config)
     }

--- a/rust-runtime/aws-smithy-http-client/tests/common/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/common/h2.rs
@@ -15,6 +15,7 @@ use aws_smithy_http_client::test_util::wire::connection::{ConnectionCloseReason,
 use bytes::Bytes;
 use h2::server::SendResponse;
 use h2::Reason;
+use h2::RecvStream;
 use http_1x::{Method, Response, StatusCode};
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
@@ -196,12 +197,25 @@ impl H2Response {
 #[derive(Clone, Debug)]
 pub(crate) enum H2StreamScript {
     Respond(H2Response),
+    /// Sends the response before a gate permits the request body to be drained.
+    RespondBeforeReceivingRequestBody {
+        response: H2Response,
+        receive: GateWaiter,
+    },
     Reset(Reason),
 }
 
 impl H2StreamScript {
     pub(crate) fn respond(response: H2Response) -> Self {
         Self::Respond(response)
+    }
+
+    /// Delays request-body reads until after the response and gate release.
+    pub(crate) fn respond_before_receiving_request_body(
+        response: H2Response,
+        receive: GateWaiter,
+    ) -> Self {
+        Self::RespondBeforeReceivingRequestBody { response, receive }
     }
 
     pub(crate) fn reset(reason: Reason) -> Self {
@@ -764,25 +778,32 @@ async fn drive_connection(
                                 "connection {connection_id:?} received unscripted H2 path {path:?}"
                             )));
                         };
-                        // Scripts cover the response side only, so the request body is
-                        // never read. Dropping the `RecvStream` marks the stream as no
-                        // longer receiving: h2 then discards incoming DATA without
-                        // charging the stream window and releases the connection
-                        // capacity, so a client streaming a request body runs to
-                        // completion. Holding it instead would charge the window on
-                        // every DATA frame and never refund it, stalling the client
-                        // once the send window is exhausted.
+                        let held_request = match &stream_script {
+                            H2StreamScript::RespondBeforeReceivingRequestBody { receive, .. } => {
+                                Some((request.into_body(), receive.clone()))
+                            }
+                            _ => {
+                                drop(request);
+                                None
+                            }
+                        };
+                        // Most scripts cover the response side only. Dropping their
+                        // `RecvStream` marks the stream as no longer receiving: h2
+                        // then discards incoming DATA without charging the stream
+                        // window and releases connection capacity, so a client
+                        // streaming a request body runs to completion.
                         //
-                        // TODO(test-utils): to script request bodies, pass
-                        // `request.into_body()` into `run_stream` and drive it there,
-                        // calling `release_capacity()` as chunks are consumed.
-                        drop(request);
+                        // A lifetime contract may retain a pending request body
+                        // behind a gate without reading DATA. General request-body
+                        // scripts must drive `RecvStream` and call
+                        // `release_capacity()` as chunks are consumed.
                         stream_tasks.spawn(run_stream(
                             connection_id,
                             stream_id,
                             stream_script,
                             respond,
                             state.clone(),
+                            held_request,
                         ));
                     }
                     Some(Err(err)) => {
@@ -851,6 +872,7 @@ async fn run_stream(
     script: H2StreamScript,
     mut respond: SendResponse<Bytes>,
     state: Arc<SharedState>,
+    held_request: Option<(RecvStream, GateWaiter)>,
 ) -> Result<(), H2HarnessError> {
     match script {
         H2StreamScript::Reset(reason) => {
@@ -861,7 +883,11 @@ async fn run_stream(
                 reason,
             });
         }
-        H2StreamScript::Respond(response) => {
+        H2StreamScript::Respond(response)
+        | H2StreamScript::RespondBeforeReceivingRequestBody {
+            response,
+            receive: _,
+        } => {
             let end_stream =
                 matches!(&response.body, H2BodyPlan::Complete(body) if body.is_empty());
             let response_head = Response::builder()
@@ -878,6 +904,7 @@ async fn run_stream(
                     connection_id,
                     stream_id,
                 });
+                receive_request_body(held_request).await?;
                 return Ok(());
             }
 
@@ -965,6 +992,32 @@ async fn run_stream(
                 }
             }
         }
+    }
+    receive_request_body(held_request).await?;
+    Ok(())
+}
+
+/// Waits for the test, then consumes a retained request body through end-of-stream.
+async fn receive_request_body(
+    held_request: Option<(RecvStream, GateWaiter)>,
+) -> Result<(), H2HarnessError> {
+    let Some((mut request_body, receive)) = held_request else {
+        return Ok(());
+    };
+    receive
+        .wait()
+        .await
+        .map_err(|err| H2HarnessError::new(format!("H2 request-body gate failed: {err}")))?;
+    while let Some(chunk) = request_body.data().await {
+        let chunk = chunk.map_err(|err| {
+            H2HarnessError::new(format!("failed while receiving H2 request body: {err}"))
+        })?;
+        request_body
+            .flow_control()
+            .release_capacity(chunk.len())
+            .map_err(|err| {
+                H2HarnessError::new(format!("failed to release H2 request capacity: {err}"))
+            })?;
     }
     Ok(())
 }

--- a/rust-runtime/aws-smithy-http-client/tests/common/h2.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/common/h2.rs
@@ -214,6 +214,7 @@ pub(crate) struct H2ConnectionScript {
     routes: HashMap<String, H2StreamScript>,
     fallback: Option<H2StreamScript>,
     allow_handshake_abandonment: bool,
+    goaway_on_ready: bool,
 }
 
 impl H2ConnectionScript {
@@ -237,6 +238,11 @@ impl H2ConnectionScript {
 
     pub(crate) fn allow_handshake_abandonment(mut self) -> Self {
         self.allow_handshake_abandonment = true;
+        self
+    }
+
+    pub(crate) fn goaway_on_ready(mut self) -> Self {
+        self.goaway_on_ready = true;
         self
     }
 
@@ -710,10 +716,13 @@ async fn drive_connection(
             Ok(Err(err)) => return Err(H2HarnessError::new(format!("H2 handshake failed: {err}"))),
         };
     state.record_event(H2Event::H2Ready { connection_id });
+    if script.goaway_on_ready {
+        connection.abrupt_shutdown(Reason::NO_ERROR);
+    }
 
     let mut stream_tasks = JoinSet::new();
     let mut shutting_down = false;
-    let mut graceful_shutdown = false;
+    let mut graceful_shutdown = script.goaway_on_ready;
     let mut control_open = true;
     // Tracks whether the connection ended because the client closed it (accept returned None)
     // vs. a scripted GOAWAY completing.

--- a/rust-runtime/aws-smithy-http-client/tests/h2_connection_behavior_test.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/h2_connection_behavior_test.rs
@@ -739,9 +739,60 @@ mod protocol_negotiation {
 
 mod idle_timeout {
     use super::*;
+    use aws_smithy_types::body::SdkBody;
+    use http_body_1x::{Body, Frame, SizeHint};
+    use std::convert::Infallible;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use std::time::Duration;
+    use tokio::sync::oneshot;
 
     const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
+
+    /// Streaming request body that remains open until the test releases it.
+    struct HeldUpload {
+        finish: oneshot::Receiver<()>,
+        complete: bool,
+    }
+
+    impl Body for HeldUpload {
+        type Data = Bytes;
+        type Error = Infallible;
+
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            if self.complete {
+                return Poll::Ready(None);
+            }
+            match Pin::new(&mut self.finish).poll(cx) {
+                Poll::Ready(_) => {
+                    self.complete = true;
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn is_end_stream(&self) -> bool {
+            self.complete
+        }
+
+        fn size_hint(&self) -> SizeHint {
+            SizeHint::default()
+        }
+    }
+
+    fn held_upload() -> (oneshot::Sender<()>, SdkBody) {
+        let (finish, finished) = oneshot::channel();
+        let body = HeldUpload {
+            finish: finished,
+            complete: false,
+        };
+        (finish, SdkBody::from_body_1_x(body))
+    }
 
     fn client_with_idle_timeout(backend: &dyn HttpsClientBackend) -> SharedHttpClient {
         backend.build_https(
@@ -879,6 +930,87 @@ mod idle_timeout {
             &PartitionedConnectionPool,
         )
         .await;
+    }
+
+    /// Idle expiration retains a physical connection while its upload remains active.
+    #[tokio::test]
+    async fn response_completion_does_not_close_active_upload_at_idle_timeout() {
+        let held_request_gate = ManualGate::new();
+        let script = H2ConnectionScript::new()
+            .route(
+                "/upload",
+                H2StreamScript::respond_before_receiving_request_body(
+                    H2Response::ok("early response"),
+                    held_request_gate.waiter(),
+                ),
+            )
+            .route("/reuse", H2StreamScript::respond(H2Response::ok("reused")));
+        let server = H2TestServer::builder()
+            .connections(H2ConnectionPlan::queue([script.clone(), script]))
+            .start()
+            .await
+            .expect("H2 server should start");
+        let client = client_with_idle_timeout(&PartitionedConnectionPool);
+        let connector = test_client::connector(&client);
+
+        let (finish_upload, upload) = held_upload();
+        let mut request = HttpRequest::new(upload);
+        request.set_method("POST").expect("valid HTTP method");
+        request
+            .set_uri(server.url("/upload"))
+            .expect("valid HTTP URI");
+        let response = test_client::send_request(&connector, request)
+            .await
+            .expect("response should arrive before upload completion");
+        let (status, body) = test_client::collect_response(response).await;
+        assert_eq!(
+            (status, body.as_slice()),
+            (200, b"early response".as_slice())
+        );
+
+        held_request_gate
+            .wait_until_reached(test_client::WAIT)
+            .await
+            .expect("server should retain the active request body");
+        let upload_connection = single_stream_connection(&server, "/upload");
+        tokio::time::sleep(IDLE_TIMEOUT * 2).await;
+        assert!(
+            !server.events().iter().any(|event| {
+                matches!(
+                    event,
+                    H2Event::ConnectionClosed { connection_id, .. }
+                        if *connection_id == upload_connection
+                )
+            }),
+            "idle expiration closed a connection with an active upload"
+        );
+
+        let (status, body) = test_client::get_and_collect(&connector, &server.url("/reuse")).await;
+        assert_eq!((status, body.as_slice()), (200, b"reused".as_slice()));
+        assert_ne!(
+            upload_connection,
+            single_stream_connection(&server, "/reuse"),
+            "an expired HTTP/2 generation accepted a new request"
+        );
+        assert_eq!(server.connection_count(), 2);
+
+        finish_upload
+            .send(())
+            .expect("request body disappeared before upload completion");
+        held_request_gate.release();
+        server
+            .wait_for_event(test_client::WAIT, |event| {
+                matches!(
+                    event,
+                    H2Event::ConnectionClosed { connection_id, .. }
+                        if *connection_id == upload_connection
+                )
+            })
+            .await
+            .expect("draining connection should close after upload completion");
+        drop(connector);
+        drop(client);
+        server.shutdown().await.expect("clean H2 server shutdown");
     }
 }
 

--- a/rust-runtime/aws-smithy-http-client/tests/h2_connection_behavior_test.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/h2_connection_behavior_test.rs
@@ -649,6 +649,43 @@ mod goaway_and_replacement {
         )
         .await;
     }
+
+    #[tokio::test]
+    async fn goaway_before_first_stream_has_bounded_reacquisition() {
+        let script = H2ConnectionScript::new()
+            .goaway_on_ready()
+            .fallback(H2StreamScript::respond(H2Response::ok("unexpected")));
+        let server = H2TestServer::builder()
+            .connections(H2ConnectionPlan::unbounded(script))
+            .start()
+            .await
+            .expect("H2 server should start");
+        let client = h2_client(&PartitionedConnectionPool);
+        let connector = test_client::connector(&client);
+
+        let outcome = tokio::time::timeout(
+            test_client::WAIT,
+            test_client::send_request(
+                &connector,
+                HttpRequest::get(server.url("/before-first-stream")).expect("valid HTTP request"),
+            ),
+        )
+        .await
+        .expect("GOAWAY before dispatch did not terminate");
+        assert!(
+            outcome.is_err(),
+            "a request succeeded after GOAWAY excluded its stream"
+        );
+        assert!(
+            server.connection_count() <= 3,
+            "GOAWAY before dispatch created {} connections",
+            server.connection_count()
+        );
+
+        drop(connector);
+        drop(client);
+        server.shutdown().await.expect("clean H2 server shutdown");
+    }
 }
 
 #[cfg(feature = "s2n-tls")]

--- a/rust-runtime/aws-smithy-http-client/tests/h2_connection_behavior_test.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/h2_connection_behavior_test.rs
@@ -12,6 +12,10 @@
 
 mod common;
 
+use aws_smithy_http_client::pool::{
+    Client as PoolClient, ConnectionPool, ConnectionReuseScope, Partition, PartitionId,
+    TokioDriverSpawner,
+};
 use aws_smithy_http_client::test_util::wire::connection::{ConnectionCloseReason, ManualGate};
 use aws_smithy_http_client::tls;
 use aws_smithy_http_client::Builder;
@@ -56,6 +60,29 @@ impl HttpsClientBackend for HyperUtilLegacyPool {
             .tls_provider(provider)
             .tls_context(tls_context)
             .build_https()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PartitionedConnectionPool;
+
+impl HttpsClientBackend for PartitionedConnectionPool {
+    fn build_https(
+        &self,
+        config: BackendConfig,
+        provider: tls::Provider,
+        tls_context: tls::TlsContext,
+    ) -> SharedHttpClient {
+        let mut builder = ConnectionPool::builder().tls_provider(provider);
+        if let Some(pool_idle_timeout) = config.pool_idle_timeout {
+            builder = builder.idle_timeout(pool_idle_timeout);
+        }
+        let pool = builder
+            .tls_context(tls_context)
+            .build_https()
+            .expect("valid connection-pool config");
+        let client = PoolClient::new(&pool).expect("anonymous partition exists");
+        SharedHttpClient::new(client)
     }
 }
 
@@ -157,6 +184,11 @@ mod reuse_and_multiplexing {
         sequential_requests_reuse_connection(&HyperUtilLegacyPool).await;
     }
 
+    #[tokio::test]
+    async fn test_sequential_requests_reuse_connection_with_partitioned_pool() {
+        sequential_requests_reuse_connection(&PartitionedConnectionPool).await;
+    }
+
     /// Concurrent requests multiplex as independent streams on a warmed H2 connection.
     async fn concurrent_requests_multiplex_on_warmed_connection(backend: &dyn HttpsClientBackend) {
         let body_gate = ManualGate::new();
@@ -207,6 +239,11 @@ mod reuse_and_multiplexing {
     #[tokio::test]
     async fn test_concurrent_requests_multiplex_on_warmed_connection_with_hyper_util_legacy_pool() {
         concurrent_requests_multiplex_on_warmed_connection(&HyperUtilLegacyPool).await;
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_requests_multiplex_on_warmed_connection_with_partitioned_pool() {
+        concurrent_requests_multiplex_on_warmed_connection(&PartitionedConnectionPool).await;
     }
 
     /// Concurrent cold-start requests converge on one established H2 connection even when
@@ -278,6 +315,11 @@ mod reuse_and_multiplexing {
     {
         concurrent_cold_start_converges_on_one_h2_connection(&HyperUtilLegacyPool).await;
     }
+
+    #[tokio::test]
+    async fn test_concurrent_cold_start_converges_on_one_h2_connection_with_partitioned_pool() {
+        concurrent_cold_start_converges_on_one_h2_connection(&PartitionedConnectionPool).await;
+    }
 }
 
 mod connection_metadata {
@@ -317,6 +359,11 @@ mod connection_metadata {
     #[tokio::test]
     async fn test_poisoned_connection_is_not_reused_with_hyper_util_legacy_pool() {
         poisoned_connection_is_not_reused(&HyperUtilLegacyPool).await;
+    }
+
+    #[tokio::test]
+    async fn test_poisoned_connection_is_not_reused_with_partitioned_pool() {
+        poisoned_connection_is_not_reused(&PartitionedConnectionPool).await;
     }
 }
 
@@ -398,6 +445,11 @@ mod stream_failures {
         stream_reset_does_not_retire_connection(&HyperUtilLegacyPool).await;
     }
 
+    #[tokio::test]
+    async fn test_stream_reset_does_not_retire_connection_with_partitioned_pool() {
+        stream_reset_does_not_retire_connection(&PartitionedConnectionPool).await;
+    }
+
     /// Dropping an incomplete response body cancels only that stream and permits reuse.
     async fn dropping_response_body_cancels_only_stream(backend: &dyn HttpsClientBackend) {
         let script = H2ConnectionScript::new()
@@ -465,6 +517,11 @@ mod stream_failures {
     #[tokio::test]
     async fn test_dropping_response_body_cancels_only_stream_with_hyper_util_legacy_pool() {
         dropping_response_body_cancels_only_stream(&HyperUtilLegacyPool).await;
+    }
+
+    #[tokio::test]
+    async fn test_dropping_response_body_cancels_only_stream_with_partitioned_pool() {
+        dropping_response_body_cancels_only_stream(&PartitionedConnectionPool).await;
     }
 }
 
@@ -583,6 +640,15 @@ mod goaway_and_replacement {
         graceful_goaway_preserves_in_flight_stream_and_replaces_connection(&HyperUtilLegacyPool)
             .await;
     }
+
+    #[tokio::test]
+    async fn test_graceful_goaway_preserves_in_flight_stream_and_replaces_connection_with_partitioned_pool(
+    ) {
+        graceful_goaway_preserves_in_flight_stream_and_replaces_connection(
+            &PartitionedConnectionPool,
+        )
+        .await;
+    }
 }
 
 #[cfg(feature = "s2n-tls")]
@@ -626,6 +692,11 @@ mod protocol_negotiation {
     #[tokio::test]
     async fn test_s2n_negotiates_h2_and_reuses_connection_with_hyper_util_legacy_pool() {
         s2n_negotiates_h2_and_reuses_connection(&HyperUtilLegacyPool).await;
+    }
+
+    #[tokio::test]
+    async fn test_s2n_negotiates_h2_and_reuses_connection_with_partitioned_pool() {
+        s2n_negotiates_h2_and_reuses_connection(&PartitionedConnectionPool).await;
     }
 }
 
@@ -686,6 +757,11 @@ mod idle_timeout {
     #[tokio::test]
     async fn test_idle_connection_is_evicted_after_timeout_with_hyper_util_legacy_pool() {
         idle_connection_is_evicted_after_timeout(&HyperUtilLegacyPool).await;
+    }
+
+    #[tokio::test]
+    async fn test_idle_connection_is_evicted_after_timeout_with_partitioned_pool() {
+        idle_connection_is_evicted_after_timeout(&PartitionedConnectionPool).await;
     }
 
     /// An active stream survives the idle deadline, but the connection is replaced after the
@@ -757,5 +833,128 @@ mod idle_timeout {
             &HyperUtilLegacyPool,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_active_stream_survives_idle_timeout_but_later_request_uses_replacement_with_partitioned_pool(
+    ) {
+        active_stream_survives_idle_timeout_but_later_request_uses_replacement(
+            &PartitionedConnectionPool,
+        )
+        .await;
+    }
+}
+
+mod partition_reuse {
+    use super::*;
+    use std::time::Duration;
+
+    fn partitioned_clients(
+        scope: ConnectionReuseScope,
+    ) -> (ConnectionPool, SharedHttpConnector, SharedHttpConnector) {
+        let first = PartitionId::from_index(1);
+        let second = PartitionId::from_index(2);
+        let pool = ConnectionPool::builder()
+            .tls_provider(rustls_aws_lc())
+            .tls_context(test_tls::server_tls_context())
+            .partitions([
+                Partition::new(first, TokioDriverSpawner::current()),
+                Partition::new(second, TokioDriverSpawner::current()),
+            ])
+            .connection_reuse_scope(scope)
+            .max_connections_per_host(1)
+            .build_https()
+            .expect("valid partitioned HTTPS pool");
+        let first_client = SharedHttpClient::new(
+            PoolClient::from_partition(&pool, first).expect("first partition should resolve"),
+        );
+        let second_client = SharedHttpClient::new(
+            PoolClient::from_partition(&pool, second).expect("second partition should resolve"),
+        );
+        (
+            pool,
+            test_client::connector(&first_client),
+            test_client::connector(&second_client),
+        )
+    }
+
+    async fn eligible_partition_reuses_peer_h2(scope: ConnectionReuseScope) {
+        let server = H2TestServer::builder()
+            .connections(H2ConnectionPlan::queue([H2ConnectionScript::new()
+                .fallback(H2StreamScript::respond(H2Response::ok("shared")))]))
+            .start()
+            .await
+            .expect("H2 server should start");
+        let (pool, first, second) = partitioned_clients(scope);
+
+        let first_result = test_client::get_and_collect(&first, &server.url("/first")).await;
+        let second_result = test_client::get_and_collect(&second, &server.url("/second")).await;
+
+        assert_eq!(first_result, (200, b"shared".to_vec()));
+        assert_eq!(second_result, (200, b"shared".to_vec()));
+        assert_eq!(server.connection_count(), 1);
+        assert_eq!(
+            single_stream_connection(&server, "/first"),
+            single_stream_connection(&server, "/second"),
+            "eligible partitions should dispatch through the connection-owning generation"
+        );
+
+        drop(first);
+        drop(second);
+        drop(pool);
+        server.shutdown().await.expect("clean H2 server shutdown");
+    }
+
+    #[tokio::test]
+    async fn pool_scope_reuses_a_peer_h2_generation() {
+        eligible_partition_reuses_peer_h2(ConnectionReuseScope::Pool).await;
+    }
+
+    #[tokio::test]
+    async fn matching_network_interface_scope_reuses_a_peer_h2_generation() {
+        eligible_partition_reuses_peer_h2(ConnectionReuseScope::NetworkInterface).await;
+    }
+
+    #[tokio::test]
+    async fn partition_scope_waits_until_out_of_scope_h2_releases_capacity() {
+        let script = H2ConnectionScript::new()
+            .fallback(H2StreamScript::respond(H2Response::ok("partition")));
+        let server = H2TestServer::builder()
+            .connections(H2ConnectionPlan::queue([script.clone(), script]))
+            .start()
+            .await
+            .expect("H2 server should start");
+        let (pool, first, second) = partitioned_clients(ConnectionReuseScope::Partition);
+
+        let (status, body, metadata) =
+            get_and_collect_with_capture(&first, &server.url("/first")).await;
+        assert_eq!((status, body.as_slice()), (200, b"partition".as_slice()));
+        let first_connection = single_stream_connection(&server, "/first");
+
+        let second_url = server.url("/second");
+        let mut pending =
+            tokio::spawn(async move { test_client::get_and_collect(&second, &second_url).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut pending)
+                .await
+                .is_err(),
+            "an out-of-scope generation must not satisfy partition-local demand"
+        );
+        assert_eq!(server.connection_count(), 1);
+
+        metadata.poison();
+        let (status, body) = tokio::time::timeout(test_client::WAIT, pending)
+            .await
+            .expect("released capacity should wake partition-local demand")
+            .expect("request task should not panic");
+        assert_eq!((status, body.as_slice()), (200, b"partition".as_slice()));
+        let second_connection = single_stream_connection(&server, "/second");
+        assert_ne!(first_connection, second_connection);
+        assert_eq!(server.connection_count(), 2);
+
+        drop(metadata);
+        drop(first);
+        drop(pool);
+        server.shutdown().await.expect("clean H2 server shutdown");
     }
 }

--- a/rust-runtime/aws-smithy-http-client/tests/tls.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/tls.rs
@@ -10,6 +10,8 @@ mod common {
 }
 
 use aws_smithy_async::time::SystemTimeSource;
+#[cfg(all(feature = "rustls-aws-lc", feature = "rt-tokio"))]
+use aws_smithy_http_client::pool::{Client as PoolClient, ConnectionPool};
 use aws_smithy_http_client::tls;
 #[cfg(any(feature = "rustls-aws-lc", feature = "s2n-tls"))]
 use aws_smithy_http_client::tls::{ServerName, TlsContext};
@@ -50,12 +52,16 @@ impl TestServer {
 }
 
 async fn server() -> Result<TestServer, BoxError> {
+    server_with_alpn(&[b"h2", b"http/1.1", b"http/1.0"]).await
+}
+
+async fn server_with_alpn(alpn_protocols: &[&[u8]]) -> Result<TestServer, BoxError> {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
     debug!("Starting to serve on https://{}", addr);
 
-    let tls_acceptor = test_tls::server_tls_acceptor(&[b"h2", b"http/1.1", b"http/1.0"])?;
+    let tls_acceptor = test_tls::server_tls_acceptor(alpn_protocols)?;
     let service = service_fn(echo);
 
     let conn_count = Arc::new(());
@@ -141,6 +147,41 @@ async fn test_rustls_aws_lc_custom_ca() {
         .build_https();
 
     run_tls_test(&client).await.unwrap()
+}
+
+#[cfg(all(feature = "rustls-aws-lc", feature = "rt-tokio"))]
+#[tokio::test]
+async fn partitioned_pool_falls_back_to_h1_after_alpn() {
+    let server = server_with_alpn(&[b"http/1.1"]).await.unwrap();
+    let pool = ConnectionPool::builder()
+        .tls_provider(tls::Provider::Rustls(
+            tls::rustls_provider::CryptoMode::AwsLc,
+        ))
+        .tls_context(test_tls::server_tls_context())
+        .build_https()
+        .expect("valid HTTPS pool");
+    let client = PoolClient::new(&pool).expect("anonymous partition exists");
+    let connector_settings = HttpConnectorSettings::builder().build();
+    let runtime_components = RuntimeComponentsBuilder::for_tests()
+        .with_time_source(Some(SystemTimeSource::new()))
+        .build()
+        .unwrap();
+    let connector = client.http_connector(&connector_settings, &runtime_components);
+    let endpoint = format!("https://localhost:{}/", server.listen_addr.port());
+
+    for _ in 0..2 {
+        let mut response = connector
+            .call(HttpRequest::get(&endpoint).unwrap())
+            .await
+            .expect("HTTP/1 request over TLS should succeed");
+        let body = ByteStream::new(response.take_body())
+            .collect()
+            .await
+            .expect("response body should be readable")
+            .into_bytes();
+        assert_eq!(b"Hello TLS!", &body[..]);
+    }
+    assert_eq!(1, server.conn_count());
 }
 
 #[cfg(feature = "rustls-aws-lc")]

--- a/rust-runtime/aws-smithy-http-client/tests/tls.rs
+++ b/rust-runtime/aws-smithy-http-client/tests/tls.rs
@@ -184,6 +184,42 @@ async fn partitioned_pool_falls_back_to_h1_after_alpn() {
     assert_eq!(1, server.conn_count());
 }
 
+#[cfg(all(feature = "rustls-aws-lc", feature = "rt-tokio"))]
+#[tokio::test]
+async fn partitioned_pool_narrows_alpn_for_h1_required_request() {
+    let server = server_with_alpn(&[b"h2", b"http/1.1"]).await.unwrap();
+    let pool = ConnectionPool::builder()
+        .tls_provider(tls::Provider::Rustls(
+            tls::rustls_provider::CryptoMode::AwsLc,
+        ))
+        .tls_context(test_tls::server_tls_context())
+        .build_https()
+        .expect("valid HTTPS pool");
+    let client = PoolClient::new(&pool).expect("anonymous partition exists");
+    let connector_settings = HttpConnectorSettings::builder().build();
+    let runtime_components = RuntimeComponentsBuilder::for_tests()
+        .with_time_source(Some(SystemTimeSource::new()))
+        .build()
+        .unwrap();
+    let connector = client.http_connector(&connector_settings, &runtime_components);
+    let endpoint = format!("https://localhost:{}/", server.listen_addr.port());
+    let mut request = HttpRequest::new(ByteStream::default().into_inner());
+    request
+        .set_method("CONNECT")
+        .expect("CONNECT is a valid HTTP method");
+    request
+        .set_uri(endpoint.as_str())
+        .expect("valid server URI");
+
+    let response = connector
+        .call(request)
+        .await
+        .expect("HTTP/1-required request should narrow the ALPN offer");
+
+    assert_eq!(StatusCode::NOT_FOUND.as_u16(), response.status().as_u16());
+    assert_eq!(1, server.conn_count());
+}
+
 #[cfg(feature = "rustls-aws-lc")]
 #[tokio::test(start_paused = false)]
 // can't have paused clock due to <https://github.com/hyperium/hyper/issues/3950>


### PR DESCRIPTION
## Summary

This is the third of five implementation PRs in the [connection-pool design and implementation series](https://github.com/smithy-lang/smithy-rs/pull/4808). It extends the partitioned HTTP/1 request path from [#4824](https://github.com/smithy-lang/smithy-rs/pull/4824) with automatic HTTP/1.1 and HTTP/2 selection, multiplexed HTTP/2 reuse, and reuse across compatible partitions.

The implementation series is:

1. [Partition-aware ownership and coordination foundation](https://github.com/smithy-lang/smithy-rs/pull/4808)
2. [Partitioned HTTP/1 request path](https://github.com/smithy-lang/smithy-rs/pull/4824)
3. **This PR: HTTP/2, automatic ALPN, and peer publication**
4. Smithy integration, telemetry, and configuration completion
5. Integration validation and compatibility closure

After this PR, an opt-in pool can establish HTTPS connections with the configured TLS provider, select HTTP/1.1 or HTTP/2 from ALPN, multiplex requests on one HTTP/2 connection, and reuse compatible HTTP/2 connections across partitions without moving their socket or driver.

This PR is stacked on #4824. The existing default client remains unchanged.

## Why

HTTP/2 changes what the pool owns and when a request is finished.

An HTTP/1 connection lends one exclusive Hyper request handle to one request. The handle returns to the pool only after that exchange proves the connection reusable. An HTTP/2 connection instead remains installed while Hyper opens many concurrent request streams through it. The pool must keep one authoritative owner for the connection while accounting for each stream independently.

Automatic ALPN adds a second coordination problem. Several cold requests may finish TCP and TLS establishment before any of them knows which HTTP protocol was selected. HTTP/1 results remain independent connections. HTTP/2 results must converge before multiple Hyper handshakes and drivers are installed for the same partition and origin.

An accepted HTTP/2 request also has two independent completion paths: Hyper may continue polling the upload after response headers arrive, while the response body may finish first or later. Pool accounting remains active until both directions terminate. Cancellation of one request must release only that stream and must not retire a healthy multiplexed connection.

This PR implements those ownership rules while preserving the partition, capacity, and HTTP/1 behavior introduced by the preceding PRs.

The detailed contracts are in [Connection establishment], [Bounded-capacity coordination], [HTTP/2 publication], [Dispatching and completing a request], and [Connection retirement and maintenance] in the connection-pool design.

## Overview

One HTTP/2 connection carries many concurrent request streams. The pool calls one installed incarnation of that connection a **generation**. A replacement connection receives a new generation identity so delayed GOAWAY, close, route, or request-completion work cannot affect it.

The HTTP/1 ownership model remains intact. HTTP/2 adds four pool concepts:

- A **flight** coordinates concurrent post-ALPN HTTP/2 establishment for one partition and origin. It is a pool term, not an HTTP/2 protocol concept.
- A **generation** owns the installed Hyper request handle, connection state, capacity, and accepting or draining residence.
- A peer **route** names one exact generation but owns no request handle, socket, driver, or capacity.
- An **activation** reserves pool accounting for a prospective stream until Hyper accepts or rejects the request.

Hyper remains responsible for HTTP/2 stream identifiers, stream credit, and flow control.

### Establish once, then select a protocol

Connection establishment and installed connection lifetime are separate ownership phases:

```text
acquisition receives establishment capacity
        |
        v
partition owner task
        |
        +-- DNS / socket / proxy / TLS / ALPN
        |
        v
connected I/O + selected HTTP protocol
        |
        +-- HTTP/1.1 --> PendingOpen --> Hyper HTTP/1 setup --> Open
        |                                                       `-- install H1 record
        |
        `-- HTTP/2 ----> select, join, or create H2 flight
                              |
                              `-- flight owner --> PendingOpen
                                                    `-- Hyper HTTP/2 setup
                                                        --> Open
                                                            `-- install generation
```

The establishment task and its optional bounded-origin permit exist before connected I/O is ready for HTTP protocol setup. `ConnectionState` begins in `PendingOpen` only after the connector returns and selects HTTP/1 or HTTP/2; TLS and ALPN are complete when the transport uses them. Hyper protocol setup produces the request handle and moves the state to `Open`. Cell installation then makes that open connection discoverable. This boundary leaves DNS, transport, and TLS attempts available to later lifecycle observation without representing failed attempts as installed connections.

Accepted HTTP/1.0, ordinary `CONNECT`, and Upgrade requests require HTTP/1 wire semantics. The default rustls connector offers only `http/1.1` for those requests; other requests offer `h2, http/1.1`. An HTTP/2-required request does not force an H2-only offer. If a server selects HTTP/1, the launching request receives the existing unsupported-version error with connection metadata. The reusable HTTP/1 handle returns to pool policy instead of being discarded solely for that mismatch, and may serve compatible demand while its owning cell still accepts it.

The connected transport and optional capacity have one owner throughout protocol selection. An HTTP/2 loser joins the existing flight or generation before dropping its extra transport and returning its capacity. The connection partition owns the flight task; cancellation removes one participant but does not cancel work needed by other participants.

### One HTTP/2 request

```text
request
  |
  +-- local accepting generation
  +-- completed local H2 flight
  +-- compatible peer route
  `-- establish + ALPN H2
           |
           v
      H2Activation
           |
           | Hyper accepts the request
           v
    accepted request lease
       /              \
 upload endpoint   response endpoint
       \              /
        both terminal
             |
      release stream accounting
```

Selection reserves a prospective request count on one exact generation and clones a transient Hyper request handle. `H2Activation` carries both to dispatch. It is a reservation for a prospective stream, not an accepted stream.

After Hyper accepts the request, the activation becomes an accepted request lease. A request-body adapter owns the upload endpoint until end-of-stream, error, or drop. The guarded response body owns the receive endpoint until end-of-stream, error, or drop. The second endpoint to finish releases the generation request count and accepted-dispatch guard.

A stream reset, incomplete body, or request cancellation terminates that request lease without retiring a healthy generation.

### Cold-start convergence and cancellation

ALPN is not known until transports connect, so several cold requests may reach the HTTP/2 branch together:

```text
accepting generation exists --> join that generation
flight exists               --> join that flight
neither exists              --> install one flight driver
```

This transition occurs under one cell lock before an HTTP/2 handshake begins. The winning flight installs its generation before making it visible. Participants remain recorded until activation. If the generation closes first, unserved participants return to acquisition.

Cancellation does not make progress depend on one request future:

- The connection-partition task owns a started flight, not the request that started it.
- Cancelling the acquisition head publishes its successor.
- Dropping or accepting a generation priority turn services the next committed waiter.

The generation gate preserves the order of waiters committed before the generation became visible. Only that finite priority set is serialized. After it drains, requests may reserve concurrent streams from the open generation.

A generation can close after selection but before Hyper accepts the request. At that point the original request remains locally owned and may select a replacement generation; it has not been replayed. This internal reacquisition is limited to two replacement selections after the initial selection. A third pre-acceptance failure returns the last connection error, preventing repeated GOAWAY or close races from creating an unbounded loop.

### Reuse across partitions

Cross-partition reuse does not move connection ownership. Partition B continues to own generation G, including its socket, Hyper driver, request handle, and capacity. Partition A stores only a route naming owner B and exact generation G.

Suppose partition B owns an accepting generation and compatible partition A has waiting demand:

```text
partition B                                 partition A
owns generation G                          has compatible demand
      |
      `-- publish route(B -> A, G) --------> stores owner B + generation G
```

An eligibility group is the exact set of partitions whose `ConnectionReuseScope` permits them to share connections. Admission may publish the route to A because A and B belong to the same group. A partition outside that group cannot receive the route.

Route publication does not reserve a stream. A later request in A follows the route back to B:

```text
partition A                                 partition B
request -- route(owner B, generation G) --> validate exact generation G
                                            reserve prospective stream
H2Activation(G) <---------------------------'
```

From `H2Activation` onward, dispatch follows [One HTTP/2 request](#one-http2-request).

Admission keeps two demand views because the resources have different eligibility:

- Origin order assigns one-to-one resources such as connection capacity and HTTP/1 handles.
- Eligibility-group order finds the oldest demand able to use a group-scoped HTTP/2 generation.

One order cannot represent both rules. An older request that cannot use a group-Y generation must retain priority for the next origin-wide permit, while a younger group-Y request may use the existing generation immediately. Each demand is therefore linked in both views. Reserving it through either view fences both positions until the requesting cell accepts or rejects the handoff, preventing capacity and HTTP/2 publication from satisfying the same request concurrently without scanning every partition.

If B closes between route installation and request dispatch, A removes the stale route and republishes its live demand. Exact generation and demand identities prevent delayed work from reviving retired state or dispatching through a replacement connection.

An HTTP/1-required request cannot use an advertised HTTP/2 generation. When an idle HTTP/2 generation holds the last origin permit, admission may close it and grant the released capacity to HTTP/1 establishment only if the transport can force HTTP/1. Without that guarantee, the pool could close a healthy HTTP/2 connection, negotiate HTTP/2 again, reject it, and repeat without satisfying the request.

The default rustls and cleartext paths provide that guarantee. The fixed-ALPN s2n path and connectors injected through the unstable test utility do not; they preserve the healthy generation until ordinary close releases capacity.

### Close, drain, and maintenance

Poison, GOAWAY, sender closure, driver completion, idle expiration, pool drop, and owner-runtime shutdown converge on one generation close transition:

```text
Pool generation:
Accepting -- logical close --> Draining -- final request lease --> Removed
    |                            |
    | stop new activation        `-- accepted streams finish independently
    `-- return bounded capacity once
    |
    `-- no request work --------------------------------------> Removed

Physical transport:
Hyper driver owns root I/O -----------------------> physical completion
```

Logical close removes the generation from new dispatch and returns its capacity once. A generation with no request work is removed in the same transition; otherwise accepted streams retain the draining record until both endpoints finish. Root I/O remains under a separate physical guard until Hyper's driver ends.

Idle maintenance considers both HTTP/1 idle records and HTTP/2 accepting generations. An HTTP/2 deadline starts at installation and resets on accepted dispatch. Expiration begins drain; it does not abort accepted streams.

## Correctness boundary

The implementation preserves these grouped obligations:

- **Connection identity and ownership:** One connection cell owns each HTTP/2 generation, including its authoritative request handle, capacity, accepting state, and request counts. Routes and delayed work name an exact generation and cannot affect a replacement.
- **Establishment and protocol selection:** Post-ALPN contenders install at most one flight and accepting generation per cell. HTTP/1-required requests never dispatch on HTTP/2, and incompatible but useful HTTP/1 results remain available to compatible demand.
- **Request lifetime and cancellation:** Hyper acceptance creates one two-ended request lease. Accounting is released only after both upload and response endpoints terminate. Stream-local failure and cancellation affect one request, while cancellation of a flight participant or priority waiter advances remaining work.
- **Admission and publication:** Capacity and HTTP/1 use origin order; HTTP/2 publication uses eligibility-group order. Delivery fences prevent duplicate service, publication transfers identity rather than connection ownership, and acknowledgements cannot retire newer demand.
- **Capacity and close:** Capacity moves from admission to establishment to the installed connection and returns exactly once at logical close. Idle-H2 reclaim requires an exact idle generation and a transport that can force HTTP/1.
- **Concurrency and placement:** Pool locks are never nested. Connector, TLS, Hyper-spawned work, and the protocol driver run through the connection partition's runtime.
- **Bounded recovery:** Pre-acceptance generation staleness may select at most two replacements. Accepted requests are never replayed by this path.

## Evidence

Evidence is grouped by the ownership boundary it exercises. The primary source files are included so a reviewer can move from a claim to its control:

- **Wire behavior** — `tests/h2_connection_behavior_test.rs` and `tests/tls.rs` cover real rustls and s2n ALPN, HTTP/1 fallback, warm multiplexing, concurrent cold start, idle expiration after a response completes while its upload remains active, stream reset isolation, dropped responses, GOAWAY replacement, and cross-partition reuse scopes.
- **State transitions** — `pool/cell/h2.rs`, `pool/establish/h2.rs`, `pool/dispatch/h2.rs`, `pool/admission/publication.rs`, and `pool/maintenance.rs` cover flight ownership, exact-generation activation, two-ended request completion, draining, reclaim, and stale route or publication rejection.
- **Concurrency crossings** — the Loom models in `pool/cell/h2.rs` and `pool/cell.rs` cover activation against close, independent lease endpoints, route installation against cancellation, publication acknowledgement against republish and close, and peer publication against connection-cell close.
- **HTTP/1 regression** — `tests/h1_connection_behavior_test.rs` keeps reuse, capacity, return, upgrade, metadata, and maintenance contracts active while protocol selection changes around them.
- **Negative controls** — mutation controls remove exact identity, residence, endpoint, publication, and priority transitions; each control fails a focused test or model.

## How to review

Start with `pool.rs` for the ownership vocabulary, especially the distinction between a connection generation, a prospective `H2Activation`, and an accepted request lease. Then review the four lifecycles below independently; each ends with the state that should remain.

### 1. Establish one HTTP/2 connection

Path:

```text
ConnectionPool::send_request -> ConnectionPool::acquire -> establish::establish
    -> OriginCell::install_or_join_h2_flight -> OriginCell::complete_h2_flight
```

Check that concurrent post-ALPN attempts produce one flight and one installed generation, losing transports release their capacity, cancelling one participant does not cancel shared work, and Hyper setup plus the driver stay on the connection partition.

End state: one accepting generation; every live participant owns an activation or a terminal error.

### 2. Dispatch and complete one request stream

Path:

```text
ConnectionPool::dispatch_acquired -> ConnectionPool::dispatch_h2
    -> H2Activation::take_dispatch_parts -> H2RequestBody + H2ResponseBody
    -> H2LeaseCore
```

Check that the original request remains recoverable before Hyper acceptance, acceptance creates one request lease, upload and response completion remain independent, and accounting ends only after both endpoints terminate.

End state: the request lease is gone; the generation remains reusable unless connection-level close won.

### 3. Reuse one peer generation

Path:

```text
DemandSchedule -> H2Publication -> OriginCell::install_h2_route
    -> H2Route::activate -> connection-owning OriginCell
```

Check that admission publishes identity rather than connection ownership, reuse respects the eligibility group, activation revalidates the exact generation at its owning cell, and cancellation or rejection republishes live demand.

End state: the connection, driver, and capacity remain with the owning cell; the requesting cell receives authority for one stream.

### 4. Close and drain one generation

Path:

```text
OriginCell::close_h2 -> H2Records::begin_close -> ConnectionState::logical_close
    -> H2LeaseCore endpoint completion -> H2Records::remove_finished_drain
```

Check that logical close stops new activation and returns capacity once, accepted streams retain the draining record, final request completion removes that record, and physical I/O remains under the independent driver guard.

End state: no dispatchable generation, no retained request accounting, and bounded capacity returned exactly once.

After these walks, use `tests/h2_connection_behavior_test.rs` for the external contracts and the Loom modules named in Evidence for the lock crossings. Make a separate HTTP/1 regression pass through `cell/h1.rs`, `dispatch/h1.rs`, and `establish/h1.rs`.

## Scope and follow-up

### Protocol policy and connectors

This PR provides automatic ALPN but no public HTTP/1-only or HTTP/2-only policy. Internal request classification enforces wire requirements for HTTP/1.0, ordinary `CONNECT`, Upgrade, and HTTP/2-required requests.

The default rustls connector honors the per-request ALPN offer. `s2n-tls-hyper` currently advertises a fixed `h2, http/1.1, http/1.0` list. Connectors injected through the unstable test utility own their protocol configuration and do not receive the offer. The pool validates negotiated results but does not implement a private s2n connector. Configurable s2n ALPN is an upstream follow-up.

### Upgrades

HTTP/2 extended `CONNECT` requires a full-stream completion hook before the request lease can represent both tunneled directions. That bridge and its WebSocket or tunnel contracts remain in the final integration work. Ordinary HTTP/1 `CONNECT` and `101` upgrades remain covered by #4824.

### Lifecycle observation and runtime validation

The next PR adds public lifecycle telemetry and statistics. Establishment and installed connection lifetime remain separate so DNS, socket, proxy, TLS, ALPN, protocol handshake, installation, drain, and close can later be correlated without placing pre-connection attempts in `ConnectionState`.

Unit tests pin partition-spawner submission for the HTTP/2 handshake, Hyper executor, and driver. The separate integration probe for connector, TLS/ALPN, driver, and socket polling across independent current-thread runtimes remains in integration hardening.

### Deliberate limits

Hyper remains authoritative for HTTP/2 stream credit and flow control. The pool stores one accepting generation per cell and adds no second `SETTINGS_MAX_CONCURRENT_STREAMS` accounting model.

The pool does not force an active out-of-scope generation to drain solely to recover a bounded-origin permit. Bounded origins publish only zero-to-one and one-to-zero request-work transitions for idle-H2 reclaim; intermediate multiplexed stream counts remain cell-local.

The connector timeout ends when the connector returns the negotiated transport. The owner-runtime Hyper handshake and driver submission do not have a separate pool timeout in this PR.

A flight remains owned by its connection-partition task even if every participant cancels. A successful fully cancelled cold start may install an idle generation that retains capacity until ordinary close or idle expiration.

The next PR adds Smithy integration, public lifecycle telemetry and statistics, proxy and DNS configuration completion, and the remaining compatibility surface without replacing this ownership model.

[Bounded-capacity coordination]: https://github.com/smithy-lang/smithy-rs/blob/df14f70c3e88c1e932e8d4e152c719ae506acace/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md#bounded-capacity-coordination
[HTTP/2 publication]: https://github.com/smithy-lang/smithy-rs/blob/df14f70c3e88c1e932e8d4e152c719ae506acace/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md#http2-publication
[Dispatching and completing a request]: https://github.com/smithy-lang/smithy-rs/blob/df14f70c3e88c1e932e8d4e152c719ae506acace/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md#dispatching-and-completing-a-request
[Connection establishment]: https://github.com/smithy-lang/smithy-rs/blob/df14f70c3e88c1e932e8d4e152c719ae506acace/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md#connection-establishment
[Connection retirement and maintenance]: https://github.com/smithy-lang/smithy-rs/blob/df14f70c3e88c1e932e8d4e152c719ae506acace/rust-runtime/aws-smithy-http-client/docs/design/connection-pool.md#connection-retirement-and-maintenance

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._