### PR TITLE
schema-based JSON deserializer should reject malformed input

### DIFF
--- a/.changelog/json-codec-strict-separators.md
+++ b/.changelog/json-codec-strict-separators.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client", "server"]
+authors: ["fahadzub"]
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+The schema-based JSON deserializer now rejects malformed JSON that it previously accepted: commas were skipped as whitespace, so `{"int": 10,}`, `[1,,2]` and `{,"a": 1}` parsed successfully; bytes after the top-level value such as `{"int": 10}abc` were ignored; and values inside unknown members were skipped without validating number grammar or string escapes. These correspond to the Smithy protocol tests `RestJsonInvalidJsonBody_case1` and `RestJsonInvalidJsonBody_case7`.

--- a/aws/rust-runtime/aws-config/Cargo.lock
+++ b/aws/rust-runtime/aws-config/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.63.0"
+version = "0.63.1"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",

--- a/aws/sdk/Cargo.lock
+++ b/aws/sdk/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.63.0"
+version = "0.63.1"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -580,7 +580,7 @@ version = "0.67.1"
 dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-http 0.64.0",
- "aws-smithy-json 0.63.0",
+ "aws-smithy-json 0.63.1",
  "aws-smithy-runtime-api 1.16.0",
  "aws-smithy-types 1.6.3",
  "aws-smithy-xml 0.62.0",
@@ -647,7 +647,7 @@ name = "aws-smithy-http-server-python"
 version = "0.68.1"
 dependencies = [
  "aws-smithy-http 0.64.0",
- "aws-smithy-json 0.63.0",
+ "aws-smithy-json 0.63.1",
  "aws-smithy-legacy-http-server",
  "aws-smithy-types 1.6.3",
  "aws-smithy-xml 0.62.0",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.63.0"
+version = "0.63.1"
 dependencies = [
  "aws-smithy-runtime-api 1.16.0",
  "aws-smithy-schema 0.2.0",
@@ -731,7 +731,7 @@ name = "aws-smithy-legacy-http-server"
 version = "0.66.1"
 dependencies = [
  "aws-smithy-cbor 0.62.0",
- "aws-smithy-json 0.63.0",
+ "aws-smithy-json 0.63.1",
  "aws-smithy-legacy-http",
  "aws-smithy-runtime-api 1.16.0",
  "aws-smithy-types 1.6.3",
@@ -2524,7 +2524,7 @@ dependencies = [
  "aws-smithy-cbor 0.62.0",
  "aws-smithy-compression",
  "aws-smithy-http 0.64.0",
- "aws-smithy-json 0.63.0",
+ "aws-smithy-json 0.63.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api 1.16.0",
  "aws-smithy-schema 0.2.0",

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-smithy-json"
-version = "0.63.0"
+version = "0.63.1"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Token streaming JSON parser for smithy-rs."
 edition = "2021"

--- a/rust-runtime/aws-smithy-json/src/codec/deserializer.rs
+++ b/rust-runtime/aws-smithy-json/src/codec/deserializer.rs
@@ -129,27 +129,17 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
 
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-
-            // Check for end of object, error on end of input, otherwise
-            // fall through to parse the next key/value pair.
-            match self.remaining().first() {
-                Some(&b'}') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in object".into(),
-                    });
-                }
-                Some(&b'"') => {}
-                Some(_) => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "expected object key".into(),
-                    });
-                }
+            // Stop at the end of the object; otherwise the next key/value pair starts here.
+            if self.next_element(first, b'}', "object")? {
+                break;
+            }
+            first = false;
+            if self.remaining().first() != Some(&b'"') {
+                return Err(SerdeError::InvalidInput {
+                    message: "expected object key".into(),
+                });
             }
 
             // Parse the key directly from bytes
@@ -176,7 +166,7 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
             }
         }
 
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(())
     }
 
@@ -197,23 +187,16 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
 
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            match self.remaining().first() {
-                Some(&b']') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in array".into(),
-                    });
-                }
-                _ => consumer(self)?,
+            if self.next_element(first, b']', "array")? {
+                break;
             }
+            first = false;
+            consumer(self)?;
         }
 
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(())
     }
 
@@ -234,24 +217,16 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
 
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            match self.remaining().first() {
-                Some(&b'}') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in object".into(),
-                    });
-                }
-                Some(&b'"') => {}
-                Some(_) => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "expected key".into(),
-                    });
-                }
+            if self.next_element(first, b'}', "object")? {
+                break;
+            }
+            first = false;
+            if self.remaining().first() != Some(&b'"') {
+                return Err(SerdeError::InvalidInput {
+                    message: "expected key".into(),
+                });
             }
 
             let key = self.parse_key()?;
@@ -268,7 +243,7 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
             consumer(key.into_owned(), self)?;
         }
 
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(())
     }
 
@@ -437,22 +412,15 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
         let mut out = Vec::new();
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            match self.remaining().first() {
-                Some(&b']') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in array".into(),
-                    })
-                }
-                _ => out.push(self.read_string(_schema)?),
+            if self.next_element(first, b']', "array")? {
+                break;
             }
+            first = false;
+            out.push(self.read_string(_schema)?);
         }
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(out)
     }
 
@@ -469,22 +437,15 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
         let mut out = Vec::new();
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            match self.remaining().first() {
-                Some(&b']') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in array".into(),
-                    })
-                }
-                _ => out.push(self.read_blob(_schema)?),
+            if self.next_element(first, b']', "array")? {
+                break;
             }
+            first = false;
+            out.push(self.read_blob(_schema)?);
         }
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(out)
     }
 
@@ -501,22 +462,15 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
         let mut out = Vec::new();
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            match self.remaining().first() {
-                Some(&b']') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in array".into(),
-                    })
-                }
-                _ => out.push(self.read_integer(_schema)?),
+            if self.next_element(first, b']', "array")? {
+                break;
             }
+            first = false;
+            out.push(self.read_integer(_schema)?);
         }
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(out)
     }
 
@@ -533,22 +487,15 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
         let mut out = Vec::new();
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            match self.remaining().first() {
-                Some(&b']') => {
-                    self.advance_by(1);
-                    break;
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input in array".into(),
-                    })
-                }
-                _ => out.push(self.read_long(_schema)?),
+            if self.next_element(first, b']', "array")? {
+                break;
             }
+            first = false;
+            out.push(self.read_long(_schema)?);
         }
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(out)
     }
 
@@ -568,12 +515,12 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
         }
         self.advance_by(1);
         let mut out = std::collections::HashMap::new();
+        let mut first = true;
         loop {
-            self.skip_whitespace();
-            if self.remaining().first() == Some(&b'}') {
-                self.advance_by(1);
+            if self.next_element(first, b'}', "object")? {
                 break;
             }
+            first = false;
             if self.remaining().first() != Some(&b'"') {
                 return Err(SerdeError::InvalidInput {
                     message: "expected key".into(),
@@ -591,7 +538,7 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
             let val = self.read_string(_schema)?;
             out.insert(key.into_owned(), val);
         }
-        self.depth -= 1;
+        self.leave_container()?;
         Ok(out)
     }
 
@@ -682,12 +629,12 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
             Some(b'{') => {
                 self.advance_by(1);
                 let mut map = std::collections::HashMap::new();
+                let mut first = true;
                 loop {
-                    self.skip_whitespace();
-                    if self.remaining().first() == Some(&b'}') {
-                        self.advance_by(1);
+                    if self.next_element(first, b'}', "document object")? {
                         break;
                     }
+                    first = false;
                     if self.remaining().first() != Some(&b'"') {
                         return Err(SerdeError::InvalidInput {
                             message: "expected object key in document".into(),
@@ -709,20 +656,13 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
             Some(b'[') => {
                 self.advance_by(1);
                 let mut arr = Vec::new();
+                let mut first = true;
                 loop {
-                    self.skip_whitespace();
-                    match self.remaining().first() {
-                        Some(&b']') => {
-                            self.advance_by(1);
-                            break;
-                        }
-                        None => {
-                            return Err(SerdeError::InvalidInput {
-                                message: "unexpected end of input in document array".into(),
-                            })
-                        }
-                        _ => arr.push(self.read_document(_schema)?),
+                    if self.next_element(first, b']', "document array")? {
+                        break;
                     }
+                    first = false;
+                    arr.push(self.read_document(_schema)?);
                 }
                 Ok(Document::Array(arr))
             }
@@ -774,7 +714,7 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
             }),
         };
         if result.is_ok() {
-            self.depth -= 1;
+            self.leave_container()?;
         }
         result
     }
@@ -854,10 +794,164 @@ impl<'a> JsonDeserializer<'a> {
     fn skip_whitespace(&mut self) {
         while self.position < self.input.len() {
             match self.input[self.position] {
-                b' ' | b'\t' | b'\n' | b'\r' | b',' => self.position += 1,
+                b' ' | b'\t' | b'\n' | b'\r' => self.position += 1,
                 _ => break,
             }
         }
+    }
+
+    /// Positions the deserializer at the next element of a container whose closing
+    /// delimiter is `close`, enforcing JSON's separator rules: elements are separated by
+    /// exactly one comma, and no comma may precede the closing delimiter.
+    ///
+    /// Returns `true` when the closing delimiter was reached and consumed, `false` when the
+    /// next element starts at the current position. `first` is whether no element has been
+    /// read from this container yet.
+    fn next_element(&mut self, first: bool, close: u8, what: &str) -> Result<bool, SerdeError> {
+        self.skip_whitespace();
+        match self.remaining().first().copied() {
+            Some(b) if b == close => {
+                self.advance_by(1);
+                Ok(true)
+            }
+            None => Err(SerdeError::InvalidInput {
+                message: format!("unexpected end of input in {what}"),
+            }),
+            Some(b',') if first => Err(SerdeError::InvalidInput {
+                message: format!("unexpected `,` before the first element of {what}"),
+            }),
+            Some(b',') => {
+                self.advance_by(1);
+                self.skip_whitespace();
+                match self.remaining().first().copied() {
+                    Some(b) if b == close => Err(SerdeError::InvalidInput {
+                        message: format!("trailing `,` in {what}"),
+                    }),
+                    Some(b',') => Err(SerdeError::InvalidInput {
+                        message: format!("repeated `,` in {what}"),
+                    }),
+                    None => Err(SerdeError::InvalidInput {
+                        message: format!("unexpected end of input in {what}"),
+                    }),
+                    Some(_) => Ok(false),
+                }
+            }
+            Some(_) if first => Ok(false),
+            Some(_) => Err(SerdeError::InvalidInput {
+                message: format!("expected `,` between elements of {what}"),
+            }),
+        }
+    }
+
+    fn enter_container(&mut self) -> Result<(), SerdeError> {
+        self.depth += 1;
+        if self.depth > self.settings.max_depth() {
+            return Err(SerdeError::custom("maximum nesting depth exceeded"));
+        }
+        Ok(())
+    }
+
+    /// Leaves a container. When it was the outermost value of the input, nothing but
+    /// whitespace may follow it: a body such as `{"a": 1}abc` is malformed JSON and is
+    /// rejected here, matching the token-based parser's "found more JSON tokens after
+    /// completing parsing" check.
+    fn leave_container(&mut self) -> Result<(), SerdeError> {
+        self.depth -= 1;
+        if self.depth == 0 {
+            self.skip_whitespace();
+            if !self.remaining().is_empty() {
+                return Err(SerdeError::InvalidInput {
+                    message: "unexpected trailing characters after the JSON value".into(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Skips a JSON number, validating it against the RFC 8259 grammar
+    /// `-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?`. Whatever follows is left for the
+    /// enclosing container's separator check, so `01` fails there as "expected `,`".
+    fn skip_number(&mut self) -> Result<(), SerdeError> {
+        let rem = self.remaining();
+        let invalid = || SerdeError::InvalidInput {
+            message: "invalid number".into(),
+        };
+        let mut i = 0;
+        if rem.get(i) == Some(&b'-') {
+            i += 1;
+        }
+        match rem.get(i) {
+            Some(b'0') => i += 1,
+            Some(b'1'..=b'9') => {
+                while rem.get(i).is_some_and(|b| b.is_ascii_digit()) {
+                    i += 1;
+                }
+            }
+            _ => return Err(invalid()),
+        }
+        if rem.get(i) == Some(&b'.') {
+            i += 1;
+            let start = i;
+            while rem.get(i).is_some_and(|b| b.is_ascii_digit()) {
+                i += 1;
+            }
+            if i == start {
+                return Err(invalid());
+            }
+        }
+        if matches!(rem.get(i), Some(b'e') | Some(b'E')) {
+            i += 1;
+            if matches!(rem.get(i), Some(b'+') | Some(b'-')) {
+                i += 1;
+            }
+            let start = i;
+            while rem.get(i).is_some_and(|b| b.is_ascii_digit()) {
+                i += 1;
+            }
+            if i == start {
+                return Err(invalid());
+            }
+        }
+        self.advance_by(i);
+        Ok(())
+    }
+
+    /// Skips a JSON string, accepting exactly the escape sequences `read_string` accepts.
+    fn skip_string(&mut self) -> Result<(), SerdeError> {
+        let rem = self.remaining();
+        debug_assert_eq!(rem.first(), Some(&b'"'));
+        let mut i = 1;
+        loop {
+            match rem.get(i) {
+                None => {
+                    return Err(SerdeError::InvalidInput {
+                        message: "unterminated string".into(),
+                    })
+                }
+                Some(b'"') => {
+                    i += 1;
+                    break;
+                }
+                Some(b'\\') => match rem.get(i + 1) {
+                    Some(b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't') => i += 2,
+                    Some(b'u')
+                        if rem
+                            .get(i + 2..i + 6)
+                            .is_some_and(|hex| hex.iter().all(u8::is_ascii_hexdigit)) =>
+                    {
+                        i += 6
+                    }
+                    _ => {
+                        return Err(SerdeError::InvalidInput {
+                            message: "invalid escape sequence in string".into(),
+                        })
+                    }
+                },
+                Some(_) => i += 1,
+            }
+        }
+        self.advance_by(i);
+        Ok(())
     }
 
     fn consume_number(&mut self) {
@@ -872,106 +966,75 @@ impl<'a> JsonDeserializer<'a> {
         self.advance_by(len);
     }
 
+    /// Skips one JSON value, validating its syntax as it goes so that an unknown member
+    /// cannot smuggle malformed JSON past the deserializer. Like `read_string`, raw control
+    /// characters inside strings are not rejected.
     fn skip_value(&mut self) -> Result<(), SerdeError> {
         self.skip_whitespace();
-        let mut depth: usize = 0;
-        loop {
-            self.skip_whitespace();
-            match self.remaining().first().copied() {
-                Some(b'{') | Some(b'[') => {
-                    self.advance_by(1);
-                    depth += 1;
-                }
-                Some(b'}') | Some(b']') => {
-                    if depth == 0 {
+        match self.remaining().first().copied() {
+            Some(b'{') => {
+                self.enter_container()?;
+                self.advance_by(1);
+                let mut first = true;
+                loop {
+                    if self.next_element(first, b'}', "object")? {
+                        break;
+                    }
+                    first = false;
+                    if self.remaining().first() != Some(&b'"') {
                         return Err(SerdeError::InvalidInput {
-                            message: "unexpected end token".into(),
+                            message: "expected object key".into(),
+                        });
+                    }
+                    self.parse_key()?;
+                    self.skip_whitespace();
+                    if self.remaining().first() != Some(&b':') {
+                        return Err(SerdeError::InvalidInput {
+                            message: "expected colon after key".into(),
                         });
                     }
                     self.advance_by(1);
-                    depth -= 1;
-                    if depth == 0 {
-                        return Ok(());
-                    }
+                    self.skip_value()?;
                 }
-                Some(b'"') => {
-                    // Skip quoted string (handles escapes)
-                    let mut i = 1;
-                    let rem = self.remaining();
-                    while i < rem.len() {
-                        if rem[i] == b'\\' {
-                            i += 2; // skip escape sequence
-                        } else if rem[i] == b'"' {
-                            i += 1;
-                            break;
-                        } else {
-                            i += 1;
-                        }
-                    }
-                    self.advance_by(i);
-                    // After a string inside an object, skip optional ':'
-                    if depth > 0 {
-                        self.skip_whitespace();
-                        if self.remaining().first() == Some(&b':') {
-                            self.advance_by(1);
-                            continue; // read the value after the colon
-                        }
-                    }
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                }
-                Some(b't') => {
-                    if !self.remaining().starts_with(b"true") {
-                        return Err(SerdeError::InvalidInput {
-                            message: "expected `true`".into(),
-                        });
-                    }
-                    self.advance_by(4);
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                }
-                Some(b'f') => {
-                    if !self.remaining().starts_with(b"false") {
-                        return Err(SerdeError::InvalidInput {
-                            message: "expected `false`".into(),
-                        });
-                    }
-                    self.advance_by(5);
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                }
-                Some(b'n') => {
-                    if !self.remaining().starts_with(b"null") {
-                        return Err(SerdeError::InvalidInput {
-                            message: "expected `null`".into(),
-                        });
-                    }
-                    self.advance_by(4);
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                }
-                Some(c) if c == b'-' || c.is_ascii_digit() => {
-                    self.consume_number();
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                }
-                Some(_) => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected token in skip_value".into(),
-                    })
-                }
-                None => {
-                    return Err(SerdeError::InvalidInput {
-                        message: "unexpected end of input".into(),
-                    })
-                }
+                self.depth -= 1;
+                Ok(())
             }
+            Some(b'[') => {
+                self.enter_container()?;
+                self.advance_by(1);
+                let mut first = true;
+                loop {
+                    if self.next_element(first, b']', "array")? {
+                        break;
+                    }
+                    first = false;
+                    self.skip_value()?;
+                }
+                self.depth -= 1;
+                Ok(())
+            }
+            Some(b'"') => self.skip_string(),
+            Some(b't') => self.skip_literal(b"true"),
+            Some(b'f') => self.skip_literal(b"false"),
+            Some(b'n') => self.skip_literal(b"null"),
+            Some(c) if c == b'-' || c.is_ascii_digit() => self.skip_number(),
+            Some(_) => Err(SerdeError::InvalidInput {
+                message: "unexpected token in skip_value".into(),
+            }),
+            None => Err(SerdeError::InvalidInput {
+                message: "unexpected end of input".into(),
+            }),
         }
+    }
+
+    fn skip_literal(&mut self, literal: &'static [u8]) -> Result<(), SerdeError> {
+        if !self.remaining().starts_with(literal) {
+            return Err(SerdeError::InvalidInput {
+                message: format!("expected `{}`", String::from_utf8_lossy(literal)),
+            });
+        }
+        self.advance_by(literal.len());
+        Ok(())
     }
 
     fn read_integer_value(&mut self) -> Result<i64, SerdeError> {
@@ -2170,5 +2233,222 @@ mod tests {
         deser_ok
             .read_list(dummy_schema(), &mut recursive_list_consumer)
             .expect("10-level nesting should succeed under custom limit");
+    }
+
+    mod separators {
+        //! JSON syntax the deserializer must reject: separators (exactly one `,` between
+        //! elements, none before a closing delimiter), bytes after the top-level value, and
+        //! malformed values inside skipped unknown members. Smithy protocol tests
+        //! `RestJsonInvalidJsonBody_case7` (`{"int": 10,}`) and `RestJsonInvalidJsonBody_case1`
+        //! (`{ "int": 10 }abc`) require the first two.
+        use super::*;
+        use aws_smithy_schema::{shape_id, ShapeType};
+
+        static INT: Schema = Schema::new_member(
+            shape_id!("test", "Input", "int"),
+            ShapeType::Integer,
+            "int",
+            0,
+        );
+        static LIST: Schema = Schema::new_member(
+            shape_id!("test", "Input", "list"),
+            ShapeType::List,
+            "list",
+            1,
+        );
+        static INPUT: Schema = Schema::new_struct(
+            shape_id!("test", "Input"),
+            ShapeType::Structure,
+            &[&INT, &LIST],
+        );
+
+        fn deser(input: &[u8]) -> JsonDeserializer<'_> {
+            JsonDeserializer::new(input, Arc::new(JsonCodecSettings::default()))
+        }
+
+        /// Reads `INPUT` and returns `(int, list)`; unknown members are skipped.
+        fn read_input(body: &[u8]) -> Result<(Option<i32>, Vec<i32>), SerdeError> {
+            let mut d = deser(body);
+            let mut int = None;
+            let mut list = Vec::new();
+            d.read_struct(&INPUT, &mut |member, d| {
+                match member.member_index() {
+                    Some(0) => int = Some(d.read_integer(member)?),
+                    Some(1) => d.read_list(member, &mut |d| {
+                        list.push(d.read_integer(member)?);
+                        Ok(())
+                    })?,
+                    _ => {}
+                }
+                Ok(())
+            })?;
+            Ok((int, list))
+        }
+
+        #[test]
+        fn well_formed_input_is_read() {
+            assert_eq!(
+                read_input(br#"{ "int": 10 , "list": [ 1 , 2 ] }"#).unwrap(),
+                (Some(10), vec![1, 2])
+            );
+            assert_eq!(read_input(br#"{}"#).unwrap(), (None, vec![]));
+            assert_eq!(read_input(br#"{"list":[]}"#).unwrap(), (None, vec![]));
+            assert_eq!(
+                read_input(b"  { \"int\": 1 }  \n").unwrap(),
+                (Some(1), vec![])
+            );
+        }
+
+        #[test]
+        fn trailing_comma_in_object_is_rejected() {
+            assert!(read_input(br#"{"int": 10,}"#).is_err());
+        }
+
+        #[test]
+        fn leading_and_repeated_commas_in_object_are_rejected() {
+            assert!(read_input(br#"{,"int": 10}"#).is_err());
+            assert!(read_input(br#"{"int": 10,,"list": []}"#).is_err());
+            assert!(read_input(br#"{"int": 10,,}"#).is_err());
+        }
+
+        #[test]
+        fn missing_comma_in_object_is_rejected() {
+            assert!(read_input(br#"{"int": 10 "list": []}"#).is_err());
+        }
+
+        #[test]
+        fn commas_in_array_are_checked() {
+            assert!(read_input(br#"{"list": [1,]}"#).is_err());
+            assert!(read_input(br#"{"list": [,1]}"#).is_err());
+            assert!(read_input(br#"{"list": [1,,2]}"#).is_err());
+            assert!(read_input(br#"{"list": [1 2]}"#).is_err());
+        }
+
+        #[test]
+        fn skipped_unknown_members_are_still_validated() {
+            assert_eq!(
+                read_input(br#"{"unknown": {"a": [1, {"b": null}], "c": "x"}, "int": 1}"#).unwrap(),
+                (Some(1), vec![])
+            );
+            assert!(read_input(br#"{"unknown": [1,,2], "int": 1}"#).is_err());
+            assert!(read_input(br#"{"unknown": {"a": 1,}, "int": 1}"#).is_err());
+            assert!(read_input(br#"{"unknown": "unterminated, "int": 1}"#).is_err());
+            assert!(read_input(br#"{"unknown": tru, "int": 1}"#).is_err());
+        }
+
+        #[test]
+        fn trailing_characters_after_the_top_level_value_are_rejected() {
+            assert!(read_input(br#"{ "int": 10 }abc"#).is_err());
+            assert!(read_input(br#"{ "int": 10 },"#).is_err());
+            assert!(read_input(br#"{ "int": 10 }{}"#).is_err());
+            assert!(deser(br#"[1]x"#).read_integer_list(&LIST).is_err());
+            assert!(deser(br#"{"k":"v"} {}"#)
+                .read_string_string_map(&LIST)
+                .is_err());
+            assert!(deser(br#"{"a":1}]"#).read_document(&INT).is_err());
+            assert!(deser(br#"[1,2]"#).read_document(&INT).is_ok());
+        }
+
+        #[test]
+        fn skipped_numbers_must_match_the_json_grammar() {
+            for ok in [
+                b"0" as &[u8],
+                b"-0",
+                b"10",
+                b"-1.5",
+                b"1e3",
+                b"1E+3",
+                b"2.5e-7",
+            ] {
+                let body = [b"{\"unknown\": " as &[u8], ok, b", \"int\": 1}"].concat();
+                assert_eq!(
+                    read_input(&body).unwrap(),
+                    (Some(1), vec![]),
+                    "{}",
+                    String::from_utf8_lossy(ok)
+                );
+            }
+            for bad in [
+                b"01" as &[u8],
+                b"1.",
+                b"--1",
+                b"+1",
+                b".5",
+                b"1e",
+                b"1e+",
+                b"-",
+                b"0x1",
+            ] {
+                let body = [b"{\"unknown\": " as &[u8], bad, b", \"int\": 1}"].concat();
+                assert!(
+                    read_input(&body).is_err(),
+                    "{}",
+                    String::from_utf8_lossy(bad)
+                );
+            }
+        }
+
+        #[test]
+        fn skipped_strings_must_use_valid_escapes() {
+            assert_eq!(
+                read_input(br#"{"unknown": "a\"b\\c\/\b\f\n\r\t\u00e9", "int": 1}"#).unwrap(),
+                (Some(1), vec![])
+            );
+            assert!(read_input(br#"{"unknown": "\q", "int": 1}"#).is_err());
+            assert!(read_input(br#"{"unknown": "\u12", "int": 1}"#).is_err());
+            assert!(read_input(br#"{"unknown": "\uZZZZ", "int": 1}"#).is_err());
+            assert!(read_input(br#"{"unknown": "abc\", "int": 1}"#).is_err());
+        }
+
+        #[test]
+        fn fast_path_collections_check_separators() {
+            assert_eq!(
+                deser(br#"["a","b"]"#).read_string_list(&LIST).unwrap(),
+                vec!["a", "b"]
+            );
+            assert!(deser(br#"["a",]"#).read_string_list(&LIST).is_err());
+            assert!(deser(br#"[,"a"]"#).read_string_list(&LIST).is_err());
+            assert!(deser(br#"[1,,2]"#).read_integer_list(&LIST).is_err());
+            assert!(deser(br#"[1,]"#).read_long_list(&LIST).is_err());
+            assert!(deser(br#"["YQ==",]"#).read_blob_list(&LIST).is_err());
+            assert_eq!(
+                deser(br#"{"k":"v"}"#)
+                    .read_string_string_map(&LIST)
+                    .unwrap()
+                    .len(),
+                1
+            );
+            assert!(deser(br#"{"k":"v",}"#)
+                .read_string_string_map(&LIST)
+                .is_err());
+            assert!(deser(br#"{"k":"v" "j":"w"}"#)
+                .read_string_string_map(&LIST)
+                .is_err());
+        }
+
+        #[test]
+        fn generic_map_checks_separators() {
+            let mut count = 0;
+            assert!(deser(br#"{"a":1,"b":2}"#)
+                .read_map(&LIST, &mut |_, d| {
+                    count += 1;
+                    d.read_integer(&INT).map(|_| ())
+                })
+                .is_ok());
+            assert_eq!(count, 2);
+            assert!(deser(br#"{"a":1,}"#)
+                .read_map(&LIST, &mut |_, d| d.read_integer(&INT).map(|_| ()))
+                .is_err());
+        }
+
+        #[test]
+        fn documents_check_separators() {
+            assert!(deser(br#"{"a":[1,2],"b":{"c":true}}"#)
+                .read_document(&INT)
+                .is_ok());
+            assert!(deser(br#"{"a":1,}"#).read_document(&INT).is_err());
+            assert!(deser(br#"[1,,2]"#).read_document(&INT).is_err());
+            assert!(deser(br#"{,"a":1}"#).read_document(&INT).is_err());
+        }
     }
 }

--- a/rust-runtime/aws-smithy-json/src/protocol/aws_json_rpc.rs
+++ b/rust-runtime/aws-smithy-json/src/protocol/aws_json_rpc.rs
@@ -192,6 +192,35 @@ mod tests {
         );
     }
 
+    /// The body deserializer handed out by `deserialize_response` must reject malformed JSON
+    /// bodies end to end, not only inside containers. These are the bodies of Smithy protocol
+    /// tests `RestJsonInvalidJsonBody_case1` and `RestJsonInvalidJsonBody_case7`.
+    #[test]
+    fn malformed_response_bodies_are_rejected() {
+        use aws_smithy_runtime_api::http::Response;
+        use aws_smithy_types::body::SdkBody;
+
+        for body in [r#"{ "int": 10 }abc"#, r#"{"int": 10,}"#] {
+            let response = Response::new(200u16.try_into().unwrap(), SdkBody::from(body));
+            let mut deser = AwsJsonRpcProtocol::aws_json_1_0("TestService")
+                .deserialize_response(&response, &TEST_SCHEMA, &ConfigBag::base())
+                .unwrap();
+            let result = deser.read_struct(&TEST_SCHEMA, &mut |_, _| Ok(()));
+            assert!(result.is_err(), "body {body:?} must be rejected");
+        }
+
+        let response = Response::new(
+            200u16.try_into().unwrap(),
+            SdkBody::from(r#"{ "int": 10 }"#),
+        );
+        let mut deser = AwsJsonRpcProtocol::aws_json_1_0("TestService")
+            .deserialize_response(&response, &TEST_SCHEMA, &ConfigBag::base())
+            .unwrap();
+        deser
+            .read_struct(&TEST_SCHEMA, &mut |_, _| Ok(()))
+            .expect("well-formed body is accepted");
+    }
+
     #[test]
     fn json_1_0_protocol_id() {
         assert_eq!(


### PR DESCRIPTION
## Motivation and Context

`JsonDeserializer` accepts malformed JSON that the token-based parser rejects. A server on the
schema-based path must answer these bodies with a 400 `SerializationException`; the restJson1
protocol tests `RestJsonInvalidJsonBody_case1` and `RestJsonInvalidJsonBody_case7` fail because
of the codec.

With the published `aws-smithy-json 0.63.0`, all of these are accepted:

| Body | Problem |
|---|---|
| `{"x":1,}`, `{"x":1,,}`, `{,,"x":1}` | `,` skipped as whitespace |
| `{"x":1 "l":[2]}` | no separator required between members |
| `{"l":[1,,2]}`, `{"l":[,1]}`, `{"l":[1,]}` | same inside arrays |
| `{"x":1}abc`, `{"x":1},` | bytes after the top-level value ignored |
| `{"unknown":[1,,2],"x":1}` | skipped values not validated |

## Description

Separators: exactly one `,` between elements, none before a closer, nothing after the
top-level value. `skip_value` validates what it skips (number grammar, string escapes,
nesting). No settings were added; the deserializer now matches the token-based parser.

Strict timestamp formats and union member rules are left for separate PRs.

## Testing

Unit tests per rule, plus tests through `AwsJsonRpcProtocol::deserialize_response`.

## Checklist

- [x] Changelog entry in `.changelog`.
