### PR TITLE
 Fix `rpcv2Cbor` deserialization for unnamed enums

### DIFF
--- a/.changelog/fix-cbor-unnamed-enum-deserialization.md
+++ b/.changelog/fix-cbor-unnamed-enum-deserialization.md
@@ -1,0 +1,10 @@
+---
+applies_to: ["client"]
+authors: ["drganjoo"]
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+Fix CBOR client deserialization for unnamed enums by removing an ambiguous
+`AsRef` conversion from the generated Rust code.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGenerator.kt
@@ -624,7 +624,7 @@ class CborParserGenerator(
                     if (this@CborParserGenerator.returnSymbolToParse(target).isUnconstrained) {
                         rust("decoder.string()")
                     } else {
-                        rust("decoder.string().map(|s| #T::from(s.as_ref()))", symbolProvider.toSymbol(target))
+                        rust("decoder.string().map(|s| #T::from(s.as_str()))", symbolProvider.toSymbol(target))
                     }
                 }
                 false -> rust("decoder.string()")

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGeneratorTest.kt
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.assertThrows
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.TestEnumType
-import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpTraitHttpBindingResolver
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolContentTypes
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.OperationNormalizer

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/CborParserGeneratorTest.kt
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.TestEnumType
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpTraitHttpBindingResolver
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolContentTypes
@@ -65,6 +68,32 @@ class CborParserGeneratorTest {
         }
         """.asSmithyModel()
 
+    private val modelWithUnnamedEnum =
+        """
+        namespace test
+        use smithy.protocols#rpcv2Cbor
+
+        @rpcv2Cbor
+        service TestService {
+            version: "test",
+            operations: [TestOp]
+        }
+
+        @enum([
+            { value: "FOO" }
+        ])
+        string TestEnum
+
+        structure TestOutput {
+            value: TestEnum
+        }
+
+        @http(uri: "/test", method: "POST")
+        operation TestOp {
+            output: TestOutput
+        }
+        """.asSmithyModel()
+
     @Test
     fun `generates parser for BigInteger with CBOR`() {
         val model = OperationNormalizer.transform(modelWithBigInteger)
@@ -92,6 +121,42 @@ class CborParserGeneratorTest {
 
         model.lookup<OperationShape>("test#TestOp").outputShape(model).also { output ->
             output.renderWithModelBuilder(model, symbolProvider, project)
+        }
+        project.compileAndTest()
+    }
+
+    @Test
+    fun `generated parser for unnamed enum with CBOR compiles`() {
+        val model = OperationNormalizer.transform(modelWithUnnamedEnum)
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
+        val parserGenerator =
+            CborParserGenerator(
+                codegenContext,
+                HttpTraitHttpBindingResolver(model, ProtocolContentTypes.consistent("application/cbor")),
+                handleNullForNonSparseCollection = { _ -> writable { } },
+            )
+        val operationParser = parserGenerator.operationParser(model.lookup("test#TestOp"))
+
+        val project = TestWorkspace.testProject(symbolProvider)
+
+        project.lib {
+            unitTest(
+                "cbor_unnamed_enum_parser",
+                """
+                let bytes: &[u8] = &[];
+                let _output = ${format(operationParser!!)};
+                """,
+            )
+        }
+
+        model.lookup<OperationShape>("test#TestOp").outputShape(model).also { output ->
+            output.renderWithModelBuilder(model, symbolProvider, project)
+        }
+        model.lookup<StringShape>("test#TestEnum").also { enum ->
+            project.moduleFor(enum) {
+                EnumGenerator(model, symbolProvider, enum, TestEnumType, emptyList()).render(this)
+            }
         }
         project.compileAndTest()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ allowLocalDeps=false
 # Avoid registering dependencies/plugins/tasks that are only used for testing purposes
 isTestingEnabled=true
 # codegen publication version
-codegenVersion=0.1.26
+codegenVersion=0.1.27


### PR DESCRIPTION
## Motivation and Context

Closes #4842.

When an unnamed enum is reachable from an operation using `rpcv2Cbor`, the generated Rust client fails to compile with `E0283`.

The CBOR deserializer previously generated:

```rust
TestEnum::from(s.as_ref())
```

Unnamed enums have a generic `From<T>` implementation where `T: AsRef<str>`. Since `String` implements `AsRef` for several target types, Rust cannot infer which `String::as_ref()` implementation should be used.

## Description

- Use `s.as_str()` when converting a decoded CBOR string into a constrained string shape, making the target type explicit.
- Add a regression test with a reachable unnamed enum and verify that the generated parser compiles.
- Add a client bug-fix changelog entry.

## Testing

Added `generated parser for unnamed enum with CBOR compiles` to `CborParserGeneratorTest`. The test generates the operation output parser and unnamed enum type, then compiles the generated Rust project.

## Checklist

- [x] For changes to the smithy-rs codegen or runtime crates, I have created a changelog entry Markdown file in the `.changelog` directory, specifying "client," "server," or both in the `applies_to` key.
