### PR TITLE
schema-based deserializer: report unknown keys to `read_struct` consumers and enforce union member rules

### DIFF
--- a/.changelog/schema-deserializer-unknown-members.md
+++ b/.changelog/schema-deserializer-unknown-members.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client", "server"]
+authors: ["drganjoo"]
+references: []
+breaking: false
+new_feature: true
+bug_fix: false
+---
+`ShapeDeserializer::read_struct` in the JSON and CBOR codecs now reports a key that names no member of the structure or union being read, instead of skipping it silently. The consumer is called with the prelude `DOCUMENT` schema, whose `member_index()` is `None`, positioned at the value; a consumer that does not read the value leaves the codec to skip it. Generated structure code ignores the call; union code uses it to decide how an unknown variant is handled. The `__type` discriminator and `null`-valued keys are not reported.

--- a/.changelog/schema-union-deserialize-unknown-members.md
+++ b/.changelog/schema-union-deserialize-unknown-members.md
@@ -1,0 +1,9 @@
+---
+applies_to: ["client", "server"]
+authors: ["drganjoo"]
+references: []
+breaking: false
+new_feature: false
+bug_fix: true
+---
+The schema-based union deserializer now enforces the union rules the token-based parser enforces. A second key in the union object, whatever it names, is an error ("encountered mixed variants in union"); previously the last member won. A key that names no member becomes the unknown variant on a client and an "unexpected union variant" error on a server; previously it was skipped. On a server, the generated `SerializableStruct` impl no longer refers to an unknown variant the union does not have. This makes the restJson1 protocol tests `RestJsonMalformedUnionMultipleFieldsSet` and `RestJsonMalformedUnionKnownAndUnknownFieldsSet` pass on the schema-based path.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/SchemaGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/SchemaGenerator.kt
@@ -40,6 +40,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.isRustBoxed
@@ -286,7 +287,10 @@ class SchemaGenerator(
                         rust("Self::$variantName(val) => { $writeExpr },")
                     }
                 }
-                rustTemplate("Self::${UnionGenerator.UNKNOWN_VARIANT_NAME} => return Err(#{SerdeError}::custom(\"cannot serialize unknown union variant\")),", *codegenScope)
+                // Only client unions carry the unknown variant.
+                if (codegenContext.target == CodegenTarget.CLIENT) {
+                    rustTemplate("Self::${UnionGenerator.UNKNOWN_VARIANT_NAME} => return Err(#{SerdeError}::custom(\"cannot serialize unknown union variant\")),", *codegenScope)
+                }
             }
 
         writer.rustTemplate(
@@ -449,7 +453,17 @@ class SchemaGenerator(
                         rust("Some($idx) => Self::$variantName($wrapped),")
                     }
                 }
-                rust("_ => Self::${UnionGenerator.UNKNOWN_VARIANT_NAME},")
+                // The deserializer reports a key that names no member with a schema whose
+                // `member_index()` is `None`. A client keeps it as the unknown variant so a newer
+                // service can add members; a server rejects it, as the token-based parser does.
+                when (codegenContext.target) {
+                    CodegenTarget.CLIENT -> rust("_ => Self::${UnionGenerator.UNKNOWN_VARIANT_NAME},")
+                    CodegenTarget.SERVER ->
+                        rustTemplate(
+                            """_ => return Err(#{SerdeError}::invalid_input("unexpected union variant")),""",
+                            *codegenScope,
+                        )
+                }
             }
 
         writer.rustTemplate(
@@ -460,6 +474,11 @@ class SchemaGenerator(
                     let mut result: ::std::option::Option<Self> = ::std::option::Option::None;
                     ##[allow(unused_variables, unreachable_code, clippy::single_match, clippy::match_single_binding)]
                     deserializer.read_struct(&${schemaPrefix}_SCHEMA, &mut |member, deser| {
+                        // A union holds exactly one member; the deserializer reports every key
+                        // (known or not), so a second one is an error whatever it names.
+                        if result.is_some() {
+                            return Err(#{SerdeError}::invalid_input("encountered mixed variants in union"));
+                        }
                         result = ::std::option::Option::Some(match member.member_index() {
                             #{variantArms}
                         });

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/SchemaGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/SchemaGeneratorTest.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.implBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
@@ -385,6 +386,77 @@ class SchemaGeneratorTest {
                 let mut deser = codec.create_deserializer(&bytes);
                 let result = MyUnion::deserialize(&mut deser).expect("deserialization");
                 assert!(matches!(result, MyUnion::StringVariant(ref s) if s == "round-trip"));
+                """,
+            )
+        }
+        project.compileAndTest()
+    }
+
+    @Test
+    fun `client union deserialize rejects mixed variants and keeps unknown keys as the unknown variant`() {
+        val project = TestWorkspace.testProject(provider)
+        val shape = model.lookup<UnionShape>("test#MyUnion")
+        project.useShapeWriter(shape) {
+            UnionGenerator(model, provider, this, shape).render()
+            SchemaGenerator(codegenContext, this, shape).render()
+            rustTemplate(
+                "use #{JsonCodec};",
+                "JsonCodec" to RuntimeType.smithyJson(codegenContext.runtimeConfig).resolve("codec::JsonCodec"),
+            )
+            unitTest(
+                "client_union_unknown_and_mixed",
+                """
+                use aws_smithy_json::codec::{JsonCodec, JsonCodecSettings};
+                use aws_smithy_schema::codec::Codec;
+
+                let codec = JsonCodec::new(JsonCodecSettings::default());
+                let read = |json: &[u8]| MyUnion::deserialize(&mut codec.create_deserializer(json));
+
+                // An unknown key is the unknown variant; its value is skipped.
+                assert!(matches!(read(br#"{"zzz":{"nested":[1,2]}}"#).unwrap(), MyUnion::Unknown));
+                // `__type` is a discriminator, not a variant.
+                assert!(matches!(read(br#"{"__type":"test#MyUnion","intVariant":42}"#).unwrap(), MyUnion::IntVariant(42)));
+                // A second key of any kind is an error.
+                let err = read(br#"{"stringVariant":"hello","intVariant":1}"#).unwrap_err();
+                assert!(err.to_string().contains("mixed variants"), "{err}");
+                let err = read(br#"{"intVariant":1,"zzz":true}"#).unwrap_err();
+                assert!(err.to_string().contains("mixed variants"), "{err}");
+                """,
+            )
+        }
+        project.compileAndTest()
+    }
+
+    @Test
+    fun `server union deserialize rejects unknown keys and mixed variants`() {
+        val serverContext = testCodegenContext(model, codegenTarget = CodegenTarget.SERVER)
+        val project = TestWorkspace.testProject(provider)
+        val shape = model.lookup<UnionShape>("test#MyUnion")
+        project.useShapeWriter(shape) {
+            UnionGenerator(model, provider, this, shape, renderUnknownVariant = false).render()
+            SchemaGenerator(serverContext, this, shape).render()
+            rustTemplate(
+                "use #{JsonCodec};",
+                "JsonCodec" to RuntimeType.smithyJson(serverContext.runtimeConfig).resolve("codec::JsonCodec"),
+            )
+            unitTest(
+                "server_union_unknown_and_mixed",
+                """
+                use aws_smithy_json::codec::{JsonCodec, JsonCodecSettings};
+                use aws_smithy_schema::codec::Codec;
+
+                let codec = JsonCodec::new(JsonCodecSettings::default());
+                let read = |json: &[u8]| MyUnion::deserialize(&mut codec.create_deserializer(json));
+
+                assert!(matches!(read(br#"{"intVariant":42}"#).unwrap(), MyUnion::IntVariant(42)));
+                // An unknown key is an error; its value is skipped.
+                let err = read(br#"{"zzz":{"nested":[1,2]}}"#).unwrap_err();
+                assert!(err.to_string().contains("unexpected union variant"), "{err}");
+                // Known plus unknown, and two known members, are both mixed variants.
+                let err = read(br#"{"intVariant":1,"zzz":true}"#).unwrap_err();
+                assert!(err.to_string().contains("mixed variants"), "{err}");
+                let err = read(br#"{"stringVariant":"hello","intVariant":1}"#).unwrap_err();
+                assert!(err.to_string().contains("mixed variants"), "{err}");
                 """,
             )
         }

--- a/rust-runtime/aws-smithy-cbor/src/codec/deserializer.rs
+++ b/rust-runtime/aws-smithy-cbor/src/codec/deserializer.rs
@@ -106,8 +106,20 @@ impl ShapeDeserializer for CborDeserializer<'_> {
             let key = self.decoder.str().map_err(deser_err)?;
             if let Some(member_schema) = schema.member_schema(&key) {
                 consumer(member_schema, self)?;
-            } else {
+            } else if &*key == "__type" || self.is_null() {
+                // A protocol discriminator is never a member, and a `null` value is an
+                // absent member. Neither is reported.
                 self.decoder.skip().map_err(deser_err)?;
+            } else {
+                // Report the unknown key so a union consumer can act on it: the prelude
+                // `DOCUMENT` schema has no member index, so generated code lands in its
+                // fallthrough arm. The consumer may read the value with a typed read; if
+                // it does not, the position is unchanged and the value is skipped here.
+                let start = self.decoder.position();
+                consumer(&aws_smithy_schema::prelude::DOCUMENT, self)?;
+                if self.decoder.position() == start {
+                    self.decoder.skip().map_err(deser_err)?;
+                }
             }
             i += 1;
         }
@@ -923,18 +935,15 @@ mod tests {
     }
 
     #[test]
-    fn union_with_only_unknown_member_yields_clean_error() {
-        // A union map whose sole key matches no member is skipped; no variant
-        // is set, so a clean error results (no panic).
+    fn union_with_only_unknown_member_is_reported_to_the_consumer() {
+        // A union map whose sole key matches no member is reported to the
+        // consumer as an unknown member; this consumer maps it to `Unknown`
+        // (as a client would) and the value is skipped for it.
         let mut e = crate::Encoder::new(Vec::new());
         e.map(1).str("zzz").str("ignored");
         let bytes = e.into_writer();
         let mut de = CborDeserializer::new(&bytes, 128);
-        let err = deser_inner_union(&mut de).unwrap_err();
-        assert!(
-            err.to_string().contains("expected a union variant"),
-            "unknown-only union must be a clean error, got {err:?}"
-        );
+        assert_eq!(deser_inner_union(&mut de).unwrap(), InnerUnion::Unknown);
     }
 
     #[test]
@@ -1071,5 +1080,100 @@ mod tests {
             Some(false),
             "required value-type enabled=false must be serialized, not dropped"
         );
+    }
+}
+
+/// `read_struct` reports keys that name no member: the consumer is called with the
+/// prelude `DOCUMENT` schema (no member index) positioned at the value. See the JSON
+/// codec's `unknown_member_tests` for the full contract; these cover the CBOR specifics
+/// (definite and indefinite maps, `null` values, `__type`).
+#[cfg(test)]
+mod unknown_member_tests {
+    use super::*;
+    use aws_smithy_schema::{shape_id, ShapeType};
+
+    static A: Schema<'static> =
+        Schema::new_member(shape_id!("test", "S"), ShapeType::String, "a", 0);
+    static S: Schema<'static> =
+        Schema::new_struct(shape_id!("test", "S"), ShapeType::Structure, &[&A]);
+
+    /// CBOR has no document type, so a consumer that wants an unknown value reads it with
+    /// a typed read. This one reads it as a string when asked.
+    fn read_s(bytes: &[u8], read_unknown_value: bool) -> (Option<String>, Vec<Option<String>>) {
+        let mut a = None;
+        let mut unknown = Vec::new();
+        CborDeserializer::new(bytes, 128)
+            .read_struct(&S, &mut |member, d| {
+                match member.member_index() {
+                    Some(0) => a = Some(d.read_string(member)?),
+                    _ => {
+                        assert_eq!(member.shape_type(), ShapeType::Document);
+                        unknown.push(if read_unknown_value {
+                            Some(d.read_string(member)?)
+                        } else {
+                            None
+                        });
+                    }
+                }
+                Ok(())
+            })
+            .unwrap();
+        (a, unknown)
+    }
+
+    #[test]
+    fn unknown_key_is_reported_and_the_consumer_can_read_the_value() {
+        let mut e = crate::Encoder::new(Vec::new());
+        e.map(2).str("zzz").str("value").str("a").str("x");
+        let (a, unknown) = read_s(&e.into_writer(), true);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert_eq!(unknown, [Some("value".to_string())]);
+    }
+
+    #[test]
+    fn unknown_key_value_is_skipped_when_not_read_in_definite_and_indefinite_maps() {
+        let mut e = crate::Encoder::new(Vec::new());
+        e.map(3)
+            .str("zzz")
+            .map(1)
+            .str("deep")
+            .array(2)
+            .integer(1)
+            .integer(2)
+            .str("a")
+            .str("x")
+            .str("yyy")
+            .str("tail");
+        let (a, unknown) = read_s(&e.into_writer(), false);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert_eq!(unknown.len(), 2);
+
+        let mut e = crate::Encoder::new(Vec::new());
+        e.begin_map()
+            .str("zzz")
+            .array(2)
+            .integer(1)
+            .integer(2)
+            .str("a")
+            .str("x")
+            .end();
+        let (a, unknown) = read_s(&e.into_writer(), false);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert_eq!(unknown.len(), 1);
+    }
+
+    #[test]
+    fn type_discriminator_and_null_values_are_not_reported() {
+        let mut e = crate::Encoder::new(Vec::new());
+        e.map(3)
+            .str("__type")
+            .str("ns#Foo")
+            .str("zzz")
+            .null()
+            .str("a")
+            .str("x");
+        let (a, unknown) = read_s(&e.into_writer(), false);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert!(unknown.is_empty());
     }
 }

--- a/rust-runtime/aws-smithy-json/src/codec/deserializer.rs
+++ b/rust-runtime/aws-smithy-json/src/codec/deserializer.rs
@@ -237,8 +237,19 @@ impl<'a> ShapeDeserializer for JsonDeserializer<'a> {
                 self.advance_by(4);
             } else if let Some(member_schema) = self.resolve_member(schema, &key_str) {
                 consumer(member_schema, self)?;
-            } else {
+            } else if &*key_str == "__type" {
+                // Protocol discriminator, never a member.
                 self.skip_value()?;
+            } else {
+                // Report the unknown key so a union consumer can act on it: the prelude
+                // `DOCUMENT` schema has no member index, so generated code lands in its
+                // fallthrough arm. The consumer may read the value (as a document); if it
+                // does not, the position is unchanged and the value is skipped here.
+                let start = self.position;
+                consumer(&aws_smithy_schema::prelude::DOCUMENT, self)?;
+                if self.position == start {
+                    self.skip_value()?;
+                }
             }
         }
 
@@ -3038,6 +3049,144 @@ mod union_deserialization_tests {
         assert_eq!(
             out.get("second"),
             Some(&OuterUnion::Mcp(InnerUnion::Lambda("b".to_string())))
+        );
+    }
+}
+
+/// `read_struct` reports keys that name no member: the consumer is called with the
+/// prelude `DOCUMENT` schema (no member index) positioned at the value. These tests
+/// pin down what is reported, what is not, and that the stream stays intact whether
+/// or not the consumer reads the value.
+#[cfg(test)]
+mod unknown_member_tests {
+    use super::*;
+    use aws_smithy_schema::{shape_id, ShapeType};
+
+    static A: Schema<'static> =
+        Schema::new_member(shape_id!("test", "S"), ShapeType::String, "a", 0);
+    static S: Schema<'static> =
+        Schema::new_struct(shape_id!("test", "S"), ShapeType::Structure, &[&A]);
+
+    static U_INT: Schema<'static> =
+        Schema::new_member(shape_id!("test", "U"), ShapeType::Integer, "int", 0);
+    static U_STR: Schema<'static> =
+        Schema::new_member(shape_id!("test", "U"), ShapeType::String, "string", 1);
+    static U: Schema<'static> =
+        Schema::new_struct(shape_id!("test", "U"), ShapeType::Union, &[&U_INT, &U_STR]);
+
+    fn deser(input: &[u8]) -> JsonDeserializer<'_> {
+        JsonDeserializer::new(input, Arc::new(JsonCodecSettings::default()))
+    }
+
+    /// Reads `S`, recording every unknown key (and its value when asked) and returning `a`.
+    fn read_s(input: &[u8], read_unknown_value: bool) -> (Option<String>, Vec<Option<Document>>) {
+        let mut a = None;
+        let mut unknown = Vec::new();
+        deser(input)
+            .read_struct(&S, &mut |member, d| {
+                match member.member_index() {
+                    Some(0) => a = Some(d.read_string(member)?),
+                    _ => {
+                        assert_eq!(member.shape_type(), ShapeType::Document);
+                        unknown.push(if read_unknown_value {
+                            Some(d.read_document(member)?)
+                        } else {
+                            None
+                        });
+                    }
+                }
+                Ok(())
+            })
+            .unwrap();
+        (a, unknown)
+    }
+
+    #[test]
+    fn unknown_key_is_reported_and_the_consumer_can_read_the_value() {
+        let (a, unknown) = read_s(br#"{"zzz":{"deep":[1,2]},"a":"x"}"#, true);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert_eq!(unknown.len(), 1);
+        match &unknown[0] {
+            Some(Document::Object(map)) => assert!(map.contains_key("deep")),
+            other => panic!("expected the object value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_key_value_is_skipped_when_the_consumer_does_not_read_it() {
+        // Nested containers and a `}` inside a string must not confuse the skip.
+        let (a, unknown) = read_s(
+            br#"{"zzz":{"deep":[1,{"q":"}"}]},"a":"x","yyy":"tail"}"#,
+            false,
+        );
+        assert_eq!(a.as_deref(), Some("x"));
+        assert_eq!(unknown.len(), 2);
+    }
+
+    #[test]
+    fn type_discriminator_is_not_reported() {
+        let (a, unknown) = read_s(br#"{"__type":"ns#Foo","a":"x"}"#, false);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert!(unknown.is_empty(), "`__type` must not be reported");
+    }
+
+    #[test]
+    fn null_valued_unknown_key_is_not_reported() {
+        let (a, unknown) = read_s(br#"{"zzz":null,"a":"x"}"#, false);
+        assert_eq!(a.as_deref(), Some("x"));
+        assert!(unknown.is_empty(), "a null value is an absent member");
+    }
+
+    #[test]
+    fn struct_consumer_that_ignores_unknown_keys_is_unaffected() {
+        let mut a = None;
+        deser(br#"{"zzz":[1,2,3],"a":"x"}"#)
+            .read_struct(&S, &mut |member, d| {
+                if member.member_index() == Some(0) {
+                    a = Some(d.read_string(member)?);
+                }
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(a.as_deref(), Some("x"));
+    }
+
+    /// The shape of a generated server union deserializer: a second key of any kind is
+    /// "mixed variants", and an unknown key is an error.
+    fn read_union(input: &[u8]) -> Result<String, SerdeError> {
+        let mut result: Option<String> = None;
+        deser(input).read_struct(&U, &mut |member, d| {
+            if result.is_some() {
+                return Err(SerdeError::invalid_input(
+                    "encountered mixed variants in union",
+                ));
+            }
+            result = Some(match member.member_index() {
+                Some(0) => format!("int={}", d.read_integer(member)?),
+                Some(1) => format!("string={}", d.read_string(member)?),
+                _ => return Err(SerdeError::invalid_input("unexpected union variant")),
+            });
+            Ok(())
+        })?;
+        result.ok_or_else(|| SerdeError::custom("expected a union variant"))
+    }
+
+    #[test]
+    fn union_consumer_sees_known_and_unknown_keys() {
+        assert_eq!(read_union(br#"{"int":2}"#).unwrap(), "int=2");
+        let err = read_union(br#"{"int":2,"string":"three"}"#).unwrap_err();
+        assert!(err.to_string().contains("mixed variants"), "{err}");
+        let err = read_union(br#"{"int":2,"unknownField":"three"}"#).unwrap_err();
+        assert!(err.to_string().contains("mixed variants"), "{err}");
+        let err = read_union(br#"{"unknownField":"three"}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("unexpected union variant"),
+            "{err}"
+        );
+        // `__type` is a discriminator, not a variant.
+        assert_eq!(
+            read_union(br#"{"__type":"ns#U","int":2}"#).unwrap(),
+            "int=2"
         );
     }
 }


### PR DESCRIPTION
## Motivation and Context

`read_struct` in the JSON and CBOR codecs skipped a key that named no member without
telling the consumer. The generated union deserializer has always had a fallthrough arm
for `member_index() == None`, but nothing ever reached it, and a server could not reject
a union carrying an unknown member next to a known one. The generated code also
overwrote its result on every key, so the last member won when two were set.

The restJson1 protocol tests `RestJsonMalformedUnionMultipleFieldsSet` and
`RestJsonMalformedUnionKnownAndUnknownFieldsSet` require a 400 `SerializationException`
for both bodies on the schema-based server path.

Based on #4721, where the schema-serde server work sits.

## Description

Codecs. `read_struct` now calls the consumer for a key that names no member, with the
prelude `DOCUMENT` schema (`member_index()` is `None`) positioned at the value. A consumer
may read the value (`read_document` on JSON, a typed read on CBOR); one that returns
without reading it leaves the codec to skip it.

Codegen. The generated union deserializer errors on any second key ("encountered mixed
variants in union"), as the token-based parser does. An unknown key is the unknown
variant on a client and an "unexpected union variant" error on a server. The serializer's
unknown-variant arm is now emitted only for clients; server unions have no such variant,
so the previous output did not compile for them.

Not changed: the XML and query codecs still skip unknown keys silently.

Overlaps with #4846 in `JsonDeserializer::read_struct`; whichever merges second needs a
manual resolution there.

## Testing

Codec unit tests for what is reported, what is not, and stream integrity whether or not
the consumer reads the value. `SchemaGeneratorTest` compiles and runs the generated union
code for both targets: mixed variants, unknown-only, known-plus-unknown, and `__type`.
