### PR TITLE
feat: Gate legacy client behavior behind legacy feature flags

### DIFF
--- a/.changelog/gate-legacy-client-behavior.md
+++ b/.changelog/gate-legacy-client-behavior.md
@@ -1,0 +1,20 @@
+---
+applies_to:
+- client
+- aws-sdk-rust
+authors:
+- jasgin
+references: []
+breaking: true
+new_feature: false
+bug_fix: false
+---
+Legacy client behavior is now gated behind feature flags. Behavior versions prior to `v2026_01_12`
+are only available when the `aws-smithy-runtime-api/legacy-client` feature is enabled (transitively
+enabled via `aws-smithy-runtime/tls-rustls`), and the legacy HTTP test utilities exposed from
+`aws-smithy-runtime::client::http::test_util` now require the `legacy-test-util` feature. Using a
+pre-`v2026_01_12` `BehaviorVersion` without the legacy TLS stack (`tls-rustls`) would result in no
+HTTP client being configured at runtime, so gating access to those older versions prevents users
+from silently ending up with no HTTP client. In addition, `test-util` no longer implicitly enables
+`legacy-test-util`; enable `legacy-test-util` explicitly if you rely on the legacy hyper 0.14 HTTP
+test utilities.

--- a/aws/rust-runtime/Cargo.lock
+++ b/aws/rust-runtime/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-config"
-version = "1.12.0"
+version = "1.13.0"
 authors = [
     "AWS Rust SDK Team <aws-sdk-rust@amazon.com>",
     "Russell Cohen <rcoh@amazon.com>",

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -1196,6 +1196,7 @@ pub(crate) mod test {
     async fn retry_connect_timeouts() {
         use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
         // Legacy: 1s backoff, total > 1s
+        #[cfg(feature = "legacy-client")]
         #[allow(deprecated)]
         retry_connect_timeouts_for_bv(
             BehaviorVersion::v2024_03_28(),

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -37,7 +37,7 @@
 //! #   }
 //! # }
 //! # async fn docs() {
-//! let config = aws_config::load_defaults(BehaviorVersion::v2023_11_09()).await;
+//! let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
 //! let client = aws_sdk_dynamodb::Client::new(&config);
 //! # }
 //! ```
@@ -197,7 +197,7 @@ pub async fn load_from_env() -> SdkConfig {
 /// ```no_run
 /// # async fn create_config() {
 /// use aws_config::BehaviorVersion;
-/// let config = aws_config::defaults(BehaviorVersion::v2023_11_09())
+/// let config = aws_config::defaults(BehaviorVersion::latest())
 ///     .region("us-east-1")
 ///     .load()
 ///     .await;
@@ -1059,10 +1059,13 @@ mod loader {
 
             let identity_cache = match self.identity_cache {
                 None => match self.behavior_version {
+                    #[cfg(feature = "legacy-client")]
                     #[allow(deprecated)]
                     Some(bv) if bv.is_at_least(BehaviorVersion::v2024_03_28()) => {
                         Some(IdentityCache::lazy().build())
                     }
+                    #[cfg(not(feature = "legacy-client"))]
+                    Some(_) => Some(IdentityCache::lazy().build()),
                     _ => None,
                 },
                 Some(user_cache) => Some(user_cache),
@@ -1401,7 +1404,7 @@ mod loader {
             assert!(config.identity_cache().is_some());
         }
 
-        #[cfg(feature = "default-https-client")]
+        #[cfg(all(feature = "default-https-client", feature = "legacy-client"))]
         #[allow(deprecated)]
         #[tokio::test]
         async fn identity_cache_old_behavior_version() {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/DisableStalledStreamProtectionTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/DisableStalledStreamProtectionTest.kt
@@ -133,7 +133,7 @@ class DisableStalledStreamProtectionTest {
                         }
 
                         let http_client =
-                            #{infallible_client_fn}(|_req| http::Response::builder().body(SdkBody::empty()).unwrap());
+                            #{infallible_client_fn}(|_req| #{http_1x}::Response::builder().body(SdkBody::empty()).unwrap());
                         let test_interceptor = TestInterceptor::default();
                         let client_config = Config::builder()
                             .interceptor(test_interceptor.clone())
@@ -150,8 +150,9 @@ class DisableStalledStreamProtectionTest {
                         );
                         """,
                         "infallible_client_fn" to
-                            CargoDependency.smithyRuntimeTestUtil(ctx.runtimeConfig)
-                                .toType().resolve("client::http::test_util::infallible_client_fn"),
+                            CargoDependency.smithyHttpClientTestUtil(ctx.runtimeConfig)
+                                .toType().resolve("test_util::infallible_client_fn"),
+                        "http_1x" to CargoDependency.Http1x.toType(),
                     )
                 }
             }

--- a/examples/legacy/pokemon-service-client-usage/Cargo.toml
+++ b/examples/legacy/pokemon-service-client-usage/Cargo.toml
@@ -22,7 +22,7 @@ aws-smithy-legacy-http = { path = "../../../rust-runtime/aws-smithy-legacy-http/
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types/" }
 
 # Required for `HyperClientBuilder` in `client-connector` example.
-aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime/", features=["test-util"] }
+aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime/", features=["legacy-test-util"] }
 
 # Required for `Metadata` in `custom-header-using-interceptor` example.
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api/", features=["client"] }

--- a/examples/legacy/pokemon-service-common/Cargo.toml
+++ b/examples/legacy/pokemon-service-common/Cargo.toml
@@ -24,4 +24,4 @@ pokemon-service-client = { path = "../pokemon-service-client/", package = "pokem
 pokemon-service-server-sdk-http0x = { path = "../pokemon-service-server-sdk-http0x" }
 
 [dev-dependencies]
-aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", features = ["test-util"] }
+aws-smithy-runtime = { path = "../../../rust-runtime/aws-smithy-runtime", features = ["legacy-test-util"] }

--- a/examples/pokemon-service-common/Cargo.toml
+++ b/examples/pokemon-service-common/Cargo.toml
@@ -27,4 +27,5 @@ pokemon-service-client = { path = "../pokemon-service-client/", features = [
 pokemon-service-server-sdk = { path = "../pokemon-service-server-sdk" }
 
 [dev-dependencies]
+aws-smithy-http-client = { path = "../../rust-runtime/aws-smithy-http-client", features = ["test-util"] }
 aws-smithy-runtime = { path = "../../rust-runtime/aws-smithy-runtime", features = ["test-util"] }

--- a/examples/pokemon-service-common/tests/plugins_execution_order.rs
+++ b/examples/pokemon-service-common/tests/plugins_execution_order.rs
@@ -16,7 +16,7 @@ use pokemon_service_server_sdk::{
 };
 use tower::{Layer, Service};
 
-use aws_smithy_runtime::client::http::test_util::capture_request;
+use aws_smithy_http_client::test_util::capture_request;
 use pokemon_service_client::{Client, Config};
 use pokemon_service_common::do_nothing;
 

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 name = "aws-smithy-cbor"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.3",
  "criterion",
@@ -412,7 +412,7 @@ dependencies = [
 name = "aws-smithy-compression"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "bytes",
  "bytes-utils",
@@ -431,7 +431,7 @@ dependencies = [
 name = "aws-smithy-dns"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "criterion",
  "hickory-resolver",
  "tokio",
@@ -483,7 +483,7 @@ version = "0.64.0"
 dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "bytes",
  "bytes-utils",
@@ -507,7 +507,7 @@ version = "1.4.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "base64 0.22.1",
  "bytes",
@@ -581,7 +581,7 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "aws-smithy-xml 0.62.0",
  "bytes",
@@ -694,7 +694,7 @@ dependencies = [
 name = "aws-smithy-json"
 version = "0.63.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.3",
  "proptest",
@@ -708,7 +708,7 @@ dependencies = [
  "async-stream",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.64.0",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "bytes",
  "bytes-utils",
@@ -733,7 +733,7 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-legacy-http",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "aws-smithy-xml 0.62.0",
  "bytes",
@@ -763,7 +763,7 @@ dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "http 1.5.0",
  "tokio",
@@ -773,7 +773,7 @@ dependencies = [
 name = "aws-smithy-observability"
 version = "0.3.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "serial_test",
 ]
 
@@ -797,7 +797,7 @@ name = "aws-smithy-protocol-test"
 version = "0.64.0"
 dependencies = [
  "assert-json-diff",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "base64-simd",
  "cbor-diag",
  "ciborium",
@@ -814,7 +814,7 @@ dependencies = [
 name = "aws-smithy-query"
 version = "0.62.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.3",
  "aws-smithy-xml 0.62.0",
@@ -824,14 +824,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "approx",
  "aws-smithy-async 1.3.0",
  "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
  "aws-smithy-observability",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.3",
  "bytes",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
  "aws-smithy-runtime-api-macros 1.1.0",
@@ -921,7 +921,7 @@ dependencies = [
 name = "aws-smithy-schema"
 version = "0.2.0"
 dependencies = [
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "http 1.5.0",
 ]
@@ -1003,7 +1003,7 @@ name = "aws-smithy-wasm"
 version = "0.2.0"
 dependencies = [
  "aws-smithy-async 1.3.0",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-types 1.6.3",
  "http-body-util",
  "sync_wrapper",
@@ -1024,7 +1024,7 @@ name = "aws-smithy-xml"
 version = "0.62.0"
 dependencies = [
  "aws-smithy-protocol-test",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.3",
  "base64 0.13.1",
@@ -2514,7 +2514,7 @@ dependencies = [
  "aws-smithy-http 0.64.0",
  "aws-smithy-json 0.63.0",
  "aws-smithy-runtime",
- "aws-smithy-runtime-api 1.16.0",
+ "aws-smithy-runtime-api 1.17.0",
  "aws-smithy-schema 0.2.0",
  "aws-smithy-types 1.6.3",
  "aws-smithy-xml 0.62.0",

--- a/rust-runtime/aws-smithy-runtime-api/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime-api"
-version = "1.16.0"
+version = "1.17.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "Smithy runtime types."
 edition = "2021"

--- a/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/behavior_version.rs
@@ -16,6 +16,7 @@ pub struct BehaviorVersion {
 }
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[allow(dead_code)] // Variants are constructed behind feature gates
 enum Inner {
     // IMPORTANT: Order matters here for the `Ord` derive. Newer versions go to the bottom.
     V2023_11_09,
@@ -55,10 +56,19 @@ impl BehaviorVersion {
         }
     }
 
+    // NOTE: Behavior versions prior to v2026_01_12 are gated behind the `legacy-client` feature.
+    // Using a pre-v2026_01_12 BehaviorVersion without the legacy TLS stack (`tls-rustls`) results
+    // in no HTTP client being configured at runtime. The default HTTP client plugin resolves
+    // pre-v2026_01_12 versions exclusively through the `connector-hyper-0-14-x` feature (the
+    // legacy hyper 0.14 stack), which is only enabled via `tls-rustls`. Without it, the client
+    // resolution falls through to None and no HTTP client is available. By gating access to old
+    // versions, we prevent users from silently ending up with no HTTP client.
+
     /// Behavior version for August 7th, 2025.
     ///
     /// This version updates the default HTTPS client to support proxy environment variables
     /// (e.g. `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) by default.
+    #[cfg(feature = "legacy-client")]
     #[deprecated(
         since = "1.10.0",
         note = "Superseded by v2026_01_12, which enables retries by default for AWS SDK clients and sets a 3.1s connect timeout for all clients."
@@ -80,6 +90,7 @@ impl BehaviorVersion {
     /// feature flags manually to keep the legacy Hyper stack as the default. Specifically the
     /// `aws-smithy-runtime/tls-rustls` feature flag combined with an older behavior version.
     /// </div>
+    #[cfg(feature = "legacy-client")]
     #[deprecated(
         since = "1.9.0",
         note = "Superseded by v2025_08_07, which enables automatic HTTP(S) proxy support from environment variables in the default HTTPS client."
@@ -95,6 +106,7 @@ impl BehaviorVersion {
     /// This version enables stalled stream protection for uploads (request bodies) by default.
     ///
     /// When a new behavior major version is released, this method will be deprecated.
+    #[cfg(feature = "legacy-client")]
     #[deprecated(
         since = "1.8.0",
         note = "Superseded by v2025_01_17, which updates the default HTTPS client stack."
@@ -106,6 +118,7 @@ impl BehaviorVersion {
     }
 
     /// Behavior version for November 9th, 2023.
+    #[cfg(feature = "legacy-client")]
     #[deprecated(
         since = "1.4.0",
         note = "Superseded by v2024_03_28, which enabled stalled stream protection for uploads (request bodies) by default."
@@ -133,6 +146,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "legacy-client")]
     #[allow(deprecated)]
     fn version_comparison() {
         assert!(BehaviorVersion::latest() == BehaviorVersion::latest());
@@ -146,6 +160,20 @@ mod tests {
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2025_08_07()));
         assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2026_01_12()));
         assert!(!BehaviorVersion::v2023_11_09().is_at_least(BehaviorVersion::v2024_03_28()));
+        assert!(Inner::V2024_03_28 > Inner::V2023_11_09);
+        assert!(Inner::V2023_11_09 < Inner::V2024_03_28);
+        assert!(Inner::V2024_03_28 < Inner::V2025_01_17);
+        assert!(Inner::V2025_01_17 < Inner::V2025_08_07);
+        assert!(Inner::V2025_08_07 < Inner::V2026_01_12);
+    }
+
+    #[test]
+    #[cfg(not(feature = "legacy-client"))]
+    #[allow(deprecated)]
+    fn version_comparison() {
+        assert!(BehaviorVersion::latest() == BehaviorVersion::latest());
+        assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::latest()));
+        assert!(BehaviorVersion::latest().is_at_least(BehaviorVersion::v2026_01_12()));
         assert!(Inner::V2024_03_28 > Inner::V2023_11_09);
         assert!(Inner::V2023_11_09 < Inner::V2024_03_28);
         assert!(Inner::V2024_03_28 < Inner::V2025_01_17);

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-runtime"
-version = "1.14.0"
+version = "1.15.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Zelda Hessler <zhessler@amazon.com>"]
 description = "The new smithy runtime crate"
 edition = "2021"
@@ -28,8 +28,6 @@ test-util = [
     "aws-smithy-runtime-api/test-util",
     "dep:tracing-subscriber",
     "aws-smithy-http-client/test-util",
-    # TODO(hyper1): Feature remains in place for backwards compat but in a future release we will break this flag and disable legacy HTTP test utils
-    "legacy-test-util",
 ]
 
 legacy-test-util = [
@@ -40,6 +38,7 @@ legacy-test-util = [
     # legacy http test utils
     "connector-hyper-0-14-x",
     "aws-smithy-http-client/legacy-test-util",
+    "test-util",
 ]
 
 wire-mock = ["legacy-test-util", "aws-smithy-http-client/wire-mock"]

--- a/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/defaults.rs
@@ -56,6 +56,7 @@ where
 }
 
 /// Runtime plugin that provides a default connector.
+#[cfg(feature = "tls-rustls")]
 #[deprecated(
     since = "1.8.0",
     note = "This function wasn't intended to be public, and didn't take the behavior major version as an argument, so it couldn't be evolved over time."
@@ -299,6 +300,7 @@ pub fn default_identity_cache_plugin() -> Option<SharedRuntimePlugin> {
 ///
 /// By default, when throughput falls below 1/Bs for more than 5 seconds, the
 /// stream is cancelled.
+#[cfg(feature = "tls-rustls")]
 #[deprecated(
     since = "1.2.0",
     note = "This function wasn't intended to be public, and didn't take the behavior major version as an argument, so it couldn't be evolved over time."
@@ -308,7 +310,7 @@ pub fn default_stalled_stream_protection_config_plugin() -> Option<SharedRuntime
     default_stalled_stream_protection_config_plugin_v2(BehaviorVersion::v2023_11_09())
 }
 fn default_stalled_stream_protection_config_plugin_v2(
-    behavior_version: BehaviorVersion,
+    _behavior_version: BehaviorVersion,
 ) -> Option<SharedRuntimePlugin> {
     Some(
         default_plugin(
@@ -320,12 +322,16 @@ fn default_stalled_stream_protection_config_plugin_v2(
             },
         )
         .with_config(layer("default_stalled_stream_protection_config", |layer| {
+            #[allow(unused_mut)]
             let mut config =
                 StalledStreamProtectionConfig::enabled().grace_period(Duration::from_secs(5));
             // Before v2024_03_28, upload streams did not have stalled stream protection by default
-            #[expect(deprecated)]
-            if !behavior_version.is_at_least(BehaviorVersion::v2024_03_28()) {
-                config = config.upload_enabled(false);
+            #[cfg(feature = "tls-rustls")]
+            {
+                #[expect(deprecated)]
+                if !_behavior_version.is_at_least(BehaviorVersion::v2024_03_28()) {
+                    config = config.upload_enabled(false);
+                }
             }
             layer.store_put(config.build());
         }))
@@ -427,14 +433,20 @@ pub fn default_plugins(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aws_smithy_runtime_api::client::runtime_plugin::{RuntimePlugin, RuntimePlugins};
+    use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
+    #[cfg(feature = "tls-rustls")]
+    use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugins;
 
+    // These helpers are only used by tests that exercise pre-v2026_01_12 behavior versions,
+    // which are gated behind the `tls-rustls` feature (via `legacy-client`).
+    #[cfg(feature = "tls-rustls")]
     fn test_plugin_params(version: BehaviorVersion) -> DefaultPluginParams {
         DefaultPluginParams::new()
             .with_behavior_version(version)
             .with_retry_partition_name("dontcare")
             .with_is_aws_sdk(false) // Default to non-AWS SDK for existing tests
     }
+    #[cfg(feature = "tls-rustls")]
     fn config_for(plugins: impl IntoIterator<Item = SharedRuntimePlugin>) -> ConfigBag {
         let mut config = ConfigBag::base();
         let plugins = RuntimePlugins::new().with_client_plugins(plugins);
@@ -443,6 +455,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tls-rustls")]
     #[expect(deprecated)]
     fn v2024_03_28_stalled_stream_protection_difference() {
         let latest = config_for(default_plugins(test_plugin_params(
@@ -489,6 +502,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tls-rustls")]
     #[expect(deprecated)]
     fn test_retry_disabled_for_aws_sdk_old_behavior_version() {
         // Any version before v2026_01_12 should have retries disabled
@@ -553,6 +567,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tls-rustls")]
     #[expect(deprecated)]
     fn test_behavior_version_gates_retry_for_aws_sdk() {
         // This test demonstrates the complete behavior:
@@ -591,6 +606,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tls-rustls")]
     #[expect(deprecated)]
     fn test_complete_default_plugins_integration() {
         // This test simulates the complete flow as it would happen in a real AWS SDK client

--- a/rust-runtime/aws-smithy-runtime/src/client/http.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http.rs
@@ -10,10 +10,11 @@ use aws_smithy_runtime_api::client::http::SharedHttpClient;
 pub mod connection_poisoning;
 
 #[deprecated = "Direct HTTP test utility support from `aws-smithy-runtime` crate is deprecated. Please use the `test-util` feature from `aws-smithy-http-client` instead"]
-#[cfg(feature = "test-util")]
+#[cfg(any(feature = "test-util", feature = "legacy-test-util"))]
 pub mod test_util {
     #![allow(missing_docs)]
 
+    #[cfg(feature = "legacy-test-util")]
     pub use aws_smithy_http_client::test_util::{
         legacy_capture_request as capture_request, CaptureRequestHandler, CaptureRequestReceiver,
     };
@@ -25,6 +26,7 @@ pub mod test_util {
 
     pub use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
 
+    #[cfg(feature = "legacy-test-util")]
     pub use aws_smithy_http_client::test_util::legacy_infallible::infallible_client_fn;
 
     pub use aws_smithy_http_client::test_util::NeverClient;
@@ -82,6 +84,7 @@ impl DefaultClientOptions {
 
 /// Creates an HTTPS client using the default TLS provider
 #[cfg(feature = "default-https-client")]
+#[allow(unused_variables)]
 pub(crate) fn default_https_client(options: DefaultClientOptions) -> Option<SharedHttpClient> {
     use aws_smithy_http_client::proxy::ProxyConfig;
     use aws_smithy_http_client::{tls, Builder, ConnectorBuilder};
@@ -97,14 +100,21 @@ pub(crate) fn default_https_client(options: DefaultClientOptions) -> Option<Shar
             conn_builder.set_sleep_impl(components.sleep_impl());
         }
 
-        #[expect(deprecated)]
-        if options
-            .behavior_version
-            .is_at_least(BehaviorVersion::v2025_08_07())
+        #[cfg(feature = "tls-rustls")]
+        {
+            #[expect(deprecated)]
+            if options
+                .behavior_version
+                .is_at_least(BehaviorVersion::v2025_08_07())
+            {
+                conn_builder.set_proxy_config(Some(ProxyConfig::from_env()));
+            } else {
+                conn_builder.set_proxy_config(Some(ProxyConfig::disabled()));
+            }
+        }
+        #[cfg(not(feature = "tls-rustls"))]
         {
             conn_builder.set_proxy_config(Some(ProxyConfig::from_env()));
-        } else {
-            conn_builder.set_proxy_config(Some(ProxyConfig::disabled()));
         }
 
         conn_builder.build()

--- a/rust-runtime/aws-smithy-runtime/tests/retries.rs
+++ b/rust-runtime/aws-smithy-runtime/tests/retries.rs
@@ -5,7 +5,7 @@
 
 #![cfg(all(feature = "client", feature = "test-util"))]
 
-use aws_smithy_runtime::client::http::test_util::infallible_client_fn;
+use aws_smithy_http_client::test_util::infallible_client_fn;
 use aws_smithy_runtime::client::retries::classifiers::HttpStatusCodeClassifier;
 use aws_smithy_runtime::client::retries::RetryPartition;
 use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
@@ -143,7 +143,7 @@ async fn token_bucket_exhausted_before_max_attempts() {
     let max_attempts = 100;
 
     let http_client = infallible_client_fn(|_req| {
-        http_02x::Response::builder()
+        http_1x::Response::builder()
             .status(503)
             .body(SdkBody::empty())
             .unwrap()
@@ -173,7 +173,7 @@ async fn token_bucket_partitioning() {
     let max_attempts = 100;
 
     let http_client = infallible_client_fn(|_req| {
-        http_02x::Response::builder()
+        http_1x::Response::builder()
             .status(503)
             .body(SdkBody::empty())
             .unwrap()

--- a/rust-runtime/aws-smithy-runtime/tests/stalled_stream_download.rs
+++ b/rust-runtime/aws-smithy-runtime/tests/stalled_stream_download.rs
@@ -262,13 +262,8 @@ mod download_test_tools {
     use tokio::sync::mpsc::Receiver;
 
     fn response(body: SdkBody) -> HttpResponse {
-        HttpResponse::try_from(
-            http_02x::Response::builder()
-                .status(200)
-                .body(body)
-                .unwrap(),
-        )
-        .unwrap()
+        HttpResponse::try_from(http_1x::Response::builder().status(200).body(body).unwrap())
+            .unwrap()
     }
 
     pub fn operation(

--- a/rust-runtime/aws-smithy-runtime/tests/stalled_stream_upload.rs
+++ b/rust-runtime/aws-smithy-runtime/tests/stalled_stream_upload.rs
@@ -257,7 +257,7 @@ mod upload_test_tools {
 
     pub fn successful_response() -> HttpResponse {
         HttpResponse::try_from(
-            http_02x::Response::builder()
+            http_1x::Response::builder()
                 .status(200)
                 .body(SdkBody::empty())
                 .unwrap(),


### PR DESCRIPTION
Gate `BehaviorVersion` constructors prior to `v2026_01_12` (v2023_11_09, v2024_03_28, v2025_01_17, v2025_08_07) behind `aws-smithy-runtime-api/legacy-client`.

These `BehaviorVersion` constructors must be gated because using a pre-`v2026_01_12` `BehaviorVersion` without the legacy TLS stack (`tls-rustls`) enabled results in no HTTP client being configured at runtime. The default HTTP client plugin only resolves a client for v2026_01_12+ when `tls-rustls` is disabled (see defaults.rs default_http_client_plugin). By removing access to old versions when the legacy feature is off, we prevent users from silently ending up with no HTTP client at runtime.

In `aws-smithy-runtime`:
- Remove `legacy-test-util` from the `test-util` feature and add `test-util` to `legacy-test-util` to make it opt-in
- Gate deprecated default plugin functions and `BehaviorVersion`-based branching in `defaults.rs` and `http.rs` behind `#[cfg(feature = "tls-rustls")]`
- Gate legacy HTTP test utility re-exports (`capture_request`, `infallible_client_fn`) in `http.rs::test_util` behind `#[cfg(feature = "legacy-test-util")]` and expose the module under `#[cfg(any(feature = "test-util", feature = "legacy-test-util"))]`

In `aws-config`:
- Gate identity cache BehaviorVersion check behind `aws-config/legacy-client`.
- Gate IMDS legacy BehaviorVersion test behind `aws-config/legacy-client`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
- [ ] For changes to the AWS SDK, generated SDK code, or SDK runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "aws-sdk-rust" in the `applies_to` key.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
