### PR TITLE
Update most codegen tests to use cargo nextest

### DIFF
--- a/aws/sdk-adhoc-test/build.gradle.kts
+++ b/aws/sdk-adhoc-test/build.gradle.kts
@@ -85,7 +85,7 @@ tasks["smithyBuild"].dependsOn("generateSmithyBuild")
 tasks["assemble"].dependsOn("generateCargoWorkspace").finalizedBy("copyCheckedInCargoLockfile")
 
 project.registerModifyMtimeTask()
-project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
+project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile, useNextest = true)
 
 tasks["test"].finalizedBy(cargoCommands(properties).map { it.toString })
 

--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -375,7 +375,19 @@ fun Project.registerModifyMtimeTask() {
     }
 }
 
-fun Project.registerCargoCommandsTasks(outputDir: File) {
+/**
+ * Registers the `cargoCheck`, `cargoTest`, `cargoDoc`, and `cargoClippy` tasks that run against the generated crates.
+ *
+ * When [useNextest] is `true`, `cargoTest` runs the generated test suite with `cargo nextest run` (mirroring how the
+ * runtime crates are tested in CI), and a companion `cargoTestDoctests` task runs the doctests that nextest does not
+ * execute. This requires `cargo-nextest` to be installed. Crates whose test harnesses are incompatible with nextest —
+ * e.g. the `cdylib` Python/TypeScript servers, which use pyo3/napi harnesses — should leave [useNextest] as `false` and
+ * continue to run with `cargo test`.
+ */
+fun Project.registerCargoCommandsTasks(
+    outputDir: File,
+    useNextest: Boolean = false,
+) {
     val dependentTasks =
         listOfNotNull(
             "assemble",
@@ -389,10 +401,28 @@ fun Project.registerCargoCommandsTasks(outputDir: File) {
         commandLine("cargo", "check", "--lib", "--tests", "--benches", "--all-features")
     }
 
-    this.tasks.register<Exec>(Cargo.TEST.toString) {
-        dependsOn(dependentTasks)
-        workingDir(outputDir)
-        commandLine("cargo", "test", "--all-features", "--no-fail-fast")
+    val testTask =
+        this.tasks.register<Exec>(Cargo.TEST.toString) {
+            dependsOn(dependentTasks)
+            workingDir(outputDir)
+            if (useNextest) {
+                // `cargo nextest run` parallelizes test execution and matches how the runtime crates are tested in CI.
+                // `--no-tests=pass` tolerates generated crates that contain no tests.
+                commandLine("cargo", "nextest", "run", "--all-features", "--no-fail-fast", "--no-tests=pass")
+            } else {
+                commandLine("cargo", "test", "--all-features", "--no-fail-fast")
+            }
+        }
+
+    if (useNextest) {
+        // `cargo nextest run` does not run doctests, so run them separately to preserve coverage.
+        val doctestTask =
+            this.tasks.register<Exec>("cargoTestDoctests") {
+                dependsOn(dependentTasks)
+                workingDir(outputDir)
+                commandLine("cargo", "test", "--all-features", "--no-fail-fast", "--doc")
+            }
+        testTask.configure { finalizedBy(doctestTask) }
     }
 
     this.tasks.register<Exec>(Cargo.DOCS.toString) {

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -138,7 +138,7 @@ tasks["smithyBuild"].dependsOn("generateSmithyBuild")
 tasks["assemble"].finalizedBy("generateCargoWorkspace", "copyCheckedInCargoLockfile")
 
 project.registerModifyMtimeTask()
-project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
+project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile, useNextest = true)
 
 tasks["test"].finalizedBy(cargoCommands(properties).map { it.toString })
 

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -160,13 +160,21 @@ tasks["smithyBuild"].dependsOn("generateSmithyBuild")
 tasks["assemble"].finalizedBy("generateCargoWorkspace", "generateCargoConfigToml")
 
 project.registerModifyMtimeTask()
-project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile)
+project.registerCargoCommandsTasks(layout.buildDirectory.dir(workingDirUnderBuildDir).get().asFile, useNextest = true)
 
 tasks.register<Exec>("cargoTestIntegration") {
     dependsOn("assemble")
     workingDir(projectDir.resolve("integration-tests"))
-    commandLine("cargo", "test")
+    commandLine("cargo", "nextest", "run", "--no-tests=pass")
 }
+
+// `cargo nextest run` does not run doctests, so run them separately to preserve coverage.
+tasks.register<Exec>("cargoTestIntegrationDoctests") {
+    dependsOn("assemble")
+    workingDir(projectDir.resolve("integration-tests"))
+    commandLine("cargo", "test", "--doc")
+}
+tasks["cargoTestIntegration"].finalizedBy("cargoTestIntegrationDoctests")
 
 tasks["test"].finalizedBy(cargoCommands(properties).map { it.toString }, "cargoTestIntegration")
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Update most codegen tests to use cargo nextest. Excluding codegen unit tests since those are small and are individual JUnit tests and likely wouldn't benefit from the parallelism of nextest.

Over a fewruns looks like it cut another 2.5/3 minutes from total CI time. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
